### PR TITLE
chore(claude): enforce UPDATE.json on feat: pushes via PreToolUse hook

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,86 @@
+# TokenTelemetry — Claude Code project rules
+
+## ⚠️ Pre-push policy (enforced by hook)
+
+**Every push to a branch destined for `main` that contains at least one
+`feat:` commit must update `UPDATE.json` at the repo root.**
+
+This is enforced by `.claude/hooks/enforce-update-json.py`, wired up via
+`.claude/settings.json` as a `PreToolUse` hook on the `Bash` tool. The hook:
+
+1. Detects `git push` / `gh pr create` invocations (via proper shell
+   tokenisation — not substring matching, so `echo "git push"` is fine).
+2. Skips enforcement if we're on `main` itself.
+3. Scans `git log origin/main..HEAD` for Conventional Commit subjects
+   matching `feat:` / `feat(scope):` / `feat!:` etc.
+4. If no `feat:` commits are present (only `fix:`, `chore:`, `docs:`,
+   `refactor:`, `style:`, `test:`, `ci:`) — **allows the push silently**,
+   because the change isn't user-facing in a way the banner should announce.
+5. If at least one `feat:` commit IS present, requires `UPDATE.json` to
+   appear in the branch's diff vs `origin/main`. Otherwise: deny.
+
+**Why this rule, not "block every push":** UPDATE.json is a CURATED feed.
+Forcing every fix/chore/docs push to add a fake entry would pollute it with
+noise users learn to ignore. The banner is only valuable when it announces
+something users actually want to know about — i.e., features.
+
+**Why this rule, not "trust the maintainer":** for actual `feat:` work it's
+easy to forget the file, and a stale banner is worse than no banner
+(eroded trust, users on prior versions miss the update prompt entirely).
+
+## UPDATE.json schema
+
+```json
+{
+  "releases": [
+    {
+      "tag": "YYYY-MM-DD",
+      "title": "Short release headline (≤50 chars)",
+      "highlights": [
+        {
+          "title": "One-line feature name",
+          "description": "1–2 sentences: what changed and why a user should care. No marketing fluff; concrete benefits.",
+          "href": "/settings"
+        },
+        {
+          "title": "Another feature",
+          "description": "..."
+        }
+      ]
+    },
+    {
+      "tag": "(prior releases stay below — drawer shows up to 6 newest)"
+    }
+  ],
+  "release_url": "https://github.com/VasiHemanth/tokentelemetry/commits/main"
+}
+```
+
+### Field rules
+- **`tag`**: ISO date (`YYYY-MM-DD`). Used as a fallback heading when `title` is absent.
+- **`title`**: short headline. Shows as the section heading in the drawer.
+- **`highlights`**: 1–5 bullets per release. Anything past 5 is truncated.
+- **`href`** (optional): internal route (`/settings`) renders as `<Link>` keeping nav in-app; external URL (`https://…`) opens a new tab.
+
+### Each release entry should
+- Go to the **top** of `releases[]` (newest first — drawer renders top-down)
+- Have a description that helps a non-technical user understand *why* this matters, not just *what* changed
+- Use an `href` when a single page is the natural landing spot for the change (e.g. a new feature page, a redesigned section)
+
+## When the hook gets in your way
+
+The hook is intentionally narrow. Cases:
+
+1. **Pure `fix:`/`chore:`/`docs:`/etc. branch**: hook allows silently. You don't need to touch UPDATE.json.
+2. **Mixed branch with one `feat:` + several `fix:` commits**: hook still requires UPDATE.json — write an entry for the feature, fixes get a free ride.
+3. **`feat:` branch where the feature genuinely isn't user-visible** (e.g. internal refactor mis-labeled `feat:`): re-label the commit to `refactor:` / `chore:` and amend, OR add a UPDATE.json note explaining what you shipped to users.
+4. **Pushing main itself** (rebase, force-push for cleanup): hook skips automatically.
+5. **Repo without `origin/main`**: hook allows through (assumes you know your setup).
+6. **Last resort**: `claude --no-hooks` for that session — but if you find yourself reaching for this often, the rule is mis-tuned and worth revisiting.
+
+## Other project conventions
+
+- **Schedules page is read-only.** The CRUD UI was built but is commented out under `# DISABLED-MUTATIONS:` markers in `backend/main.py`. Re-enable by uncommenting; don't reimplement.
+- **Backend default port: 8000** (matches `bin/cli.js`). If you start uvicorn elsewhere, frontend's `NEXT_PUBLIC_API_BASE` must follow.
+- **`UPDATE.json` is committed.** It's not generated, not gitignored. Treat it as source code.
+- **Test pollution: clear `~/.tokentelemetry/.update-check.json`** if you manually seed it for testing; the SHA validator added in PR #34 catches obvious garbage but doesn't catch all dev mistakes.

