### PR TITLE
feat(traffic): weekly GitHub traffic sync to Google Sheets

### DIFF
--- a/.github/workflows/sync-traffic.yml
+++ b/.github/workflows/sync-traffic.yml
@@ -6,14 +6,6 @@ on:
     # so running weekly guarantees no daily rows are lost.
     - cron: "0 23 * * 0"
   workflow_dispatch:
-  # TEMPORARY: remove before merging to main. Lets us smoke-test on the
-  # feature branch since workflow_dispatch only works once a workflow
-  # exists on the default branch.
-  push:
-    branches: [feat/traffic-sync]
-    paths:
-      - .github/workflows/sync-traffic.yml
-      - scripts/sync_github_traffic.py
 
 jobs:
   sync:

--- a/.github/workflows/sync-traffic.yml
+++ b/.github/workflows/sync-traffic.yml
@@ -25,4 +25,5 @@ jobs:
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
           GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
+          TT_SHEET_ID: ${{ secrets.TT_SHEET_ID }}
         run: python scripts/sync_github_traffic.py

--- a/.github/workflows/sync-traffic.yml
+++ b/.github/workflows/sync-traffic.yml
@@ -6,6 +6,14 @@ on:
     # so running weekly guarantees no daily rows are lost.
     - cron: "0 23 * * 0"
   workflow_dispatch:
+  # TEMPORARY: remove before merging to main. Lets us smoke-test on the
+  # feature branch since workflow_dispatch only works once a workflow
+  # exists on the default branch.
+  push:
+    branches: [feat/traffic-sync]
+    paths:
+      - .github/workflows/sync-traffic.yml
+      - scripts/sync_github_traffic.py
 
 jobs:
   sync:

--- a/.github/workflows/sync-traffic.yml
+++ b/.github/workflows/sync-traffic.yml
@@ -1,0 +1,28 @@
+name: Sync GitHub Traffic to Sheets
+
+on:
+  schedule:
+    # Every Sunday at 23:00 UTC. GitHub only keeps 14 days of traffic data,
+    # so running weekly guarantees no daily rows are lost.
+    - cron: "0 23 * * 0"
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install gspread google-auth requests
+
+      - name: Run traffic sync
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
+          GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
+        run: python scripts/sync_github_traffic.py

--- a/scripts/sync_github_traffic.py
+++ b/scripts/sync_github_traffic.py
@@ -20,9 +20,7 @@ import gspread
 import requests
 from google.oauth2.service_account import Credentials
 
