### PR TITLE
feat(hermes): HERMES_HOME, Dashboard plugin + standalone publishing repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,17 @@ Hermes Agent isn't a coding agent — it runs across CLI, messaging platforms (T
 
 Run TokenTelemetry on the same host as Hermes — we read `$HERMES_HOME` (or `~/.hermes/` if unset) locally, no remote-DB mode yet.
 
+### Hermes Dashboard plugin (`:9119` → `:3000`)
+
+If you run Hermes's own web dashboard (`hermes dashboard`, port `9119`), install the plugin so TokenTelemetry shows up as a tab inside it — one port to remember, deep-link cards to every TT page:
+
+```bash
+./scripts/install-hermes-plugin.sh
+hermes dashboard
+```
+
+Pure-frontend launcher, no extra backend, no network access beyond your local TT. See [`plugin/hermes-dashboard/README.md`](plugin/hermes-dashboard/README.md) for details.
+
 ---
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Hermes Agent isn't a coding agent — it runs across CLI, messaging platforms (T
 - **Skills + memory pages**, **cron health**, **gateway health**, **cost anomaly detection**
 - **Provider-aware pricing** — same model priced correctly across direct / OpenRouter / Together / Fireworks
 
-Run TokenTelemetry on the same host as Hermes — we read `~/.hermes/` locally, no remote-DB mode yet.
+Run TokenTelemetry on the same host as Hermes — we read `$HERMES_HOME` (or `~/.hermes/` if unset) locally, no remote-DB mode yet.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -79,14 +79,23 @@ Run TokenTelemetry on the same host as Hermes — we read `$HERMES_HOME` (or `~/
 
 ### Hermes Dashboard plugin (`:9119` → `:3000`)
 
-If you run Hermes's own web dashboard (`hermes dashboard`, port `9119`), install the plugin so TokenTelemetry shows up as a tab inside it — one port to remember, deep-link cards to every TT page:
+If you run Hermes's own web dashboard (`hermes dashboard`, port `9119`), install the plugin so TokenTelemetry shows up as a tab inside it — one port to remember, deep-link cards to every TT page.
+
+**Standalone install** (recommended — uses Hermes's own plugin manager):
+
+```bash
+hermes plugins install VasiHemanth/tokentelemetry-hermes-plugin
+hermes dashboard
+```
+
+**From this repo** (canonical source, useful if you're hacking on the plugin):
 
 ```bash
 ./scripts/install-hermes-plugin.sh
 hermes dashboard
 ```
 
-Pure-frontend launcher, no extra backend, no network access beyond your local TT. See [`plugin/hermes-dashboard/README.md`](plugin/hermes-dashboard/README.md) for details.
+The launcher tab works for every TT page, not just `/hermes` — Analytics, Projects, and All Agents views all open from inside Hermes Dashboard. Pure-frontend, no extra backend, no network access beyond your local TT. See [`plugin/hermes-dashboard/README.md`](plugin/hermes-dashboard/README.md) for details.
 
 ---
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -73,7 +73,10 @@ CURSOR_DIR = HOME / ".cursor"
 OLLAMA_DIR = HOME / ".ollama"
 HF_DIR = HOME / ".cache/huggingface"
 OPENCODE_DB = HOME / ".local/share/opencode/opencode.db"
-HERMES_DIR = HOME / ".hermes"
+# Hermes installs to ~/.hermes by default, but the agent honors HERMES_HOME for
+# users who relocate their data dir (shared hosts, containerized setups, etc.).
+# Mirror that contract so we read from wherever the agent actually writes.
+HERMES_DIR = Path(os.environ.get("HERMES_HOME") or (HOME / ".hermes")).expanduser()
 HERMES_DB = HERMES_DIR / "state.db"
 HERMES_PROFILES_DIR = HERMES_DIR / "profiles"
 

--- a/frontend/src/app/hermes/page.tsx
+++ b/frontend/src/app/hermes/page.tsx
@@ -201,7 +201,7 @@ export default function HermesPage() {
       {!loading && hermesSessions.length === 0 && (
         <EmptyState
           title="No Hermes sessions yet"
-          description="Run Hermes Agent locally (~/.hermes/state.db) to see sessions appear here. TokenTelemetry scans every refresh."
+          description="Run Hermes Agent locally (state.db lives under $HERMES_HOME, or ~/.hermes by default) to see sessions appear here. TokenTelemetry scans every refresh."
         />
       )}
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,12 +1,12 @@
 # TokenTelemetry
 
-> Local token + cost monitoring dashboard for AI coding agents. 100% local, no signup, no cloud.
+> Local token + cost + trace observability for AI coding agents AND autonomous agents. 100% local, no signup, no cloud. The only observability tool that supports Nous Research's Hermes Agent.
 
 ## What is TokenTelemetry?
 
-TokenTelemetry is a free, open-source observability dashboard that automatically tracks token usage, LLM costs, tool calls, session traces, and reasoning steps across AI coding agents including Claude Code, Gemini CLI, OpenAI Codex, Cursor, GitHub Copilot, OpenCode, Qwen, and more.
+TokenTelemetry is a free, open-source observability dashboard that automatically tracks token usage, LLM costs, tool calls, session traces, reasoning steps, subagent delegations, scheduled-job (cron) health, and gateway health across AI coding agents AND autonomous agents — Claude Code, Gemini CLI, OpenAI Codex, Cursor, GitHub Copilot, Qwen, OpenCode, Vibe, Antigravity, and Nous Research's Hermes Agent.
 
-It reads session logs directly from the filesystem (no instrumentation required) and presents them in a unified local web dashboard at http://localhost:3000.
+It reads session logs and SQLite state directly from the filesystem (no SDK, no instrumentation) and presents them in a unified local web dashboard at http://localhost:3000.
 
 ## Key Facts
 
@@ -15,65 +15,127 @@ It reads session logs directly from the filesystem (no instrumentation required)
 - **GitHub:** https://github.com/VasiHemanth/tokentelemetry
 - **License:** MIT (free and open source)
 - **Author:** Hemanth Vasi
-- **Category:** AI observability, LLM monitoring, developer tools
+- **Category:** AI observability, LLM monitoring, autonomous agent observability, developer tools
 - **Tech stack:** Node.js (frontend: Next.js 16), Python (backend: FastAPI)
 - **Platforms:** macOS, Linux, Windows
+- **Privacy:** 100% local — no telemetry, no cloud, no account
 
 ## Supported Agents
 
+### Coding agents (9)
+
 - Claude Code (Anthropic)
-- Gemini CLI (Google)
 - OpenAI Codex CLI
+- Gemini CLI (Google)
 - Cursor
 - GitHub Copilot
+- Qwen CLI (Alibaba)
 - OpenCode
-- Qwen
 - Vibe
-- Antigravity
+- Antigravity (Google)
+
+### Autonomous agents (1)
+
+- **Hermes Agent** (Nous Research) — fully supported with a dedicated dashboard at `/hermes`. The only third-party observability tool that supports Hermes today.
+
+## Hermes Agent: autonomous observability
+
+Hermes Agent is structurally different from coding agents — it runs across CLI, messaging platforms (Telegram, Discord, Slack, WhatsApp, Signal, Matrix, Feishu, DingTalk, WeChat, Google Chat, IRC, Line, SimpleX, Teams, BlueBubbles, …), scheduled cron jobs, webhooks, email, and SMS. TokenTelemetry gives it a dedicated dashboard surface that respects its shape:
+
+- **38 source platforms** observed via the `sessions.source` column in `~/.hermes/state.db`
+- **Per-API-call latency and cache-hit %** parsed from `~/.hermes/logs/agent.log`
+- **Inline `delegate_task` subagent cards** showing summary, tokens, duration, and tool trace
+- **Skills page** — 90+ loaded skills with platform conditions, read from the prompt snapshot
+- **Memory page** — `MEMORY.md` and `USER.md` with character-limit progress bars
+- **Cron health tile** — at-risk schedules flagged automatically
+- **Gateway health pill** — running / stale / stopped, per-platform status
+- **Cost anomaly detection** — silent reasoning-token waste (MiMo thinking mode) flagged
+- **Provider-aware pricing** — the same model priced correctly across direct API / OpenRouter / Together / Fireworks aggregators
+- **Honors `HERMES_HOME`** — works for users who relocate the Hermes data directory
+
+## Hermes Dashboard Plugin
+
+TokenTelemetry ships a plugin for Hermes Agent's own web dashboard (port 9119). After a one-command install, a "TokenTelemetry" tab appears inside Hermes Dashboard with deep-link cards that open TT pages (Hermes Overview, Skills, Memory, Analytics, Projects) in a new browser tab.
+
+Install:
+
+```bash
+git clone https://github.com/VasiHemanth/tokentelemetry.git
+cd tokentelemetry
+./scripts/install-hermes-plugin.sh
+hermes dashboard
+```
+
+The plugin is pure-frontend (no backend routes, no extra network access) and lives at `plugin/hermes-dashboard/`. It solves the "two ports to remember" friction — users see TokenTelemetry from inside Hermes's own UI at `:9119` without context-switching.
 
 ## Core Features
 
-1. Token usage dashboard (real-time tokens in/out per agent and model)
-2. LLM cost tracking (exact costs per session, cumulative over time)
-3. Session trace viewer (waterfall: prompts, reasoning, tool calls, responses)
-4. Tool call analytics (which tools agents call, success/failure rates)
-5. Per-project insights (heatmap, activity timeline, agent leaderboard)
-6. Plan capture (Claude Code plan-mode outputs)
-7. Model comparison analytics (GPT-4o vs Claude 3.5 Sonnet vs Gemini 2.0 Flash)
+1. **Hermes Agent dashboard** — autonomous-agent observability at `/hermes` (see above)
+2. **Token usage dashboard** — real-time tokens in/out per agent, model, and project
+3. **LLM cost tracking** — exact costs per session, cumulative over time, with provider-aware pricing
+4. **Session trace viewer** — waterfall view of prompts, reasoning, tool calls, responses
+5. **Tool call analytics** — which tools agents call, success/failure rates
+6. **Per-project insights** — heatmap, activity timeline, agent leaderboard per codebase
+7. **Plan capture** — view plan-mode outputs from Claude Code
+8. **Model analytics** — compare Claude Opus 4.7 / Sonnet 4.6 vs GPT-5 vs Gemini 3.1 vs DeepSeek vs Kimi efficiency
+9. **Custom agent support** — bring your own log adapter via `backend/custom_agents.example.json`
+10. **B/T number suffixes** — token counts scale through K → M → B → T for power users
 
 ## Installation
 
 ```bash
-# macOS/Linux
+# macOS/Linux one-line
 curl -fsSL https://tokentelemetry.com/install.sh | bash
 
 # Windows
 irm https://tokentelemetry.com/install.ps1 | iex
 
-# Clone
-git clone https://github.com/VasiHemanth/tokentelemetry.git && cd tokentelemetry && ./start.sh
+# From source
+git clone https://github.com/VasiHemanth/tokentelemetry.git
+cd tokentelemetry
+./start.sh
 ```
 
 ## Common Questions
 
 **Q: How do I track Claude Code token usage?**
-A: Install TokenTelemetry, run Claude Code normally, and open http://localhost:3000. TokenTelemetry auto-detects Claude Code sessions from ~/.claude/ logs.
+A: Install TokenTelemetry, run Claude Code normally, and open http://localhost:3000. TokenTelemetry auto-detects Claude Code sessions from `~/.claude/` logs — no instrumentation, no SDK, no config.
 
-**Q: How do I monitor Gemini CLI costs?**
-A: TokenTelemetry auto-reads Gemini CLI logs and displays token counts and costs.
+**Q: How do I monitor Gemini CLI and Codex costs?**
+A: TokenTelemetry auto-reads logs from Gemini CLI, OpenAI Codex CLI, Cursor, GitHub Copilot, Qwen CLI, OpenCode, Vibe, and Antigravity. Token counts and dollar costs appear in the local dashboard automatically.
+
+**Q: Does TokenTelemetry support Hermes Agent from Nous Research?**
+A: Yes — TokenTelemetry is the only third-party observability tool that supports Hermes Agent. It reads `~/.hermes/state.db` (or wherever `HERMES_HOME` points), parses `agent.log` for per-API-call latency and cache hits, exposes a dedicated `/hermes` dashboard with 38 source platforms, gateway health, cron health, skills + memory pages, and renders `delegate_task` subagents inline.
+
+**Q: Can I use TokenTelemetry inside Hermes Dashboard?**
+A: Yes — there is a Hermes Dashboard plugin that registers a "TokenTelemetry" tab inside Hermes's web UI at port 9119. Install with `./scripts/install-hermes-plugin.sh` from the TokenTelemetry repo, then run `hermes dashboard`. Deep-link cards open TT pages in a new browser tab — one port to remember.
+
+**Q: Why does Hermes Agent get its own page?**
+A: Hermes is structurally different from coding agents — it runs across messaging platforms, supports persistent skills and memory, delegates to subagents, and runs scheduled cron jobs. Forcing it into the same UI as Claude Code would hide most of what it does, so it gets a dedicated surface that respects its shape.
+
+**Q: Does TokenTelemetry honor `HERMES_HOME`?**
+A: Yes. TokenTelemetry reads `$HERMES_HOME` if set, otherwise falls back to `~/.hermes/`. Users who relocate their Hermes data directory (shared hosts, containerized setups, multi-profile boxes) work without modification.
+
+**Q: How does the provider-aware pricing for Hermes work?**
+A: Hermes can route the same model through different inference providers (direct, OpenRouter, Together, Fireworks). The same model can have different prices per provider. TokenTelemetry reads the `billing_provider` column from `sessions` in `state.db` and applies provider-specific pricing automatically.
 
 **Q: Is there a free tool to monitor AI coding agent token usage?**
-A: Yes — TokenTelemetry is free, open-source, and local. No account needed.
+A: Yes — TokenTelemetry is free, open-source (MIT), and runs 100% locally. No account, no signup, no cloud.
+
+**Q: Does TokenTelemetry send my data to the cloud?**
+A: No. Everything runs on your machine. The dashboard reads session log files from your local filesystem and serves a UI on localhost. Nothing leaves your computer.
+
+**Q: How does TokenTelemetry compare to Langfuse or Helicone?**
+A: TokenTelemetry is purpose-built for AI coding agents and autonomous agents, and is zero-config — no SDK instrumentation. Langfuse and Helicone are general LLM-app observability platforms that require code changes and (typically) a cloud account. Neither supports Hermes Agent specifically.
 
 **Q: What is the best open source LLM observability tool for coding agents?**
-A: TokenTelemetry is purpose-built for AI coding agents (Claude Code, Codex, Gemini CLI). For general LLM app monitoring, alternatives include Langfuse and LangSmith (both require cloud setup).
-
-**Q: How does TokenTelemetry compare to Langfuse?**
-A: TokenTelemetry is 100% local and zero-config for coding agents. Langfuse requires SDK instrumentation and cloud setup.
+A: TokenTelemetry is purpose-built for AI coding agents (Claude Code, Codex, Gemini CLI, Cursor) and autonomous agents (Hermes). For general LLM-app monitoring, alternatives include Langfuse and LangSmith (both require cloud setup and SDK instrumentation).
 
 ## Docs
 
 - Full documentation: https://tokentelemetry.com
 - GitHub README: https://github.com/VasiHemanth/tokentelemetry#readme
+- Hermes Dashboard plugin: https://github.com/VasiHemanth/tokentelemetry/tree/main/plugin/hermes-dashboard
+- Hermes Agent (upstream): https://github.com/NousResearch/hermes-agent
 - Issues / Feature requests: https://github.com/VasiHemanth/tokentelemetry/issues
 - Contributing: https://github.com/VasiHemanth/tokentelemetry/blob/main/CONTRIBUTING.md

--- a/llms.txt
+++ b/llms.txt
@@ -55,9 +55,20 @@ Hermes Agent is structurally different from coding agents — it runs across CLI
 
 ## Hermes Dashboard Plugin
 
-TokenTelemetry ships a plugin for Hermes Agent's own web dashboard (port 9119). After a one-command install, a "TokenTelemetry" tab appears inside Hermes Dashboard with deep-link cards that open TT pages (Hermes Overview, Skills, Memory, Analytics, Projects) in a new browser tab.
+TokenTelemetry ships a plugin for Hermes Agent's own web dashboard (port 9119). After a one-command install, a "TokenTelemetry" tab appears inside Hermes Dashboard with deep-link cards that open TT pages (Hermes Overview, Skills, Memory, Analytics, Projects, All Agents) in a new browser tab. Important: the plugin is a launcher, not the engine — TokenTelemetry itself must be installed and running for the launcher to do anything. When TT isn't running, the plugin shows an onboarding card explaining what TokenTelemetry is (a local observability dashboard for Hermes Agent AND 9 coding agents) with a copy-paste install command.
 
-Install:
+Install (recommended, via Hermes's own plugin manager):
+
+```bash
+# 1. Install TokenTelemetry itself (the engine)
+curl -fsSL https://tokentelemetry.com/install.sh | bash
+
+# 2. Install the plugin (the bridge into Hermes Dashboard)
+hermes plugins install VasiHemanth/tokentelemetry-hermes-plugin
+hermes dashboard
+```
+
+Install from the TokenTelemetry repo (canonical source, useful if hacking on the plugin):
 
 ```bash
 git clone https://github.com/VasiHemanth/tokentelemetry.git
@@ -66,7 +77,7 @@ cd tokentelemetry
 hermes dashboard
 ```
 
-The plugin is pure-frontend (no backend routes, no extra network access) and lives at `plugin/hermes-dashboard/`. It solves the "two ports to remember" friction — users see TokenTelemetry from inside Hermes's own UI at `:9119` without context-switching.
+The plugin source is at `plugin/hermes-dashboard/` in the main TokenTelemetry repo. The standalone repo at github.com/VasiHemanth/tokentelemetry-hermes-plugin is a publishing mirror, auto-synced from the canonical source. Pure-frontend (no backend routes, no extra network access). Solves the "two ports to remember" friction — users see TokenTelemetry from inside Hermes's own UI at port 9119 without context-switching.
 
 ## Core Features
 
@@ -108,7 +119,7 @@ A: TokenTelemetry auto-reads logs from Gemini CLI, OpenAI Codex CLI, Cursor, Git
 A: Yes — TokenTelemetry is the only third-party observability tool that supports Hermes Agent. It reads `~/.hermes/state.db` (or wherever `HERMES_HOME` points), parses `agent.log` for per-API-call latency and cache hits, exposes a dedicated `/hermes` dashboard with 38 source platforms, gateway health, cron health, skills + memory pages, and renders `delegate_task` subagents inline.
 
 **Q: Can I use TokenTelemetry inside Hermes Dashboard?**
-A: Yes — there is a Hermes Dashboard plugin that registers a "TokenTelemetry" tab inside Hermes's web UI at port 9119. Install with `./scripts/install-hermes-plugin.sh` from the TokenTelemetry repo, then run `hermes dashboard`. Deep-link cards open TT pages in a new browser tab — one port to remember.
+A: Yes — there is a Hermes Dashboard plugin that registers a "TokenTelemetry" tab inside Hermes's web UI at port 9119. Install with `hermes plugins install VasiHemanth/tokentelemetry-hermes-plugin`, then run `hermes dashboard`. Deep-link cards open TokenTelemetry pages in a new browser tab — one port to remember. The plugin is a launcher only, so TokenTelemetry itself must be installed and running for the cards to work. When TT isn't running, the plugin tab shows an onboarding card with the install command.
 
 **Q: Why does Hermes Agent get its own page?**
 A: Hermes is structurally different from coding agents — it runs across messaging platforms, supports persistent skills and memory, delegates to subagents, and runs scheduled cron jobs. Forcing it into the same UI as Claude Code would hide most of what it does, so it gets a dedicated surface that respects its shape.

--- a/plugin/hermes-dashboard/README.md
+++ b/plugin/hermes-dashboard/README.md
@@ -1,0 +1,54 @@
+# TokenTelemetry — Hermes Dashboard Plugin
+
+A thin launcher for [TokenTelemetry](https://github.com/VasiHemanth/tokentelemetry) inside the [Hermes Agent](https://github.com/NousResearch/hermes-agent) web dashboard (port `9119`).
+
+Instead of remembering a second port, click the **TokenTelemetry** tab inside Hermes Dashboard and launch any TT page in a new browser tab — Hermes Overview, Skills, Memory, Analytics, Projects.
+
+## Install
+
+From this repo root:
+
+```bash
+./scripts/install-hermes-plugin.sh
+```
+
+Or manually:
+
+```bash
+mkdir -p ~/.hermes/plugins/tokentelemetry
+ln -s "$(pwd)/plugin/hermes-dashboard" ~/.hermes/plugins/tokentelemetry/dashboard
+```
+
+Then start (or restart) the dashboard:
+
+```bash
+hermes dashboard
+```
+
+Open `http://127.0.0.1:9119`, click **TokenTelemetry** in the sidebar. If TT isn't running, you'll see start-up instructions; once it's up, the launcher lights up with six deep-link cards.
+
+## What it does
+
+- Registers a nav tab in Hermes Dashboard (position: `after:analytics`)
+- Probes your local TokenTelemetry instance (default `http://localhost:3000`) and shows a reachability pill
+- Six launcher cards that open TT in a new tab at the right page
+- Inline base-URL editor (persists to `localStorage`) for non-default deployments
+- Pure frontend — no backend routes, no `plugin_api.py`, no network access beyond your local TT
+
+## File layout
+
+```
+plugin/hermes-dashboard/
+├── manifest.json        # nav tab + icon + position
+├── dist/
+│   ├── index.js         # IIFE launcher (uses window.__HERMES_PLUGIN_SDK__)
+│   └── style.css        # optional, minimal
+└── README.md            # this file
+```
+
+## Uninstall
+
+```bash
+rm -rf ~/.hermes/plugins/tokentelemetry
+hermes dashboard --stop && hermes dashboard
+```

--- a/plugin/hermes-dashboard/README.md
+++ b/plugin/hermes-dashboard/README.md
@@ -6,10 +6,20 @@ Instead of remembering a second port, click the **TokenTelemetry** tab inside He
 
 ## Install
 
-From this repo root:
+### Most users — via Hermes's plugin manager
 
 ```bash
-./scripts/install-hermes-plugin.sh
+hermes plugins install VasiHemanth/tokentelemetry-hermes-plugin
+hermes dashboard
+```
+
+The standalone repo at [`VasiHemanth/tokentelemetry-hermes-plugin`](https://github.com/VasiHemanth/tokentelemetry-hermes-plugin) is auto-synced from this directory by `scripts/publish-plugin.sh`.
+
+### Hacking on the plugin — from this repo
+
+```bash
+./scripts/install-hermes-plugin.sh    # symlinks into ~/.hermes/plugins/
+hermes dashboard
 ```
 
 Or manually:
@@ -17,11 +27,6 @@ Or manually:
 ```bash
 mkdir -p ~/.hermes/plugins/tokentelemetry
 ln -s "$(pwd)/plugin/hermes-dashboard" ~/.hermes/plugins/tokentelemetry/dashboard
-```
-
-Then start (or restart) the dashboard:
-
-```bash
 hermes dashboard
 ```
 

--- a/plugin/hermes-dashboard/dist/index.js
+++ b/plugin/hermes-dashboard/dist/index.js
@@ -74,6 +74,139 @@
     );
   }
 
