### PR TITLE
ga: integrate GA4 on the marketing website

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -35,6 +35,7 @@ jobs:
         env:
           BING_VERIFICATION: ${{ secrets.BING_VERIFICATION }}
           GOOGLE_VERIFICATION: ${{ secrets.GOOGLE_VERIFICATION }}
+          NEXT_PUBLIC_GA_ID: ${{ secrets.NEXT_PUBLIC_GA_ID }}
       - uses: actions/upload-pages-artifact@v3
         with:
           path: website/out

--- a/website/src/app/layout.tsx
+++ b/website/src/app/layout.tsx
@@ -1,8 +1,11 @@
 import type { Metadata } from "next";
+import Script from "next/script";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { FAQ_ITEMS } from "@/components/FAQ";
 import SiteHeader from "@/components/SiteHeader";
+
+const GA_ID = process.env.NEXT_PUBLIC_GA_ID;
 
 const geistSans = Geist({ variable: "--font-geist-sans", subsets: ["latin"] });
 const geistMono = Geist_Mono({ variable: "--font-geist-mono", subsets: ["latin"] });
@@ -132,6 +135,26 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(JSON_LD) }} />
         <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(ORG_LD) }} />
         <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(FAQ_LD) }} />
+        {GA_ID && (
+          <>
+            <Script
+              id="ga4-loader"
+              strategy="afterInteractive"
+              src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}
+            />
+            <Script id="ga4-init" strategy="afterInteractive">
+              {`
+                const host = location.hostname;
+                if (host !== 'localhost' && host !== '127.0.0.1' && host !== '0.0.0.0') {
+                  window.dataLayer = window.dataLayer || [];
+                  function gtag(){dataLayer.push(arguments);}
+                  gtag('js', new Date());
+                  gtag('config', '${GA_ID}', { anonymize_ip: true });
+                }
+              `}
+            </Script>
+          </>
+        )}
       </body>
     </html>
   );


### PR DESCRIPTION
## What
Adds Google Analytics 4 (`G-64TLWG7E65`) to the marketing site only.

## How it stays opt-in for local users
- The GA `<Script>` blocks render only when `process.env.NEXT_PUBLIC_GA_ID` is set at build time. Local clones and forks won't have the secret, so their builds emit zero GA bytes.
- A runtime hostname guard inside the init script aborts if `location.hostname` is \`localhost\` / \`127.0.0.1\` / \`0.0.0.0\` — covers the case where someone hardcodes the var and runs the built site locally.
- Tracking is set with \`anonymize_ip: true\`.

## Pipeline change
\`.github/workflows/deploy-website.yml\` passes \`NEXT_PUBLIC_GA_ID\` from repo secrets to the \`npm run build\` step, alongside the existing search-console verification secrets.

## What is *not* changed
- No GA on \`frontend/\` (the dashboard) — that product is 100% local; adding GA would contradict the positioning.
- No custom router page-view listener — GA4 enhanced measurement already handles single-page anchor scrolling and outbound link clicks.

## Verification
- Built with \`NEXT_PUBLIC_GA_ID=G-64TLWG7E65 npm run build\` → grep confirms \`G-64TLWG7E65\`, \`gtag/js\`, \`dataLayer\`, hostname guard in \`out/index.html\`.
- Built without the var → 0 occurrences.

## Test plan
- [ ] After merge & deploy, visit https://tokentelemetry.com in incognito → confirm GA Realtime in GA4 dashboard shows the hit.
- [ ] Visit on \`localhost\` → no GA requests in network tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)