### PR TITLE
Add per-model cost pricing, fix reasoning trace UX, surface Antigravi…

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 import os
 import json
+import yaml
 import sqlite3
 from pathlib import Path
 from typing import List, Optional, Dict, Any, Set
@@ -70,9 +71,17 @@ OPENCODE_DB = HOME / ".local/share/opencode/opencode.db"
 VSCODE_STORAGE = VSCODE_BASE / "User/workspaceStorage"
 CURSOR_STORAGE = CURSOR_BASE / "User/workspaceStorage"
 ANTIGRAVITY_BRAIN_DIR = GEMINI_DIR / "antigravity" / "brain"
+PROJECT_ALIASES_FILE = HOME / ".agent-harness" / "aliases.json"
 
-def _now():
-    return datetime.now(timezone.utc)
+def _load_project_aliases() -> Dict[str, str]:
+    # Ensure directory exists
+    PROJECT_ALIASES_FILE.parent.mkdir(parents=True, exist_ok=True)
+    if PROJECT_ALIASES_FILE.exists():
+        try:
+            with open(PROJECT_ALIASES_FILE, "r") as f:
+                return json.load(f)
+        except: pass
+    return {}
 
 def _antigravity_infer_project(text: str) -> str:
     import re
@@ -117,6 +126,11 @@ class PlanSnippet(BaseModel):
     timestamp: datetime
     content: str
 
+class Artifact(BaseModel):
+    name: str
+    path: str
+    type: str # 'video', 'image', 'document', 'terminal'
+
 class Session(BaseModel):
     id: str
     agent: str
@@ -129,6 +143,7 @@ class Session(BaseModel):
     has_plan: bool = False
     tokens: TokenUsage = TokenUsage()
     plans: List[PlanSnippet] = []
+    artifacts: List[Artifact] = []
 
 @app.get("/")
 async def root():
@@ -171,6 +186,10 @@ async def get_available_agents():
 
 def _scan_sessions_sync():
     sessions = []
+    aliases = _load_project_aliases()
+
+    def apply_alias(path: str) -> str:
+        return aliases.get(path, path)
 
     # 1. Claude
     claude_history = CLAUDE_DIR / "history.jsonl"
@@ -194,13 +213,21 @@ def _scan_sessions_sync():
                         if not sid: continue
                         ts = datetime.fromtimestamp(data.get("timestamp") / 1000, tz=timezone.utc) if data.get("timestamp") else _now()
                         if sid not in claude_sessions or ts > claude_sessions[sid]["timestamp"]:
-                            claude_sessions[sid] = {"id": sid, "agent": "claude", "project": data.get("project", "unknown"), "timestamp": ts, "display": data.get("display"), "tokens": {"input": 0, "output": 0, "cached": 0, "total": 0}, "mcp_tools": [], "has_plan": False, "plans": [], "model": None}
+                            claude_sessions[sid] = {"id": sid, "agent": "claude", "project": apply_alias(data.get("project", "unknown")), "timestamp": ts, "display": data.get("display"), "tokens": {"input": 0, "output": 0, "cached": 0, "total": 0}, "mcp_tools": [], "has_plan": False, "plans": [], "model": None, "artifacts": []}
                     except: continue
         except: pass
 
         for sid, sess in list(claude_sessions.items())[:100]:
             session_file = claude_file_map.get(sid)
             if session_file:
+                # Discover Claude Project Memory artifacts
+                try:
+                    memory_dir = session_file.parent.parent / "memory"
+                    if memory_dir.exists():
+                        for mf in memory_dir.glob("*.md"):
+                            sess["artifacts"].append({"name": mf.name, "path": str(mf), "type": "document"})
+                except: pass
+
                 try:
                     with open(session_file, "r", encoding="utf-8", errors="replace") as f:
                         for line in f:
@@ -218,6 +245,7 @@ def _scan_sessions_sync():
                                     sess["tokens"]["output"] += usage.get("output_tokens", 0)
                                     sess["tokens"]["cached"] += usage.get("cache_read_input_tokens", 0)
                                 sess["tokens"]["total"] = sess["tokens"]["input"] + sess["tokens"]["output"] + sess["tokens"]["cached"]
+                                sess["cost"] = calculate_cost(sess.get("model"), sess["tokens"]["input"], sess["tokens"]["output"], sess["tokens"]["cached"])
                                 for item in msg.get("content", []):
                                     if item.get("type") == "tool_use":
                                         tool = item.get("name")
@@ -250,25 +278,29 @@ def _scan_sessions_sync():
                     codex_file_map[sid] = f
         except: pass
 
-        with open(codex_index, "r") as f:
-            for line in f:
-                try:
-                    data = json.loads(line); sid = data.get("id")
-                    if not sid: continue
-                    ts = _aware(datetime.fromisoformat(data.get("updated_at").replace('Z', '+00:00'))) if data.get("updated_at") else _now()
-                    if sid not in codex_sessions or ts > codex_sessions[sid]["timestamp"]:
-                        codex_sessions[sid] = {"id": sid, "agent": "codex", "project": "unknown", "timestamp": ts, "text": data.get("thread_name"), "tokens": {"input": 0, "output": 0, "cached": 0, "total": 0}, "mcp_tools": [], "has_plan": False, "plans": [], "model": None}
-                except: continue
+        try:
+            with open(codex_index, "r", encoding="utf-8", errors="replace") as f:
+                for line in f:
+                    try:
+                        data = json.loads(line); sid = data.get("id")
+                        if not sid: continue
+                        ts = _aware(datetime.fromisoformat(data.get("updated_at").replace('Z', '+00:00'))) if data.get("updated_at") else _now()
+                        if sid not in codex_sessions or ts > codex_sessions[sid]["timestamp"]:
+                            codex_sessions[sid] = {"id": sid, "agent": "codex", "project": "unknown", "timestamp": ts, "text": data.get("thread_name"), "tokens": {"input": 0, "output": 0, "cached": 0, "total": 0}, "mcp_tools": [], "has_plan": False, "plans": [], "model": None, "artifacts": []}
+                    except: continue
+        except: pass
         
         for sid, sess in list(codex_sessions.items())[:100]:
             rollout_file = codex_file_map.get(sid)
             if rollout_file:
                 try:
-                    with open(rollout_file, "r") as f:
+                    with open(rollout_file, "r", encoding="utf-8", errors="replace") as f:
                         for line in f:
-                            data = json.loads(line)
+                            try:
+                                data = json.loads(line)
+                            except: continue
                             if data.get("type") == "session_meta":
-                                sess["project"] = data["payload"].get("cwd", "unknown")
+                                sess["project"] = apply_alias(data["payload"].get("cwd", "unknown"))
                                 if not sess.get("model") and data["payload"].get("model"):
                                     sess["model"] = data["payload"].get("model")
                                 if not sess.get("_provider"):
@@ -282,6 +314,7 @@ def _scan_sessions_sync():
                                     sess["tokens"]["output"] = max(sess["tokens"]["output"], usage.get("output_tokens", 0))
                                     sess["tokens"]["cached"] = max(sess["tokens"]["cached"], usage.get("cached_input_tokens", 0))
                                     sess["tokens"]["total"] = sess["tokens"]["input"] + sess["tokens"]["output"] + sess["tokens"]["cached"]
+                                    sess["cost"] = calculate_cost(sess.get("model"), sess["tokens"]["input"], sess["tokens"]["output"], sess["tokens"]["cached"])
                             if data.get("type") == "response_item":
                                 if data.get("payload", {}).get("type") == "function_call":
                                     tool = data["payload"].get("name")
@@ -318,10 +351,10 @@ def _scan_sessions_sync():
                 chat_dir = tmp_dir / "chats"
                 if chat_dir.exists():
                     agent_type = "gemini" if slug in gemini_slugs else "antigravity"
-                    project_path = gemini_slug_to_path.get(slug, f"System / {slug[:8]}")
+                    project_path = apply_alias(gemini_slug_to_path.get(slug, f"System / {slug[:8]}"))
                     for cf in chat_dir.glob("*.json"):
                         try:
-                            with open(cf, "r") as f:
+                            with open(cf, "r", encoding="utf-8", errors="replace") as f:
                                 data = json.load(f); sid = data.get("sessionId")
                                 if not sid: continue
                                 ts = _aware(datetime.fromisoformat(data.get("lastUpdated").replace('Z', '+00:00'))) if data.get("lastUpdated") else _now()
@@ -345,68 +378,120 @@ def _scan_sessions_sync():
                                                 plan_text = ""
                                                 pp = (tc.get("args") or {}).get("plan_path")
                                                 if pp:
-                                                    try: plan_text = open(pp).read()
+                                                    try: 
+                                                        with open(pp, "r", encoding="utf-8", errors="replace") as pf:
+                                                            plan_text = pf.read()
                                                     except: plan_text = f"(plan stored at {pp})"
                                                 if not plan_text:
                                                     plan_text = (tc.get("args") or {}).get("plan") or tc.get("resultDisplay") or ""
                                                 if plan_text:
                                                     has_plan = True
                                                     plans.append({"session_id": sid, "agent": agent_type, "timestamp": ts, "content": plan_text})
-                                # Skip "ghost" sessions: file exists only because the CLI opened,
-                                # but the user never sent a prompt (e.g. only an `info` update notice).
+                                
+                                # Skip "ghost" sessions
                                 if not has_user and tokens["total"] == 0 and not mcp_tools:
                                     continue
+                                    
                                 model = None
                                 for msg in data.get("messages", []):
                                     if msg.get("model"): model = msg.get("model"); break
                                     if msg.get("modelVersion"): model = msg.get("modelVersion"); break
-                                sessions.append({"id": sid, "agent": agent_type, "project": project_path, "timestamp": ts, "display": first_msg[:100], "tokens": tokens, "mcp_tools": mcp_tools, "has_plan": has_plan, "plans": plans, "model": model})
+                                
+                                # Discover Antigravity chat-level media artifacts
+                                artifacts = []
+                                try:
+                                    art_dir = chat_dir.parent / "artifacts"
+                                    if art_dir.exists():
+                                        for af in art_dir.iterdir():
+                                            if af.suffix.lower() in (".mp4", ".mov"): artifacts.append({"name": af.name, "path": str(af), "type": "video"})
+                                            elif af.suffix.lower() in (".png", ".webp", ".jpg", ".jpeg"): artifacts.append({"name": af.name, "path": str(af), "type": "image"})
+                                except: pass
+
+                                tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"])
+                                sessions.append({"id": sid, "agent": agent_type, "project": project_path, "timestamp": ts, "display": first_msg[:100], "tokens": tokens, "mcp_tools": mcp_tools, "has_plan": has_plan, "plans": plans, "model": model, "artifacts": artifacts, "cost": tokens["cost"]})
                         except: continue
         except: pass
 
     # 3b. Antigravity brain/ folder — richer per-session artifacts (task/plan/walkthrough)
     if ANTIGRAVITY_BRAIN_DIR.exists():
         for sess_dir in ANTIGRAVITY_BRAIN_DIR.iterdir():