-SPREADSHEET_ID = os.environ.get(
-    "TT_SHEET_ID", "1EKo8Z8vd7D0XN_7u5W5vUG23YI7f3zE2sYOscQ2PlEs"
-)
+SPREADSHEET_ID = os.environ["TT_SHEET_ID"]
 
 REPOS_TO_TRACK = {
     "VasiHemanth/tokentelemetry": "TokenTelemetry",

--- a/scripts/sync_github_traffic.py
+++ b/scripts/sync_github_traffic.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Sync GitHub traffic (views, clones, referrers, popular paths) into Google Sheets.
+
+Env vars:
+  GCP_CREDENTIALS  JSON string of the service-account key (full contents).
+  GH_PAT           GitHub PAT with `repo` (or admin:repo) scope for the target repos.
+
+The target spreadsheet must already exist and be shared (Editor) with the
+service account email. Per-repo tabs expected:
+  <base>            daily views + clones timeline
+  <base>_Referrers  14-day referrer snapshots
+  <base>_Paths      14-day popular-path snapshots
+"""
+
+import json
+import os
+from datetime import datetime
+
+import gspread
+import requests
+from google.oauth2.service_account import Credentials
+
+SPREADSHEET_ID = os.environ.get(
+    "TT_SHEET_ID", "1EKo8Z8vd7D0XN_7u5W5vUG23YI7f3zE2sYOscQ2PlEs"
+)
+
+REPOS_TO_TRACK = {
+    "VasiHemanth/tokentelemetry": "TokenTelemetry",
+    "VasiHemanth/tokentelemetry-hermes-plugin": "Hermes-Plugin",
+}
+
+
+def gh_get(url, headers):
+    r = requests.get(url, headers=headers, timeout=30)
+    r.raise_for_status()
+    return r.json()
+
+
+def ensure_tab(spreadsheet, title, header):
+    try:
+        ws = spreadsheet.worksheet(title)
+    except gspread.exceptions.WorksheetNotFound:
+        ws = spreadsheet.add_worksheet(title=title, rows=1000, cols=max(8, len(header)))
+        ws.append_row(header)
+        return ws
+    # Backfill a header row if the sheet is empty.
+    if not ws.row_values(1):
+        ws.update("A1", [header])
+    return ws
+
+
+def main():
+    scopes = ["https://www.googleapis.com/auth/spreadsheets"]
+    creds_json = json.loads(os.environ["GCP_CREDENTIALS"])
+    creds = Credentials.from_service_account_info(creds_json, scopes=scopes)
+    client = gspread.authorize(creds)
+    spreadsheet = client.open_by_key(SPREADSHEET_ID)
+
+    gh_token = os.environ["GH_PAT"]
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {gh_token}",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+    today_snapshot = datetime.utcnow().strftime("%Y-%m-%d")
+
+    for repo_path, base_tab in REPOS_TO_TRACK.items():
+        print(f"Fetching traffic for {repo_path}...")
+
+        # --- Views & Clones (time-series) ---
+        views = gh_get(
+            f"https://api.github.com/repos/{repo_path}/traffic/views", headers
+        ).get("views", [])
+        clones = gh_get(
+            f"https://api.github.com/repos/{repo_path}/traffic/clones", headers
+        ).get("clones", [])
+
+        daily = {}
+        for v in views:
+            d = v["timestamp"][:10]
+            daily.setdefault(d, {"views": 0, "u_views": 0, "clones": 0, "u_clones": 0})
+            daily[d]["views"] = v["count"]
+            daily[d]["u_views"] = v["uniques"]
+        for c in clones:
+            d = c["timestamp"][:10]
+            daily.setdefault(d, {"views": 0, "u_views": 0, "clones": 0, "u_clones": 0})
+            daily[d]["clones"] = c["count"]
+            daily[d]["u_clones"] = c["uniques"]
+
+        main_sheet = ensure_tab(
+            spreadsheet, base_tab, ["date", "views", "unique_views", "clones", "unique_clones"]
+        )
+        existing_dates = set(main_sheet.col_values(1))
+        new_rows = [
+            [d, m["views"], m["u_views"], m["clones"], m["u_clones"]]
+            for d, m in sorted(daily.items())
+            if d not in existing_dates
+        ]
+        if new_rows:
+            main_sheet.append_rows(new_rows, value_input_option="USER_ENTERED")
+            print(f"  + {len(new_rows)} daily rows -> {base_tab}")
+        else:
+            print(f"  = no new daily rows for {base_tab}")
+
+        # --- Referrers (14-day snapshot) ---
+        referrers = gh_get(
+            f"https://api.github.com/repos/{repo_path}/traffic/popular/referrers", headers
+        )
+        ref_sheet = ensure_tab(
+            spreadsheet,
+            f"{base_tab}_Referrers",
+            ["snapshot_date", "referrer", "views", "uniques"],
+        )
+        if referrers:
+            ref_sheet.append_rows(
+                [
+                    [today_snapshot, r["referrer"], r["count"], r["uniques"]]
+                    for r in referrers
+                ],
+                value_input_option="USER_ENTERED",
+            )
+            print(f"  + {len(referrers)} referrer rows -> {base_tab}_Referrers")
+
+        # --- Popular paths (14-day snapshot) ---
+        paths = gh_get(
+            f"https://api.github.com/repos/{repo_path}/traffic/popular/paths", headers
+        )
+        path_sheet = ensure_tab(
+            spreadsheet,
+            f"{base_tab}_Paths",
+            ["snapshot_date", "title", "path", "views", "uniques"],
+        )
+        if paths:
+            path_sheet.append_rows(
+                [
+                    [today_snapshot, p["title"], p["path"], p["count"], p["uniques"]]
+                    for p in paths
+                ],
+                value_input_option="USER_ENTERED",
+            )
+            print(f"  + {len(paths)} path rows -> {base_tab}_Paths")
+
+    print("Total traffic sync complete!")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds `scripts/sync_github_traffic.py` — fetches views, clones, referrers, and popular paths for `tokentelemetry` and `tokentelemetry-hermes-plugin`, writes to the TokenTelemetry Traffic sheet.
- Adds `.github/workflows/sync-traffic.yml` — runs every Sunday at 23:00 UTC (plus manual `workflow_dispatch`). Weekly cadence stays within GitHub's 14-day traffic retention so no daily rows are lost.
- Auto-creates missing tabs with header rows; daily views/clones dedupe by date, referrers/paths append a fresh snapshot each run.

## Test plan
- [x] Local run populated all six tabs (14 daily rows + referrer/path snapshots per repo).
- [x] Workflow smoke-tested on `feat/traffic-sync` via a temporary `push:` trigger — green in 15s, dedupe + snapshot behavior confirmed.
- [ ] After merge, confirm next scheduled run fires Sunday 23:00 UTC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)