+  const INSTALL_CURL =
+    "curl -fsSL https://tokentelemetry.com/install.sh | bash";
+
+  const SUPPORTED_AGENTS = [
+    "Claude Code", "Codex", "Gemini CLI", "Cursor",
+    "Copilot", "Qwen", "OpenCode", "Vibe", "Antigravity",
+    "Hermes Agent"
+  ];
+
+  function NotInstalledCard({ base, onRefresh }) {
+    const [copied, setCopied] = useState(false);
+    const copyInstall = () => {
+      try {
+        navigator.clipboard.writeText(INSTALL_CURL);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      } catch (_) {}
+    };
+
+    return React.createElement(
+      Card,
+      null,
+      React.createElement(
+        CardContent,
+        { className: "py-8 px-6 max-w-2xl mx-auto" },
+
+        // Header
+        React.createElement(
+          "div",
+          { className: "flex items-start justify-between mb-4" },
+          React.createElement(
+            "div",
+            null,
+            React.createElement(
+              "div",
+              { className: "text-[10px] font-medium uppercase tracking-[0.18em] text-amber-400 mb-1" },
+              "TokenTelemetry not detected on ", base.replace(/^https?:\/\//, "")
+            ),
+            React.createElement(
+              "h2",
+              { className: "text-lg font-semibold text-zinc-100" },
+              "One install, observability for every agent you use"
+            )
+          ),
+          React.createElement(
+            Button,
+            { size: "sm", variant: "outline", onClick: onRefresh },
+            "Refresh"
+          )
+        ),
+
+        // What TT is — multi-agent pitch
+        React.createElement(
+          "p",
+          { className: "text-sm text-zinc-300 leading-relaxed mb-3" },
+          React.createElement("strong", { className: "text-zinc-100" }, "TokenTelemetry"),
+          " is a free, local observability dashboard for your AI agents — coding agents and autonomous ones. Sessions, costs, traces, tool calls, and reasoning, all in one place. No SDK, no signup, no cloud."
+        ),
+
+        // Agent chips
+        React.createElement(
+          "div",
+          { className: "flex flex-wrap gap-1.5 mb-5" },
+          ...SUPPORTED_AGENTS.map((name) =>
+            React.createElement(
+              "span",
+              {
+                key: name,
+                className: name === "Hermes Agent"
+                  ? "text-[10px] font-medium px-2 py-0.5 rounded-full bg-amber-500/15 text-amber-300 border border-amber-500/30"
+                  : "text-[10px] font-medium px-2 py-0.5 rounded-full bg-zinc-800/80 text-zinc-300 border border-zinc-700"
+              },
+              name
+            )
+          )
+        ),
+
+        // Install command card
+        React.createElement(
+          "div",
+          { className: "rounded-lg border border-zinc-800 bg-zinc-950/60 overflow-hidden mb-3" },
+          React.createElement(
+            "div",
+            { className: "flex items-center justify-between px-3 py-2 border-b border-zinc-800 bg-zinc-900/60" },
+            React.createElement(
+              "span",
+              { className: "text-[10px] font-medium uppercase tracking-[0.18em] text-zinc-400" },
+              "Install — macOS / Linux"
+            ),
+            React.createElement(
+              "button",
+              {
+                onClick: copyInstall,
+                className: `text-[11px] font-medium px-2 py-0.5 rounded ${
+                  copied ? "text-emerald-400" : "text-zinc-400 hover:text-zinc-100"
+                }`
+              },
+              copied ? "✓ Copied" : "Copy"
+            )
+          ),
+          React.createElement(
+            "pre",
+            { className: "px-3 py-2.5 text-xs font-mono text-zinc-200 overflow-x-auto" },
+            INSTALL_CURL
+          )
+        ),
+
+        // Footer hints
+        React.createElement(
+          "div",
+          { className: "flex flex-wrap items-center gap-x-4 gap-y-1 text-[11px] text-zinc-500" },
+          React.createElement(
+            "span",
+            null,
+            "Already installed? Run ",
+            React.createElement("code", { className: "font-mono text-zinc-300" }, "./start.sh"),
+            " then click Refresh"
+          ),
+          React.createElement(
+            "a",
+            {
+              href: "https://tokentelemetry.com",
+              target: "_blank",
+              rel: "noopener noreferrer",
+              className: "text-amber-400 hover:text-amber-300"
+            },
+            "Learn more ↗"
+          )
+        )
+      )
+    );
+  }
+
   function TokenTelemetryLauncher() {
     const [base, setBase] = useState(loadBase());
     const [draft, setDraft] = useState(base);
@@ -188,26 +321,7 @@
 
       // Launch grid
       status === "down"
-        ? React.createElement(
-            Card,
-            null,
-            React.createElement(
-              CardContent,
-              { className: "py-10 text-center" },
-              React.createElement("div", { className: "text-3xl mb-3" }, "⚠"),
-              React.createElement("p", { className: "text-sm text-zinc-200 mb-2" },
-                "Can't reach TokenTelemetry at ",
-                React.createElement("code", { className: "font-mono text-amber-400" }, base)
-              ),
-              React.createElement("p", { className: "text-xs text-zinc-500 mb-4 max-w-md mx-auto" },
-                "Start it from the tokentelemetry repo, then click Refresh:"),
-              React.createElement(
-                "pre",
-                { className: "text-xs text-zinc-400 bg-zinc-900/60 rounded p-3 text-left font-mono inline-block" },
-                "cd backend && uvicorn main:app --port 8000 &\ncd frontend && npm run dev"
-              )
-            )
-          )
+        ? React.createElement(NotInstalledCard, { base, onRefresh: () => probe(base) })
         : React.createElement(
             "div",
             {

--- a/plugin/hermes-dashboard/dist/index.js
+++ b/plugin/hermes-dashboard/dist/index.js
@@ -1,0 +1,248 @@
+(function () {
+  "use strict";
+
+  const SDK = window.__HERMES_PLUGIN_SDK__;
+  const { React } = SDK;
+  const { useState, useEffect, useCallback } = SDK.hooks;
+  const { Card, CardHeader, CardTitle, CardContent, Badge, Button, Input, Label } = SDK.components;
+
+  const STORAGE_KEY = "tt.baseUrl";
+  const DEFAULT_BASE = "http://localhost:3000";
+
+  function loadBase() {
+    try { return localStorage.getItem(STORAGE_KEY) || DEFAULT_BASE; }
+    catch (_) { return DEFAULT_BASE; }
+  }
+  function saveBase(v) {
+    try { localStorage.setItem(STORAGE_KEY, v); } catch (_) {}
+  }
+
+  function joinUrl(base, path) {
+    return base.replace(/\/+$/, "") + path;
+  }
+
+  function HealthPill({ status }) {
+    const variant =
+      status === "ok"      ? { bg: "bg-emerald-500/15", text: "text-emerald-400", dot: "bg-emerald-400", label: "Reachable" } :
+      status === "loading" ? { bg: "bg-zinc-500/15",    text: "text-zinc-400",    dot: "bg-zinc-400",    label: "Checking…" } :
+                             { bg: "bg-rose-500/15",    text: "text-rose-400",    dot: "bg-rose-400",    label: "Unreachable" };
+    return React.createElement(
+      "span",
+      { className: `inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium ${variant.bg} ${variant.text}` },
+      React.createElement("span", { className: `w-1.5 h-1.5 rounded-full ${variant.dot}` }),
+      variant.label
+    );
+  }
+
+  function LaunchCard({ base, status, target, title, subtitle, icon }) {
+    const disabled = status !== "ok";
+    const href = joinUrl(base, target);
+    const className = `group flex flex-col gap-2.5 p-5 rounded-lg border transition-all ${
+      disabled
+        ? "border-zinc-800 bg-zinc-900/30 opacity-50 cursor-not-allowed"
+        : "border-zinc-800 bg-zinc-900/50 hover:bg-zinc-800/60 hover:border-amber-500/40 cursor-pointer"
+    }`;
+
+    const inner = React.createElement(
+      React.Fragment,
+      null,
+      React.createElement(
+        "div",
+        { className: "flex items-center justify-between" },
+        React.createElement("span", { className: "text-2xl" }, icon),
+        React.createElement(
+          "span",
+          {
+            className: `text-xs ${
+              disabled ? "text-zinc-600" : "text-zinc-500 group-hover:text-amber-400"
+            }`
+          },
+          "Open ↗"
+        )
+      ),
+      React.createElement("div", { className: "text-sm font-semibold text-zinc-100" }, title),
+      React.createElement("div", { className: "text-xs text-zinc-400 leading-snug" }, subtitle)
+    );
+
+    if (disabled) {
+      return React.createElement("div", { className }, inner);
+    }
+    return React.createElement(
+      "a",
+      { href, target: "_blank", rel: "noopener noreferrer", className },
+      inner
+    );
+  }
+
+  function TokenTelemetryLauncher() {
+    const [base, setBase] = useState(loadBase());
+    const [draft, setDraft] = useState(base);
+    const [editing, setEditing] = useState(false);
+    const [status, setStatus] = useState("loading");
+
+    const probe = useCallback(async (url) => {
+      setStatus("loading");
+      try {
+        await fetch(url, { mode: "no-cors", cache: "no-store" });
+        setStatus("ok");
+      } catch (_) {
+        setStatus("down");
+      }
+    }, []);
+
+    useEffect(() => { probe(base); }, [base, probe]);
+
+    const apply = () => {
+      const v = draft.trim() || DEFAULT_BASE;
+      saveBase(v);
+      setBase(v);
+      setEditing(false);
+    };
+
+    const cards = [
+      { target: "/hermes",          title: "Hermes Overview",  subtitle: "Sessions, sources, models, cron health", icon: "☤" },
+      { target: "/hermes/skills",   title: "Skills",           subtitle: "Loaded skills from your prompt snapshot", icon: "✦" },
+      { target: "/hermes/memory",   title: "Memory",           subtitle: "MEMORY.md and USER.md with progress bars", icon: "✎" },
+      { target: "/analytics",       title: "Analytics",        subtitle: "Tokens, cost, and trends across all agents", icon: "📈" },
+      { target: "/projects",        title: "Projects",         subtitle: "Per-project rollups, all agents combined", icon: "▣" },
+      { target: "/",                title: "All Agents",       subtitle: "Connected coding + autonomous agents", icon: "◉" }
+    ];
+
+    return React.createElement(
+      "div",
+      { className: "flex flex-col h-full gap-4 p-4" },
+
+      // Header card
+      React.createElement(
+        Card,
+        null,
+        React.createElement(
+          CardHeader,
+          { className: "flex flex-row items-start justify-between gap-3 pb-3" },
+          React.createElement(
+            "div",
+            { className: "flex flex-col gap-1" },
+            React.createElement(
+              "div",
+              { className: "flex items-center gap-2" },
+              React.createElement(CardTitle, { className: "text-lg" }, "TokenTelemetry"),
+              React.createElement(HealthPill, { status })
+            ),
+            React.createElement(
+              "p",
+              { className: "text-xs text-zinc-400 max-w-prose leading-relaxed" },
+              "Local cost / token / trace observability for Hermes Agent and 9 coding agents. Click any tile below to open the relevant TokenTelemetry page in a new tab — no need to remember a second port."
+            )
+          ),
+          React.createElement(
+            Button,
+            {
+              size: "sm",
+              variant: "outline",
+              onClick: () => probe(base)
+            },
+            "Refresh"
+          )
+        ),
+
+        // Base URL row (collapsed by default, click to edit)
+        React.createElement(
+          CardContent,
+          { className: "pt-0 pb-3" },
+          editing
+            ? React.createElement(
+                "div",
+                { className: "flex items-end gap-2" },
+                React.createElement(
+                  "div",
+                  { className: "flex flex-col gap-1 grow" },
+                  React.createElement(Label, { className: "text-xs text-zinc-400" }, "TokenTelemetry base URL"),
+                  React.createElement(Input, {
+                    value: draft,
+                    onChange: (e) => setDraft(e.target.value),
+                    placeholder: DEFAULT_BASE,
+                    className: "font-mono text-sm",
+                    autoFocus: true,
+                    onKeyDown: (e) => { if (e.key === "Enter") apply(); }
+                  })
+                ),
+                React.createElement(Button, { size: "sm", onClick: apply }, "Save"),
+                React.createElement(Button, { size: "sm", variant: "ghost", onClick: () => { setDraft(base); setEditing(false); } }, "Cancel")
+              )
+            : React.createElement(
+                "div",
+                { className: "flex items-center gap-2 text-xs text-zinc-500" },
+                React.createElement("span", null, "Base:"),
+                React.createElement("code", { className: "font-mono text-zinc-300 bg-zinc-900/60 rounded px-1.5 py-0.5" }, base),
+                React.createElement(
+                  "button",
+                  {
+                    onClick: () => setEditing(true),
+                    className: "text-zinc-500 hover:text-amber-400 underline-offset-2 hover:underline"
+                  },
+                  "edit"
+                )
+              )
+        )
+      ),
+
+      // Launch grid
+      status === "down"
+        ? React.createElement(
+            Card,
+            null,
+            React.createElement(
+              CardContent,
+              { className: "py-10 text-center" },
+              React.createElement("div", { className: "text-3xl mb-3" }, "⚠"),
+              React.createElement("p", { className: "text-sm text-zinc-200 mb-2" },
+                "Can't reach TokenTelemetry at ",
+                React.createElement("code", { className: "font-mono text-amber-400" }, base)
+              ),
+              React.createElement("p", { className: "text-xs text-zinc-500 mb-4 max-w-md mx-auto" },
+                "Start it from the tokentelemetry repo, then click Refresh:"),
+              React.createElement(
+                "pre",
+                { className: "text-xs text-zinc-400 bg-zinc-900/60 rounded p-3 text-left font-mono inline-block" },
+                "cd backend && uvicorn main:app --port 8000 &\ncd frontend && npm run dev"
+              )
+            )
+          )
+        : React.createElement(
+            "div",
+            {
+              className: "grid gap-3",
+              style: { gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))" }
+            },
+            ...cards.map((c) =>
+              React.createElement(LaunchCard, {
+                key: c.target,
+                base,
+                status,
+                target: c.target,
+                title: c.title,
+                subtitle: c.subtitle,
+                icon: c.icon
+              })
+            )
+          ),
+
+      // Footer hint
+      React.createElement(
+        "p",
+        { className: "text-[11px] text-zinc-600 text-center pt-2" },
+        "TokenTelemetry runs locally and reads ",
+        React.createElement("code", { className: "font-mono" }, "$HERMES_HOME"),
+        " (or ",
+        React.createElement("code", { className: "font-mono" }, "~/.hermes"),
+        " by default). Your data never leaves your machine."
+      )
+    );
+  }
+
+  if (window.__HERMES_PLUGINS__ && typeof window.__HERMES_PLUGINS__.register === "function") {
+    window.__HERMES_PLUGINS__.register("tokentelemetry", TokenTelemetryLauncher);
+  } else {
+    console.error("[tokentelemetry] Hermes plugin loader not found on window");
+  }
+})();

--- a/plugin/hermes-dashboard/dist/style.css
+++ b/plugin/hermes-dashboard/dist/style.css
@@ -1,0 +1,8 @@
+/* TokenTelemetry plugin — minimal styling. SDK provides Tailwind + shadcn,
+   so we only need overrides for the iframe wrapper. */
+.tt-plugin-iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  background: #09090b;
+}

--- a/plugin/hermes-dashboard/manifest.json
+++ b/plugin/hermes-dashboard/manifest.json
@@ -1,0 +1,13 @@
+{
+  "name": "tokentelemetry",
+  "label": "TokenTelemetry",
+  "description": "Local cost / token / trace observability for Hermes Agent. Embeds the TokenTelemetry dashboard (default http://localhost:3000) inside Hermes Dashboard so you don't context-switch between ports.",
+  "icon": "Activity",
+  "version": "0.1.0",
+  "tab": {
+    "path": "/tokentelemetry",
+    "position": "after:analytics"
+  },
+  "entry": "dist/index.js",
+  "css": "dist/style.css"
+}

--- a/scripts/install-hermes-plugin.sh
+++ b/scripts/install-hermes-plugin.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Symlink the TokenTelemetry plugin into ~/.hermes/plugins/ so Hermes Dashboard
+# discovers it on next launch. Honors HERMES_HOME if set.
+set -euo pipefail
+
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SRC="$REPO_ROOT/plugin/hermes-dashboard"
+DEST_DIR="$HERMES_HOME/plugins/tokentelemetry"
+DEST_LINK="$DEST_DIR/dashboard"
+
+if [[ ! -d "$SRC" ]]; then
+  echo "✗ Plugin source not found at $SRC" >&2
+  exit 1
+fi
+
+mkdir -p "$DEST_DIR"
+
+# If destination already exists, back it up (skip if it's already our symlink).
+if [[ -L "$DEST_LINK" ]]; then
+  current_target="$(readlink "$DEST_LINK")"
+  if [[ "$current_target" == "$SRC" ]]; then
+    echo "✓ Already installed: $DEST_LINK → $SRC"
+    exit 0
+  fi
+  rm "$DEST_LINK"
+elif [[ -e "$DEST_LINK" ]]; then
+  backup="$DEST_LINK.bak.$(date +%s)"
+  mv "$DEST_LINK" "$backup"
+  echo "ℹ Backed up existing $DEST_LINK → $backup"
+fi
+
+ln -s "$SRC" "$DEST_LINK"
+echo "✓ Installed: $DEST_LINK → $SRC"
+echo ""
+echo "Next steps:"
+echo "  1. Start (or restart) the Hermes Dashboard:"
+echo "       hermes dashboard"
+echo "  2. Open http://127.0.0.1:9119 and click TokenTelemetry in the sidebar."

--- a/scripts/publish-plugin-template/.gitignore
+++ b/scripts/publish-plugin-template/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+*.log
+node_modules/
+.idea/
+.vscode/

--- a/scripts/publish-plugin-template/LICENSE
+++ b/scripts/publish-plugin-template/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Hemanth Vasi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/scripts/publish-plugin-template/README.md
+++ b/scripts/publish-plugin-template/README.md
@@ -1,0 +1,77 @@
+# TokenTelemetry — Hermes Dashboard Plugin
+
+> A launcher tab inside [Hermes Agent](https://github.com/NousResearch/hermes-agent)'s web dashboard for **[TokenTelemetry](https://tokentelemetry.com)** — local observability for **Hermes Agent AND 9 coding agents** (Claude Code, OpenAI Codex, Gemini CLI, Cursor, GitHub Copilot, Qwen, OpenCode, Vibe, Antigravity).
+
+> ℹ️ This repo is **auto-generated** from the canonical source in [`VasiHemanth/tokentelemetry`](https://github.com/VasiHemanth/tokentelemetry). File issues and PRs upstream.
+
+## What this plugin does
+
+Registers a `TokenTelemetry` tab in your Hermes Dashboard sidebar. Deep-link cards open TT pages in a new browser tab — one port to remember (`:9119`), no context-switching to `:3000`.
+
+Pages reachable from the launcher:
+
+- `/hermes` — overview (sessions, sources, models, cron health)
+- `/hermes/skills` — loaded skills with platform conditions
+- `/hermes/memory` — `MEMORY.md` and `USER.md` with progress bars
+- `/analytics` — tokens, cost, trends **across all agents** (not just Hermes)
+- `/projects` — per-project rollups, all agents combined
+- `/` — connected agents (coding + autonomous)
+
+## Install
+
+### Prereq: install TokenTelemetry itself
+
+The plugin is a **launcher, not the engine**. You need TokenTelemetry running:
+
+```bash
+# macOS / Linux
+curl -fsSL https://tokentelemetry.com/install.sh | bash
+
+# Windows
+irm https://tokentelemetry.com/install.ps1 | iex
+```
+
+Or clone the repo: <https://github.com/VasiHemanth/tokentelemetry>
+
+### Install the plugin
+
+```bash
+hermes plugins install VasiHemanth/tokentelemetry-hermes-plugin
+hermes dashboard
+```
+
+Then open `http://127.0.0.1:9119` and click **TokenTelemetry** in the sidebar.
+
+## What TokenTelemetry covers (so this plugin earns its keep)
+
+TokenTelemetry isn't a Hermes-only tool. It tracks every AI agent you use:
+
+| Agent | What TT shows |
+|---|---|
+| **Hermes Agent** | Dedicated `/hermes` dashboard — 38 source platforms, gateway health, cron jobs, skills + memory, subagent cards, per-API-call latency |
+| Claude Code | Sessions, tool calls, plan-mode capture, costs |
+| OpenAI Codex CLI | Sessions, tool calls, costs |
+| Gemini CLI | Sessions, costs, tool calls |
+| Cursor | Session activity |
+| GitHub Copilot | Token / cost tracking |
+| Qwen CLI | Sessions, costs |
+| OpenCode | Sessions, costs |
+| Vibe | Sessions |
+| Antigravity | Sessions |
+
+Plus a unified `/analytics` view across all of them.
+
+## Privacy
+
+The plugin is pure-frontend. It reads no Hermes data directly, makes no network requests beyond your local TokenTelemetry instance, and ships no telemetry. Your data never leaves your machine.
+
+## License
+
+MIT — see [LICENSE](LICENSE).
+
+## Links
+
+- **TokenTelemetry homepage**: <https://tokentelemetry.com>
+- **TokenTelemetry source**: <https://github.com/VasiHemanth/tokentelemetry>
+- **Hermes Agent**: <https://github.com/NousResearch/hermes-agent>
+- **Report a bug / request a feature**: <https://github.com/VasiHemanth/tokentelemetry/issues>

--- a/scripts/publish-plugin-template/plugin.yaml
+++ b/scripts/publish-plugin-template/plugin.yaml
@@ -1,0 +1,13 @@
+# Hermes Agent plugin manifest. Auto-synced by scripts/publish-plugin.sh from
+# the canonical source in github.com/VasiHemanth/tokentelemetry.
+name: tokentelemetry
+version: 0.1.0
+description: >
+  Launcher tab inside Hermes Dashboard for TokenTelemetry — local
+  observability for Hermes Agent and 9 coding agents (Claude Code,
+  Codex, Gemini CLI, Cursor, Copilot, Qwen, OpenCode, Vibe, Antigravity).
+author: Hemanth Vasi
+homepage: https://tokentelemetry.com
+repository: https://github.com/VasiHemanth/tokentelemetry-hermes-plugin
+license: MIT
+manifest_version: 1

--- a/scripts/publish-plugin.sh
+++ b/scripts/publish-plugin.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Sync the canonical plugin source (plugin/hermes-dashboard/) into the
+# standalone publishing repo (tokentelemetry-hermes-plugin), bump the
+# version, commit, tag, and push.
+#
+# Prerequisites:
+#   1. The standalone repo exists on GitHub. Create it once:
+#        gh repo create VasiHemanth/tokentelemetry-hermes-plugin \
+#          --public --license MIT \
+#          --description "TokenTelemetry launcher for Hermes Dashboard"
+#   2. You have push access to that repo.
+#
+# Usage:
+#   ./scripts/publish-plugin.sh              # sync HEAD, no tag
+#   ./scripts/publish-plugin.sh 0.2.0        # also bump version and tag v0.2.0
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SRC_PLUGIN="$REPO_ROOT/plugin/hermes-dashboard"
+TEMPLATE="$REPO_ROOT/scripts/publish-plugin-template"
+PUBLISH_REPO="${PUBLISH_REPO:-git@github.com:VasiHemanth/tokentelemetry-hermes-plugin.git}"
+NEW_VERSION="${1:-}"
+
+if [[ ! -d "$SRC_PLUGIN" ]]; then
+  echo "✗ Canonical plugin source not found: $SRC_PLUGIN" >&2
+  exit 1
+fi
+if [[ ! -d "$TEMPLATE" ]]; then
+  echo "✗ Publishing template missing: $TEMPLATE" >&2
+  exit 1
+fi
+
+# Resolve the current commit so we can record provenance in the commit msg.
+UPSTREAM_SHA="$(git -C "$REPO_ROOT" rev-parse --short HEAD)"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+echo "→ Cloning publishing repo to temp dir…"
+git clone "$PUBLISH_REPO" "$TMP/repo"
+cd "$TMP/repo"
+
+# Wipe everything except .git so a removal upstream propagates.
+find . -mindepth 1 -maxdepth 1 -not -name ".git" -exec rm -rf {} +
+
+# Copy template scaffolding (plugin.yaml, README, LICENSE, .gitignore).
+cp -a "$TEMPLATE/." .
+
+# Copy the dashboard payload from the canonical source.
+cp -a "$SRC_PLUGIN/dashboard" .
+
+# If a new version was supplied, bump plugin.yaml.
+if [[ -n "$NEW_VERSION" ]]; then
+  sed -i.bak -E "s/^version:.*/version: $NEW_VERSION/" plugin.yaml
+  rm -f plugin.yaml.bak
+  echo "→ Bumped plugin.yaml version → $NEW_VERSION"
+fi
+
+CURRENT_VERSION="$(awk '/^version:/ {print $2}' plugin.yaml)"
+
+git add -A
+if git diff --cached --quiet; then
+  echo "✓ Nothing to publish — repo already in sync with $UPSTREAM_SHA."
+  exit 0
+fi
+
+COMMIT_MSG="release: sync from tokentelemetry@$UPSTREAM_SHA"
+[[ -n "$NEW_VERSION" ]] && COMMIT_MSG="$COMMIT_MSG (v$NEW_VERSION)"
+
+git commit -m "$COMMIT_MSG"
+
+if [[ -n "$NEW_VERSION" ]]; then
+  git tag -a "v$NEW_VERSION" -m "v$NEW_VERSION"
+fi
+
+echo "→ Pushing to $PUBLISH_REPO…"
+git push origin HEAD
+[[ -n "$NEW_VERSION" ]] && git push origin "v$NEW_VERSION"
+
+echo ""
+echo "✓ Published version $CURRENT_VERSION from tokentelemetry@$UPSTREAM_SHA"
+echo "  Install: hermes plugins install VasiHemanth/tokentelemetry-hermes-plugin"

--- a/scripts/publish-plugin.sh
+++ b/scripts/publish-plugin.sh
@@ -47,8 +47,13 @@ find . -mindepth 1 -maxdepth 1 -not -name ".git" -exec rm -rf {} +
 # Copy template scaffolding (plugin.yaml, README, LICENSE, .gitignore).
 cp -a "$TEMPLATE/." .
 
-# Copy the dashboard payload from the canonical source.
-cp -a "$SRC_PLUGIN/dashboard" .
+# Copy the dashboard payload from the canonical source. The canonical layout
+# (plugin/hermes-dashboard/) has manifest.json + dist/ at the root, but
+# Hermes expects them under dashboard/ in the installed plugin tree, so we
+# nest them here.
+mkdir -p dashboard
+cp -a "$SRC_PLUGIN/manifest.json" dashboard/manifest.json
+cp -a "$SRC_PLUGIN/dist" dashboard/dist
 
 # If a new version was supplied, bump plugin.yaml.
 if [[ -n "$NEW_VERSION" ]]; then
@@ -74,7 +79,7 @@ if [[ -n "$NEW_VERSION" ]]; then
   git tag -a "v$NEW_VERSION" -m "v$NEW_VERSION"
 fi
 
-echo "→ Pushing to $PUBLISH_REPO…"
+echo "→ Pushing to ${PUBLISH_REPO}…"
 git push origin HEAD
 [[ -n "$NEW_VERSION" ]] && git push origin "v$NEW_VERSION"
 

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -1,12 +1,12 @@
 # TokenTelemetry
 
-> Local token + cost monitoring dashboard for AI coding agents. 100% local, no signup, no cloud.
+> Local token + cost + trace observability for AI coding agents AND autonomous agents. 100% local, no signup, no cloud. The only observability tool that supports Nous Research's Hermes Agent.
 
 ## What is TokenTelemetry?
 
-TokenTelemetry is a free, open-source observability dashboard that automatically tracks token usage, LLM costs, tool calls, session traces, and reasoning steps across AI coding agents including Claude Code, Gemini CLI, OpenAI Codex, Cursor, GitHub Copilot, OpenCode, Qwen, and more.
+TokenTelemetry is a free, open-source observability dashboard that automatically tracks token usage, LLM costs, tool calls, session traces, reasoning steps, subagent delegations, scheduled-job (cron) health, and gateway health across AI coding agents AND autonomous agents — Claude Code, Gemini CLI, OpenAI Codex, Cursor, GitHub Copilot, Qwen, OpenCode, Vibe, Antigravity, and Nous Research's Hermes Agent.
 
-It reads session logs directly from the filesystem (no instrumentation required) and presents them in a unified local web dashboard at http://localhost:3000.
+It reads session logs and SQLite state directly from the filesystem (no SDK, no instrumentation) and presents them in a unified local web dashboard at http://localhost:3000.
 
 ## Key Facts
 
@@ -15,65 +15,127 @@ It reads session logs directly from the filesystem (no instrumentation required)
 - **GitHub:** https://github.com/VasiHemanth/tokentelemetry
 - **License:** MIT (free and open source)
 - **Author:** Hemanth Vasi
-- **Category:** AI observability, LLM monitoring, developer tools
+- **Category:** AI observability, LLM monitoring, autonomous agent observability, developer tools
 - **Tech stack:** Node.js (frontend: Next.js 16), Python (backend: FastAPI)
 - **Platforms:** macOS, Linux, Windows
+- **Privacy:** 100% local — no telemetry, no cloud, no account
 
 ## Supported Agents
 
+### Coding agents (9)
+
 - Claude Code (Anthropic)
-- Gemini CLI (Google)
 - OpenAI Codex CLI
+- Gemini CLI (Google)
 - Cursor
 - GitHub Copilot
+- Qwen CLI (Alibaba)
 - OpenCode
-- Qwen
 - Vibe
-- Antigravity
+- Antigravity (Google)
+
+### Autonomous agents (1)
+
+- **Hermes Agent** (Nous Research) — fully supported with a dedicated dashboard at `/hermes`. The only third-party observability tool that supports Hermes today.
+
+## Hermes Agent: autonomous observability
+
+Hermes Agent is structurally different from coding agents — it runs across CLI, messaging platforms (Telegram, Discord, Slack, WhatsApp, Signal, Matrix, Feishu, DingTalk, WeChat, Google Chat, IRC, Line, SimpleX, Teams, BlueBubbles, …), scheduled cron jobs, webhooks, email, and SMS. TokenTelemetry gives it a dedicated dashboard surface that respects its shape:
+
+- **38 source platforms** observed via the `sessions.source` column in `~/.hermes/state.db`
+- **Per-API-call latency and cache-hit %** parsed from `~/.hermes/logs/agent.log`
+- **Inline `delegate_task` subagent cards** showing summary, tokens, duration, and tool trace
+- **Skills page** — 90+ loaded skills with platform conditions, read from the prompt snapshot
+- **Memory page** — `MEMORY.md` and `USER.md` with character-limit progress bars
+- **Cron health tile** — at-risk schedules flagged automatically
+- **Gateway health pill** — running / stale / stopped, per-platform status
+- **Cost anomaly detection** — silent reasoning-token waste (MiMo thinking mode) flagged
+- **Provider-aware pricing** — the same model priced correctly across direct API / OpenRouter / Together / Fireworks aggregators
+- **Honors `HERMES_HOME`** — works for users who relocate the Hermes data directory
+
+## Hermes Dashboard Plugin
+
+TokenTelemetry ships a plugin for Hermes Agent's own web dashboard (port 9119). After a one-command install, a "TokenTelemetry" tab appears inside Hermes Dashboard with deep-link cards that open TT pages (Hermes Overview, Skills, Memory, Analytics, Projects) in a new browser tab.
+
+Install:
+
+```bash
+git clone https://github.com/VasiHemanth/tokentelemetry.git
+cd tokentelemetry
+./scripts/install-hermes-plugin.sh
+hermes dashboard
+```
+
+The plugin is pure-frontend (no backend routes, no extra network access) and lives at `plugin/hermes-dashboard/`. It solves the "two ports to remember" friction — users see TokenTelemetry from inside Hermes's own UI at `:9119` without context-switching.
 
 ## Core Features
 
-1. Token usage dashboard (real-time tokens in/out per agent and model)
-2. LLM cost tracking (exact costs per session, cumulative over time)
-3. Session trace viewer (waterfall: prompts, reasoning, tool calls, responses)
-4. Tool call analytics (which tools agents call, success/failure rates)
-5. Per-project insights (heatmap, activity timeline, agent leaderboard)
-6. Plan capture (Claude Code plan-mode outputs)
-7. Model comparison analytics (GPT-4o vs Claude 3.5 Sonnet vs Gemini 2.0 Flash)
+1. **Hermes Agent dashboard** — autonomous-agent observability at `/hermes` (see above)
+2. **Token usage dashboard** — real-time tokens in/out per agent, model, and project
+3. **LLM cost tracking** — exact costs per session, cumulative over time, with provider-aware pricing
+4. **Session trace viewer** — waterfall view of prompts, reasoning, tool calls, responses
+5. **Tool call analytics** — which tools agents call, success/failure rates
+6. **Per-project insights** — heatmap, activity timeline, agent leaderboard per codebase
+7. **Plan capture** — view plan-mode outputs from Claude Code
+8. **Model analytics** — compare Claude Opus 4.7 / Sonnet 4.6 vs GPT-5 vs Gemini 3.1 vs DeepSeek vs Kimi efficiency
+9. **Custom agent support** — bring your own log adapter via `backend/custom_agents.example.json`
+10. **B/T number suffixes** — token counts scale through K → M → B → T for power users
 
 ## Installation
 
 ```bash
-# macOS/Linux
+# macOS/Linux one-line
 curl -fsSL https://tokentelemetry.com/install.sh | bash
 
 # Windows
 irm https://tokentelemetry.com/install.ps1 | iex
 
-# Clone
-git clone https://github.com/VasiHemanth/tokentelemetry.git && cd tokentelemetry && ./start.sh
+# From source
+git clone https://github.com/VasiHemanth/tokentelemetry.git
+cd tokentelemetry
+./start.sh
 ```
 
 ## Common Questions
 
 **Q: How do I track Claude Code token usage?**
-A: Install TokenTelemetry, run Claude Code normally, and open http://localhost:3000. TokenTelemetry auto-detects Claude Code sessions from ~/.claude/ logs.
+A: Install TokenTelemetry, run Claude Code normally, and open http://localhost:3000. TokenTelemetry auto-detects Claude Code sessions from `~/.claude/` logs — no instrumentation, no SDK, no config.
 
-**Q: How do I monitor Gemini CLI costs?**
-A: TokenTelemetry auto-reads Gemini CLI logs and displays token counts and costs.
+**Q: How do I monitor Gemini CLI and Codex costs?**
+A: TokenTelemetry auto-reads logs from Gemini CLI, OpenAI Codex CLI, Cursor, GitHub Copilot, Qwen CLI, OpenCode, Vibe, and Antigravity. Token counts and dollar costs appear in the local dashboard automatically.
+
+**Q: Does TokenTelemetry support Hermes Agent from Nous Research?**
+A: Yes — TokenTelemetry is the only third-party observability tool that supports Hermes Agent. It reads `~/.hermes/state.db` (or wherever `HERMES_HOME` points), parses `agent.log` for per-API-call latency and cache hits, exposes a dedicated `/hermes` dashboard with 38 source platforms, gateway health, cron health, skills + memory pages, and renders `delegate_task` subagents inline.
+
+**Q: Can I use TokenTelemetry inside Hermes Dashboard?**
+A: Yes — there is a Hermes Dashboard plugin that registers a "TokenTelemetry" tab inside Hermes's web UI at port 9119. Install with `./scripts/install-hermes-plugin.sh` from the TokenTelemetry repo, then run `hermes dashboard`. Deep-link cards open TT pages in a new browser tab — one port to remember.
+
+**Q: Why does Hermes Agent get its own page?**
+A: Hermes is structurally different from coding agents — it runs across messaging platforms, supports persistent skills and memory, delegates to subagents, and runs scheduled cron jobs. Forcing it into the same UI as Claude Code would hide most of what it does, so it gets a dedicated surface that respects its shape.
+
+**Q: Does TokenTelemetry honor `HERMES_HOME`?**
+A: Yes. TokenTelemetry reads `$HERMES_HOME` if set, otherwise falls back to `~/.hermes/`. Users who relocate their Hermes data directory (shared hosts, containerized setups, multi-profile boxes) work without modification.
+
+**Q: How does the provider-aware pricing for Hermes work?**
+A: Hermes can route the same model through different inference providers (direct, OpenRouter, Together, Fireworks). The same model can have different prices per provider. TokenTelemetry reads the `billing_provider` column from `sessions` in `state.db` and applies provider-specific pricing automatically.
 
 **Q: Is there a free tool to monitor AI coding agent token usage?**
-A: Yes — TokenTelemetry is free, open-source, and local. No account needed.
+A: Yes — TokenTelemetry is free, open-source (MIT), and runs 100% locally. No account, no signup, no cloud.
+
+**Q: Does TokenTelemetry send my data to the cloud?**
+A: No. Everything runs on your machine. The dashboard reads session log files from your local filesystem and serves a UI on localhost. Nothing leaves your computer.
+
+**Q: How does TokenTelemetry compare to Langfuse or Helicone?**
+A: TokenTelemetry is purpose-built for AI coding agents and autonomous agents, and is zero-config — no SDK instrumentation. Langfuse and Helicone are general LLM-app observability platforms that require code changes and (typically) a cloud account. Neither supports Hermes Agent specifically.
 
 **Q: What is the best open source LLM observability tool for coding agents?**
-A: TokenTelemetry is purpose-built for AI coding agents (Claude Code, Codex, Gemini CLI). For general LLM app monitoring, alternatives include Langfuse and LangSmith (both require cloud setup).
-
-**Q: How does TokenTelemetry compare to Langfuse?**
-A: TokenTelemetry is 100% local and zero-config for coding agents. Langfuse requires SDK instrumentation and cloud setup.
+A: TokenTelemetry is purpose-built for AI coding agents (Claude Code, Codex, Gemini CLI, Cursor) and autonomous agents (Hermes). For general LLM-app monitoring, alternatives include Langfuse and LangSmith (both require cloud setup and SDK instrumentation).
 
 ## Docs
 
 - Full documentation: https://tokentelemetry.com
 - GitHub README: https://github.com/VasiHemanth/tokentelemetry#readme
+- Hermes Dashboard plugin: https://github.com/VasiHemanth/tokentelemetry/tree/main/plugin/hermes-dashboard
+- Hermes Agent (upstream): https://github.com/NousResearch/hermes-agent
 - Issues / Feature requests: https://github.com/VasiHemanth/tokentelemetry/issues
 - Contributing: https://github.com/VasiHemanth/tokentelemetry/blob/main/CONTRIBUTING.md

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -55,9 +55,20 @@ Hermes Agent is structurally different from coding agents — it runs across CLI
 
 ## Hermes Dashboard Plugin
 
-TokenTelemetry ships a plugin for Hermes Agent's own web dashboard (port 9119). After a one-command install, a "TokenTelemetry" tab appears inside Hermes Dashboard with deep-link cards that open TT pages (Hermes Overview, Skills, Memory, Analytics, Projects) in a new browser tab.
+TokenTelemetry ships a plugin for Hermes Agent's own web dashboard (port 9119). After a one-command install, a "TokenTelemetry" tab appears inside Hermes Dashboard with deep-link cards that open TT pages (Hermes Overview, Skills, Memory, Analytics, Projects, All Agents) in a new browser tab. Important: the plugin is a launcher, not the engine — TokenTelemetry itself must be installed and running for the launcher to do anything. When TT isn't running, the plugin shows an onboarding card explaining what TokenTelemetry is (a local observability dashboard for Hermes Agent AND 9 coding agents) with a copy-paste install command.
 
-Install:
+Install (recommended, via Hermes's own plugin manager):
+
+```bash
+# 1. Install TokenTelemetry itself (the engine)
+curl -fsSL https://tokentelemetry.com/install.sh | bash
+
+# 2. Install the plugin (the bridge into Hermes Dashboard)
+hermes plugins install VasiHemanth/tokentelemetry-hermes-plugin
+hermes dashboard
+```
+
+Install from the TokenTelemetry repo (canonical source, useful if hacking on the plugin):
 
 ```bash
 git clone https://github.com/VasiHemanth/tokentelemetry.git
@@ -66,7 +77,7 @@ cd tokentelemetry
 hermes dashboard
 ```
 
-The plugin is pure-frontend (no backend routes, no extra network access) and lives at `plugin/hermes-dashboard/`. It solves the "two ports to remember" friction — users see TokenTelemetry from inside Hermes's own UI at `:9119` without context-switching.
+The plugin source is at `plugin/hermes-dashboard/` in the main TokenTelemetry repo. The standalone repo at github.com/VasiHemanth/tokentelemetry-hermes-plugin is a publishing mirror, auto-synced from the canonical source. Pure-frontend (no backend routes, no extra network access). Solves the "two ports to remember" friction — users see TokenTelemetry from inside Hermes's own UI at port 9119 without context-switching.
 
 ## Core Features
 
@@ -108,7 +119,7 @@ A: TokenTelemetry auto-reads logs from Gemini CLI, OpenAI Codex CLI, Cursor, Git
 A: Yes — TokenTelemetry is the only third-party observability tool that supports Hermes Agent. It reads `~/.hermes/state.db` (or wherever `HERMES_HOME` points), parses `agent.log` for per-API-call latency and cache hits, exposes a dedicated `/hermes` dashboard with 38 source platforms, gateway health, cron health, skills + memory pages, and renders `delegate_task` subagents inline.
 
 **Q: Can I use TokenTelemetry inside Hermes Dashboard?**
-A: Yes — there is a Hermes Dashboard plugin that registers a "TokenTelemetry" tab inside Hermes's web UI at port 9119. Install with `./scripts/install-hermes-plugin.sh` from the TokenTelemetry repo, then run `hermes dashboard`. Deep-link cards open TT pages in a new browser tab — one port to remember.
+A: Yes — there is a Hermes Dashboard plugin that registers a "TokenTelemetry" tab inside Hermes's web UI at port 9119. Install with `hermes plugins install VasiHemanth/tokentelemetry-hermes-plugin`, then run `hermes dashboard`. Deep-link cards open TokenTelemetry pages in a new browser tab — one port to remember. The plugin is a launcher only, so TokenTelemetry itself must be installed and running for the cards to work. When TT isn't running, the plugin tab shows an onboarding card with the install command.
 
 **Q: Why does Hermes Agent get its own page?**
 A: Hermes is structurally different from coding agents — it runs across messaging platforms, supports persistent skills and memory, delegates to subagents, and runs scheduled cron jobs. Forcing it into the same UI as Claude Code would hide most of what it does, so it gets a dedicated surface that respects its shape.

--- a/website/src/components/FAQ.tsx
+++ b/website/src/components/FAQ.tsx
@@ -31,6 +31,10 @@ export const FAQ_ITEMS = [
     q: "Why does Hermes Agent get its own page?",
     a: "Hermes is structurally different from coding agents — it runs across messaging platforms (Telegram / Discord / Slack / WhatsApp / Signal / Matrix / Feishu / DingTalk / WeChat), supports persistent skills and memory, delegates to subagents, and runs scheduled cron jobs. Forcing it into the same UI as Claude Code would hide most of what it does, so it gets a dedicated surface that respects its shape.",
   },
+  {
+    q: "Can I use TokenTelemetry from inside Hermes Dashboard?",
+    a: "Yes — there's a Hermes Dashboard plugin that registers a 'TokenTelemetry' tab inside Hermes's web UI at port 9119. It's a thin launcher: deep-link cards open the relevant TokenTelemetry page (Hermes Overview, Skills, Memory, Analytics, Projects) in a new browser tab, so you don't have to remember a second port. Install with `./scripts/install-hermes-plugin.sh` from the TokenTelemetry repo, then run `hermes dashboard`.",
+  },
 ];
 
 export default function FAQ() {

--- a/website/src/components/HermesSpotlight.tsx
+++ b/website/src/components/HermesSpotlight.tsx
@@ -163,6 +163,28 @@ export default function HermesSpotlight() {
                 </li>
               </ul>
             </div>
+
+            {/* Plugin callout — embeds inside Hermes Dashboard */}
+            <div className="rounded-[var(--tt-radius-lg)] border border-[var(--tt-border)] bg-[var(--tt-panel)] p-5">
+              <div className="flex items-center gap-2 mb-2">
+                <span className="text-[10px] font-medium uppercase tracking-[0.18em] text-[#eab308]">
+                  Hermes Dashboard plugin
+                </span>
+                <span className="text-[10px] font-mono text-[var(--tt-fg-dim)]">
+                  :9119 → :3000
+                </span>
+              </div>
+              <p className="text-[13px] text-[var(--tt-fg-muted)] leading-relaxed mb-3">
+                One port to remember. Install the plugin and{" "}
+                <strong className="text-[var(--tt-fg)]">TokenTelemetry shows up as a tab inside Hermes&apos;s own web dashboard</strong>
+                {" "}— deep-link cards open Overview, Skills, Memory, Analytics, and Projects in a new tab.
+              </p>
+              <div className="flex flex-wrap gap-x-3 gap-y-1 text-[11px] font-mono text-[var(--tt-fg-dim)]">
+                <span>./scripts/install-hermes-plugin.sh</span>
+                <span className="text-[var(--tt-fg-dim)]/60">·</span>
+                <span>hermes dashboard</span>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/website/src/components/HermesSpotlight.tsx
+++ b/website/src/components/HermesSpotlight.tsx
@@ -3,6 +3,7 @@ import {
   Send, Bell, Clock, Webhook, Terminal, MessageSquare, Hash,
   ArrowRight,
 } from "lucide-react";
+import PluginInstallBlock from "./PluginInstallBlock";
 
 // Inline caduceus — matches the icon shipped in the app's frontend so the
 // brand is consistent between the marketing site and the dashboard.
@@ -165,25 +166,12 @@ export default function HermesSpotlight() {
             </div>
 
             {/* Plugin callout — embeds inside Hermes Dashboard */}
-            <div className="rounded-[var(--tt-radius-lg)] border border-[var(--tt-border)] bg-[var(--tt-panel)] p-5">
-              <div className="flex items-center gap-2 mb-2">
-                <span className="text-[10px] font-medium uppercase tracking-[0.18em] text-[#eab308]">
-                  Hermes Dashboard plugin
-                </span>
-                <span className="text-[10px] font-mono text-[var(--tt-fg-dim)]">
-                  :9119 → :3000
-                </span>
-              </div>
-              <p className="text-[13px] text-[var(--tt-fg-muted)] leading-relaxed mb-3">
-                One port to remember. Install the plugin and{" "}
-                <strong className="text-[var(--tt-fg)]">TokenTelemetry shows up as a tab inside Hermes&apos;s own web dashboard</strong>
-                {" "}— deep-link cards open Overview, Skills, Memory, Analytics, and Projects in a new tab.
+            <div className="space-y-3">
+              <p className="text-[13px] text-[var(--tt-fg-muted)] leading-relaxed">
+                <strong className="text-[var(--tt-fg)]">One port to remember.</strong>{" "}
+                Install the plugin and TokenTelemetry shows up as a tab inside Hermes&apos;s own web dashboard — deep-link cards open Overview, Skills, Memory, Analytics, and Projects in a new tab.
               </p>
-              <div className="flex flex-wrap gap-x-3 gap-y-1 text-[11px] font-mono text-[var(--tt-fg-dim)]">
-                <span>./scripts/install-hermes-plugin.sh</span>
-                <span className="text-[var(--tt-fg-dim)]/60">·</span>
-                <span>hermes dashboard</span>
-              </div>
+              <PluginInstallBlock />
             </div>
           </div>
         </div>

--- a/website/src/components/HermesSpotlight.tsx
+++ b/website/src/components/HermesSpotlight.tsx
@@ -1,8 +1,5 @@
 import Link from "next/link";
-import {
-  Send, Bell, Clock, Webhook, Terminal, MessageSquare, Hash,
-  ArrowRight,
-} from "lucide-react";
+import { ArrowRight } from "lucide-react";
 import PluginInstallBlock from "./PluginInstallBlock";
 
 // Inline caduceus — matches the icon shipped in the app's frontend so the
@@ -35,20 +32,9 @@ function Caduceus({ size = 24 }: { size?: number }) {
 
 const HERMES_HEX = "#eab308";
 
-const PLATFORM_CHIPS = [
-  { icon: Terminal,       label: "CLI" },
-  { icon: Send,           label: "Telegram" },
-  { icon: MessageSquare,  label: "Discord" },
-  { icon: Hash,           label: "Slack" },
-  { icon: Bell,           label: "DingTalk" },
-  { icon: Clock,          label: "Cron" },
-  { icon: Webhook,        label: "Webhook" },
-];
-
 const STATS = [
   { label: "Source platforms", value: "38" },
   { label: "Skills observable", value: "90+" },
-  { label: "Per-call latency", value: "tracked" },
   { label: "Hermes stars (★)", value: "153k" },
 ];
 
@@ -79,20 +65,6 @@ export default function HermesSpotlight() {
               <strong className="text-[var(--tt-fg)]"> 38 source platforms in total</strong>. TokenTelemetry is the only tool that observes them as a single agent, with a dedicated dashboard that respects how Hermes actually works.
             </p>
 
-            <div className="flex flex-wrap gap-1.5 mb-7">
-              {PLATFORM_CHIPS.map(({ icon: Icon, label }) => (
-                <span
-                  key={label}
-                  className="inline-flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-tight text-[var(--tt-fg-muted)] bg-[var(--tt-panel)] border border-[var(--tt-border)] px-2 py-1 rounded"
-                >
-                  <Icon size={11} /> {label}
-                </span>
-              ))}
-              <span className="inline-flex items-center text-[11px] font-medium text-[var(--tt-fg-dim)] px-1.5 py-1 italic">
-                +31 more
-              </span>
-            </div>
-
             <div className="flex flex-wrap gap-3">
               <Link
                 href="#features"
@@ -110,9 +82,9 @@ export default function HermesSpotlight() {
             </div>
           </div>
 
-          {/* Right: signals + previews */}
+          {/* Right: signals + install */}
           <div className="space-y-4">
-            <div className="grid grid-cols-2 gap-3">
+            <div className="grid grid-cols-3 gap-3">
               {STATS.map((s) => (
                 <div
                   key={s.label}
@@ -128,51 +100,7 @@ export default function HermesSpotlight() {
               ))}
             </div>
 
-            <div className="rounded-[var(--tt-radius-lg)] border border-[#eab308]/30 bg-[var(--tt-panel)] p-5">
-              <div className="flex items-center gap-2 mb-3">
-                <span className="h-6 w-6 grid place-items-center rounded-md bg-[#eab308]/15 text-[#eab308]">
-                  <Caduceus size={12} />
-                </span>
-                <span className="text-[11px] font-mono text-[var(--tt-fg-muted)]">
-                  /hermes <span className="text-[var(--tt-fg-dim)]">·</span> dashboard
-                </span>
-              </div>
-              <ul className="space-y-2.5 text-[13px] text-[var(--tt-fg-muted)] leading-relaxed">
-                <li className="flex gap-2.5">
-                  <span className="text-[#eab308] mt-0.5">▸</span>
-                  <span><strong className="text-[var(--tt-fg)]">Gateway health pill</strong> — running / stale / stopped, per-platform status</span>
-                </li>
-                <li className="flex gap-2.5">
-                  <span className="text-[#eab308] mt-0.5">▸</span>
-                  <span><strong className="text-[var(--tt-fg)]">Cron health tile</strong> — "did my 8am cron run?" answered, at-risk flagged</span>
-                </li>
-                <li className="flex gap-2.5">
-                  <span className="text-[#eab308] mt-0.5">▸</span>
-                  <span><strong className="text-[var(--tt-fg)]">Per-API-call latency + cache hit</strong> parsed from agent.log</span>
-                </li>
-                <li className="flex gap-2.5">
-                  <span className="text-[#eab308] mt-0.5">▸</span>
-                  <span><strong className="text-[var(--tt-fg)]">delegate_task subagents</strong> rendered inline with summary, tokens, tool trace</span>
-                </li>
-                <li className="flex gap-2.5">
-                  <span className="text-[#eab308] mt-0.5">▸</span>
-                  <span><strong className="text-[var(--tt-fg)]">Skills + memory pages</strong> — 90 loaded skills, MEMORY.md / USER.md</span>
-                </li>
-                <li className="flex gap-2.5">
-                  <span className="text-[#eab308] mt-0.5">▸</span>
-                  <span><strong className="text-[var(--tt-fg)]">Cost anomaly detection</strong> — silent thinking-token waste flagged</span>
-                </li>
-              </ul>
-            </div>
-
-            {/* Plugin callout — embeds inside Hermes Dashboard */}
-            <div className="space-y-3">
-              <p className="text-[13px] text-[var(--tt-fg-muted)] leading-relaxed">
-                <strong className="text-[var(--tt-fg)]">One port to remember.</strong>{" "}
-                Install the plugin and TokenTelemetry shows up as a tab inside Hermes&apos;s own web dashboard — deep-link cards open Overview, Skills, Memory, Analytics, and Projects in a new tab.
-              </p>
-              <PluginInstallBlock />
-            </div>
+            <PluginInstallBlock />
           </div>
         </div>
       </div>

--- a/website/src/components/PluginInstallBlock.tsx
+++ b/website/src/components/PluginInstallBlock.tsx
@@ -1,0 +1,66 @@
+"use client";
+import { useState } from "react";
+import { Copy, Check } from "lucide-react";
+
+const COMMAND =
+  "git clone https://github.com/VasiHemanth/tokentelemetry.git && cd tokentelemetry && ./scripts/install-hermes-plugin.sh && hermes dashboard";
+
+const LINES = [
+  { prompt: "$", text: "git clone https://github.com/VasiHemanth/tokentelemetry.git" },
+  { prompt: "$", text: "cd tokentelemetry" },
+  { prompt: "$", text: "./scripts/install-hermes-plugin.sh" },
+  { prompt: "$", text: "hermes dashboard" },
+];
+
+export default function PluginInstallBlock() {
+  const [copied, setCopied] = useState(false);
+
+  const copy = () => {
+    navigator.clipboard?.writeText(COMMAND);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+
+  return (
+    <div className="rounded-[var(--tt-radius-lg)] border border-[var(--tt-border)] bg-[var(--tt-panel)] overflow-hidden">
+      <div className="flex items-center justify-between px-4 py-2 border-b border-[var(--tt-border)] bg-[var(--tt-raised)]">
+        <div className="flex items-center gap-2">
+          <span className="text-[10px] font-medium uppercase tracking-[0.18em] text-[#eab308]">
+            Install the plugin
+          </span>
+          <span className="text-[10px] font-mono text-[var(--tt-fg-dim)]">
+            :9119 → :3000
+          </span>
+        </div>
+        <button
+          onClick={copy}
+          aria-label="Copy install command"
+          className="inline-flex items-center gap-1.5 px-2 py-1 rounded text-[11px] font-medium text-[var(--tt-fg-muted)] hover:text-[var(--tt-fg)] hover:bg-[var(--tt-panel)] transition-colors"
+        >
+          {copied ? (
+            <>
+              <Check size={12} className="text-emerald-400" /> Copied
+            </>
+          ) : (
+            <>
+              <Copy size={12} /> Copy
+            </>
+          )}
+        </button>
+      </div>
+      <pre className="px-4 py-3 text-[12.5px] font-mono leading-relaxed overflow-x-auto">
+        {LINES.map((line, i) => (
+          <div key={i} className="flex gap-2">
+            <span className="text-[var(--tt-fg-dim)] select-none">{line.prompt}</span>
+            <span className="text-[var(--tt-fg)]">{line.text}</span>
+          </div>
+        ))}
+      </pre>
+      <div className="px-4 py-2 border-t border-[var(--tt-border)] text-[11px] text-[var(--tt-fg-dim)] leading-relaxed">
+        Then open{" "}
+        <code className="font-mono text-[var(--tt-fg-muted)]">http://127.0.0.1:9119</code>{" "}
+        and click <strong className="text-[var(--tt-fg-muted)]">TokenTelemetry</strong> in the sidebar.
+      </div>
+    </div>
+  );
+}

--- a/website/src/components/PluginInstallBlock.tsx
+++ b/website/src/components/PluginInstallBlock.tsx
@@ -3,23 +3,21 @@ import { useState } from "react";
 import { Copy, Check, Info } from "lucide-react";
 
 const FULL_COMMAND =
-  "git clone https://github.com/VasiHemanth/tokentelemetry.git && cd tokentelemetry && ./start.sh && ./scripts/install-hermes-plugin.sh && hermes dashboard";
+  "curl -fsSL https://tokentelemetry.com/install.sh | bash && hermes plugins install VasiHemanth/tokentelemetry-hermes-plugin && hermes dashboard";
 
 const STEPS: { kicker: string; tagline: string; lines: string[] }[] = [
   {
     kicker: "1 · Run TokenTelemetry",
     tagline: "the engine — port :3000",
     lines: [
-      "git clone https://github.com/VasiHemanth/tokentelemetry.git",
-      "cd tokentelemetry",
-      "./start.sh",
+      "curl -fsSL https://tokentelemetry.com/install.sh | bash",
     ],
   },
   {
     kicker: "2 · Plug it into Hermes Dashboard",
     tagline: "the bridge — port :9119",
     lines: [
-      "./scripts/install-hermes-plugin.sh",
+      "hermes plugins install VasiHemanth/tokentelemetry-hermes-plugin",
       "hermes dashboard",
     ],
   },

--- a/website/src/components/PluginInstallBlock.tsx
+++ b/website/src/components/PluginInstallBlock.tsx
@@ -1,32 +1,46 @@
 "use client";
 import { useState } from "react";
-import { Copy, Check } from "lucide-react";
+import { Copy, Check, Info } from "lucide-react";
 
-const COMMAND =
-  "git clone https://github.com/VasiHemanth/tokentelemetry.git && cd tokentelemetry && ./scripts/install-hermes-plugin.sh && hermes dashboard";
+const FULL_COMMAND =
+  "git clone https://github.com/VasiHemanth/tokentelemetry.git && cd tokentelemetry && ./start.sh && ./scripts/install-hermes-plugin.sh && hermes dashboard";
 
-const LINES = [
-  { prompt: "$", text: "git clone https://github.com/VasiHemanth/tokentelemetry.git" },
-  { prompt: "$", text: "cd tokentelemetry" },
-  { prompt: "$", text: "./scripts/install-hermes-plugin.sh" },
-  { prompt: "$", text: "hermes dashboard" },
+const STEPS: { kicker: string; tagline: string; lines: string[] }[] = [
+  {
+    kicker: "1 · Run TokenTelemetry",
+    tagline: "the engine — port :3000",
+    lines: [
+      "git clone https://github.com/VasiHemanth/tokentelemetry.git",
+      "cd tokentelemetry",
+      "./start.sh",
+    ],
+  },
+  {
+    kicker: "2 · Plug it into Hermes Dashboard",
+    tagline: "the bridge — port :9119",
+    lines: [
+      "./scripts/install-hermes-plugin.sh",
+      "hermes dashboard",
+    ],
+  },
 ];
 
 export default function PluginInstallBlock() {
   const [copied, setCopied] = useState(false);
 
   const copy = () => {
-    navigator.clipboard?.writeText(COMMAND);
+    navigator.clipboard?.writeText(FULL_COMMAND);
     setCopied(true);
     setTimeout(() => setCopied(false), 1500);
   };
 
   return (
     <div className="rounded-[var(--tt-radius-lg)] border border-[var(--tt-border)] bg-[var(--tt-panel)] overflow-hidden">
+      {/* Header */}
       <div className="flex items-center justify-between px-4 py-2 border-b border-[var(--tt-border)] bg-[var(--tt-raised)]">
         <div className="flex items-center gap-2">
           <span className="text-[10px] font-medium uppercase tracking-[0.18em] text-[#eab308]">
-            Install the plugin
+            Install in two acts
           </span>
           <span className="text-[10px] font-mono text-[var(--tt-fg-dim)]">
             :9119 → :3000
@@ -34,32 +48,53 @@ export default function PluginInstallBlock() {
         </div>
         <button
           onClick={copy}
-          aria-label="Copy install command"
+          aria-label="Copy full install sequence"
           className="inline-flex items-center gap-1.5 px-2 py-1 rounded text-[11px] font-medium text-[var(--tt-fg-muted)] hover:text-[var(--tt-fg)] hover:bg-[var(--tt-panel)] transition-colors"
         >
           {copied ? (
             <>
-              <Check size={12} className="text-emerald-400" /> Copied
+              <Check size={12} className="text-emerald-400" /> Copied all
             </>
           ) : (
             <>
-              <Copy size={12} /> Copy
+              <Copy size={12} /> Copy all
             </>
           )}
         </button>
       </div>
-      <pre className="px-4 py-3 text-[12.5px] font-mono leading-relaxed overflow-x-auto">
-        {LINES.map((line, i) => (
-          <div key={i} className="flex gap-2">
-            <span className="text-[var(--tt-fg-dim)] select-none">{line.prompt}</span>
-            <span className="text-[var(--tt-fg)]">{line.text}</span>
+
+      {/* Two steps */}
+      <div className="divide-y divide-[var(--tt-border)]">
+        {STEPS.map((step, i) => (
+          <div key={i} className="px-4 py-3">
+            <div className="flex items-baseline justify-between mb-1.5">
+              <span className="text-[11px] font-semibold tracking-[-0.005em] text-[var(--tt-fg)]">
+                {step.kicker}
+              </span>
+              <span className="text-[10px] font-mono text-[var(--tt-fg-dim)]">
+                {step.tagline}
+              </span>
+            </div>
+            <pre className="text-[12.5px] font-mono leading-relaxed overflow-x-auto">
+              {step.lines.map((line, j) => (
+                <div key={j} className="flex gap-2">
+                  <span className="text-[var(--tt-fg-dim)] select-none">$</span>
+                  <span className="text-[var(--tt-fg)]">{line}</span>
+                </div>
+              ))}
+            </pre>
           </div>
         ))}
-      </pre>
-      <div className="px-4 py-2 border-t border-[var(--tt-border)] text-[11px] text-[var(--tt-fg-dim)] leading-relaxed">
-        Then open{" "}
-        <code className="font-mono text-[var(--tt-fg-muted)]">http://127.0.0.1:9119</code>{" "}
-        and click <strong className="text-[var(--tt-fg-muted)]">TokenTelemetry</strong> in the sidebar.
+      </div>
+
+      {/* The honesty footer */}
+      <div className="flex items-start gap-2 px-4 py-2.5 border-t border-[var(--tt-border)] bg-[#eab308]/[0.04]">
+        <Info size={12} className="text-[#eab308] mt-0.5 shrink-0" />
+        <p className="text-[11px] text-[var(--tt-fg-muted)] leading-relaxed">
+          <strong className="text-[var(--tt-fg)]">The plugin is a launcher, not the engine.</strong>{" "}
+          It opens TokenTelemetry pages inside Hermes Dashboard — but only when TT itself is running. Skip step 1 if you already have TT on
+          <code className="font-mono text-[var(--tt-fg-muted)] mx-0.5">:3000</code>.
+        </p>
       </div>
     </div>
   );

--- a/website/src/data/features.ts
+++ b/website/src/data/features.ts
@@ -17,6 +17,7 @@ export const FEATURES: Feature[] = [
       "Subagent delegation rendered inline: each delegate_task call expands to show the child's summary, tokens, duration, and tool trace.",
       "Skills + memory pages: 90 loaded skills with platform conditions, MEMORY.md / USER.md with char-limit progress bars.",
       "Cost anomaly detection: silent reasoning-token waste (MiMo thinking-mode) flagged automatically.",
+      "Hermes Dashboard plugin: one-command install adds a TokenTelemetry tab inside Hermes's own web UI (port 9119) — deep-link launcher to Overview, Skills, Memory, Analytics, Projects.",
     ],
     screenshot: "/screenshots/hermes.png",
   },


### PR DESCRIPTION
## Summary

Builds on the merged PR #21 to land the rest of the Hermes Agent work — reviewer feedback fixes, the Hermes Dashboard plugin (now installable via `hermes plugins install`), and full website/llms.txt coverage of the new integration.

### Reviewer feedback from #21
- **`HERMES_HOME` env var** honored everywhere (`4e94325`). Hermes itself reads `HERMES_HOME` at startup to relocate its data dir (containers, multi-profile boxes). We now mirror that contract: `Path(os.environ.get("HERMES_HOME") or (HOME / ".hermes")).expanduser()`. `HERMES_DB` and `HERMES_PROFILES_DIR` derive from it, so the override flows through automatically.

### Hermes Dashboard plugin
- **Launcher tab** inside Hermes Dashboard at `:9119` — opens TokenTelemetry pages in a new browser tab, no port-juggling. Solves the friction raised in [NousResearch/hermes-agent#26696](https://github.com/NousResearch/hermes-agent/issues/26696).
- **Six deep-link cards**: Hermes Overview, Skills, Memory, Analytics, Projects, All Agents.
- **Multi-agent onboarding empty state**: when TT isn't running, the plugin tab shows a real onboarding card naming all 10 supported agents (the 9 coding agents + Hermes Agent highlighted) with a copy-paste install command. Turns the most painful failure mode into the most useful conversion moment.
- **Both install paths supported**:
  - `hermes plugins install VasiHemanth/tokentelemetry-hermes-plugin` (recommended)
  - `./scripts/install-hermes-plugin.sh` (from this repo, for plugin hackers)

### Standalone publishing repo
- New repo: **[VasiHemanth/tokentelemetry-hermes-plugin](https://github.com/VasiHemanth/tokentelemetry-hermes-plugin)** — first release `v0.1.0` already published.
- Canonical source stays here at `plugin/hermes-dashboard/`. `scripts/publish-plugin.sh` syncs to the standalone repo, bumps version, commits, tags, pushes. Idempotent.
- Standalone repo is read-only-ish — issues and PRs come back here.
- End-to-end install verified: `hermes plugins install …` clones, Hermes Dashboard discovers it, bundle serves correctly.

### Website + llms.txt
- **HermesSpotlight**: copy-to-clipboard "two acts" install block (Act 1 = engine, Act 2 = bridge) with honest "plugin is a launcher, not the engine" footer.
- **Trim**: dropped the 6-bullet feature card and platform-chip strip that overlapped with the FeatureShowcase carousel. Spotlight density down ~72 lines.
- **FAQ**: new Q&A for "Can I use TokenTelemetry inside Hermes Dashboard?"
- **llms.txt** (both root and `website/public/`): full standalone install section, all 5 new Q&As for AEO (TokenTelemetry as the only third-party tool supporting Hermes Agent observability).

### `format.ts` follow-ups
- Number formatters scale through K → M → **B → T** so power users with billions of tokens get readable values (`1.23B`, `2.5T`).
- Three duplicate impls in page.tsx / projects/page.tsx / analytics/page.tsx replaced with the centralized helper.

## Commit log

\`\`\`
5503c4c fix(scripts): publish-plugin.sh — brace var, copy correct paths
2c23050 feat(hermes): prep standalone plugin repo + multi-agent empty state
86d770a docs(hermes): trim spotlight density (less Hermes overload on homepage)
d6edbce docs(hermes): make plugin/TT dependency explicit in install block
f63734a docs(hermes): add copy-to-clipboard plugin install block on homepage
9ea050f docs(hermes): refresh llms.txt with Hermes Agent + plugin coverage (AEO)
61eef2f docs(hermes): surface Hermes Dashboard plugin on website + README
80f12d1 feat(hermes): add Hermes Dashboard plugin (launcher for TokenTelemetry)
4e94325 fix(hermes): honor HERMES_HOME env var instead of hardcoding ~/.hermes
\`\`\`

## Test plan

- [x] `HERMES_HOME=/tmp/fake-hermes python3 -c "import main; print(main.HERMES_DIR)"` → `/tmp/fake-hermes` (verified)
- [x] Plugin loads via `hermes plugins install VasiHemanth/tokentelemetry-hermes-plugin` (verified end-to-end on this machine; published v0.1.0)
- [x] Hermes Dashboard discovers it as `source: user` (verified via `/api/dashboard/plugins`)
- [x] Plugin bundle served correctly at `/dashboard-plugins/tokentelemetry/dist/index.js`
- [x] Launcher cards open the right TT URLs in a new tab
- [x] Empty state renders when TT is unreachable (verified by killing TT and screenshotting)
- [x] Website TypeScript: `npx tsc --noEmit` clean
- [ ] Smoke test from a fresh `~/.hermes/` install on another machine

## Out of scope for this PR (follow-ups)

- GitHub release notes / changelog for the standalone repo v0.1.0
- Discord announcement in NousResearch's plugins channel
- Comment on hermes-agent#26696 with the new install command + screenshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)