### PR TITLE
fix(update-check): reject cache entries with non-SHA `latest`

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -896,6 +896,13 @@ def _local_commit() -> Optional[str]:
     return None
 
 
+def _looks_like_sha(s: Any) -> bool:
+    """Real commit SHAs are 40 hex chars. Rejecting anything else guards
+    against bogus dev-seeded cache values lingering on disk (e.g. literal
+    "preview-local"), which would otherwise pin `behind=true` forever."""
+    return isinstance(s, str) and len(s) == 40 and all(c in "0123456789abcdef" for c in s.lower())
+
+
 def _read_cache() -> Optional[Dict[str, Any]]:
     if not _UPDATE_CACHE.exists():
         return None
@@ -903,6 +910,8 @@ def _read_cache() -> Optional[Dict[str, Any]]:
         with open(_UPDATE_CACHE, "r", encoding="utf-8") as f:
             cached = json.load(f)
         if not isinstance(cached, dict):
+            return None
+        if not _looks_like_sha(cached.get("latest")):
             return None
         age = _upd_time.time() - float(cached.get("fetched_at", 0))
         if age > _UPDATE_CACHE_TTL:


### PR DESCRIPTION
## Summary

Tiny hardening to the update-checker's cache. If \`~/.tokentelemetry/.update-check.json\` ever contains a \`latest\` value that isn't a real 40-hex-char commit SHA (e.g. a stale dev-seeded \"preview-local\" string from local testing), the banner gets stuck on \`behind=true\` forever — \`latest != current\` is always true when \`latest\` is a fake string.

\`_read_cache()\` in \`backend/main.py\` now sanity-checks that \`latest\` looks like a SHA via \`_looks_like_sha()\` and rejects the entry otherwise, forcing a fresh GitHub query.

Discovered while testing on a fresh clone — a previously seeded test cache was making the banner persist incorrectly.

## Test plan

- [ ] Write a bogus cache: \`echo '{\"latest\":\"preview-local\",\"releases\":[],\"release_url\":\"\",\"fetched_at\":9999999999}' > ~/.tokentelemetry/.update-check.json\`
- [ ] Hit \`GET /version\` — \`source\` should be \`github\` (not \`cache\`), \`latest\` should be the real main SHA, \`behind\` should be \`false\` when local matches main.
- [ ] Real cache (a fresh fetch) should be honored normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)