### PR TITLE
fix: mobile responsiveness on marketing website

### DIFF
--- a/website/src/components/AgentsGrid.tsx
+++ b/website/src/components/AgentsGrid.tsx
@@ -2,13 +2,13 @@ import { AGENTS } from "@/data/agents";
 
 export default function AgentsGrid() {
   return (
-    <section id="agents" className="max-w-[1320px] mx-auto px-5 sm:px-8 py-24">
-      <div className="text-center mb-12">
+    <section id="agents" className="max-w-[1320px] mx-auto px-5 sm:px-8 py-16 sm:py-24">
+      <div className="text-center mb-10 sm:mb-12">
         <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--tt-fg-dim)] mb-3">Supported</p>
-        <h2 className="text-[34px] sm:text-[44px] leading-[1.05] tracking-[-0.02em] font-semibold text-[var(--tt-fg)] mb-4">
+        <h2 className="text-[28px] sm:text-[44px] leading-[1.1] tracking-[-0.02em] font-semibold text-[var(--tt-fg)] mb-4">
           Nine agents. <span className="text-[var(--tt-brand)]">Zero config.</span>
         </h2>
-        <p className="text-[15px] text-[var(--tt-fg-muted)] max-w-2xl mx-auto leading-relaxed">
+        <p className="text-[14px] sm:text-[15px] text-[var(--tt-fg-muted)] max-w-2xl mx-auto leading-relaxed">
           TokenTelemetry reads logs your agents already write. No proxies, no wrappers, no SDK to register.
         </p>
       </div>