-            if not sess_dir.is_dir(): continue
-            sid = sess_dir.name
-            task = plan = walkthrough = ""
-            latest_ts = None
-            for fname in ("task.md", "implementation_plan.md", "walkthrough.md"):
-                fp = sess_dir / fname
-                mp = sess_dir / f"{fname}.metadata.json"
-                if fp.exists():
-                    try: body = fp.read_text(errors="ignore")
-                    except: body = ""
-                    if fname == "task.md": task = body
-                    elif fname == "implementation_plan.md": plan = body
-                    else: walkthrough = body
-                if mp.exists():
-                    try:
-                        md = json.loads(mp.read_text())
-                        updated = md.get("updatedAt")
-                        if updated:
-                            ts = _aware(datetime.fromisoformat(updated.replace("Z", "+00:00")))
-                            if latest_ts is None or ts > latest_ts: latest_ts = ts
-                    except: pass
-            if not (task or plan or walkthrough): continue
-            project = _antigravity_infer_project((task or "") + "\n" + (plan or ""))
-            first_line = next((ln.strip() for ln in (task or plan or walkthrough).splitlines() if ln.strip() and not ln.strip().startswith("#")), "")
-            display = (first_line or "Antigravity session")[:100]
-            plans: List[dict] = []
-            if plan:
-                plans.append({"session_id": sid, "agent": "antigravity", "timestamp": latest_ts or _now(), "content": plan})
-            sessions.append({
-                "id": sid,
-                "agent": "antigravity",
-                "project": project,
-                "timestamp": latest_ts or datetime.fromtimestamp(sess_dir.stat().st_mtime, tz=timezone.utc),
-                "display": display,
-                "tokens": {"input": 0, "output": 0, "cached": 0, "total": 0},
-                "mcp_tools": [],
-                "has_plan": bool(plan),
-                "plans": plans,
-                "model": "gemini (antigravity)",
-            })
+            try:
+                if not sess_dir.is_dir(): continue
+                sid = sess_dir.name
+                task = plan = walkthrough = ""
+                latest_ts = None
+                artifacts = []
+                # Scan for base documents as artifacts
+                for fname in ("task.md", "implementation_plan.md", "walkthrough.md"):
+                    fp = sess_dir / fname
+                    mp = sess_dir / f"{fname}.metadata.json"
+                    if fp.exists():
+                        artifacts.append({"name": fname, "path": str(fp), "type": "document"})
+                        try: 
+                            with open(fp, "r", encoding="utf-8", errors="replace") as f:
+                                body = f.read()
+                        except: body = ""
+                        if fname == "task.md": task = body
+                        elif fname == "implementation_plan.md": plan = body
+                        else: walkthrough = body
+                    if mp.exists():
+                        try:
+                            md = json.loads(mp.read_text(encoding="utf-8", errors="replace"))
+                            updated = md.get("updatedAt")
+                            if updated:
+                                ts = _aware(datetime.fromisoformat(updated.replace("Z", "+00:00")))
+                                if latest_ts is None or ts > latest_ts: latest_ts = ts
+                        except: pass
+                
+                # Scan for media artifacts at the brain session root (Antigravity drops
+                # previews/screenshots here) and optionally in an artifacts/ subdir.
+                try:
+                    media_dirs = [sess_dir]
+                    sub = sess_dir / "artifacts"
+                    if sub.exists(): media_dirs.append(sub)
+                    for d in media_dirs:
+                        for af in d.iterdir():
+                            if not af.is_file(): continue
+                            ext = af.suffix.lower()
+                            if ext in (".mp4", ".mov", ".webm"):
+                                artifacts.append({"name": af.name, "path": str(af), "type": "video"})
+                            elif ext in (".png", ".webp", ".jpg", ".jpeg", ".gif"):
+                                artifacts.append({"name": af.name, "path": str(af), "type": "image"})
+                except: pass
+
+                # Pull in a sampled slice of browser_recordings/<sid> frames
+                try:
+                    rec_dir = GEMINI_DIR / "antigravity" / "browser_recordings" / sid
+                    if rec_dir.is_dir():
+                        frames = sorted([p for p in rec_dir.iterdir() if p.is_file() and p.suffix.lower() in (".jpg", ".jpeg", ".png", ".webp")])
+                        total = len(frames)
+                        if total:
+                            step = max(1, total // 12)  # cap at ~12 thumbnails
+                            for p in frames[::step]:
+                                artifacts.append({"name": f"frame {p.name}", "path": str(p), "type": "image"})
+                except: pass
+
+                if not (task or plan or walkthrough or artifacts): continue
+                project = apply_alias(_antigravity_infer_project((task or "") + "\n" + (plan or "")))
+                first_line = next((ln.strip() for ln in (task or plan or walkthrough).splitlines() if ln.strip() and not ln.strip().startswith("#")), "")
+                display = (first_line or "Antigravity session")[:100]
+                plans: List[dict] = []
+                if plan:
+                    plans.append({"session_id": sid, "agent": "antigravity", "timestamp": latest_ts or _now(), "content": plan})
+                sessions.append({
+                    "id": sid,
+                    "agent": "antigravity",
+                    "project": project,
+                    "timestamp": latest_ts or datetime.fromtimestamp(sess_dir.stat().st_mtime, tz=timezone.utc),
+                    "display": display,
+                    "tokens": {"input": 0, "output": 0, "cached": 0, "total": 0},
+                    "mcp_tools": [],
+                    "has_plan": bool(plan),
+                    "plans": plans,
+                    "model": "gemini (antigravity)",
+                    "artifacts": artifacts
+                })
+            except: continue
 
     # 4. Qwen
     if QWEN_DIR.exists():
@@ -417,10 +502,11 @@ def _scan_sessions_sync():
                         sid = cf.stem; mcp_tools = []; has_plan = False; first_msg = ""; plans = []
                         tokens = {"input": 0, "output": 0, "cached": 0, "total": 0}
                         project_path = "unknown"; last_ts = _now(); model = None
-                        with open(cf, "r") as f:
+                        artifacts = []
+                        with open(cf, "r", encoding="utf-8", errors="replace") as f:
                             for line in f:
                                 try:
-                                    data = json.loads(line); project_path = data.get("cwd", project_path)
+                                    data = json.loads(line); project_path = apply_alias(data.get("cwd", project_path))
                                     if data.get("timestamp"): last_ts = _aware(datetime.fromisoformat(data["timestamp"].replace('Z', '+00:00')))
                                     if data.get("type") == "user":
                                         txt = data.get("message", {}).get("content", "")
@@ -442,7 +528,8 @@ def _scan_sessions_sync():
                                                     plans.append({"session_id": sid, "agent": "qwen", "timestamp": last_ts, "content": t_text})
                                 except: continue
                         tokens["total"] = tokens["input"] + tokens["output"] + tokens["cached"]
-                        sessions.append({"id": sid, "agent": "qwen", "project": project_path, "timestamp": last_ts, "display": first_msg[:100], "tokens": tokens, "mcp_tools": mcp_tools, "has_plan": has_plan, "plans": plans, "model": model})
+                        tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"])
+                        sessions.append({"id": sid, "agent": "qwen", "project": project_path, "timestamp": last_ts, "display": first_msg[:100], "tokens": tokens, "mcp_tools": mcp_tools, "has_plan": has_plan, "plans": plans, "model": model, "artifacts": artifacts, "cost": tokens["cost"]})
                     except: continue
 
     # 5. Vibe
@@ -457,7 +544,8 @@ def _scan_sessions_sync():
                     tokens = {"input": stats.get("session_prompt_tokens", 0), "output": stats.get("session_completion_tokens", 0), "cached": stats.get("context_tokens", 0), "total": stats.get("session_total_llm_tokens", 0)}
                     mcp_tools = [t.get("function", {}).get("name") for t in meta.get("tools_available", []) if t.get("function", {}).get("name")]
                     model = meta.get("agent_config", {}).get("active_model")
-                    sessions.append({"id": sid, "agent": "vibe", "project": meta.get("environment", {}).get("working_directory", "unknown"), "timestamp": ts, "display": f"Vibe Session {sid[:8]}", "tokens": tokens, "mcp_tools": list(set(mcp_tools)), "has_plan": False, "plans": [], "model": model})
+                    project_path = apply_alias(meta.get("environment", {}).get("working_directory", "unknown"))
+                    sessions.append({"id": sid, "agent": "vibe", "project": project_path, "timestamp": ts, "display": f"Vibe Session {sid[:8]}", "tokens": tokens, "mcp_tools": list(set(mcp_tools)), "has_plan": False, "plans": [], "model": model, "artifacts": []})
             except: continue
 
     # 6. Cursor
@@ -491,16 +579,26 @@ def _scan_sessions_sync():
                     if trans_dir.is_dir():
                         sid = trans_dir.name
                         cf = trans_dir / f"{sid}.jsonl"
+                        artifacts = []
+                        # Discover Cursor Terminal artifacts
+                        try:
+                            term_dir = pd / "terminals"
+                            if term_dir.exists():
+                                for tf in term_dir.glob("*.txt"):
+                                    artifacts.append({"name": f"Terminal: {tf.name}", "path": str(tf), "type": "terminal"})
+                        except: pass
+
                         if cf.exists():
                             try:
                                 mtime = datetime.fromtimestamp(cf.stat().st_mtime, tz=timezone.utc)
                                 first_msg = ""
                                 tokens = {"input": 0, "output": 0, "cached": 0, "total": 0}
                                 mcp_tools = []
+                                subagents = []
                                 has_plan = False
                                 plans = []
                                 model = None
-                                with open(cf, "r") as f:
+                                with open(cf, "r", encoding="utf-8", errors="replace") as f:
                                     for line in f:
                                         try:
                                             data = json.loads(line)
@@ -520,14 +618,21 @@ def _scan_sessions_sync():
                                             tokens["cached"] += usage.get("cache_read_input_tokens", 0)
                                             for item in msg.get("content", []) if isinstance(msg.get("content"), list) else []:
                                                 if item.get("type") == "tool_use":
-                                                    if item.get("name") not in mcp_tools: mcp_tools.append(item.get("name"))
+                                                    name = item.get("name")
+                                                    if name not in mcp_tools: mcp_tools.append(name)
+                                                    if name == "Subagent":
+                                                        sub_input = item.get("input") or {}
+                                                        sub_name = sub_input.get("name") or sub_input.get("subagent_type")
+                                                        if sub_name and sub_name not in subagents:
+                                                            subagents.append(sub_name)
                                                 if item.get("type") == "thinking":
                                                     t_text = item.get("thinking", "")
                                                     if "plan" in t_text.lower() and len(t_text) > 100:
                                                         has_plan = True
                                                         plans.append({"session_id": sid, "agent": "cursor", "timestamp": mtime, "content": t_text})
                                 tokens["total"] = tokens["input"] + tokens["output"] + tokens["cached"]
-                                sessions.append({"id": sid, "agent": "cursor", "project": project_path, "timestamp": mtime, "display": first_msg[:100], "tokens": tokens, "mcp_tools": mcp_tools, "has_plan": has_plan, "plans": plans, "model": model})
+                                tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"])
+                                sessions.append({"id": sid, "agent": "cursor", "project": project_path, "timestamp": mtime, "display": first_msg[:100], "tokens": tokens, "mcp_tools": mcp_tools, "subagents": subagents, "has_plan": has_plan, "plans": plans, "model": model, "artifacts": artifacts, "cost": tokens["cost"]})
                             except: continue
 
     # 7. Copilot
@@ -566,7 +671,8 @@ def _scan_sessions_sync():
                                         plans.append({"session_id": sid, "agent": "copilot", "timestamp": last_ts, "content": t_text})
                                 if "response" in req:
                                     for part in req["response"]: tokens["total"] += part.get("tokens", 0)
-                            sessions.append({"id": sid, "agent": "copilot", "project": project_path, "timestamp": last_ts, "display": first_msg[:100], "tokens": tokens, "mcp_tools": [], "has_plan": len(plans) > 0, "plans": plans, "model": model})
+                            tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"])
+                            sessions.append({"id": sid, "agent": "copilot", "project": project_path, "timestamp": last_ts, "display": first_msg[:100], "tokens": tokens, "mcp_tools": [], "has_plan": len(plans) > 0, "plans": plans, "model": model, "artifacts": [], "cost": tokens["cost"]})
                     except: continue
             except: continue
 
@@ -628,25 +734,14 @@ def _scan_sessions_sync():
                         plan_text = "\n".join(f"- [{r['status']}] {r['content']}" for r in todo_rows)
                         plans.append({"session_id": sid, "agent": "opencode", "timestamp": ts, "content": plan_text})
                     sessions.append({
-                        "id": sid, "agent": "opencode", "project": project_path, "timestamp": ts,
+                        "id": sid, "agent": "opencode", "project": apply_alias(srow["directory"] or "unknown"), "timestamp": ts,
                         "display": display, "tokens": tokens, "mcp_tools": mcp_tools,
-                        "has_plan": has_plan, "plans": plans, "model": model,
+                        "has_plan": has_plan, "plans": plans, "model": model, "artifacts": []
                     })
             finally:
                 conn.close()
         except Exception:
             pass
-
-    # Apply user-defined project aliases in a single pass.
-    # Logs stay authentic; this only rewrites the grouping key.
-    aliases = load_aliases()
-    if aliases:
-        for s in sessions:
-            s["project"] = apply_alias(s.get("project", ""), aliases)
-            for pl in s.get("plans", []) or []:
-                # plans don't usually carry a project field, but be defensive
-                if isinstance(pl, dict) and pl.get("project"):
-                    pl["project"] = apply_alias(pl["project"], aliases)
 
     # Global sort by timestamp descending
     sessions.sort(key=lambda x: x["timestamp"], reverse=True)
@@ -662,6 +757,7 @@ def _scan_sessions_sync():
 # and asyncio.to_thread keeps the event loop free while we scan.
 import asyncio as _asyncio
 import time as _time
+from pricing import calculate_cost, PRICING, PRICING_UPDATED
 import logging as _logging
 
 _log = _logging.getLogger("harness.cache")
@@ -726,12 +822,31 @@ async def get_sessions(fresh: bool = False):
     return await get_sessions_cached(fresh=fresh)
 
 
-@app.post("/cache/invalidate")
-async def invalidate_cache():
-    """Drop the sessions cache so the next read triggers a fresh scan."""
-    _sessions_cache["data"] = None
-    _sessions_cache["at"] = 0.0
-    return {"ok": True}
+@app.get("/pricing")
+async def get_pricing():
+    """Return the static pricing table and the date it was last refreshed."""
+    return {"updated": PRICING_UPDATED, "models": PRICING}
+
+
+@app.get("/artifacts")
+async def get_artifact(path: str):
+    """Stream a local artifact file securely."""
+    from fastapi.responses import FileResponse
+    p = Path(path)
+    # Security: only serve files from known agent directories
+    allowed = [CLAUDE_DIR, CODEX_DIR, GEMINI_DIR, QWEN_DIR, VIBE_DIR, CURSOR_DIR, VSCODE_BASE, CURSOR_BASE]
+    is_safe = False
+    for a in allowed:
+        try:
+            if p.resolve().is_relative_to(a.resolve()):
+                is_safe = True; break
+        except: continue
+
+    if not is_safe or not p.exists() or not p.is_file():
+        from fastapi import HTTPException
+        raise HTTPException(status_code=403, detail="Unauthorized or not found")
+
+    return FileResponse(path)
 
 
 @app.get("/cache/status")
@@ -743,7 +858,16 @@ async def cache_status():
         "ttl_sec": SESSIONS_TTL_SEC,
         "entries": len(_sessions_cache["data"]) if _sessions_cache.get("data") is not None else 0,
         "building": _sessions_cache.get("building", False),
+        "last_error": _sessions_cache.get("last_error")
     }
+
+
+@app.post("/cache/invalidate")
+async def invalidate_cache():
+    """Drop the sessions cache so the next read triggers a fresh scan."""
+    _sessions_cache["data"] = None
+    _sessions_cache["at"] = 0.0
+    return {"ok": True}
 
 
 @app.get("/sessions/{session_id}")
@@ -966,13 +1090,14 @@ async def get_projects(include_hidden: bool = False):
     for s in sessions:
         proj = s["project"]
         if proj not in projects:
-            projects[proj] = {"name": proj.split("/")[-1], "path": proj, "session_count": 0, "agents": set(), "mcp_tools": set(), "subagent_count": 0, "plan_count": 0, "tokens": {"input": 0, "output": 0, "cached": 0, "total": 0}, "plans": []}
+            projects[proj] = {"name": proj.split("/")[-1], "path": proj, "session_count": 0, "agents": set(), "mcp_tools": set(), "subagent_count": 0, "plan_count": 0, "tokens": {"input": 0, "output": 0, "cached": 0, "total": 0, "cost": 0.0}, "plans": []}
         projects[proj]["session_count"] += 1; projects[proj]["agents"].add(s["agent"])
         for t in s.get("mcp_tools", []): projects[proj]["mcp_tools"].add(t)
         if s.get("has_plan"): projects[proj]["plan_count"] += 1
         projects[proj]["subagent_count"] += len(s.get("subagents", []))
         st = s.get("tokens", {})
         for k in ["input", "output", "cached", "total"]: projects[proj]["tokens"][k] += st.get(k, 0)
+        projects[proj]["tokens"]["cost"] += s.get("cost", 0.0)
         projects[proj]["plans"].extend(s.get("plans", []))
     for p in projects.values():
         p["agents"] = list(p["agents"])
@@ -986,9 +1111,21 @@ async def get_projects(include_hidden: bool = False):
         p["hidden"] = p["path"] in hidden
         # Count configured subagents on disk for this project path
         try:
-            agents_dir = Path(p["path"]) / ".claude" / "agents"
-            p["configured_subagent_count"] = len(list(agents_dir.glob("*.md"))) if agents_dir.exists() else 0
-        except: p["configured_subagent_count"] = 0
+            p["configured_subagent_count"] = 0
+            # 1. Standard Claude agents
+            claude_dir = Path(p["path"]) / ".claude" / "agents"
+            if claude_dir.exists():
+                p["configured_subagent_count"] += len(list(claude_dir.glob("*.md")))
+            # 2. Cursor skills/agents
+            cursor_dir = Path(p["path"]) / ".cursor" / "skills-cursor"
+            if cursor_dir.exists():
+                # For Cursor, we count directories that contain a SKILL.md
+                p["configured_subagent_count"] += len(list(cursor_dir.glob("*/SKILL.md")))
+            # 3. Generic .agents directory
+            agents_dir = Path(p["path"]) / ".agents" / "skills"
+            if agents_dir.exists():
+                p["configured_subagent_count"] += len(list(agents_dir.glob("*/SKILL.md")))
+        except: pass
     out = list(projects.values())
     if not include_hidden:
         out = [p for p in out if not p["hidden"]]