--- a/.claude/hooks/enforce-update-json.py
+++ b/.claude/hooks/enforce-update-json.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: block `git push` / `gh pr create` from a non-main branch
+when UPDATE.json hasn't been touched in the branch's diff vs origin/main.
+
+Why: every push that lands in main should refresh the dashboard's "what's
+new" banner. Without this guard, banners go stale and users on prior
+versions see "update available" with no real highlights.
+
+Reads the tool invocation as JSON on stdin (Claude Code's hook contract).
+Exits 0 always — block decisions are communicated via the JSON payload to
+stdout, not via exit code.
+
+Uses real command-tokenisation (shlex) instead of substring grep so it
+doesn't trip on commands like `echo "git push"` or `grep "git push" file`.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+from typing import List, Optional
+
+
+BLOCK_PAYLOAD = {
+    "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": (
+            "UPDATE.json wasn't modified on this branch — the in-app update "
+            "banner won't have fresh highlights. Add or update an entry in "
+            "UPDATE.json (see .claude/CLAUDE.md for the schema) before pushing. "
+            "To bypass (e.g. docs-only change), re-run with `--no-hooks`."
+        ),
+    }
+}
+
+
+def _allow() -> None:
+    """Allow the tool call. Hook contract: silent + exit 0."""
+    sys.exit(0)
+
+
+def _deny() -> None:
+    """Deny the tool call. Hook contract: structured JSON on stdout + exit 0."""
+    print(json.dumps(BLOCK_PAYLOAD))
+    sys.exit(0)
+
+
+def _is_push_subcommand(tokens: List[str]) -> bool:
+    """Given a single command's tokens, return True iff it's `git push ...`
+    or `gh pr create ...`. Handles common prefixes: env var assignments, `env`,
+    `cd <dir> && ...`, and git's global options (`-C`, `--git-dir`)."""
+    i = 0
+    # Skip leading env assignments (FOO=bar BAR=baz cmd …)
+    while i < len(tokens) and re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", tokens[i]):
+        i += 1
+    if i >= len(tokens):
+        return False
+
+    head = tokens[i]
+
+    if head == "git":
+        # Walk past git's global options to find the subcommand
+        j = i + 1
+        while j < len(tokens):
+            tok = tokens[j]
+            if tok in ("-C", "--git-dir", "--work-tree", "--namespace"):
+                j += 2  # takes an argument
+            elif tok.startswith("--git-dir=") or tok.startswith("--work-tree=") or tok.startswith("--namespace="):
+                j += 1
+            elif tok.startswith("-"):
+                j += 1  # other flags
+            else:
+                break
+        return j < len(tokens) and tokens[j] == "push"
+
+    if head == "gh":
+        # `gh pr create [...]` (no globals worth handling here)
+        return len(tokens) >= i + 3 and tokens[i + 1] == "pr" and tokens[i + 2] == "create"
+
+    return False
+
+
+def _command_contains_push(command_str: str) -> bool:
+    """Split on shell chain operators (`&&`, `||`, `;`, `|`) and check if any
+    resulting command-fragment is a push/PR-create. Anything inside literal
+    strings, comments, or grep patterns is correctly ignored by shlex."""
+    # First, get a sane tokenisation; if shlex fails (bad quoting in the
+    # caller's command), be permissive and don't block.
+    try:
+        shlex.split(command_str)
+    except ValueError:
+        return False
+
+    # Walk through chain operators by splitting on them at the source-text
+    # level. shlex strips quoting before we can see operator context, so we
+    # need to find the operator positions ourselves while respecting quotes.
+    fragments = _split_on_chain_operators(command_str)
+    for frag in fragments:
+        frag = frag.strip()
+        if not frag:
+            continue
+        try:
+            tokens = shlex.split(frag)
+        except ValueError:
+            continue
+        if _is_push_subcommand(tokens):
+            return True
+    return False
+
+
+def _split_on_chain_operators(s: str) -> List[str]:
+    """Split a shell command line on `;`, `&&`, `||`, `|`, respecting quotes.
+    Returns the list of sub-commands."""
+    fragments: List[str] = []
+    buf: List[str] = []
+    i = 0
+    n = len(s)
+    quote: Optional[str] = None
+    while i < n:
+        c = s[i]
+        if quote:
+            buf.append(c)
+            if c == quote:
+                quote = None
+            elif c == "\\" and i + 1 < n:
+                # consume escaped char inside double-quote / etc.
+                buf.append(s[i + 1])
+                i += 1
+            i += 1
+            continue
+        if c in ("'", '"'):
+            quote = c
+            buf.append(c)
+            i += 1
+            continue
+        # Operators outside quotes
+        if c == ";":
+            fragments.append("".join(buf))
+            buf = []
+            i += 1
+            continue
+        if c == "|" and i + 1 < n and s[i + 1] == "|":
+            fragments.append("".join(buf))
+            buf = []
+            i += 2
+            continue
+        if c == "&" and i + 1 < n and s[i + 1] == "&":
+            fragments.append("".join(buf))
+            buf = []
+            i += 2
+            continue
+        if c == "|":  # plain pipe
+            fragments.append("".join(buf))
+            buf = []
+            i += 1
+            continue
+        buf.append(c)
+        i += 1
+    if buf:
+        fragments.append("".join(buf))
+    return fragments
+
+
+def _git(*args: str, cwd: Optional[str] = None, timeout: int = 10) -> Optional[str]:
+    try:
+        out = subprocess.check_output(
+            ["git", *args],
+            stderr=subprocess.DEVNULL,
+            cwd=cwd,
+            timeout=timeout,
+        )
+        return out.decode("utf-8", errors="replace").strip()
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+
+
+def main() -> None:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        _allow()
+        return
+
+    command = (payload.get("tool_input") or {}).get("command") or ""
+    if not command:
+        _allow()
+        return
+
+    if not _command_contains_push(command):
+        _allow()
+        return
+
+    # It IS a push / PR-create. Now check the branch state.
+    repo_root = _git("rev-parse", "--show-toplevel")
+    if not repo_root:
+        _allow()
+        return
+
+    branch = _git("rev-parse", "--abbrev-ref", "HEAD", cwd=repo_root)
+    if branch in (None, "main", "master", "HEAD"):
+        _allow()
+        return
+
+    # Best-effort refresh of origin/main; tolerate offline / unauth.
+    subprocess.run(
+        ["git", "fetch", "origin", "main", "--quiet"],
+        cwd=repo_root,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        timeout=15,
+    )
+
+    # Pick a base ref to diff against.
+    base_ref: Optional[str] = None
+    for candidate in ("origin/main", "main"):
+        if subprocess.run(
+            ["git", "rev-parse", "--verify", candidate],
+            cwd=repo_root,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        ).returncode == 0:
+            base_ref = candidate
+            break
+    if not base_ref:
+        # No anchor — don't block; user knows their setup.
+        _allow()
+        return
+
+    # Only enforce when this branch contains at least one `feat:` commit
+    # vs main. Pushes that are purely fix:/chore:/docs:/refactor:/etc.
+    # don't need a UPDATE.json entry — they aren't user-facing features.
+    # Conventional Commits prefix scheme; matches with or without scope and
+    # the `!` breaking-change marker.
+    log = _git("log", f"{base_ref}..HEAD", "--pretty=format:%s", cwd=repo_root) or ""
+    feat_re = re.compile(r"^(feat|feature)(\([^)]+\))?!?:", re.IGNORECASE | re.MULTILINE)
+    if not feat_re.search(log):
+        _allow()
+        return
+
+    changed = _git("diff", "--name-only", f"{base_ref}...HEAD", cwd=repo_root) or ""
+    if "UPDATE.json" in changed.splitlines():
+        _allow()
+        return
+
+    _deny()
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "$comment": "Project-level Claude Code settings. Committed to the repo so every contributor's Claude inherits these rules. User-specific overrides go in .claude/settings.local.json (not committed).",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/enforce-update-json.py"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds a project-level Claude Code hook that blocks `git push` / `gh pr create` if the branch contains at least one `feat:` commit but doesn't touch `UPDATE.json`. Non-feature branches (`fix:`/`chore:`/`docs:`/etc.) push through silently — `UPDATE.json` is a curated user-facing feed, not a per-commit log.