--- a/website/src/components/FAQ.tsx
+++ b/website/src/components/FAQ.tsx
@@ -28,10 +28,10 @@ export const FAQ_ITEMS = [
 export default function FAQ() {
   return (
     <section id="faq" className="border-t border-[var(--tt-border)]">
-      <div className="max-w-3xl mx-auto px-5 sm:px-8 py-20 sm:py-28">
-        <div className="text-center mb-10">
+      <div className="max-w-3xl mx-auto px-5 sm:px-8 py-14 sm:py-28">
+        <div className="text-center mb-8 sm:mb-10">
           <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--tt-fg-dim)] mb-3">FAQ</p>
-          <h2 className="text-[30px] sm:text-[38px] leading-[1.1] tracking-[-0.02em] font-semibold text-[var(--tt-fg)]">
+          <h2 className="text-[26px] sm:text-[38px] leading-[1.1] tracking-[-0.02em] font-semibold text-[var(--tt-fg)]">
             Common questions
           </h2>
         </div>

--- a/website/src/components/FeatureShowcase.tsx
+++ b/website/src/components/FeatureShowcase.tsx
@@ -9,23 +9,24 @@ export default function FeatureShowcase() {
   const feature = FEATURES.find((f) => f.id === active)!;
 
   return (
-    <section id="features" className="max-w-[1320px] mx-auto px-5 sm:px-8 py-24">
-      <div className="text-center mb-10">
+    <section id="features" className="max-w-[1320px] mx-auto px-5 sm:px-8 py-16 sm:py-24">
+      <div className="text-center mb-8 sm:mb-10">
         <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--tt-fg-dim)] mb-3">
           What you&apos;ll see
         </p>
-        <h2 className="text-[34px] sm:text-[44px] leading-[1.05] tracking-[-0.02em] font-semibold text-[var(--tt-fg)] max-w-2xl mx-auto">
+        <h2 className="text-[28px] sm:text-[44px] leading-[1.1] tracking-[-0.02em] font-semibold text-[var(--tt-fg)] max-w-2xl mx-auto">
           One dashboard. <span className="text-[var(--tt-brand)]">Every agent.</span>
         </h2>
       </div>
 
-      {/* Tabs */}
-      <div className="flex flex-wrap items-center justify-center gap-1 mb-10 p-1 mx-auto w-fit rounded-[var(--tt-radius-lg)] border border-[var(--tt-border)] bg-[var(--tt-panel)]">
+      {/* Tabs — horizontally scrollable on mobile, wraps on larger screens */}
+      <div className="-mx-5 sm:mx-auto mb-8 sm:mb-10 sm:w-fit overflow-x-auto sm:overflow-visible">
+        <div className="flex sm:flex-wrap items-center sm:justify-center gap-1 px-5 sm:px-1 py-1 mx-auto sm:rounded-[var(--tt-radius-lg)] sm:border sm:border-[var(--tt-border)] sm:bg-[var(--tt-panel)] w-max sm:w-auto">
         {FEATURES.map((f) => (
           <button
             key={f.id}
             onClick={() => setActive(f.id)}
-            className={`relative h-9 px-4 rounded-[var(--tt-radius)] text-[12.5px] font-medium tracking-tight transition-colors ${
+            className={`relative h-9 px-4 rounded-[var(--tt-radius)] text-[12.5px] font-medium tracking-tight transition-colors whitespace-nowrap ${
               active === f.id
                 ? "tt-tint-2 text-[var(--tt-fg)]"
                 : "text-[var(--tt-fg-muted)] hover:text-[var(--tt-fg)]"
@@ -37,6 +38,7 @@ export default function FeatureShowcase() {
             )}
           </button>
         ))}
+        </div>
       </div>
 
       <AnimatePresence mode="wait">
@@ -47,15 +49,15 @@ export default function FeatureShowcase() {
           exit={{ opacity: 0, y: -12 }}
           transition={{ duration: 0.25 }}
         >
-          <h3 className="text-center text-[26px] sm:text-[32px] leading-[1.15] tracking-[-0.02em] font-semibold text-[var(--tt-fg)] max-w-3xl mx-auto mb-10">
+          <h3 className="text-center text-[20px] sm:text-[32px] leading-[1.2] tracking-[-0.02em] font-semibold text-[var(--tt-fg)] max-w-3xl mx-auto mb-8 sm:mb-10">
             {feature.headline}
           </h3>
 
           {/* Screenshot */}
-          <div className="relative mb-10">
+          <div className="relative mb-8 sm:mb-10">
             <div aria-hidden className="absolute -inset-x-6 -inset-y-6 pointer-events-none bg-gradient-to-tr from-[color:var(--tt-brand-glow)] via-transparent to-emerald-500/5 blur-3xl" />
-            <div className="relative rounded-[var(--tt-radius-xl)] overflow-hidden border border-[var(--tt-border-strong)] bg-[var(--tt-panel)] shadow-[0_30px_120px_-30px_rgba(96,165,250,0.30)]">
-              <div className="flex items-center gap-1.5 px-4 h-9 bg-[var(--tt-raised)] border-b border-[var(--tt-border)]">
+            <div className="relative rounded-[var(--tt-radius-lg)] sm:rounded-[var(--tt-radius-xl)] overflow-hidden border border-[var(--tt-border-strong)] bg-[var(--tt-panel)] shadow-[0_30px_120px_-30px_rgba(96,165,250,0.30)]">
+              <div className="flex items-center gap-1.5 px-3 sm:px-4 h-9 bg-[var(--tt-raised)] border-b border-[var(--tt-border)]">
                 <span className="w-2.5 h-2.5 rounded-full bg-rose-400/50" />
                 <span className="w-2.5 h-2.5 rounded-full bg-amber-400/50" />
                 <span className="w-2.5 h-2.5 rounded-full bg-emerald-400/50" />

--- a/website/src/components/Hero.tsx
+++ b/website/src/components/Hero.tsx
@@ -32,8 +32,8 @@ export default function Hero() {
 
   return (
     <section className="relative overflow-hidden">
-      <div className="max-w-[1320px] mx-auto px-5 sm:px-8 pt-16 sm:pt-24 pb-10 sm:pb-16">
-        <div className="grid lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] lg:gap-12 lg:items-center">
+      <div className="max-w-[1320px] mx-auto px-5 sm:px-8 pt-12 sm:pt-24 pb-8 sm:pb-16">
+        <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] lg:gap-12 lg:items-center">
           {/* Left column — copy + install */}
           <div className="lg:text-left text-center">
             {/* Eyebrow */}
@@ -52,7 +52,7 @@ export default function Hero() {
             </div>
 
             {/* Headline */}
-            <h1 className="text-[40px] sm:text-[52px] lg:text-[58px] xl:text-[64px] leading-[1.04] tracking-[-0.025em] font-semibold text-[var(--tt-fg)] mb-5 max-w-4xl mx-auto lg:mx-0">
+            <h1 className="text-[32px] sm:text-[52px] lg:text-[58px] xl:text-[64px] leading-[1.08] sm:leading-[1.04] tracking-[-0.025em] font-semibold text-[var(--tt-fg)] mb-5 max-w-4xl mx-auto lg:mx-0">
               See exactly what your{" "}
               <span className="text-[var(--tt-brand)]">coding agents</span>{" "}
               cost, think, and do.

--- a/website/src/components/TrustStrip.tsx
+++ b/website/src/components/TrustStrip.tsx
@@ -9,8 +9,8 @@ const ITEMS = [
 export default function TrustStrip() {
   return (
     <section className="border-t border-[var(--tt-border)]">
-      <div className="max-w-[1320px] mx-auto px-5 sm:px-8 py-20">
-        <div className="grid md:grid-cols-3 gap-6 mb-14">
+      <div className="max-w-[1320px] mx-auto px-5 sm:px-8 py-14 sm:py-20">
+        <div className="grid md:grid-cols-3 gap-4 sm:gap-6 mb-10 sm:mb-14">
           {ITEMS.map(({ icon: Icon, title, body }) => (
             <div
               key={title}


### PR DESCRIPTION
## Summary
- Hero grid was auto-sizing to intrinsic child content (672px from `max-w-2xl`), pushing the left column past mobile viewports. Adding `grid-cols-1` constrains it.
- FeatureShowcase tabs were `w-fit + flex-wrap`, which still overflowed on narrow screens. Tabs now scroll horizontally on mobile and wrap on larger screens.
- Reduced section padding and headline sizes below the `sm` breakpoint (Hero, FeatureShowcase, AgentsGrid, FAQ, TrustStrip) so vertical rhythm and text scale better on phones.

## Test plan
- [x] Verified at 390px (iPhone), 768px (tablet), 870px (small laptop) — `documentElement.scrollWidth === innerWidth`, no horizontal overflow.
- [x] Hero headline wraps cleanly; install command stays within its container.
- [x] FeatureShowcase tabs are horizontally scrollable on mobile.
- [x] Agents grid collapses to single column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)