@@ -1054,48 +1191,83 @@ async def get_analytics():
     sessions = await get_sessions_cached(); by_agent = {}; by_day = {}; by_model = {}
     for s in sessions:
         agent = s["agent"]
-        if agent not in by_agent: by_agent[agent] = {"input": 0, "output": 0, "cached": 0, "total": 0, "session_count": 0}
+        if agent not in by_agent: by_agent[agent] = {"input": 0, "output": 0, "cached": 0, "total": 0, "cost": 0.0, "session_count": 0}
         st = s.get("tokens", {})
+        scost = s.get("cost", 0.0)
         for k in ["input", "output", "cached", "total"]: by_agent[agent][k] += st.get(k, 0)
+        by_agent[agent]["cost"] += scost
         by_agent[agent]["session_count"] += 1
         model_name = s.get("model") or f"{agent} (unknown)"
         if model_name not in by_model:
-            by_model[model_name] = {"input": 0, "output": 0, "cached": 0, "total": 0, "session_count": 0, "agent": agent}
+            by_model[model_name] = {"input": 0, "output": 0, "cached": 0, "total": 0, "cost": 0.0, "session_count": 0, "agent": agent}
         for k in ["input", "output", "cached", "total"]: by_model[model_name][k] += st.get(k, 0)
+        by_model[model_name]["cost"] += scost
         by_model[model_name]["session_count"] += 1
         day = s["timestamp"].strftime("%Y-%m-%d")
-        if day not in by_day: by_day[day] = {"total": 0, "input": 0, "output": 0, "cached": 0}
+        if day not in by_day: by_day[day] = {"total": 0, "input": 0, "output": 0, "cached": 0, "cost": 0.0}
         for k in ["input", "output", "cached", "total"]: by_day[day][k] += st.get(k, 0)
+        by_day[day]["cost"] += scost
     sorted_days = sorted([{"date": d, **v} for d, v in by_day.items()], key=lambda x: x["date"])
-    return {"by_agent": by_agent, "by_day": sorted_days, "by_model": by_model, "total": {"input": sum(a["input"] for a in by_agent.values()), "output": sum(a["output"] for a in by_agent.values()), "cached": sum(a["cached"] for a in by_agent.values()), "total": sum(a["total"] for a in by_agent.values())}}
+    return {
+        "by_agent": by_agent, 
+        "by_day": sorted_days, 
+        "by_model": by_model, 
+        "total": {
+            "input": sum(a["input"] for a in by_agent.values()), 
+            "output": sum(a["output"] for a in by_agent.values()), 
+            "cached": sum(a["cached"] for a in by_agent.values()), 
+            "total": sum(a["total"] for a in by_agent.values()),
+            "cost": sum(a["cost"] for a in by_agent.values())
+        },
+        "pricing_updated": PRICING_UPDATED,
+    }
 
 def _parse_skill_md(p: Path):
     """Read SKILL.md frontmatter; return {name, description}."""
     try:
         text = p.read_text(errors="ignore")
     except: return None
+    
     name = p.parent.name
     description = ""
+    
     if text.startswith("---"):
         end = text.find("---", 3)
         if end > 0:
-            for line in text[3:end].splitlines():
-                if ":" in line:
-                    k, v = line.split(":", 1)
-                    k = k.strip().lower(); v = v.strip().strip('"').strip("'")
-                    if k == "name": name = v
-                    elif k == "description": description = v
-    return {"name": name, "description": description[:200]}
+            try:
+                frontmatter = yaml.safe_load(text[3:end])
+                if isinstance(frontmatter, dict):
+                    if frontmatter.get("name"):
+                        name = str(frontmatter["name"])
+                    if frontmatter.get("description"):
+                        description = str(frontmatter["description"])
+            except:
+                # Fallback to manual line parsing if YAML is slightly malformed
+                for line in text[3:end].splitlines():
+                    if ":" in line:
+                        k, v = line.split(":", 1)
+                        k = k.strip().lower(); v = v.strip().strip('"').strip("'")
+                        if k == "name": name = v
+                        elif k == "description": description = v
+                        
+    return {"name": name, "description": (description or "")[:500]}
 
 def _collect_skills(base: Path, scope: str, agent: str):
     out = []
-    skills_dir = base / "skills"
-    if not skills_dir.exists(): return out
+    # If the base folder itself looks like a skills folder (e.g. skills-cursor), scan it directly
+    # otherwise look for a 'skills' subfolder.
+    skills_dir = base
+    if not (base / "SKILL.md").exists() and (base / "skills").exists():
+        skills_dir = base / "skills"
+    elif not base.exists():
+        return out
+        
     for skill_md in skills_dir.glob("*/SKILL.md"):
         s = _parse_skill_md(skill_md)
         if s:
             out.append({**s, "scope": scope, "agent": agent, "source": str(skill_md)})
-    # Plugin-bundled skills (Claude)
+    
+    # Check for deeper nested skills (common in plugin structures)
     for skill_md in skills_dir.glob("*/skills/*/SKILL.md"):
         s = _parse_skill_md(skill_md)
         if s:
@@ -1155,14 +1327,22 @@ def _collect_subagents(base: Path, scope: str, agent: str):
         if txt.startswith("---"):
             end = txt.find("---", 3)
             if end > 0:
-                for line in txt[3:end].splitlines():
-                    if ":" in line:
-                        k, v = line.split(":", 1)
-                        k = k.strip().lower(); v = v.strip().strip('"').strip("'")
-                        if k == "name": name = v
-                        elif k == "description": description = v
-                        elif k == "tools": tools = v
-                        elif k == "model": model = v
+                try:
+                    fm = yaml.safe_load(txt[3:end])
+                    if isinstance(fm, dict):
+                        if fm.get("name"): name = str(fm["name"])
+                        if fm.get("description"): description = str(fm["description"])
+                        if fm.get("tools"): tools = str(fm["tools"])
+                        if fm.get("model"): model = str(fm["model"])
+                except:
+                    for line in txt[3:end].splitlines():
+                        if ":" in line:
+                            k, v = line.split(":", 1)
+                            k = k.strip().lower(); v = v.strip().strip('"').strip("'")
+                            if k == "name": name = v
+                            elif k == "description": description = v
+                            elif k == "tools": tools = v
+                            elif k == "model": model = v
         out.append({
             "name": name, "description": description[:300], "tools": tools, "model": model,
             "scope": scope, "agent": agent, "source": str(md),
@@ -1184,11 +1364,16 @@ def _collect_commands(base: Path, scope: str, agent: str):
             if txt.startswith("---"):
                 end = txt.find("---", 3)
                 if end > 0:
-                    for line in txt[3:end].splitlines():
-                        if ":" in line:
-                            k, v = line.split(":", 1)
-                            if k.strip().lower() == "description":
-                                description = v.strip().strip('"').strip("'")
+                    try:
+                        fm = yaml.safe_load(txt[3:end])
+                        if isinstance(fm, dict) and fm.get("description"):
+                            description = str(fm["description"])
+                    except:
+                        for line in txt[3:end].splitlines():
+                            if ":" in line:
+                                k, v = line.split(":", 1)
+                                if k.strip().lower() == "description":
+                                    description = v.strip().strip('"').strip("'")
             out.append({"name": name, "description": description[:200], "scope": scope, "agent": agent, "source": str(md)})
     return out
 
@@ -1278,9 +1463,22 @@ async def get_config(project: Optional[str] = None):
 
             # Cursor
             mcps += _mcps_from_json(proj / ".cursor" / "mcp.json", "project", "cursor")
+            skills += _collect_skills(proj / ".cursor" / "skills-cursor", "project", "cursor")
+            subagents += _collect_subagents(proj / ".cursor", "project", "cursor")
+
+            # Generic .agents
+            skills += _collect_skills(proj / ".agents", "project", "agents")
+            subagents += _collect_subagents(proj / ".agents", "project", "agents")
 
             # Gemini
             mcps += _mcps_from_json(proj / ".gemini" / "settings.json", "project", "gemini")
+
+    # Dedupe skills by (name, scope)
+    seen_skills = set(); deduped_skills = []
+    for s in skills:
+        key = (s.get("name"), s.get("scope"))
+        if key in seen_skills: continue
+        seen_skills.add(key); deduped_skills.append(s)
 
     # Dedupe MCPs by (name, scope, agent)
     seen = set(); deduped = []
@@ -1292,13 +1490,13 @@ async def get_config(project: Optional[str] = None):
     return {
         "project": project,
         "project_valid": project_valid,
-        "skills": skills,
+        "skills": deduped_skills,
         "mcps": deduped,
         "memory": memory,
         "commands": commands,
         "subagents": subagents,
         "counts": {
-            "skills": len(skills),
+            "skills": len(deduped_skills),
             "mcps": len(deduped),
             "memory_files": len(memory),
             "commands": len(commands),

--- a/backend/pricing.py
+++ b/backend/pricing.py
@@ -1,0 +1,80 @@
+# Price per 1M tokens in USD (Last Updated: 2026-04-25)
+# Includes 2026 flagship models detected in session traces.
+
+PRICING = {
+    # --- Claude 4 Series (Anthropic) ---
+    "claude-4.7-opus":   {"in": 5.00, "out": 25.00, "cached_read": 0.50},
+    "claude-4.5-opus":   {"in": 5.00, "out": 25.00, "cached_read": 0.50},
+    "claude-4.6-sonnet": {"in": 3.00, "out": 15.00, "cached_read": 0.30},
+    "claude-4.5-haiku":  {"in": 1.00, "out": 5.00,  "cached_read": 0.10},
+    
+    # Aliases/Versions for Claude 4
+    "claude-opus-4-7":   {"in": 5.00, "out": 25.00, "cached_read": 0.50},
+    "claude-opus-4-6":   {"in": 5.00, "out": 25.00, "cached_read": 0.50},
+    "claude-sonnet-4-6": {"in": 3.00, "out": 15.00, "cached_read": 0.30},
+    "claude-haiku-4-5":  {"in": 1.00, "out": 5.00,  "cached_read": 0.10},
+    "claude-haiku-4.5":  {"in": 1.00, "out": 5.00,  "cached_read": 0.10},  # dot variant emitted by some agents (Copilot)
+    
+    # Claude 3.5
+    "claude-3-5-sonnet": {"in": 3.00, "out": 15.00, "cached_read": 0.30},
+    "claude-3.5-sonnet": {"in": 3.00, "out": 15.00, "cached_read": 0.30},
+    "claude-3.5-haiku":  {"in": 0.80, "out": 4.00,  "cached_read": 0.08},
+
+    # --- GPT-5 Series (OpenAI) ---
+    "gpt-5.5-pro":       {"in": 30.00, "out": 180.00, "cached_read": 3.00},
+    "gpt-5.5-standard":  {"in": 5.00,  "out": 30.00,  "cached_read": 0.50},
+    "gpt-5.4":           {"in": 2.50,  "out": 15.00,  "cached_read": 0.25},
+    "gpt-5-mini":        {"in": 0.15,  "out": 0.60,   "cached_read": 0.015},
+    "gpt-5":             {"in": 0.625, "out": 5.00,   "cached_read": 0.06},
+    "gpt-4.1":           {"in": 2.50,  "out": 10.00,  "cached_read": 1.25},
+
+    # --- Gemini 3 Series (Google) ---
+    "gemini-3.1-pro":    {"in": 2.00, "out": 12.00, "cached_read": 0.20},
+    "gemini-3.1-flash":  {"in": 0.25, "out": 1.50,  "cached_read": 0.025},
+    "gemini-3-pro":      {"in": 2.00, "out": 12.00, "cached_read": 0.20},
+    "gemini-3-flash":    {"in": 0.25, "out": 1.50,  "cached_read": 0.025},
+    "auto-gemini-3":     {"in": 2.00, "out": 12.00, "cached_read": 0.20},  # auto-router targeting Gemini 3 (assume Pro tier)
+    
+    # Gemini 2.x
+    "gemini-2.5-pro":    {"in": 1.25, "out": 5.00,  "cached_read": 0.125},
+    "gemini-2.5-flash":  {"in": 0.15, "out": 0.60,  "cached_read": 0.015},
+    "gemini-2.0-flash":  {"in": 0.075, "out": 0.30, "cached_read": 0.0075},
+    "gemini":            {"in": 1.25, "out": 5.00,  "cached_read": 0.125}, # Default Gemini tier
+
+    # --- Specialized & Local ---
+    "devstral-2":        {"in": 0.40, "out": 0.90,  "cached_read": 0.04},
+    "glm-5.1":           {"in": 1.15, "out": 3.75,  "cached_read": 0.115},
+    "gemma4":            {"in": 0.00, "out": 0.00,  "cached_read": 0.00}, # Local
+    "auto":              {"in": 3.00, "out": 15.00, "cached_read": 0.30}, # Typical 'auto' maps to Sonnet/GPT-4o
+    
+    # Default (Safe baseline for unknown models)
+    "_default":          {"in": 2.00, "out": 10.00, "cached_read": 0.50}
+}
+
+PRICING_UPDATED = "2026-04-25"
+
+def calculate_cost(model_name: str, input_tokens: int, output_tokens: int, cached_tokens: int = 0) -> float:
+    """Returns estimated cost in USD based on 2026 model rates."""
+    if not model_name:
+        config = PRICING["_default"]
+    else:
+        model_name = str(model_name).lower()
+        config = PRICING.get(model_name)
+        if not config:
+            # Try fuzzy prefix match (longer keys first)
+            sorted_keys = sorted([k for k in PRICING.keys() if k != "_default"], key=len, reverse=True)
+            for k in sorted_keys:
+                if k in model_name: # More robust than startswith for names like "gemini (antigravity)"
+                    config = PRICING[k]
+                    break
+        if not config:
+            config = PRICING["_default"]
+            
+    in_cost = (input_tokens / 1_000_000) * config["in"]
+    out_cost = (output_tokens / 1_000_000) * config["out"]
+    
+    # Use cached_read if available, otherwise 10% of input as default fallback for 2026 era
+    cached_rate = config.get("cached_read", config["in"] * 0.1)
+    cached_cost = (cached_tokens / 1_000_000) * cached_rate
+    
+    return in_cost + out_cost + cached_cost

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,13 +1,7 @@
 import type { NextConfig } from "next";
-import path from "path";
 
 const nextConfig: NextConfig = {
   /* config options here */
-  experimental: {
-    turbopack: {
-       root: path.resolve(__dirname, "..")
-    }
-  }
 };
 
 export default nextConfig;

--- a/frontend/src/app/analytics/page.tsx
+++ b/frontend/src/app/analytics/page.tsx
@@ -13,6 +13,7 @@ interface AnalyticsData {
     output: number;
     cached: number;
     total: number;
+    cost: number;
     session_count: number;
   }>;
   by_day: {
@@ -21,12 +22,14 @@ interface AnalyticsData {
     input: number;
     output: number;
     cached: number;
+    cost: number;
   }[];
   by_model?: Record<string, {
     input: number;
     output: number;
     cached: number;
     total: number;
+    cost: number;
     session_count: number;
     agent: string;
   }>;
@@ -35,7 +38,9 @@ interface AnalyticsData {
     output: number;
     cached: number;
     total: number;
+    cost: number;
   };
+  pricing_updated?: string;
 }
 
 const AGENT_COLORS: Record<string, string> = {
@@ -45,7 +50,9 @@ const AGENT_COLORS: Record<string, string> = {
   antigravity: "#10b981",  // Emerald
   qwen: "#3b82f6",         // Blue
   vibe: "#f472b6",         // Pink
-  copilot: "#6366f1"       // Indigo
+  copilot: "#6366f1",      // Indigo
+  cursor: "#3b82f6",       // Blue
+  opencode: "#f59e0b"      // Amber
 };
 
 export default function AnalyticsPage() {
@@ -105,7 +112,7 @@ export default function AnalyticsPage() {
       <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
          <MetricCard title="Total Tokens" value={data.total.total.toLocaleString()} subValue="Overall across all agents" icon={<TrendingUp className="text-blue-400" />} />
          <MetricCard title="Input Tokens" value={data.total.input.toLocaleString()} subValue={`${((data.total.input / Math.max(1, data.total.total)) * 100).toFixed(1)}% of total`} icon={<MousePointer2 className="text-emerald-400" />} />
-         <MetricCard title="Est. Lifetime Cost" value={`$${((data.total.total / 1000000) * 10).toFixed(2)}`} subValue="Based on blended pricing" icon={<DollarSign className="text-amber-400" />} />
+         <MetricCard title="Est. Lifetime Cost" value={`$${data.total.cost.toFixed(2)}`} subValue={data.pricing_updated ? `Rates updated ${data.pricing_updated}` : "Based on actual model rates"} icon={<DollarSign className="text-amber-400" />} />
          <MetricCard title="Cache Efficiency" value={`${((data.total.cached / Math.max(1, (data.total.input + data.total.cached))) * 100).toFixed(1)}%`} subValue="Tokens saved via caching" icon={<Zap className="text-cyan-400" />} />
       </div>
 
@@ -184,6 +191,7 @@ export default function AnalyticsPage() {
                 <th className="px-6 py-4 font-semibold text-right">Output</th>
                 <th className="px-6 py-4 font-semibold text-right">Cached</th>
                 <th className="px-6 py-4 font-semibold text-right">Total Tokens</th>
+                <th className="px-6 py-4 font-semibold text-right text-amber-500">Cost</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-slate-800">
@@ -207,6 +215,7 @@ export default function AnalyticsPage() {
                   <td className="px-6 py-4 text-sm text-slate-400 text-right font-mono">{stats.output.toLocaleString()}</td>
                   <td className="px-6 py-4 text-sm text-cyan-400/70 text-right font-mono">{stats.cached.toLocaleString()}</td>
                   <td className="px-6 py-4 text-sm text-white text-right font-bold font-mono group-hover:text-blue-400 transition-colors">{stats.total.toLocaleString()}</td>
+                  <td className="px-6 py-4 text-sm text-amber-400 text-right font-bold font-mono group-hover:text-amber-300 transition-colors">${stats.cost.toFixed(2)}</td>
                 </tr>
               ))}
             </tbody>
@@ -223,16 +232,41 @@ export default function AnalyticsPage() {
           </div>
 
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-            <div className="bg-slate-900 border border-slate-800 rounded-2xl p-6 shadow-xl">
+            <div className="bg-slate-900 border border-slate-800 rounded-2xl p-6 shadow-xl overflow-hidden">
               <h3 className="text-sm font-bold text-white mb-4">Tokens per Model</h3>
-              <div className="h-72 w-full">
-                <ResponsiveContainer width="100%" height="100%">
-                  <BarChart data={modelData} layout="vertical" margin={{ left: 40 }}>
+              <div className="h-[500px] w-full min-h-[500px]">
+                <ResponsiveContainer width="99%" height="100%">
+                  <BarChart 
+                    data={modelData} 
+                    layout="vertical" 
+                    margin={{ left: 10, right: 40, top: 10, bottom: 10 }}
+                  >
                     <CartesianGrid strokeDasharray="3 3" stroke="#1e293b" horizontal={false} />
-                    <XAxis type="number" stroke="#64748b" fontSize={10} tickLine={false} axisLine={false} tickFormatter={(v) => `${(v / 1000).toFixed(0)}k`} />
-                    <YAxis type="category" dataKey="name" stroke="#64748b" fontSize={10} tickLine={false} axisLine={false} width={140} />
-                    <Tooltip contentStyle={{ backgroundColor: '#0f172a', border: '1px solid #1e293b', borderRadius: '8px' }} itemStyle={{ fontSize: '12px' }} />
-                    <Bar dataKey="total" radius={[0, 6, 6, 0]}>
+                    <XAxis 
+                      type="number" 
+                      stroke="#64748b" 
+                      fontSize={10} 
+                      tickLine={false} 
+                      axisLine={false} 
+                      tickFormatter={(v) => `${(v / 1000).toFixed(0)}k`} 
+                    />
+                    <YAxis 
+                      type="category" 
+                      dataKey="name" 
+                      stroke="#94a3b8" 
+                      fontSize={10} 
+                      tickLine={false} 
+                      axisLine={false} 
+                      width={220}
+                      interval={0}
+                      tick={{ fill: '#94a3b8', fontSize: 10, width: 220 }}
+                    />
+                    <Tooltip 
+                      contentStyle={{ backgroundColor: '#0f172a', border: '1px solid #1e293b', borderRadius: '8px' }} 
+                      itemStyle={{ fontSize: '12px' }}
+                      cursor={{ fill: 'rgba(255,255,255,0.05)' }}
+                    />
+                    <Bar dataKey="total" radius={[0, 4, 4, 0]} barSize={20}>
                       {modelData.map((m, i) => <Cell key={i} fill={m.color} />)}
                     </Bar>
                   </BarChart>
@@ -246,7 +280,14 @@ export default function AnalyticsPage() {
                 <div className="w-1/2 h-full">
                   <ResponsiveContainer width="100%" height="100%">
                     <RePieChart>
-                      <Pie data={modelData} innerRadius={55} outerRadius={85} paddingAngle={3} dataKey="total">
+                      <Pie 
+                        data={modelData} 
+                        innerRadius={55} 
+                        outerRadius={85} 
+                        paddingAngle={3} 
+                        dataKey="total"
+                        nameKey="name"
+                      >
                         {modelData.map((m, i) => <Cell key={i} fill={m.color} />)}
                       </Pie>
                       <Tooltip contentStyle={{ backgroundColor: '#0f172a', border: '1px solid #1e293b', borderRadius: '8px' }} />
@@ -283,6 +324,7 @@ export default function AnalyticsPage() {
                     <th className="px-6 py-4 font-semibold text-right">Output</th>
                     <th className="px-6 py-4 font-semibold text-right">Cached</th>
                     <th className="px-6 py-4 font-semibold text-right">Total</th>
+                    <th className="px-6 py-4 font-semibold text-right text-amber-500">Cost</th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-slate-800">
@@ -301,6 +343,7 @@ export default function AnalyticsPage() {
                       <td className="px-6 py-4 text-sm text-slate-400 text-right font-mono">{m.output.toLocaleString()}</td>
                       <td className="px-6 py-4 text-sm text-cyan-400/70 text-right font-mono">{m.cached.toLocaleString()}</td>
                       <td className="px-6 py-4 text-sm text-white text-right font-bold font-mono group-hover:text-blue-400 transition-colors">{m.total.toLocaleString()}</td>
+                      <td className="px-6 py-4 text-sm text-amber-400 text-right font-bold font-mono group-hover:text-amber-300 transition-colors">${m.cost.toFixed(2)}</td>
                     </tr>
                   ))}
                 </tbody>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -13,8 +13,12 @@ interface Session {
   display?: string;
   text?: string;
   tokens?: {
+    input: number;
+    output: number;
+    cached: number;
     total: number;
   };
+  cost?: number;
 }
 
 const AGENT_CONFIG: Record<string, { label: string, color: string, icon: any }> = {
@@ -39,6 +43,7 @@ export default function Home() {
   const [sessions, setSessions] = useState<Session[]>([]);
   const [availableAgents, setAvailableAgents] = useState<string[]>([]);
   const [byModel, setByModel] = useState<Record<string, { total: number; session_count: number; agent: string }>>({});
+  const [pricingUpdated, setPricingUpdated] = useState<string>("");
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -54,6 +59,7 @@ export default function Home() {
       setSessions(sessionsData.sort((a: Session, b: Session) => ts(b) - ts(a)));
       setAvailableAgents(agentsData);
       setByModel(analyticsData?.by_model || {});
+      setPricingUpdated(analyticsData?.pricing_updated || "");
       setLoading(false);
     }).catch(err => {
       console.error("Failed to fetch dashboard data:", err);
@@ -70,6 +76,7 @@ export default function Home() {
   const totalModelSessions = modelRows.reduce((a, r) => a + r.session_count, 0) || 1;
 
   const totalTokens = sessions.reduce((acc, s) => acc + (s.tokens?.total || 0), 0);
+  const totalCost = sessions.reduce((acc, s) => acc + (s.cost || 0), 0);
 
   return (
     <div className="p-8 max-w-[1600px] mx-auto space-y-10 pb-20">
@@ -94,7 +101,7 @@ export default function Home() {
         <StatCard title="Total Sessions" value={sessions.length} icon={<Clock className="text-blue-400" />} color="blue" />
         <StatCard title="Total Tokens" value={totalTokens > 1000000 ? `${(totalTokens / 1000000).toFixed(1)}M` : totalTokens.toLocaleString()} icon={<TrendingUp className="text-emerald-400" />} color="emerald" />
         <StatCard title="Active Projects" value={new Set(sessions.map(s => s.project)).size} icon={<Activity className="text-blue-400" />} color="blue" />
-        <StatCard title="Cost Estimate" value={`$${((totalTokens / 1000000) * 10).toFixed(2)}`} icon={<Zap className="text-amber-400" />} color="amber" />
+        <StatCard title="Cost Estimate" value={totalCost < 0.01 && totalCost > 0 ? "<$0.01" : `$${totalCost.toFixed(2)}`} subValue={pricingUpdated ? `Rates updated ${pricingUpdated}` : undefined} icon={<Zap className="text-amber-400" />} color="amber" />
       </div>
 
       {/* Dynamic Agent Roster */}
@@ -271,7 +278,7 @@ export default function Home() {
   );
 }
 
-function StatCard({ title, value, icon, color }: { title: string; value: string | number; icon: React.ReactNode; color: string }) {
+function StatCard({ title, value, icon, color, subValue }: { title: string; value: string | number; icon: React.ReactNode; color: string; subValue?: string }) {
   const colorMap: Record<string, string> = {
     blue: "border-blue-500/20 bg-blue-500/5",
     emerald: "border-emerald-500/20 bg-emerald-500/5",
@@ -284,6 +291,7 @@ function StatCard({ title, value, icon, color }: { title: string; value: string 
       <div>
         <p className="text-[10px] font-black text-slate-500 uppercase tracking-[0.2em] mb-2">{title}</p>
         <p className="text-3xl font-black text-white tracking-tighter">{value}</p>
+        {subValue && <p className="text-[9px] font-mono text-slate-500 mt-1.5 italic">{subValue}</p>}
       </div>
       <div className="p-3 bg-slate-950/50 rounded-xl border border-slate-800 shadow-inner">{icon}</div>
     </div>

--- a/frontend/src/app/projects/[path]/page.tsx
+++ b/frontend/src/app/projects/[path]/page.tsx
@@ -312,8 +312,8 @@ export default function ProjectSessionsPage() {
                                  </td>
                                  <td className="px-6 py-4">
                                     <div className="flex gap-2 opacity-40 group-hover:opacity-100 transition-opacity">
-                                       {session.has_plan && <ClipboardList size={14} className="text-emerald-400" title="Plan Detected" />}
-                                       {(session.mcp_tools?.length > 0) && <Cpu size={14} className="text-blue-400" title={`${session.mcp_tools.length} Tools Used`} />}
+                                       {session.has_plan && <span title="Plan Detected"><ClipboardList size={14} className="text-emerald-400" /></span>}
+                                       {(session.mcp_tools?.length > 0) && <span title={`${session.mcp_tools.length} Tools Used`}><Cpu size={14} className="text-blue-400" /></span>}
                                     </div>
                                  </td>
                                  <td className="px-6 py-4 text-[10px] text-slate-500 group-hover:text-blue-400 transition-colors text-right font-mono tabular-nums leading-tight">

--- a/frontend/src/app/projects/page.tsx
+++ b/frontend/src/app/projects/page.tsx
@@ -13,13 +13,19 @@ interface Project {
   subagent_count: number;
   configured_subagent_count?: number;
   plan_count: number;
-  tokens?: { input: number; output: number; cached: number; total: number };
+  tokens?: { input: number; output: number; cached: number; total: number; cost: number };
+}
+
+function formatCost(usd: number): string {
+  if (!usd) return "$0.00";
+  if (usd < 0.01) return `<$0.01`;
+  return `$${usd.toFixed(2)}`;
 }
 
 function formatTokens(n: number): string {
   if (!n) return "0";
-  if (n >= 1_000_000) return (n / 1_000_000).toFixed(n >= 10_000_000 ? 0 : 1) + "M";
-  if (n >= 1_000) return (n / 1_000).toFixed(n >= 10_000 ? 0 : 1) + "K";
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
   return String(n);
 }
 
@@ -154,9 +160,9 @@ export default function ProjectsPage() {
                      </div>
                   )}
                   {(project.tokens?.total || 0) > 0 && (
-                     <div className="flex flex-col items-center gap-1" title={`${(project.tokens?.total || 0).toLocaleString()} total tokens`}>
-                        <span className="text-sm font-black text-amber-400 leading-none tabular-nums">{(project.tokens?.total || 0).toLocaleString()}</span>
-                        <span className="text-[8px] font-black text-slate-500 uppercase tracking-widest">Tokens</span>
+                     <div className="flex flex-col items-center gap-1" title={`${(project.tokens?.total || 0).toLocaleString()} tokens`}>
+                        <span className="text-lg font-black text-amber-400 leading-none tabular-nums">{formatCost(project.tokens?.cost || 0)}</span>
+                        <span className="text-[8px] font-black text-slate-500 uppercase tracking-widest">Cost</span>
                      </div>
                   )}
                 </div>

--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useMemo, useRef } from "react";
+import React, { useEffect, useState, useMemo, useRef } from "react";
 import { useParams, useSearchParams, useRouter } from "next/navigation";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -8,9 +8,32 @@ import { ArrowLeft, Brain, Code, MessageSquare, Terminal, User, FileText, Activi
 import Link from "next/link";
 import { format } from "date-fns";
 
+interface Artifact {
+  name: string;
+  path: string;
+  type: 'video' | 'image' | 'document' | 'terminal';
+}
+
+interface Session {
+  id: string;
+  agent: string;
+  project: string;
+  timestamp: string;
+  display?: string;
+  text?: string;
+  mcp_tools: string[];
+  subagents: string[];
+  has_plan: boolean;
+  plans: any[];
+  model?: string;
+  tokens?: { input: number; output: number; cached: number; total: number };
+  artifacts?: Artifact[];
+}
+
 interface Event {
   id?: string;
   type: string;
+  role?: string;
   timestamp?: string;
   normalized_timestamp?: number;
   payload?: any;
@@ -33,14 +56,18 @@ interface Step {
 }
 
 function eventKind(evt: Event): StepKind {
-  if (evt.type === "session_meta" || evt.type === "event_msg" || evt.type === "turn_context") return "meta";
-  if (evt.type === "agent_reasoning" || evt.thoughts || evt.payload?.type === "reasoning") return "reasoning";
-  if (evt.message?.role === "assistant" && Array.isArray(evt.message?.content) && evt.message.content.some((c: any) => c.type === "thinking")) return "reasoning";
+  const type = evt.type;
+  const role = evt.role || evt.message?.role;
+  
+  if (type === "session_meta" || type === "event_msg" || type === "turn_context") return "meta";
+  if (type === "agent_reasoning" || evt.thoughts || evt.payload?.type === "reasoning" || type === "assistant_thinking") return "reasoning";
+  if (Array.isArray(evt.payload) && evt.payload.some((p: any) => p.kind === "thinking" || p.type === "thinking")) return "reasoning";
+  if (role === "assistant" && Array.isArray(evt.message?.content) && evt.message.content.some((c: any) => c.type === "thinking" || c.type === "thought")) return "reasoning";
   if (evt.toolCalls || evt.payload?.type === "function_call" || evt.payload?.type === "tool_use") return "tool";
-  if (evt.message?.role === "assistant" && Array.isArray(evt.message?.content) && evt.message.content.some((c: any) => c.type === "tool_use")) return "tool";
-  if (evt.type === "user" && Array.isArray(evt.message?.content) && evt.message.content.some((c: any) => c.type === "tool_result")) return "tool_result";
-  if (evt.type === "user" || (evt.type === "response_item" && evt.payload?.role === "user") || evt.type === "request_item") return "user";
-  if (evt.type === "assistant" || (evt.type === "response_item" && evt.payload?.role === "assistant" && evt.payload?.type === "message")) return "assistant";
+  if (role === "assistant" && Array.isArray(evt.message?.content) && evt.message.content.some((c: any) => c.type === "tool_use")) return "tool";
+  if ((type === "user" || role === "user") && Array.isArray(evt.message?.content) && evt.message.content.some((c: any) => c.type === "tool_result")) return "tool_result";
+  if (type === "user" || role === "user" || (type === "response_item" && evt.payload?.role === "user") || type === "request_item") return "user";
+  if (type === "assistant" || role === "assistant" || role === "model" || role === "gemini" || type === "model" || type === "gemini" || (type === "response_item" && evt.payload?.role === "assistant" && evt.payload?.type === "message")) return "assistant";
   return "other";
 }
 
@@ -52,6 +79,16 @@ function normalizeTs(evt: Event): number | undefined {
   }
   return undefined;
 }
+
+const stepRingClass: Record<StepKind, string> = {
+  user: "ring-2 ring-blue-500/70",
+  assistant: "ring-2 ring-emerald-500/70",
+  reasoning: "ring-2 ring-amber-500/70",
+  tool: "ring-2 ring-sky-500/70",
+  tool_result: "ring-2 ring-slate-500/70",
+  meta: "ring-2 ring-slate-600/60",
+  other: "ring-2 ring-slate-600/60",
+};
 
 function stepLabel(evt: Event, kind: StepKind): string {
   if (kind === "tool") {
@@ -66,7 +103,7 @@ function stepLabel(evt: Event, kind: StepKind): string {
     return (text || "User Query").slice(0, 40);
   }
   if (kind === "assistant") return "Response";
-  if (kind === "reasoning") return "Thinking";
+  if (kind === "reasoning") return "Reasoning";
   if (kind === "tool_result") return "Tool output";
   if (kind === "meta") return evt.type;
   return evt.type || "event";
@@ -81,13 +118,13 @@ export default function SessionDetailPage() {
   
   const [events, setEvents] = useState<Event[]>([]);
   const [loading, setLoading] = useState(true);
-  const [sessionInfo, setSessionInfo] = useState<any>(null);
+  const [sessionInfo, setSessionInfo] = useState<Session | null>(null);
   
   // Trace View States
   const [splitView, setSplitView] = useState(false);
   const [playbackIndex, setPlaybackIndex] = useState(1000);
   const [isPlaying, setIsPlaying] = useState(false);
-  const [sidebarTab, setSidebarTab] = useState<"context" | "tools" | "raw">("context");
+  const [sidebarTab, setSidebarTab] = useState<"context" | "tools" | "artifacts" | "raw">("context");
   const [activeStep, setActiveStep] = useState<number | null>(null);
   const [timelineOpen, setTimelineOpen] = useState(true);
   const [sidebarOpen, setSidebarOpen] = useState(true);
@@ -380,6 +417,7 @@ export default function SessionDetailPage() {
                <div className="flex items-center gap-1.5 flex-wrap">
                   <StatPill icon={<Hash size={12} />} label="Steps" value={stats.total} />
                   <StatPill icon={<Wrench size={12} />} label="Tools" value={stats.toolCalls} tone="blue" />
+                  {sessionInfo?.artifacts && sessionInfo.artifacts.length > 0 && <StatPill icon={<LayoutPanelLeft size={12} />} label="Arts" value={sessionInfo.artifacts.length} tone="emerald" />}
                   <StatPill icon={<Brain size={12} />} label="Reason" value={stats.reasoning} tone="amber" />
                   <StatPill icon={<User size={12} />} label="Turns" value={stats.userTurns} />
                   <StatPill icon={<Clock size={12} />} label="Dur" value={stats.duration} />
@@ -485,23 +523,25 @@ export default function SessionDetailPage() {
                 <div className="space-y-8">
                    {splitView && <h3 className="text-[10px] font-black text-slate-500 uppercase tracking-[0.2em] ml-2 mb-2 flex items-center gap-2"><User size={14}/> User & Agent Dialogue</h3>}
                    {visibleEvents.map((event, idx) => {
-                      const isReasoning = event.type === "agent_reasoning" || event.thoughts || (event.message?.role === "assistant" && hasContentType(event, "thinking")) || event.payload?.type === "reasoning" || event.type === "assistant_thinking";
+                      const isReasoning = event.type === "agent_reasoning" || event.thoughts || (event.message?.role === "assistant" && (hasContentType(event, "thinking") || hasContentType(event, "thought"))) || event.payload?.type === "reasoning" || event.type === "assistant_thinking";
                       const isTool = event.toolCalls || (event.message?.role === "assistant" && hasContentType(event, "tool_use")) || (event.type === "user" && hasContentType(event, "tool_result")) || event.payload?.type === "function_call";
                       
                       // Check for thinking inside Copilot assistant payload array
-                      const hasThinkingPart = Array.isArray(event.payload) && event.payload.some((p: any) => p.kind === "thinking");
+                      const hasThinkingPart = Array.isArray(event.payload) && event.payload.some((p: any) => p.kind === "thinking" || p.type === "thinking");
                       
                       // For Cursor/Claude/Codex/Copilot: If it's an message with BOTH text and tools/reasoning, 
                       // we want the text to show up in the dialogue column.
                       const hasText = (Array.isArray(event.message?.content) && event.message.content.some((c: any) => (c.type === "text" || c.type === "input_text") && (c.text || c.input_text))) || 
                                       (event.type === "response_item" && event.payload?.type === "message" && Array.isArray(event.payload.content) && event.payload.content.some((c: any) => c.text || c.input_text)) ||
                                       (event.type === "assistant" && Array.isArray(event.payload) && event.payload.some((p: any) => p.value && p.kind !== "thinking")) ||
-                                      (event.type === "user" && (event.payload?.text || typeof event.payload === 'string'));
+                                      (event.type === "user" && (event.payload?.text || typeof event.payload === 'string')) ||
+                                      (typeof event.content === 'string' && event.content.trim().length > 0);
                       
                       if (splitView && ((isReasoning || hasThinkingPart) && !hasText)) return null;
+                      const kind = eventKind(event);
                       return (
-                         <div key={idx} ref={(el) => { stepRefs.current[idx] = el; }} className={activeStep === idx ? "ring-2 ring-blue-500/60 rounded-3xl" : ""}>
-                            <EventCard event={event} mode="dialogue" agent={agent} />
+                         <div key={idx} ref={(el) => { stepRefs.current[idx] = el; }} className={activeStep === idx ? `${stepRingClass[kind]} rounded-3xl` : ""}>
+                            <EventCard event={event} mode={splitView ? "dialogue" : "all"} agent={agent} />
                          </div>
                       );
                    })}
@@ -510,14 +550,15 @@ export default function SessionDetailPage() {
                    <div className="space-y-8 border-l border-slate-800/50 pl-8">
                       <h3 className="text-[10px] font-black text-emerald-500 uppercase tracking-[0.2em] mb-2 flex items-center gap-2"><Brain size={14}/> Internal Reasoning & Tools</h3>
                       {visibleEvents.map((event, idx) => {
-                         const isReasoning = event.type === "agent_reasoning" || event.thoughts || (event.message?.role === "assistant" && hasContentType(event, "thinking")) || event.payload?.type === "reasoning" || event.type === "assistant_thinking";
+                         const isReasoning = event.type === "agent_reasoning" || event.thoughts || (event.message?.role === "assistant" && (hasContentType(event, "thinking") || hasContentType(event, "thought"))) || event.payload?.type === "reasoning" || event.type === "assistant_thinking";
                          const isTool = event.toolCalls || (event.message?.role === "assistant" && hasContentType(event, "tool_use")) || (event.type === "user" && hasContentType(event, "tool_result")) || event.payload?.type === "function_call";
                          
-                         const hasThinkingPart = Array.isArray(event.payload) && event.payload.some((p: any) => p.kind === "thinking");
+                         const hasThinkingPart = Array.isArray(event.payload) && event.payload.some((p: any) => p.kind === "thinking" || p.type === "thinking");
 
                          if (!isReasoning && !isTool && !hasThinkingPart) return null;
+                         const kind = eventKind(event);
                          return (
-                            <div key={idx} ref={(el) => { stepRefs.current[idx] = el; }} className={activeStep === idx ? "ring-2 ring-blue-500/60 rounded-3xl" : ""}>
+                            <div key={idx} ref={(el) => { stepRefs.current[idx] = el; }} className={activeStep === idx ? `${stepRingClass[kind]} rounded-3xl` : ""}>
                                <EventCard event={event} mode="brain" agent={agent} />
                             </div>
                          );
@@ -543,6 +584,7 @@ export default function SessionDetailPage() {
              <div className="flex border-b border-slate-800 text-[10px] font-black uppercase tracking-[0.2em]">
                 <TabBtn active={sidebarTab === "context"} onClick={() => setSidebarTab("context")} icon={<Settings2 size={12} />}>Context</TabBtn>
                 <TabBtn active={sidebarTab === "tools"} onClick={() => setSidebarTab("tools")} icon={<Wrench size={12} />}>Tools</TabBtn>
+                {sessionInfo?.artifacts && sessionInfo.artifacts.length > 0 && <TabBtn active={sidebarTab === "artifacts"} onClick={() => setSidebarTab("artifacts")} icon={<LayoutPanelLeft size={12} />}>Artifacts</TabBtn>}
                 <TabBtn active={sidebarTab === "raw"} onClick={() => setSidebarTab("raw")} icon={<FileCode size={12} />}>Raw</TabBtn>
                 <button
                    onClick={() => setSidebarOpen(false)}
@@ -562,6 +604,7 @@ export default function SessionDetailPage() {
                    });
                    if (idx >= 0) jumpTo(idx);
                 }} />}
+                {sidebarTab === "artifacts" && <ArtifactsPanel artifacts={sessionInfo?.artifacts || []} />}
                 {sidebarTab === "raw" && (
                    <pre className="text-[9px] font-mono text-slate-400 whitespace-pre-wrap break-all max-h-[calc(100vh-260px)] overflow-y-auto">
                       {JSON.stringify(activeStep !== null ? events[activeStep] : events[0], null, 2)}
@@ -633,8 +676,14 @@ export default function SessionDetailPage() {
   );
 }
 
-function StatPill({ icon, label, value, tone }: { icon: React.ReactNode; label: string; value: number | string; tone?: "blue" | "amber" | "red" }) {
-  const toneCls = tone === "blue" ? "text-blue-400" : tone === "amber" ? "text-amber-400" : tone === "red" ? "text-red-400" : "text-slate-300";
+function StatPill({ icon, label, value, tone }: { icon: React.ReactNode; label: string; value: number | string; tone?: "blue" | "amber" | "red" | "emerald" | "cyan" }) {
+  const toneCls = 
+    tone === "blue" ? "text-blue-400" : 
+    tone === "amber" ? "text-amber-400" : 
+    tone === "red" ? "text-red-400" : 
+    tone === "emerald" ? "text-emerald-400" :
+    tone === "cyan" ? "text-cyan-400" :
+    "text-slate-300";
   return (
     <div className="flex items-center gap-1.5 bg-slate-900 border border-slate-800 rounded-lg px-2.5 py-1 shadow-inner">
       <span className="text-slate-600">{icon}</span>
@@ -826,8 +875,100 @@ function ToolsPanel({ summary, onJump }: { summary: { name: string; count: numbe
   );
 }
 
+function ArtifactsPanel({ artifacts }: { artifacts: Artifact[] }) {
+  if (!artifacts.length) return <div className="text-slate-600 text-[10px] italic">No artifacts for this session.</div>;
+  
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-2 text-[10px] font-black uppercase tracking-[0.2em] text-slate-400">
+        <LayoutPanelLeft size={12} /> Session Artifacts
+      </div>
+      <div className="space-y-4">
+        {artifacts.map((a, i) => (
+          <div key={i} className="bg-slate-900/60 border border-slate-800 rounded-xl overflow-hidden shadow-lg group text-[11px]">
+            <div className="px-3 py-2 border-b border-slate-800 bg-slate-950/40 flex items-center justify-between">
+               <div className="flex items-center gap-2 min-w-0">
+                  {a.type === 'video' ? <Play size={10} className="text-blue-400" /> : 
+                   a.type === 'image' ? <LayoutPanelLeft size={10} className="text-emerald-400" /> :
+                   a.type === 'terminal' ? <Terminal size={10} className="text-purple-400" /> :
+                   <FileText size={10} className="text-slate-400" />}
+                  <span className="text-[10px] font-mono text-slate-300 truncate" title={a.name}>{a.name}</span>
+               </div>
+               <a 
+                 href={`http://localhost:8000/artifacts?path=${encodeURIComponent(a.path)}`} 
+                 download={a.name}
+                 className="text-[8px] font-black uppercase text-slate-500 hover:text-white transition-colors"
+               >
+                 DL
+               </a>
+            </div>
+            
+            <div className="p-3">
+               {a.type === 'video' && (
+                 <video controls className="w-full rounded-lg shadow-inner bg-black aspect-video">
+                   <source src={`http://localhost:8000/artifacts?path=${encodeURIComponent(a.path)}`} type="video/mp4" />
+                   Your browser does not support the video tag.
+                 </video>
+               )}
+               {a.type === 'image' && (
+                 <img 
+                    src={`http://localhost:8000/artifacts?path=${encodeURIComponent(a.path)}`} 
+                    alt={a.name} 
+                    className="w-full rounded-lg shadow-inner bg-slate-950" 
+                 />
+               )}
+               {(a.type === 'terminal' || a.type === 'document') && (
+                 <div className="max-h-48 overflow-y-auto scrollbar-thin">
+                    <ArtifactViewer path={a.path} />
+                 </div>
+               )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ArtifactViewer({ path }: { path: string }) {
+  const [content, setContent] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch(`http://localhost:8000/artifacts?path=${encodeURIComponent(path)}`)
+      .then(res => res.text())
+      .then(t => {
+        setContent(t);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, [path]);
+
+  if (loading) return <div className="animate-pulse h-4 bg-slate-800 rounded w-1/2"></div>;
+  return (
+    <pre className="text-[9px] font-mono text-slate-400 whitespace-pre-wrap break-all leading-relaxed">
+      {content || "Failed to load content."}
+    </pre>
+  );
+}
+
 function EventCard({ event, mode = "all", agent }: { event: any, mode?: "dialogue" | "brain" | "all", agent?: string | null }) {
   const { type, timestamp, message, attachment, toolUseResult, payload, content, thoughts, toolCalls } = event;
+
+  // Render a tiny timestamp badge if available
+  const renderTimestamp = () => {
+    const ts = timestamp || event.normalized_timestamp;
+    if (!ts) return null;
+    const date = new Date(ts);
+    if (Number.isNaN(date.getTime())) return null;
+    const timeStr = date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit", hour12: false });
+    return (
+      <div className="flex items-center gap-1 text-[9px] font-mono text-slate-500 mb-2 opacity-60 group-hover:opacity-100 transition-opacity">
+        <Clock size={10} />
+        {timeStr}
+      </div>
+    );
+  };
 
   // Helper to extract text from content array (Used by Claude and Cursor)
   const extractText = (contentArr: any[]) => {
@@ -839,122 +980,141 @@ function EventCard({ event, mode = "all", agent }: { event: any, mode?: "dialogu
       .join("\n");
   };
 
-  // --- OLLAMA ---
+  const parts: React.ReactNode[] = [];
+
+  // 1. OLLAMA
   if (agent === "ollama") {
-     return (
-        <div className="bg-slate-900 border border-slate-800 rounded-3xl p-6 shadow-2xl relative overflow-hidden group hover:border-slate-600 transition-all">
+     parts.push(
+        <div className="bg-slate-900 border border-slate-800 rounded-3xl p-6 shadow-2xl relative overflow-hidden group hover:border-slate-600 transition-all text-left">
           <div className="absolute top-0 left-0 w-1 h-full bg-blue-600"></div>
-          <div className="flex items-center gap-2 text-blue-400 font-black text-[10px] uppercase tracking-[0.2em] mb-4">
-              <User size={16} strokeWidth={3} /> Ollama History
+          <div className="flex justify-between items-start mb-4">
+            <div className="flex items-center gap-2 text-blue-400 font-black text-[10px] uppercase tracking-[0.2em]">
+                <User size={16} strokeWidth={3} /> Ollama History
+            </div>
+            {renderTimestamp()}
           </div>
           <div className="text-slate-200 whitespace-pre-wrap text-sm leading-relaxed font-medium">{content}</div>
         </div>
      );
   }
 
-  // --- COPILOT ---
-  if (agent === "copilot" && type === "user" && payload) {
-    const text = typeof payload === "string" ? payload : (payload.text || (Array.isArray(payload.parts) ? payload.parts.map((p: any) => typeof p === 'string' ? p : (p.text || "")).join("") : ""));
-    if (text) {
-      if (mode === "brain") return null;
-      return (
-        <div className="bg-slate-900 border border-slate-800 rounded-3xl p-6 shadow-2xl relative overflow-hidden group hover:border-slate-600 transition-all">
+  // 2. COPILOT (Separate blocks for user/assistant parts)
+  if (agent === "copilot") {
+    if (type === "user" && payload?.text) {
+       parts.push(
+        <div className="bg-slate-900 border border-slate-800 rounded-3xl p-6 shadow-2xl relative overflow-hidden group hover:border-slate-600 transition-all text-left">
           <div className="absolute top-0 left-0 w-1 h-full bg-blue-600"></div>
-          <div className="flex items-center gap-2 text-blue-400 font-black text-[10px] uppercase tracking-[0.2em] mb-4">
-              <User size={16} strokeWidth={3} /> User Prompt
+          <div className="flex justify-between items-start mb-4">
+            <div className="flex items-center gap-2 text-blue-400 font-black text-[10px] uppercase tracking-[0.2em]">
+                <User size={16} strokeWidth={3} /> User Prompt
+            </div>
+            {renderTimestamp()}
           </div>
-          <div className="text-slate-200 whitespace-pre-wrap text-sm leading-relaxed font-medium">{text}</div>
+          <div className="text-slate-200 whitespace-pre-wrap text-sm leading-relaxed font-medium">{payload.text}</div>
         </div>
-      );
+       );
+    }
+    if (type === "assistant_thinking" && payload?.text && mode !== "dialogue") {
+       parts.push(
+        <div className="bg-indigo-500/5 border border-indigo-500/20 rounded-2xl p-6 shadow-sm ml-4 border-l-4 border-l-indigo-500/50 group">
+          <div className="flex justify-between items-start mb-3">
+            <div className="flex items-center gap-2 text-indigo-400 font-bold text-xs uppercase tracking-widest">
+              <Brain size={16} /> Copilot Reasoning
+            </div>
+            {renderTimestamp()}
+          </div>
+          <div className="text-slate-400 whitespace-pre-wrap italic text-xs leading-relaxed font-mono opacity-80">{payload.text}</div>
+        </div>
+       );
+    }
+    if (type === "assistant" && Array.isArray(payload)) {
+       const thinkingParts = payload.filter((p: any) => p.kind === "thinking" || p.type === "thinking");
+       const textParts = payload.filter((p: any) => p.kind !== "thinking" && p.type !== "thinking" && (p.value || typeof p === 'string'));
+       const combinedText = textParts.map((p: any) => typeof p === 'string' ? p : (p.value || "")).join("");
+
+       if (thinkingParts.length > 0 && mode !== "dialogue") {
+         thinkingParts.forEach((p: any, i: number) => {
+           parts.push(
+             <div key={`copilot-think-${i}`} className="bg-indigo-500/5 border border-indigo-500/20 rounded-2xl p-6 shadow-sm ml-4 border-l-4 border-l-indigo-500/50 group">
+               <div className="flex justify-between items-start mb-3">
+                 <div className="flex items-center gap-2 text-indigo-400 font-bold text-xs uppercase tracking-widest">
+                   <Brain size={16} /> Reasoning
+                 </div>
+                 {renderTimestamp()}
+               </div>
+               <div className="text-slate-400 whitespace-pre-wrap italic text-xs leading-relaxed font-mono opacity-80">{p.value}</div>
+             </div>
+           );
+         });
+       }
+       if (combinedText && mode !== "brain") {
+         parts.push(
+           <div className="bg-slate-900 border border-slate-800 rounded-3xl p-6 shadow-2xl relative overflow-hidden group hover:border-slate-600 transition-all">
+             <div className="absolute top-0 left-0 w-1 h-full bg-indigo-600"></div>
+             <div className="flex justify-between items-start mb-4">
+               <div className="flex items-center gap-2 text-indigo-400 font-black text-[10px] uppercase tracking-[0.2em]">
+                   <GitBranch size={16} strokeWidth={3} /> Response
+               </div>
+               {renderTimestamp()}
+             </div>
+             <ResponseBody text={combinedText} />
+           </div>
+         );
+       }
     }
   }
 
-  if (type === "assistant_thinking" && payload?.text) {
-     if (mode === "dialogue") return null;
-     return (
-      <div className="bg-indigo-500/5 border border-indigo-500/20 rounded-2xl p-6 shadow-sm ml-4 border-l-4 border-l-indigo-500/50">
-        <div className="flex items-center gap-2 text-indigo-400 font-bold mb-3 text-xs uppercase tracking-widest">
-          <Brain size={16} /> Copilot Reasoning
-        </div>
-        <div className="text-slate-400 whitespace-pre-wrap italic text-xs leading-relaxed font-mono opacity-80">{payload.text}</div>
-      </div>
-    );
-  }
-
-  if (type === "assistant" && Array.isArray(payload)) {
-    const thinkingParts = payload.filter((p: any) => p.kind === "thinking" || p.type === "thinking");
-    const textParts = payload.filter((p: any) => p.kind !== "thinking" && p.type !== "thinking" && (p.value || typeof p === 'string'));
-    const combinedText = textParts.map((p: any) => typeof p === 'string' ? p : (p.value || "")).join("");
-
-    return (
-      <div className="space-y-6 w-full">
-        {thinkingParts.length > 0 && (mode === "all" || mode === "brain") && (
-           <div className="space-y-4">
-              {thinkingParts.map((p: any, i: number) => (
-                <div key={i} className="bg-indigo-500/5 border border-indigo-500/20 rounded-2xl p-6 shadow-sm ml-4 border-l-4 border-l-indigo-500/50">
-                  <div className="flex items-center gap-2 text-indigo-400 font-bold mb-3 text-xs uppercase tracking-widest">
-                    <Brain size={16} /> Copilot Reasoning
-                  </div>
-                  <div className="text-slate-400 whitespace-pre-wrap italic text-xs leading-relaxed font-mono opacity-80">{p.value}</div>
-                </div>
-              ))}
-           </div>
-        )}
-        {combinedText && (mode === "all" || mode === "dialogue") && (
-          <div className="bg-slate-900 border border-slate-800 rounded-3xl p-6 shadow-2xl relative overflow-hidden group hover:border-slate-600 transition-all">
-            <div className="absolute top-0 left-0 w-1 h-full bg-indigo-600"></div>
-            <div className="flex items-center gap-2 text-indigo-400 font-black text-[10px] uppercase tracking-[0.2em] mb-4">
-                <GitBranch size={16} strokeWidth={3} /> Copilot Response
-            </div>
-            <ResponseBody text={combinedText} />
-          </div>
-        )}
-      </div>
-    );
-  }
-
-  // --- VIBE ---
+  // 3. VIBE / OPENCODE Common User Prompt
   if (type === "user" && payload?.content && !message) {
-     return (
-        <div className="bg-slate-900 border border-slate-800 rounded-3xl p-6 shadow-2xl relative overflow-hidden group hover:border-slate-600 transition-all">
+     parts.push(
+        <div className="bg-slate-900 border border-slate-800 rounded-3xl p-6 shadow-2xl relative overflow-hidden group hover:border-slate-600 transition-all text-left">
           <div className="absolute top-0 left-0 w-1 h-full bg-blue-600"></div>
-          <div className="flex items-center gap-2 text-blue-400 font-black text-[10px] uppercase tracking-[0.2em] mb-4">
-              <User size={16} strokeWidth={3} /> User Prompt
+          <div className="flex justify-between items-start mb-4">
+            <div className="flex items-center gap-2 text-blue-400 font-black text-[10px] uppercase tracking-[0.2em]">
+                <User size={16} strokeWidth={3} /> User Prompt
+            </div>
+            {renderTimestamp()}
           </div>
           <div className="text-slate-200 whitespace-pre-wrap text-sm leading-relaxed font-medium">{payload.content}</div>
         </div>
      );
   }
 
+  // 4. VIBE / OPENCODE Assistant Response
   if (type === "assistant" && payload?.content && !message) {
     const isOpencode = agent === "opencode";
     const accent = isOpencode ? "bg-amber-600" : "bg-pink-600";
     const textColor = isOpencode ? "text-amber-400" : "text-pink-400";
-    const label = isOpencode ? "OpenCode Response" : "Vibe Response";
-    return (
-      <div className="bg-slate-900 border border-slate-800 rounded-3xl p-6 shadow-2xl relative overflow-hidden group hover:border-slate-600 transition-all">
+    parts.push(
+      <div className="bg-slate-900 border border-slate-800 rounded-3xl p-6 shadow-2xl relative overflow-hidden group hover:border-slate-600 transition-all text-left">
         <div className={`absolute top-0 left-0 w-1 h-full ${accent}`}></div>
-        <div className={`flex items-center gap-2 ${textColor} font-black text-[10px] uppercase tracking-[0.2em] mb-4`}>
-            <Zap size={16} strokeWidth={3} /> {label}
+        <div className="flex justify-between items-start mb-4">
+          <div className={`flex items-center gap-2 ${textColor} font-black text-[10px] uppercase tracking-[0.2em]`}>
+              <Zap size={16} strokeWidth={3} /> Thinking
+          </div>
+          {renderTimestamp()}
         </div>
         <ResponseBody text={payload.content} />
       </div>
     );
   }
 
-  // --- OPENCODE tool_call ---
-  if (agent === "opencode" && type === "tool_call" && payload) {
+  // 5. OPENCODE tool_call
+  if (agent === "opencode" && type === "tool_call" && payload && mode !== "dialogue") {
     const state = payload.state || {};
     const status = state.status;
     const input = state.input;
     const output = state.output;
-    return (
-      <div className="bg-slate-900/60 border border-slate-800 rounded-2xl p-4 shadow-lg">
+    parts.push(
+      <div className="bg-slate-900/60 border border-slate-800 rounded-2xl p-4 shadow-lg group">
         <div className="flex items-center justify-between mb-2">
           <div className="flex items-center gap-2 text-amber-400 font-black text-[10px] uppercase tracking-[0.2em]">
             <Wrench size={14} strokeWidth={3} /> Tool · {payload.tool || "unknown"}
           </div>
-          {status && <span className="text-[9px] font-bold uppercase tracking-widest text-slate-500">{status}</span>}
+          <div className="flex items-center gap-3">
+             {renderTimestamp()}
+             {status && <span className="text-[9px] font-bold uppercase tracking-widest text-slate-500">{status}</span>}
+          </div>
         </div>
         {input && (
           <details className="mt-1">
@@ -972,42 +1132,17 @@ function EventCard({ event, mode = "all", agent }: { event: any, mode?: "dialogu
     );
   }
 
-  // --- GEMINI ---
-  if (type === "user" && content) {
-    const textContent = Array.isArray(content) ? content.map((c: any) => c.text).filter(Boolean).join("\n") : (typeof content === 'string' ? content : "");
-    if (textContent) {
-      return (
-        <div className="bg-slate-900 border border-slate-800 rounded-3xl p-6 shadow-2xl relative overflow-hidden group hover:border-slate-600 transition-all">
-          <div className="absolute top-0 left-0 w-1 h-full bg-blue-600"></div>
-          <div className="flex items-center gap-2 text-blue-400 font-black text-[10px] uppercase tracking-[0.2em] mb-4">
-              <User size={16} strokeWidth={3} /> User Prompt
-          </div>
-          <div className="text-slate-200 whitespace-pre-wrap text-sm leading-relaxed font-medium">{textContent}</div>
-        </div>
-      );
-    }
-  }
-
-  if (type === "assistant" && typeof content === 'string' && content.trim()) {
-    return (
-      <div className="bg-slate-900 border border-slate-800 rounded-3xl p-6 shadow-2xl relative overflow-hidden group hover:border-slate-600 transition-all">
-        <div className="absolute top-0 left-0 w-1 h-full bg-cyan-600"></div>
-        <div className="flex items-center gap-2 text-cyan-400 font-black text-[10px] uppercase tracking-[0.2em] mb-4">
-            <Sparkles size={16} strokeWidth={3} /> Gemini Response
-        </div>
-        <ResponseBody text={content} />
-      </div>
-    );
-  }
-  
-  if (thoughts && Array.isArray(thoughts)) {
-    if (mode === "dialogue") return null;
-    return (
+  // 6. GEMINI / ANTIGRAVITY (Multi-part support: thoughts + content + toolCalls)
+  if (thoughts && Array.isArray(thoughts) && mode !== "dialogue") {
+    parts.push(
       <div className="space-y-4">
         {thoughts.map((thought: any, i: number) => (
-          <div key={i} className="bg-cyan-500/5 border border-cyan-500/20 rounded-2xl p-6 shadow-sm ml-4 border-l-4 border-l-cyan-500/50">
-            <div className="flex items-center gap-2 text-cyan-400 font-bold mb-3 text-xs uppercase tracking-widest">
-              <Brain size={16} /> {thought.subject || "Reasoning Step"}
+          <div key={i} className="bg-cyan-500/5 border border-cyan-500/20 rounded-2xl p-6 shadow-sm ml-4 border-l-4 border-l-cyan-500/50 group">
+            <div className="flex justify-between items-start mb-3">
+              <div className="flex items-center gap-2 text-cyan-400 font-bold text-xs uppercase tracking-widest">
+                <Brain size={16} /> {thought.subject || "Reasoning"}
+              </div>
+              {renderTimestamp()}
             </div>
             <div className="text-slate-400 whitespace-pre-wrap italic text-[11px] leading-relaxed font-mono opacity-80">{thought.description}</div>
           </div>
@@ -1016,15 +1151,17 @@ function EventCard({ event, mode = "all", agent }: { event: any, mode?: "dialogu
     );
   }
 
-  if (toolCalls && Array.isArray(toolCalls)) {
-    if (mode === "dialogue") return null;
-    return (
+  if (toolCalls && Array.isArray(toolCalls) && mode !== "dialogue") {
+    parts.push(
       <div className="space-y-4">
         {toolCalls.map((call: any, i: number) => (
           <div key={i} className="space-y-4">
-            <div className="bg-blue-500/5 border border-blue-500/20 rounded-2xl p-6 shadow-sm ml-4 border-l-4 border-l-blue-500/50">
-              <div className="flex items-center gap-2 text-blue-400 font-bold mb-4 text-xs uppercase tracking-widest">
-                <Code size={16} /> Tool Call: {call.name}
+            <div className="bg-blue-500/5 border border-blue-500/20 rounded-2xl p-6 shadow-sm ml-4 border-l-4 border-l-blue-500/50 group">
+              <div className="flex justify-between items-start mb-4">
+                <div className="flex items-center gap-2 text-blue-400 font-bold text-xs uppercase tracking-widest">
+                  <Code size={16} /> Tool Call: {call.name}
+                </div>
+                {renderTimestamp()}
               </div>
               <pre className="bg-slate-950 text-blue-300 p-5 rounded-xl text-[11px] overflow-x-auto font-mono border border-slate-800 shadow-inner">
                 {JSON.stringify(call.args, null, 2)}
@@ -1032,8 +1169,11 @@ function EventCard({ event, mode = "all", agent }: { event: any, mode?: "dialogu
             </div>
             {call.result && (
               <div className="bg-slate-900 border border-slate-800 rounded-2xl p-5 shadow-xl ml-8 group hover:border-emerald-500/30 transition-all">
-                <div className="flex items-center gap-2 text-slate-500 font-bold mb-4 text-xs uppercase tracking-widest group-hover:text-emerald-500">
-                  <Terminal size={16} /> Tool Output
+                <div className="flex justify-between items-start mb-4">
+                  <div className="flex items-center gap-2 text-slate-500 font-bold text-xs uppercase tracking-widest group-hover:text-emerald-500">
+                    <Terminal size={16} /> Tool Output
+                  </div>
+                  {renderTimestamp()}
                 </div>
                 <pre className="bg-slate-950 text-emerald-400 p-5 rounded-xl text-[11px] overflow-x-auto font-mono border border-slate-800 shadow-inner">
                   {typeof call.result === 'string' ? call.result : JSON.stringify(call.result, null, 2)}
@@ -1046,31 +1186,81 @@ function EventCard({ event, mode = "all", agent }: { event: any, mode?: "dialogu
     );
   }
 
-  // --- CLAUDE / CURSOR ---
-  if (type === "agent_reasoning" || (message?.role === "assistant" && Array.isArray(message?.content) && message.content.some((c: any) => c.type === "thinking"))) {
-    if (mode === "dialogue") return null;
-    const text = payload?.text || message?.content?.find((c: any) => c.type === "thinking")?.thinking;
-    if (!text) return null;
-    return (
-      <div className="bg-amber-500/5 border border-amber-500/20 rounded-2xl p-6 shadow-sm ml-4 border-l-4 border-l-amber-500/50">
-        <div className="flex items-center gap-2 text-amber-500 font-bold mb-3 text-xs uppercase tracking-widest">
-          <Brain size={16} /> Reasoning Step
+  if (type === "user" && content && (agent === "gemini" || agent === "antigravity")) {
+    const textContent = Array.isArray(content) ? content.map((c: any) => c.text).filter(Boolean).join("\n") : (typeof content === 'string' ? content : "");
+    if (textContent) {
+      parts.push(
+        <div className="bg-slate-900 border border-slate-800 rounded-3xl p-6 shadow-2xl relative overflow-hidden group hover:border-slate-600 transition-all text-left">
+          <div className="absolute top-0 left-0 w-1 h-full bg-blue-600"></div>
+          <div className="flex justify-between items-start mb-4">
+            <div className="flex items-center gap-2 text-blue-400 font-black text-[10px] uppercase tracking-[0.2em]">
+                <User size={16} strokeWidth={3} /> User Prompt
+            </div>
+            {renderTimestamp()}
+          </div>
+          <div className="text-slate-200 whitespace-pre-wrap text-sm leading-relaxed font-medium">{textContent}</div>
         </div>
-        <div className="text-slate-400 whitespace-pre-wrap italic text-[11px] leading-relaxed font-mono opacity-80">{text}</div>
+      );
+    }
+  }
+
+  const role = event.role || event.message?.role;
+  if ((type === "assistant" || role === "assistant" || role === "model" || role === "gemini" || type === "model" || type === "gemini") && typeof content === 'string' && content.trim() && mode !== "brain") {
+    parts.push(
+      <div className="bg-slate-900 border border-slate-800 rounded-3xl p-6 shadow-2xl relative overflow-hidden group hover:border-slate-600 transition-all text-left">
+        <div className="absolute top-0 left-0 w-1 h-full bg-cyan-600"></div>
+        <div className="flex justify-between items-start mb-4">
+          <div className="flex items-center gap-2 text-cyan-400 font-black text-[10px] uppercase tracking-[0.2em]">
+              <Sparkles size={16} strokeWidth={3} /> Response
+          </div>
+          {renderTimestamp()}
+        </div>
+        <ResponseBody text={content} />
       </div>
     );
   }
 
-  if (type === "user" && message?.role === "user") {
-    const isToolResult = Array.isArray(message.content) && message.content.some((c: any) => c.type === "tool_result");
-    if (isToolResult) {
-      if (mode === "dialogue") return null;
-      return (
-        <div className="bg-slate-900 border border-slate-800 rounded-2xl p-5 shadow-xl ml-8 group hover:border-emerald-500/30 transition-all">
-          <div className="flex items-center gap-2 text-slate-500 font-bold mb-4 text-xs uppercase tracking-widest group-hover:text-emerald-500">
-            <Terminal size={16} /> Tool Output
+  // 7. CATCH-ALL for separate reasoning events (Claude/Cursor/Copilot/Qwen)
+  if ((type === "agent_reasoning" || type === "assistant_thinking" || type === "reasoning" || payload?.type === "reasoning") && mode !== "dialogue") {
+    const rawReasoning = payload?.text ?? payload?.content ?? payload?.thinking ?? payload?.summary ?? payload?.value ?? payload?.message ?? event.thoughts ?? (typeof payload === 'string' ? payload : payload);
+    let text = "";
+    if (typeof rawReasoning === 'string') text = rawReasoning;
+    else if (Array.isArray(rawReasoning)) text = rawReasoning.map((p: any) => (typeof p === 'string' ? p : (p?.text ?? p?.thinking ?? p?.content ?? p?.value ?? ""))).filter(Boolean).join("\n\n");
+    else if (rawReasoning && typeof rawReasoning === 'object') text = rawReasoning.text ?? rawReasoning.thinking ?? rawReasoning.content ?? rawReasoning.value ?? JSON.stringify(rawReasoning, null, 2);
+    if (text) {
+      const isCopilot = agent === "copilot" || type === "assistant_thinking";
+      const accent = isCopilot ? "border-l-indigo-500/50" : "border-l-amber-500/50";
+      const textColor = isCopilot ? "text-indigo-400" : "text-amber-500";
+      const bg = isCopilot ? "bg-indigo-500/5" : "bg-amber-500/5";
+      const border = isCopilot ? "border-indigo-500/20" : "border-amber-500/20";
+
+      parts.push(
+        <div className={`${bg} border ${border} rounded-2xl p-6 shadow-sm ml-4 border-l-4 ${accent} group`}>
+          <div className="flex justify-between items-start mb-3">
+            <div className={`flex items-center gap-2 ${textColor} font-bold text-xs uppercase tracking-widest`}>
+              <Brain size={16} /> Reasoning
+            </div>
+            {renderTimestamp()}
           </div>
-          {message.content.map((c: any, i: number) => c.type === "tool_result" && (
+          <div className="text-slate-400 whitespace-pre-wrap italic text-[11px] leading-relaxed font-mono opacity-80">{text}</div>
+        </div>
+      );
+    }
+  }
+
+  // 8. CLAUDE / CURSOR (Multi-part support: thinkingArr + text + tool_result)
+  if ((type === "user" || role === "user") && message?.role === "user") {
+    const toolResults = Array.isArray(message.content) ? message.content.filter((c: any) => c.type === "tool_result") : [];
+    if (toolResults.length > 0 && mode !== "dialogue") {
+      parts.push(
+        <div className="bg-slate-900 border border-slate-800 rounded-2xl p-5 shadow-xl ml-8 group hover:border-emerald-500/30 transition-all">
+          <div className="flex justify-between items-start mb-4">
+            <div className="flex items-center gap-2 text-slate-500 font-bold text-xs uppercase tracking-widest group-hover:text-emerald-500">
+              <Terminal size={16} /> Tool Output
+            </div>
+            {renderTimestamp()}
+          </div>
+          {toolResults.map((c: any, i: number) => (
             <div key={i} className="space-y-3 mb-6 last:mb-0">
                <div className="text-[9px] font-mono text-slate-600 bg-slate-950 px-2 py-0.5 rounded border border-slate-800 w-fit">ID: {c.tool_use_id}</div>
               <pre className="bg-slate-950 text-emerald-400 p-5 rounded-xl text-[11px] overflow-x-auto font-mono border border-slate-800 shadow-inner">
@@ -1082,75 +1272,118 @@ function EventCard({ event, mode = "all", agent }: { event: any, mode?: "dialogu
       );
     }
     const textContent = Array.isArray(message.content) ? extractText(message.content) : (typeof message.content === 'string' ? message.content : "");
-    if (!textContent) return null;
-    return (
-      <div className="bg-slate-900 border border-slate-800 rounded-3xl p-6 shadow-2xl relative overflow-hidden group hover:border-slate-600 transition-all">
-        <div className="absolute top-0 left-0 w-1 h-full bg-blue-600"></div>
-        <div className="flex items-center gap-2 text-blue-400 font-black text-[10px] uppercase tracking-[0.2em] mb-4">
-            <User size={16} strokeWidth={3} /> User Prompt
+    if (textContent && mode !== "brain") {
+      parts.push(
+        <div className="bg-slate-900 border border-slate-800 rounded-3xl p-6 shadow-2xl relative overflow-hidden group hover:border-slate-600 transition-all text-left">
+          <div className="absolute top-0 left-0 w-1 h-full bg-blue-600"></div>
+          <div className="flex justify-between items-start mb-4">
+            <div className="flex items-center gap-2 text-blue-400 font-black text-[10px] uppercase tracking-[0.2em]">
+                <User size={16} strokeWidth={3} /> User Prompt
+            </div>
+            {renderTimestamp()}
+          </div>
+          <div className="text-slate-200 whitespace-pre-wrap text-sm leading-relaxed font-medium">{textContent}</div>
         </div>
-        <div className="text-slate-200 whitespace-pre-wrap text-sm leading-relaxed font-medium">{textContent}</div>
-      </div>
-    );
+      );
+    }
   }
 
-  if (type === "assistant" && message?.role === "assistant") {
-    const contentArr = Array.isArray(message.content) ? message.content : [];
+  if ((type === "assistant" || role === "assistant") && (message?.role === "assistant" || role === "assistant")) {
+    const contentArr = Array.isArray(message?.content) ? message.content : [];
     const toolCallsArr = contentArr.filter((c: any) => c.type === "tool_use");
+    const thinkingArr = contentArr.filter((c: any) => c.type === "thinking");
     const text = extractText(contentArr);
 
-    return (
-      <div className="space-y-6 w-full">
-        {text && (mode === "all" || mode === "dialogue") && (
-          <div className="bg-slate-900 border border-slate-800 rounded-3xl p-6 shadow-2xl relative overflow-hidden group hover:border-slate-600 transition-all">
-            <div className="absolute top-0 left-0 w-1 h-full bg-emerald-500"></div>
-            <div className="flex items-center gap-2 text-emerald-400 font-black text-[10px] uppercase tracking-[0.2em] mb-4">
-                <MessageSquare size={16} strokeWidth={3} /> Agent Response
-            </div>
-            <ResponseBody text={text} />
-          </div>
-        )}
-        {toolCallsArr.length > 0 && (mode === "all" || mode === "brain") && (
-          <div className="space-y-4">
-            {toolCallsArr.map((toolUse: any, i: number) => (
-              <div key={i} className="bg-blue-500/5 border border-blue-500/20 rounded-2xl p-6 shadow-sm ml-4 border-l-4 border-l-blue-500/50">
-                <div className="flex items-center gap-2 text-blue-400 font-bold mb-4 text-xs uppercase tracking-widest">
-                  <Code size={16} /> Tool Call: {toolUse.name}
+    if (thinkingArr.length > 0 && mode !== "dialogue") {
+       thinkingArr.forEach((t: any, i: number) => {
+         const body = t.thinking || t.text || t.content || "";
+         const isEncrypted = !body && (t.signature || t.type === "redacted_thinking");
+         parts.push(
+            <div key={`think-${i}`} className="bg-amber-500/5 border border-amber-500/20 rounded-2xl p-6 shadow-sm ml-4 border-l-4 border-l-amber-500/50 group">
+              <div className="flex justify-between items-start mb-3">
+                <div className="flex items-center gap-2 text-amber-500 font-bold text-xs uppercase tracking-widest">
+                  <Brain size={16} /> Reasoning {isEncrypted && <span className="text-[9px] font-mono normal-case tracking-normal text-amber-500/70 bg-amber-500/10 px-1.5 py-0.5 rounded border border-amber-500/30">encrypted</span>}
                 </div>
-                <pre className="bg-slate-950 text-blue-300 p-5 rounded-xl text-[11px] overflow-x-auto font-mono border border-slate-800 shadow-inner">
-                  {JSON.stringify(toolUse.input || toolUse.args || toolUse.payload, null, 2)}
-                </pre>
+                {renderTimestamp()}
               </div>
-            ))}
+              {isEncrypted ? (
+                <div className="text-slate-500 italic text-[11px] leading-relaxed">
+                  Extended thinking is sealed by the API — the local log stores only the cryptographic signature, not the reasoning text.
+                  <div className="mt-2 text-[9px] font-mono text-slate-600 break-all opacity-60">sig: {String(t.signature || "").slice(0, 64)}…</div>
+                </div>
+              ) : (
+                <div className="text-slate-400 whitespace-pre-wrap italic text-[11px] leading-relaxed font-mono opacity-80">{body || JSON.stringify(t)}</div>
+              )}
+            </div>
+         );
+       });
+    }
+
+    if (text && mode !== "brain") {
+      parts.push(
+        <div className="bg-slate-900 border border-slate-800 rounded-3xl p-6 shadow-2xl relative overflow-hidden group hover:border-slate-600 transition-all text-left">
+          <div className="absolute top-0 left-0 w-1 h-full bg-emerald-500"></div>
+          <div className="flex justify-between items-start mb-4">
+            <div className="flex items-center gap-2 text-emerald-400 font-black text-[10px] uppercase tracking-[0.2em]">
+                <MessageSquare size={16} strokeWidth={3} /> Response
+            </div>
+            {renderTimestamp()}
           </div>
-        )}
-      </div>
-    );
+          <ResponseBody text={text} />
+        </div>
+      );
+    }
+
+    if (toolCallsArr.length > 0 && mode !== "dialogue") {
+      toolCallsArr.forEach((toolUse: any, i: number) => {
+        parts.push(
+          <div key={`tool-${i}`} className="bg-blue-500/5 border border-blue-500/20 rounded-2xl p-6 shadow-sm ml-4 border-l-4 border-l-blue-500/50 group">
+            <div className="flex justify-between items-start mb-4">
+              <div className="flex items-center gap-2 text-blue-400 font-bold text-xs uppercase tracking-widest">
+                <Code size={16} /> Tool Call: {toolUse.name}
+              </div>
+              {renderTimestamp()}
+            </div>
+            <pre className="bg-slate-950 text-blue-300 p-5 rounded-xl text-[11px] overflow-x-auto font-mono border border-slate-800 shadow-inner">
+              {JSON.stringify(toolUse.input || toolUse.args || toolUse.payload, null, 2)}
+            </pre>
+          </div>
+        );
+      });
+    }
   }
 
-  // --- CODEX ---
+  // 9. CODEX (request_item / response_item)
   if (type === "response_item" || type === "request_item") {
     const role = payload?.role || (type === "request_item" ? "user" : "assistant");
     const itemType = payload?.type;
     
-    if (itemType === "reasoning") {
-       if (mode === "dialogue") return null;
-       return (
-          <div className="bg-purple-500/5 border border-purple-500/20 rounded-2xl p-6 shadow-sm ml-4 border-l-4 border-l-purple-500/50">
-            <div className="flex items-center gap-2 text-purple-400 font-bold mb-3 text-xs uppercase tracking-widest">
-              <Brain size={16} /> Codex Reasoning
+    if (itemType === "reasoning" && mode !== "dialogue") {
+       parts.push(
+          <div className="bg-purple-500/5 border border-purple-500/20 rounded-2xl p-6 shadow-sm ml-4 border-l-4 border-l-purple-500/50 group">
+            <div className="flex justify-between items-start mb-3">
+              <div className="flex items-center gap-2 text-purple-400 font-bold mb-3 text-xs uppercase tracking-widest">
+                <Brain size={16} /> Reasoning
+              </div>
+              {renderTimestamp()}
             </div>
-            <div className="text-slate-400 whitespace-pre-wrap italic text-xs leading-relaxed font-mono opacity-80">{payload.content}</div>
+            <div className="text-slate-400 whitespace-pre-wrap italic text-xs leading-relaxed font-mono opacity-80">{
+              Array.isArray(payload.content)
+                ? payload.content.map((c: any) => c?.text ?? c?.summary ?? c?.content ?? (typeof c === 'string' ? c : "")).filter(Boolean).join("\n\n")
+                : (typeof payload.content === 'string' ? payload.content : (payload.summary ?? payload.text ?? ""))
+            }</div>
           </div>
        );
     }
 
-    if (itemType === "function_call" || itemType === "tool_use") {
-       if (mode === "dialogue") return null;
-       return (
-          <div className="bg-blue-500/5 border border-blue-500/20 rounded-2xl p-6 shadow-sm ml-4 border-l-4 border-l-blue-500/50">
-            <div className="flex items-center gap-2 text-blue-400 font-bold mb-4 text-xs uppercase tracking-widest">
-              <Code size={16} /> Tool Call: {payload.name}
+    if ((itemType === "function_call" || itemType === "tool_use") && mode !== "dialogue") {
+       parts.push(
+          <div className="bg-blue-500/5 border border-blue-500/20 rounded-2xl p-6 shadow-sm ml-4 border-l-4 border-l-blue-500/50 group">
+            <div className="flex justify-between items-start mb-4">
+              <div className="flex items-center gap-2 text-blue-400 font-bold mb-4 text-xs uppercase tracking-widest">
+                <Code size={16} /> Tool Call: {payload.name}
+              </div>
+              {renderTimestamp()}
             </div>
             <pre className="bg-slate-950 text-blue-300 p-5 rounded-xl text-[11px] overflow-x-auto font-mono border border-slate-800 shadow-inner">
               {JSON.stringify(payload.arguments || payload.input || payload.parameters, null, 2)}
@@ -1168,28 +1401,32 @@ function EventCard({ event, mode = "all", agent }: { event: any, mode?: "dialogu
           text = content;
        }
 
-       if (!text) return null;
-
-       const isAssistant = role === "assistant";
-       if (mode === "brain") return null; // Logic is handled by isReasoning/isTool in the main loop anyway
-
-       return (
-          <div className="bg-slate-900 border border-slate-800 rounded-3xl p-6 shadow-2xl relative overflow-hidden group hover:border-slate-600 transition-all">
-            <div className={`absolute top-0 left-0 w-1 h-full ${isAssistant ? 'bg-emerald-600' : 'bg-blue-600'}`}></div>
-            <div className={`flex items-center gap-2 ${isAssistant ? 'text-emerald-400' : 'text-blue-400'} font-black text-[10px] uppercase tracking-[0.2em] mb-4`}>
-                {isAssistant ? <MessageSquare size={16} strokeWidth={3} /> : <User size={16} strokeWidth={3} />}
-                {isAssistant ? 'Codex Response' : 'User Prompt'}
-            </div>
-            {isAssistant
-              ? <ResponseBody text={text} />
-              : <div className="text-slate-200 whitespace-pre-wrap text-sm leading-relaxed font-medium">{text}</div>}
-          </div>
-       );
+       if (text) {
+         const isAssistant = role === "assistant";
+         if (mode !== "brain") {
+           parts.push(
+              <div className="bg-slate-900 border border-slate-800 rounded-3xl p-6 shadow-2xl relative overflow-hidden group hover:border-slate-600 transition-all text-left">
+                <div className={`absolute top-0 left-0 w-1 h-full ${isAssistant ? 'bg-emerald-600' : 'bg-blue-600'}`}></div>
+                <div className="flex justify-between items-start mb-4">
+                  <div className={`flex items-center gap-2 ${isAssistant ? 'text-emerald-400' : 'text-blue-400'} font-black text-[10px] uppercase tracking-[0.2em]`}>
+                      {isAssistant ? <MessageSquare size={16} strokeWidth={3} /> : <User size={16} strokeWidth={3} />}
+                      {isAssistant ? 'Response' : 'User Prompt'}
+                  </div>
+                  {renderTimestamp()}
+                </div>
+                {isAssistant
+                  ? <ResponseBody text={text} />
+                  : <div className="text-slate-200 whitespace-pre-wrap text-sm leading-relaxed font-medium">{text}</div>}
+              </div>
+           );
+         }
+       }
     }
   }
 
+  // 10. SYSTEM METADATA
   if (type === "session_meta") {
-    return (
+    parts.push(
       <div className="bg-slate-900 border border-slate-800 rounded-2xl p-5 shadow-2xl opacity-90 border-dashed">
         <div className="flex items-center gap-2 text-slate-400 font-bold mb-4 text-xs uppercase tracking-widest">
           <Info size={16} /> Session Metadata
@@ -1209,7 +1446,7 @@ function EventCard({ event, mode = "all", agent }: { event: any, mode?: "dialogu
   }
 
   if (type === "event_msg") {
-    return (
+    parts.push(
       <div className="bg-slate-900/30 border border-slate-800/50 rounded-xl p-4 text-[10px] text-slate-500 flex items-center gap-4 group hover:bg-slate-800/20 transition-all">
         <Zap size={14} className="text-purple-500/50 group-hover:text-purple-400" />
         <span className="font-bold text-slate-400 uppercase tracking-[0.2em]">{payload?.type}</span>
@@ -1217,13 +1454,16 @@ function EventCard({ event, mode = "all", agent }: { event: any, mode?: "dialogu
     );
   }
 
-  return (mode === "all") ? (
-    <div className="bg-slate-900/20 border border-slate-800/30 rounded-xl p-3 text-[10px] text-slate-600 flex justify-between items-center opacity-40 hover:opacity-100 transition-opacity">
-      <span className="font-mono">System Event: {type}</span>
-    </div>
-  ) : null;
-}
+  if (parts.length === 0 && mode === "all") {
+    parts.push(
+      <div className="bg-slate-900/20 border border-slate-800/30 rounded-xl p-3 text-[10px] text-slate-600 flex justify-between items-center opacity-40 hover:opacity-100 transition-opacity">
+        <span className="font-mono">System Event: {type}</span>
+      </div>
+    );
+  }
 
+  return <div className="space-y-6 w-full">{parts.map((p, i) => <React.Fragment key={i}>{p}</React.Fragment>)}</div>;
+}
 function ResponseBody({ text, tone = "default" }: { text: string; tone?: "default" | "muted" }) {
   const [mode, setMode] = useState<"md" | "raw">("md");
   if (!text) return null;
@@ -1231,14 +1471,7 @@ function ResponseBody({ text, tone = "default" }: { text: string; tone?: "defaul
     ? "text-slate-400 whitespace-pre-wrap italic text-xs leading-relaxed font-mono opacity-80"
     : "text-slate-200 whitespace-pre-wrap text-sm leading-relaxed font-medium";
   return (
-    <>
-      <button
-        onClick={(e) => { e.stopPropagation(); setMode(mode === "md" ? "raw" : "md"); }}
-        className="absolute top-4 right-4 text-[9px] font-black uppercase tracking-widest px-2 py-0.5 rounded bg-slate-950/70 border border-slate-800 text-slate-500 hover:text-slate-200 hover:border-slate-600 transition-colors z-10"
-        title={mode === "md" ? "Show raw text" : "Render markdown"}
-      >
-        {mode === "md" ? "MD" : "Raw"}
-      </button>
+    <div className="relative group/body">
       {mode === "md" ? (
         <div className="prose prose-invert prose-sm max-w-none text-slate-200 text-sm leading-relaxed">
           <ReactMarkdown remarkPlugins={[remarkGfm]}>{text}</ReactMarkdown>
@@ -1246,6 +1479,13 @@ function ResponseBody({ text, tone = "default" }: { text: string; tone?: "defaul
       ) : (
         <div className={base}>{text}</div>
       )}
-    </>
+      <button
+        onClick={(e) => { e.stopPropagation(); setMode(mode === "md" ? "raw" : "md"); }}
+        className="absolute -bottom-2 -right-2 text-[8px] font-black uppercase tracking-widest px-2 py-1 rounded-lg bg-slate-900/80 backdrop-blur-md border border-slate-800 text-slate-500 hover:text-blue-400 hover:border-blue-500/50 transition-all opacity-0 group-hover/body:opacity-100 shadow-xl z-10"
+        title={mode === "md" ? "Show raw text" : "Render markdown"}
+      >
+        {mode === "md" ? "View Raw" : "View MD"}
+      </button>
+    </div>
   );
 }


### PR DESCRIPTION
…ty artifacts

- pricing.py: per-model in/out/cached_read rates with fuzzy fallback; calculate_cost wired into all session aggregation sites
- /pricing endpoint + pricing_updated stamp on /analytics so the UI can show table freshness
- Dashboard + Analytics cost cards now display 'Rates updated YYYY-MM-DD'
- Session trace: kind-aware active-step rings, correct labels (assistant=Response, reasoning=Reasoning), inline reasoning in non-split view, defensive content extraction across Claude/Cursor/Copilot/Codex shapes, encrypted-thinking pill for Anthropic sealed reasoning, React keys on EventCard parts
- Antigravity: discover media at brain session root and sample browser_recordings frames so artifacts surface in session detail