- **`.claude/hooks/enforce-update-json.py`** — PreToolUse hook script. Uses `shlex` to tokenise the Bash command instead of substring-matching, so `echo "git push"` or `grep "push" file` don't falsely trigger. Walks shell chain operators (`&&`, `||`, `;`, `|`) so `make build && git push` is correctly caught. Detects `feat:` / `feat(scope):` / `feat!:` via Conventional Commits regex on `git log origin/main..HEAD`.
- **`.claude/settings.json`** — wires the hook as a `PreToolUse` matcher on the `Bash` tool. Committed to the repo so every contributor's Claude inherits.
- **`.claude/CLAUDE.md`** — policy doc with the rule, the UPDATE.json schema, bypass paths (`--no-hooks` for the rare legitimate case, commit re-labeling for mis-categorized changes), and other project conventions (read-only schedules page, port defaults).

## Test plan

- [ ] `chore:`/`fix:` branch with no UPDATE.json change → push allowed.
- [ ] Branch containing a `feat:` commit, UPDATE.json untouched → push denied with a clear message pointing at `.claude/CLAUDE.md`.
- [ ] Same branch after editing UPDATE.json → push allowed.
- [ ] `echo "git push foo"` (literal string) → not blocked (proper tokenisation).
- [ ] On `main` itself → hook skips, no enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)