### PR TITLE
Grok Build (xAI) support + Copilot & back-nav fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Token Telemetry (TokenTelemetry)
 
-> **Local observability for AI coding agents AND autonomous agents — Claude Code, Codex, Gemini CLI, Cursor, Copilot, Qwen, OpenCode, Vibe, Antigravity, _and_ Nous Research's Hermes Agent.**
+> **Local observability for AI coding agents AND autonomous agents — Claude Code, Codex, Gemini CLI, Cursor, Copilot, Qwen, OpenCode, Vibe, Antigravity, Grok Build, _and_ Nous Research's Hermes Agent.**
 
 **Token Telemetry** (one word: **TokenTelemetry**) — free, open-source, 100% local.
 
@@ -54,6 +54,7 @@ TokenTelemetry reads session logs from these agents automatically.
 | **Qwen**                    | ✅ Fully supported |
 | **Vibe**                    | ✅ Fully supported |
 | **Antigravity**             | ✅ Fully supported |
+| **Grok Build** (xAI)        | ✅ Fully supported |
 
 ### Autonomous agents
 

--- a/UPDATE.json
+++ b/UPDATE.json
@@ -1,6 +1,26 @@
 {
   "releases": [
     {
+      "tag": "2026-06-02",
+      "title": "Grok Build support + tracking fixes",
+      "highlights": [
+        {
+          "title": "Grok Build (xAI) support",
+          "description": "TokenTelemetry now tracks xAI's Grok Build coding agent — sessions, context usage, tool calls, permission decisions, and plan mode — with a dedicated forensics card. That's 11 agents tracked in total.",
+          "href": "/"
+        },
+        {
+          "title": "GitHub Copilot tracking restored",
+          "description": "Recent VS Code versions changed how Copilot chats are stored on disk, which made new sessions read as zero. TokenTelemetry now reads the new format, so your recent Copilot sessions show up again.",
+          "href": "/"
+        },
+        {
+          "title": "Smarter 'Back' from a session",
+          "description": "Opening a session and hitting Back now returns you to the page you came from — e.g. the project you were viewing — instead of always jumping to the dashboard."
+        }
+      ]
+    },
+    {
       "tag": "2026-05-28",
       "title": "Summarizer + ports + update banner",
       "highlights": [

--- a/backend/main.py
+++ b/backend/main.py
@@ -112,6 +112,19 @@ HERMES_DIR = Path(os.environ.get("HERMES_HOME") or (HOME / ".hermes")).expanduse
 HERMES_DB = HERMES_DIR / "state.db"
 HERMES_PROFILES_DIR = HERMES_DIR / "profiles"
 
+# Grok Build (xAI) — the TUI/agent this conversation is running in.
+# Stores rich per-session data under ~/.grok/sessions/<encoded-cwd>/<uuid>/
+GROK_DIR = HOME / ".grok"
+GROK_SESSIONS_DIR = GROK_DIR / "sessions"
+
+# Grok Build session file names (per <cwd-uuid> directory)
+GROK_SUMMARY = "summary.json"
+GROK_EVENTS = "events.jsonl"
+GROK_UPDATES = "updates.jsonl"
+GROK_CHAT_HISTORY = "chat_history.jsonl"
+GROK_PLAN_MODE = "plan_mode.json"
+GROK_SIGNALS = "signals.json"
+
 # Specialized storage paths
 VSCODE_STORAGE = VSCODE_BASE / "User/workspaceStorage"
 CURSOR_STORAGE = CURSOR_BASE / "User/workspaceStorage"
@@ -472,6 +485,129 @@ async def hermes_tools():
         except Exception:
             pass
     return {"enabled_tools": enabled_tools}
+
+
+@app.get("/sessions/{session_id}/grok-forensics")
+async def grok_session_forensics(session_id: str):
+    """Rich forensics payload for a Grok Build session (phases, permissions, tool lifecycle, token progression)."""
+    sess_dir = None
+    for bucket in GROK_SESSIONS_DIR.glob("*"):
+        candidate = bucket / session_id
+        if candidate.is_dir():
+            sess_dir = candidate
+            break
+    if not sess_dir:
+        return {"error": "Not found"}
+
+    summary = {}
+    try:
+        with open(sess_dir / GROK_SUMMARY, "r", encoding="utf-8") as f:
+            summary = json.load(f)
+    except Exception:
+        pass
+
+    # Extract high-signal events
+    tool_events = []
+    permission_events = []
+    phase_events = []
+    token_progression = []
+
+    events_path = sess_dir / GROK_EVENTS
+    if events_path.exists():
+        try:
+            with open(events_path, "r", encoding="utf-8", errors="ignore") as f:
+                for line in f:
+                    try:
+                        ev = json.loads(line)
+                        t = ev.get("type")
+                        if t in ("tool_started", "tool_completed"):
+                            tool_events.append(ev)
+                        elif t in ("permission_requested", "permission_resolved"):
+                            permission_events.append(ev)
+                        elif t == "phase_changed":
+                            phase_events.append(ev)
+                    except Exception:
+                        continue
+        except Exception:
+            pass
+
+    updates_path = sess_dir / GROK_UPDATES
+    if updates_path.exists():
+        try:
+            with open(updates_path, "r", encoding="utf-8", errors="ignore") as f:
+                for line in f:
+                    if "totalTokens" in line:
+                        try:
+                            u = json.loads(line)
+                            meta = (u.get("params") or {}).get("_meta") or {}
+                            if "totalTokens" in meta:
+                                token_progression.append({
+                                    "ts": u.get("timestamp"),
+                                    "totalTokens": meta["totalTokens"],
+                                    "updateType": meta.get("updateType"),
+                                })
+                        except Exception:
+                            continue
+        except Exception:
+            pass
+
+    plan = {}
+    try:
+        with open(sess_dir / GROK_PLAN_MODE, "r", encoding="utf-8") as f:
+            plan = json.load(f)
+    except Exception:
+        pass
+
+    # signals.json — Grok's rich accurate metrics. Mapped to a fixed snake_case
+    # shape the frontend reads; {} when the file is missing entirely.
+    signals_block: Dict[str, Any] = {}
+    raw_signals: Dict[str, Any] = {}
+    signals_path = sess_dir / GROK_SIGNALS
+    if signals_path.exists():
+        try:
+            with open(signals_path, "r", encoding="utf-8") as f:
+                raw_signals = json.load(f) or {}
+        except Exception:
+            raw_signals = {}
+        signals_block = {
+            "context_tokens_used": raw_signals.get("contextTokensUsed", 0),
+            "context_window_tokens": raw_signals.get("contextWindowTokens", 0),
+            "context_window_usage_pct": raw_signals.get("contextWindowUsage", 0),
+            "tool_call_count": raw_signals.get("toolCallCount", 0),
+            "tools_used": raw_signals.get("toolsUsed", []) or [],
+            "models_used": raw_signals.get("modelsUsed", []) or [],
+            "session_duration_seconds": raw_signals.get("sessionDurationSeconds", 0),
+            "turn_count": raw_signals.get("turnCount", 0),
+            "user_message_count": raw_signals.get("userMessageCount", 0),
+            "assistant_message_count": raw_signals.get("assistantMessageCount", 0),
+            "error_count": raw_signals.get("errorCount", 0),
+            "tool_failure_count": raw_signals.get("toolFailureCount", 0),
+            "cancellation_count": raw_signals.get("cancellationCount", 0),
+            "compaction_count": raw_signals.get("compactionCount", 0),
+            "doom_loop_detections": raw_signals.get("doomLoopDetections", 0),
+            "agent_lines_added": raw_signals.get("agentLinesAdded", 0),
+            "agent_lines_removed": raw_signals.get("agentLinesRemoved", 0),
+            "agent_files_touched": raw_signals.get("agentFilesTouched", 0),
+            "avg_time_to_first_token_ms": raw_signals.get("avgTimeToFirstTokenMs", None),
+            "avg_response_time_ms": raw_signals.get("avgResponseTimeMs", None),
+        }
+
+    return {
+        "session_id": session_id,
+        "summary": summary,
+        "plan_mode": plan,
+        "signals": signals_block,
+        "tool_events": tool_events[-100:],          # cap for UI
+        "permission_events": permission_events[-50:],
+        "phase_events": phase_events[-30:],
+        "token_progression": token_progression[-100:],
+        "counts": {
+            "tools": len(tool_events),
+            "permissions": len(permission_events),
+            "phases": len(phase_events),
+            "token_samples": len(token_progression),
+        }
+    }
 
 
 @app.get("/sessions/{session_id}/hermes-overlay")
@@ -1058,6 +1194,7 @@ async def get_available_agents():
     if VSCODE_STORAGE.exists(): agents.append("copilot")
     if OPENCODE_DB.exists(): agents.append("opencode")
     if _hermes_dbs(): agents.append("hermes")
+    if GROK_SESSIONS_DIR.exists(): agents.append("grok")
     # if OLLAMA_DIR.exists(): agents.append("ollama")
     return agents
 
@@ -1078,6 +1215,260 @@ async def get_available_agents():
 #             status["hf_usage"] = f"{total_size / (1024**3):.1f}GB"
 #         except: pass
 #     return status
+
+
+def _scan_grok_sessions() -> List[Dict[str, Any]]:
+    """Scan Grok Build sessions under ~/.grok/sessions/.
+
+    Produces the standard TokenTelemetry session record with rich Grok-specific forensics.
+    """
+    if not GROK_SESSIONS_DIR.exists():
+        return []
+
+    # Load aliases locally so this top-level function doesn't depend on closures inside _scan_sessions_sync
+    aliases = _load_project_aliases()
+    def _apply_alias(p: str) -> str:
+        return aliases.get(p, p)
+
+    out: List[Dict[str, Any]] = []
+
+    for proj_bucket in GROK_SESSIONS_DIR.iterdir():
+        if not proj_bucket.is_dir():
+            continue
+
+        try:
+            from urllib.parse import unquote
+            cwd = unquote(proj_bucket.name)
+        except Exception:
+            cwd = proj_bucket.name
+
+        for sess_id_dir in proj_bucket.iterdir():
+            if not sess_id_dir.is_dir():
+                continue
+            sid = sess_id_dir.name
+
+            summary_path = sess_id_dir / GROK_SUMMARY
+            if not summary_path.exists():
+                continue
+
+            try:
+                with open(summary_path, "r", encoding="utf-8") as f:
+                    summary = json.load(f)
+            except Exception:
+                continue
+
+            info = summary.get("info", {}) or {}
+            project_path = _apply_alias(info.get("cwd") or cwd or "unknown")
+
+            created = summary.get("created_at")
+            updated = summary.get("updated_at") or created
+            try:
+                ts = datetime.fromisoformat((updated or created).replace("Z", "+00:00"))
+            except Exception:
+                ts = _file_mtime_utc(summary_path)
+
+            title = summary.get("generated_title") or summary.get("session_summary") or f"Grok session {sid[:8]}"
+            display = title[:120]
+            model = summary.get("current_model_id") or "grok-build"
+
+            # Load signals.json — Grok's rich, accurate per-session metrics file.
+            signals: Dict[str, Any] = {}
+            signals_path = sess_id_dir / GROK_SIGNALS
+            if signals_path.exists():
+                try:
+                    with open(signals_path, "r", encoding="utf-8") as f:
+                        signals = json.load(f) or {}
+                except Exception:
+                    signals = {}
+
+            # Token forensics. Grok exposes no prompt/completion split anywhere, so we
+            # use signals.contextTokensUsed (the measured context footprint) when present,
+            # falling back to the max cumulative totalTokens scanned from updates.jsonl.
+            tokens = {"input": 0, "output": 0, "cached": 0, "total": 0}
+            ctx_used = signals.get("contextTokensUsed")
+            if isinstance(ctx_used, (int, float)) and ctx_used > 0:
+                total = int(ctx_used)
+            else:
+                # Fallback only when signals lacks a usable figure: scan the (large)
+                # updates.jsonl for the max cumulative totalTokens. Skipped entirely
+                # in the common case so the list scan stays cheap.
+                max_total = 0
+                updates_path = sess_id_dir / GROK_UPDATES
+                if updates_path.exists():
+                    try:
+                        with open(updates_path, "r", encoding="utf-8", errors="ignore") as f:
+                            for line in f:
+                                if "totalTokens" not in line:
+                                    continue
+                                try:
+                                    u = json.loads(line)
+                                    meta = (u.get("params") or {}).get("_meta") or {}
+                                    val = meta.get("totalTokens")
+                                    if isinstance(val, (int, float)) and val > max_total:
+                                        max_total = int(val)
+                                except Exception:
+                                    continue
+                    except Exception:
+                        pass
+                total = max_total
+
+            # Grok exposes no prompt/completion split; the agentic context is overwhelmingly
+            # fed-in tool/file content, so we attribute the measured context footprint to input
+            # rather than fabricating a 50/50 guess. Cost is therefore a lower-bound estimate.
+            tokens["total"] = total
+            tokens["input"] = total
+            tokens["output"] = 0
+            tokens["cached"] = 0
+
+            tokens["cost"] = calculate_cost(model, tokens.get("input", 0), tokens.get("output", 0), tokens.get("cached", 0))
+
+            # Prefer signals.modelsUsed for the model when available.
+            models_used = signals.get("modelsUsed")
+            if isinstance(models_used, list) and models_used:
+                model = summary.get("current_model_id") or models_used[0] or model
+
+            # Tool names — prefer signals.toolsUsed (accurate, deduped) and avoid the
+            # redundant full events.jsonl scan when it's available.
+            mcp_tools: List[str] = []
+            tools_used = signals.get("toolsUsed")
+            if isinstance(tools_used, list) and tools_used:
+                mcp_tools = [t for t in tools_used if t]
+            else:
+                events_path = sess_id_dir / GROK_EVENTS
+                if events_path.exists():
+                    try:
+                        with open(events_path, "r", encoding="utf-8", errors="ignore") as f:
+                            for line in f:
+                                try:
+                                    ev = json.loads(line)
+                                except Exception:
+                                    continue
+                                t = ev.get("type")
+                                if t in ("tool_started", "tool_completed"):
+                                    name = ev.get("tool_name")
+                                    if name and name not in mcp_tools:
+                                        mcp_tools.append(name)
+                    except Exception:
+                        pass
+
+            # Plan mode
+            has_plan = False
+            plans: List[Dict[str, Any]] = []
+            plan_path = sess_id_dir / GROK_PLAN_MODE
+            if plan_path.exists():
+                try:
+                    with open(plan_path, "r", encoding="utf-8") as f:
+                        pm = json.load(f)
+                    if pm.get("state") == "Active" or pm.get("was_previously_active"):
+                        has_plan = True
+                        plans.append({
+                            "session_id": sid,
+                            "agent": "grok",
+                            "timestamp": ts,
+                            "content": f"Plan mode was active (state={pm.get('state')})"
+                        })
+                except Exception:
+                    pass
+
+            artifacts: List[Dict[str, Any]] = []
+            if plan_path.exists():
+                artifacts.append({"name": "plan_mode.json", "path": str(plan_path), "type": "document"})
+            artifacts.append({"name": "summary.json", "path": str(summary_path), "type": "document"})
+
+            git_info = {
+                "root": summary.get("git_root_dir"),
+                "branch": summary.get("head_branch"),
+                "commit": summary.get("head_commit"),
+            }
+
+            sess = {
+                "id": sid,
+                "agent": "grok",
+                "project": project_path,
+                "timestamp": ts,
+                "display": display,
+                "text": summary.get("session_summary"),
+                "tokens": tokens,
+                "mcp_tools": mcp_tools,
+                "has_plan": has_plan,
+                "plans": plans,
+                "model": model,
+                "artifacts": artifacts,
+                "cost": tokens.get("cost", 0.0),
+                "grok": {
+                    "cwd": info.get("cwd"),
+                    "git": git_info,
+                    "num_messages": summary.get("num_messages"),
+                    "num_chat_messages": summary.get("num_chat_messages"),
+                    "agent_name": summary.get("agent_name"),
+                    "last_active_at": summary.get("last_active_at"),
+                },
+            }
+            out.append(sess)
+
+    return out
+
+
+def _reconstruct_vscode_chat_jsonl(path) -> Dict[str, Any]:
+    """Reconstruct a Copilot chat session object from VS Code's newer .jsonl
+    delta-log format (VS Code ~1.100+ writes <id>.jsonl instead of <id>.json).
+
+    The file is an append-only event log, not a single JSON object:
+      - kind 0: full session snapshot (base state); v is the session dict.
+      - kind 1: SET the value at key-path k (e.g. ["customTitle"]).
+      - kind 2: APPEND/extend the array at key-path k (e.g. ["requests"]).
+    Replaying these yields a dict shaped like the legacy single-object .json,
+    so the existing per-request extraction below works unchanged.
+    """
+    data: Dict[str, Any] = {}
+
+    def _navigate(root, keys):
+        cur = root
+        for key in keys:
+            if isinstance(cur, dict):
+                cur = cur.get(key)
+            elif isinstance(cur, list) and isinstance(key, int) and 0 <= key < len(cur):
+                cur = cur[key]
+            else:
+                return None
+        return cur
+
+    with open(path, "r", encoding="utf-8", errors="replace") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                ev = json.loads(line)
+            except Exception:
+                continue
+            kind = ev.get("kind")
+            k = ev.get("k")
+            v = ev.get("v")
+            if kind == 0:
+                if isinstance(v, dict):
+                    data = v
+                continue
+            if kind not in (1, 2) or not isinstance(k, list) or not k:
+                continue
+            parent = _navigate(data, k[:-1]) if len(k) > 1 else data
+            leaf = k[-1]
+            if isinstance(parent, dict):
+                if kind == 1:
+                    parent[leaf] = v
+                else:  # append/extend the array at leaf
+                    arr = parent.get(leaf)
+                    if not isinstance(arr, list):
+                        arr = []
+                        parent[leaf] = arr
+                    arr.extend(v) if isinstance(v, list) else arr.append(v)
+            elif isinstance(parent, list) and isinstance(leaf, int):
+                if kind == 1 and 0 <= leaf < len(parent):
+                    parent[leaf] = v
+                elif kind == 2 and 0 <= leaf < len(parent) and isinstance(parent[leaf], list):
+                    parent[leaf].extend(v) if isinstance(v, list) else parent[leaf].append(v)
+    return data
+
 
 def _scan_sessions_sync():
     sessions = []
@@ -1733,38 +2124,49 @@ def _scan_sessions_sync():
                     with open(workspace_json, "r") as f:
                         wj = json.load(f); folder_url = wj.get("folder")
                         if folder_url: project_path = unquote(folder_url.replace("file://", ""))
-                for cf in ws_folder.glob("*.json"):
+                # VS Code ~1.100+ switched session files from <id>.json (single
+                # object) to <id>.jsonl (append-only delta log). Scan both so
+                # sessions created after that cutover aren't silently dropped.
+                session_files = list(ws_folder.glob("*.json")) + list(ws_folder.glob("*.jsonl"))
+                for cf in session_files:
                     try:
-                        with open(cf, "r", encoding="utf-8", errors="replace") as f:
-                            data = json.load(f); sid = cf.stem; tokens = {"input": 0, "output": 0, "cached": 0, "total": 0}
-                            first_msg = ""; plans = []; model = None
-                            
-                            # Fallback to creation date if no requests
-                            creation_ts = data.get("creationDate") or data.get("timestamp")
-                            last_ts = datetime.fromtimestamp(creation_ts / 1000, tz=timezone.utc) if isinstance(creation_ts, (int, float)) else _file_mtime_utc(cf)
-                            
-                            for req in data.get("requests", []):
-                                msg_text = req.get("message", {}).get("text", "") or ""
-                                if not first_msg: first_msg = msg_text
-                                if req.get("modelId") and not model:
-                                    model = req.get("modelId").split("/")[-1]
-                                if req.get("timestamp"):
-                                    ts_val = req.get("timestamp")
-                                    if isinstance(ts_val, (int, float)):
-                                        req_ts = datetime.fromtimestamp(ts_val / 1000, tz=timezone.utc)
-                                        if req_ts > last_ts: last_ts = req_ts
-                                # Copilot doesn't record input tokens; estimate from prompt chars (~4 chars/token).
-                                tokens["input"] += len(msg_text) // 4
-                                if "thinking" in req:
-                                    tokens["output"] += req["thinking"].get("tokens", 0) or 0
-                                    t_text = req["thinking"].get("text", "")
-                                    if "plan" in t_text.lower() and len(t_text) > 100:
-                                        plans.append({"session_id": sid, "agent": "copilot", "timestamp": last_ts, "content": t_text})
-                                if "response" in req:
-                                    for part in req["response"]: tokens["output"] += part.get("tokens", 0) or 0
-                            tokens["total"] = tokens["input"] + tokens["output"] + tokens["cached"]
-                            tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"])
-                            sessions.append({"id": sid, "agent": "copilot", "project": project_path, "timestamp": last_ts, "display": first_msg[:100], "tokens": tokens, "mcp_tools": [], "has_plan": len(plans) > 0, "plans": plans, "model": model, "artifacts": [], "cost": tokens["cost"]})
+                        if cf.suffix == ".jsonl":
+                            data = _reconstruct_vscode_chat_jsonl(cf)
+                        else:
+                            with open(cf, "r", encoding="utf-8", errors="replace") as f:
+                                data = json.load(f)
+                        sid = cf.stem; tokens = {"input": 0, "output": 0, "cached": 0, "total": 0}
+                        first_msg = ""; plans = []; model = None
+
+                        # Fallback to creation date if no requests
+                        creation_ts = data.get("creationDate") or data.get("timestamp")
+                        last_ts = datetime.fromtimestamp(creation_ts / 1000, tz=timezone.utc) if isinstance(creation_ts, (int, float)) else _file_mtime_utc(cf)
+
+                        for req in data.get("requests", []):
+                            msg_text = req.get("message", {}).get("text", "") or ""
+                            if not first_msg: first_msg = msg_text
+                            if req.get("modelId") and not model:
+                                model = req.get("modelId").split("/")[-1]
+                            if req.get("timestamp"):
+                                ts_val = req.get("timestamp")
+                                if isinstance(ts_val, (int, float)):
+                                    req_ts = datetime.fromtimestamp(ts_val / 1000, tz=timezone.utc)
+                                    if req_ts > last_ts: last_ts = req_ts
+                            # Copilot doesn't record input tokens; estimate from prompt chars (~4 chars/token).
+                            tokens["input"] += len(msg_text) // 4
+                            if "thinking" in req:
+                                tokens["output"] += req["thinking"].get("tokens", 0) or 0
+                                t_text = req["thinking"].get("text", "")
+                                if "plan" in t_text.lower() and len(t_text) > 100:
+                                    plans.append({"session_id": sid, "agent": "copilot", "timestamp": last_ts, "content": t_text})
+                            # New .jsonl schema records completionTokens per request directly.
+                            if isinstance(req.get("completionTokens"), (int, float)):
+                                tokens["output"] += int(req["completionTokens"])
+                            elif "response" in req:
+                                for part in req["response"]: tokens["output"] += part.get("tokens", 0) or 0
+                        tokens["total"] = tokens["input"] + tokens["output"] + tokens["cached"]
+                        tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"])
+                        sessions.append({"id": sid, "agent": "copilot", "project": project_path, "timestamp": last_ts, "display": first_msg[:100], "tokens": tokens, "mcp_tools": [], "has_plan": len(plans) > 0, "plans": plans, "model": model, "artifacts": [], "cost": tokens["cost"]})
                     except Exception: continue
             except Exception: continue
 
@@ -1840,6 +2242,9 @@ def _scan_sessions_sync():
                 conn.close()
         except Exception:
             pass
+
+    # 8. Grok Build (xAI) — rich per-session directory with events, updates, chat history
+    sessions.extend(_scan_grok_sessions())
 
     # 9. Hermes Agent (SQLite: sessions / messages, pre-aggregated tokens)
     hermes_cwd_map = _hermes_cwd_by_session() if _hermes_dbs() else {}
@@ -2072,6 +2477,116 @@ async def get_session_detail(session_id: str, agent: str):
                     events.append(data)
                 except Exception: continue
         return events
+    elif agent == "grok":
+        # Grok Build dialogue. chat_history.jsonl is the canonical conversation in
+        # FILE ORDER and carries NO per-message timestamps, so we normalize each
+        # entry into Claude-shaped message events (the mature EventCard path already
+        # pairs assistant tool_use with the following user tool_result) and assign
+        # synthetic, order-preserving timestamps. Lifecycle events from events.jsonl
+        # are NOT merged here — they can't be aligned to the dialogue and are surfaced
+        # in the grok-forensics card instead.
+        sess_dir = None
+        for bucket in GROK_SESSIONS_DIR.glob("*"):
+            candidate = bucket / session_id
+            if candidate.is_dir() and (candidate / GROK_SUMMARY).exists():
+                sess_dir = candidate
+                break
+        if not sess_dir:
+            return {"error": "Not found"}
+
+        # Synthetic timeline base: summary.created_at -> epoch-ms, else dir mtime.
+        base_ms = None
+        summary = {}
+        try:
+            with open(sess_dir / GROK_SUMMARY, "r", encoding="utf-8") as f:
+                summary = json.load(f)
+        except Exception:
+            summary = {}
+        created = summary.get("created_at")
+        if created:
+            try:
+                base_ms = _aware(datetime.fromisoformat(str(created).replace("Z", "+00:00"))).timestamp() * 1000
+            except Exception:
+                base_ms = None
+        if base_ms is None:
+            base_ms = _file_mtime_utc(sess_dir).timestamp() * 1000
+
+        events: List[Dict[str, Any]] = []
+        seq = 0
+        chat_path = sess_dir / GROK_CHAT_HISTORY
+        if chat_path.exists():
+            try:
+                with open(chat_path, "r", encoding="utf-8", errors="ignore") as f:
+                    for line in f:
+                        try:
+                            entry = json.loads(line)
+                        except Exception:
+                            continue
+                        etype = entry.get("type")
+                        norm = None  # set when we emit an event
+
+                        if etype == "user":
+                            parts = entry.get("content") or []
+                            text = "".join(
+                                p.get("text", "") for p in parts
+                                if isinstance(p, dict) and p.get("type") == "text"
+                            )
+                            norm = {"type": "user", "message": {"role": "user", "content": [{"type": "text", "text": text}]}}
+
+                        elif etype == "assistant":
+                            content_blocks: List[Dict[str, Any]] = []
+                            text = entry.get("content") or ""
+                            if isinstance(text, str) and text.strip():
+                                content_blocks.append({"type": "text", "text": text})
+                            for tc in (entry.get("tool_calls") or []):
+                                if not isinstance(tc, dict):
+                                    continue
+                                try:
+                                    args = json.loads(tc.get("arguments") or "{}")
+                                except Exception:
+                                    args = {}
+                                if not isinstance(args, dict):
+                                    args = {}
+                                content_blocks.append({
+                                    "type": "tool_use",
+                                    "id": tc.get("id"),
+                                    "name": tc.get("name"),
+                                    "input": args,
+                                })
+                            if content_blocks:
+                                norm = {"type": "assistant", "message": {"role": "assistant", "content": content_blocks}}
+
+                        elif etype == "reasoning":
+                            summ = entry.get("summary") or []
+                            thinking = "".join(
+                                s.get("text", "") for s in summ
+                                if isinstance(s, dict) and s.get("type") == "summary_text"
+                            )
+                            if thinking.strip():
+                                norm = {"type": "assistant", "message": {"role": "assistant", "content": [{"type": "thinking", "thinking": thinking}]}}
+
+                        elif etype == "tool_result":
+                            norm = {"type": "user", "message": {"role": "user", "content": [{
+                                "type": "tool_result",
+                                "tool_use_id": entry.get("tool_call_id"),
+                                "content": entry.get("content") or "",
+                            }]}}
+
+                        # system / backend_tool_call and any empty entries are skipped.
+                        if norm is None:
+                            continue
+
+                        # Synthetic order-preserving timestamp: Grok's chat_history has no
+                        # per-message timestamps, so we space events 1s apart in file order.
+                        norm["normalized_timestamp"] = base_ms + seq * 1000
+                        seq += 1
+                        events.append(norm)
+            except Exception:
+                pass
+
+        # Already in file order (monotonic via seq).
+        return events
+
     elif agent in ["gemini", "antigravity"]:
         # Antigravity brain-based session (has no .json file; synthesize from markdown artifacts)
         brain_dir = ANTIGRAVITY_BRAIN_DIR / session_id
@@ -2234,18 +2749,25 @@ async def get_session_detail(session_id: str, agent: str):
                 except Exception: continue
         return events
     elif agent == "copilot":
-        files = list(VSCODE_STORAGE.glob(f"**/chatSessions/{session_id}.json"))
+        # VS Code ~1.100+ stores sessions as <id>.jsonl (delta log) instead of
+        # <id>.json (single object); match both and reconstruct the .jsonl form.
+        files = list(VSCODE_STORAGE.glob(f"**/chatSessions/{session_id}.json")) \
+            + list(VSCODE_STORAGE.glob(f"**/chatSessions/{session_id}.jsonl"))
         if not files: return {"error": "Not found"}
-        with open(files[0], "r", encoding="utf-8", errors="replace") as f:
-            data = json.load(f)
-            events = []
-            for req in data.get("requests", []):
-                ts_val = req.get("timestamp")
-                norm_ts = ts_val if isinstance(ts_val, (int, float)) else None
-                events.append({"type": "user", "payload": req.get("message"), "timestamp": req.get("timestamp"), "normalized_timestamp": norm_ts})
-                if "thinking" in req: events.append({"type": "assistant_thinking", "payload": req["thinking"], "timestamp": req.get("timestamp"), "normalized_timestamp": norm_ts})
-                if "response" in req: events.append({"type": "assistant", "payload": req["response"], "timestamp": req.get("timestamp"), "normalized_timestamp": norm_ts})
-            return events
+        cf = files[0]
+        if cf.suffix == ".jsonl":
+            data = _reconstruct_vscode_chat_jsonl(cf)
+        else:
+            with open(cf, "r", encoding="utf-8", errors="replace") as f:
+                data = json.load(f)
+        events = []
+        for req in data.get("requests", []):
+            ts_val = req.get("timestamp")
+            norm_ts = ts_val if isinstance(ts_val, (int, float)) else None
+            events.append({"type": "user", "payload": req.get("message"), "timestamp": req.get("timestamp"), "normalized_timestamp": norm_ts})
+            if "thinking" in req: events.append({"type": "assistant_thinking", "payload": req["thinking"], "timestamp": req.get("timestamp"), "normalized_timestamp": norm_ts})
+            if "response" in req: events.append({"type": "assistant", "payload": req["response"], "timestamp": req.get("timestamp"), "normalized_timestamp": norm_ts})
+        return events
     elif agent == "opencode":
         if not OPENCODE_DB.exists(): return {"error": "Not found"}
         uri = f"file:{OPENCODE_DB}?mode=ro"

--- a/backend/pricing.py
+++ b/backend/pricing.py
@@ -78,6 +78,13 @@ PRICING = {
     # --- xAI (Grok) ---
     "grok-4.3":                     {"in": 1.25,  "out": 2.50,  "cached_read": None},
     "grok-4.3-latest":              {"in": 1.25,  "out": 2.50,  "cached_read": None},
+    # Grok Build — xAI's agentic coding CLI. Sessions record the model id as the
+    # generic "grok-build"; the underlying model is grok-build-0.1 (256K context;
+    # grok-code-fast-1 requests route here after 2026-05-15). API rates below.
+    "grok-build":                   {"in": 0.20,  "out": 1.50,  "cached_read": None},
+    "grok-build-0.1":               {"in": 0.20,  "out": 1.50,  "cached_read": None},
+    "grok-code-fast-1":             {"in": 0.20,  "out": 1.50,  "cached_read": None},
+    "grok-code-fast":               {"in": 0.20,  "out": 1.50,  "cached_read": None},
 
     # --- Moonshot (Kimi, direct) ---
     "kimi-k2.6":                    {"in": 0.95,  "out": 4.00,  "cached_read": 0.16},

--- a/frontend/src/app/hermes/page.tsx
+++ b/frontend/src/app/hermes/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { format, formatDistanceToNow } from "date-fns";
 import { useMemo } from "react";
 import {
@@ -69,6 +70,7 @@ interface Group {
 }
 
 export default function HermesPage() {
+  const pathname = usePathname();
   const sessionsRes = useResource<Session[]>("/sessions", { pollMs: 15_000, initial: [] });
   const overviewRes = useResource<Overview>("/hermes/overview", { pollMs: 30_000 });
   const gateway = overviewRes.data?.gateway;
@@ -417,17 +419,17 @@ export default function HermesPage() {
                 .map((s) => (
                   <TR key={s.id} interactive>
                     <TD className="pl-5">
-                      <Link href={`/sessions/${s.id}?agent=hermes`} className="block">
+                      <Link href={`/sessions/${s.id}?agent=hermes&from=${encodeURIComponent(pathname)}`} className="block">
                         <SourceBadge source={s.source_subtype} size="xs" />
                       </Link>
                     </TD>
                     <TD className="font-mono text-[11px] text-[var(--tt-fg-muted)] max-w-[180px] truncate" title={s.model}>
-                      <Link href={`/sessions/${s.id}?agent=hermes`} className="block truncate">
+                      <Link href={`/sessions/${s.id}?agent=hermes&from=${encodeURIComponent(pathname)}`} className="block truncate">
                         {s.model || "—"}
                       </Link>
                     </TD>
                     <TD className="text-[var(--tt-fg)] max-w-[480px] truncate">
-                      <Link href={`/sessions/${s.id}?agent=hermes`} className="block truncate">
+                      <Link href={`/sessions/${s.id}?agent=hermes&from=${encodeURIComponent(pathname)}`} className="block truncate">
                         <span className="inline-flex items-center gap-1.5">
                           {s.cost_anomaly && (
                             <span
@@ -446,7 +448,7 @@ export default function HermesPage() {
                       </Link>
                     </TD>
                     <TD className="text-right tabular text-[11px] text-[var(--tt-fg-muted)]">
-                      <Link href={`/sessions/${s.id}?agent=hermes`} className="block">
+                      <Link href={`/sessions/${s.id}?agent=hermes&from=${encodeURIComponent(pathname)}`} className="block">
                         {s.cost && s.cost > 0 ? formatCost(s.cost) : "—"}
                         {s.tokens?.reasoning && s.tokens.reasoning > 0 ? (
                           <div className="text-[9px] text-[var(--tt-fg-faint)] uppercase tracking-wider">
@@ -456,7 +458,7 @@ export default function HermesPage() {
                       </Link>
                     </TD>
                     <TD className="text-right pr-5 tabular text-[11px] text-[var(--tt-fg-muted)]">
-                      <Link href={`/sessions/${s.id}?agent=hermes`} className="block">
+                      <Link href={`/sessions/${s.id}?agent=hermes&from=${encodeURIComponent(pathname)}`} className="block">
                         <div>{format(new Date(s.timestamp), "HH:mm:ss")}</div>
                         <div className="text-[10px] text-[var(--tt-fg-faint)] uppercase tracking-wider">
                           {format(new Date(s.timestamp), "MMM d")}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { format } from "date-fns";
 import {
   Activity, Clock, TrendingUp, Folders, DollarSign, Cpu, ArrowUpRight, Radio, Terminal,
@@ -35,6 +36,7 @@ interface AnalyticsResponse {
 }
 
 export default function Home() {
+  const pathname = usePathname();
   const sessionsRes = useResource<Session[]>("/sessions", { pollMs: 15_000, initial: [] });
   const agentsRes   = useResource<string[]>("/agents", { pollMs: 30_000, initial: [] });
   const analyticsRes = useResource<AnalyticsResponse>("/analytics", { pollMs: 30_000 });
@@ -226,12 +228,12 @@ export default function Home() {
                   {sessions.slice(0, 50).map((s, i) => (
                     <TR key={`${s.agent}-${s.id}-${i}`} interactive>
                       <TD className="pl-5">
-                        <Link href={`/sessions/${s.id}?agent=${s.agent}`} className="block">
+                        <Link href={`/sessions/${s.id}?agent=${s.agent}&from=${encodeURIComponent(pathname)}`} className="block">
                           <AgentBadge agent={s.agent} />
                         </Link>
                       </TD>
                       <TD className="font-mono text-[12px] text-[var(--tt-fg-muted)] max-w-[160px] truncate" title={s.agent === "hermes" ? `Hermes source: ${s.source_subtype || "unknown"}` : s.project}>
-                        <Link href={`/sessions/${s.id}?agent=${s.agent}`} className="block truncate">
+                        <Link href={`/sessions/${s.id}?agent=${s.agent}&from=${encodeURIComponent(pathname)}`} className="block truncate">
                           {s.agent === "hermes" ? (
                             <SourceBadge source={s.source_subtype} size="xs" />
                           ) : (
@@ -240,14 +242,14 @@ export default function Home() {
                         </Link>
                       </TD>
                       <TD className="text-[var(--tt-fg)] max-w-[480px] truncate">
-                        <Link href={`/sessions/${s.id}?agent=${s.agent}`} className="block truncate">
+                        <Link href={`/sessions/${s.id}?agent=${s.agent}&from=${encodeURIComponent(pathname)}`} className="block truncate">
                           {s.display || s.text || (
                             <span className="italic text-[var(--tt-fg-faint)]">No message content</span>
                           )}
                         </Link>
                       </TD>
                       <TD className="text-right pr-5 tabular text-[11px] text-[var(--tt-fg-muted)] group-hover:text-[var(--tt-brand)] transition-colors">
-                        <Link href={`/sessions/${s.id}?agent=${s.agent}`} className="block">
+                        <Link href={`/sessions/${s.id}?agent=${s.agent}&from=${encodeURIComponent(pathname)}`} className="block">
                           <div>{format(new Date(s.timestamp), "HH:mm:ss")}</div>
                           <div className="text-[10px] text-[var(--tt-fg-faint)] uppercase tracking-wider">
                             {format(new Date(s.timestamp), "MMM d")}

--- a/frontend/src/app/projects/[path]/activity/page.tsx
+++ b/frontend/src/app/projects/[path]/activity/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { format } from "date-fns";
 import { Activity, ClipboardList, Cpu, Terminal } from "lucide-react";
 
@@ -11,6 +12,7 @@ import {
 import { useProject } from "../_lib/project-context";
 
 export default function ActivityTab() {
+  const pathname = usePathname();
   const { sessions, loading } = useProject();
 
   return (
@@ -45,12 +47,12 @@ export default function ActivityTab() {
               {sessions.map((s, i) => (
                 <TR key={`${s.agent}-${s.id}-${i}`} interactive>
                   <TD className="pl-5">
-                    <Link href={`/sessions/${s.id}?agent=${s.agent}`} className="block">
+                    <Link href={`/sessions/${s.id}?agent=${s.agent}&from=${encodeURIComponent(pathname)}`} className="block">
                       <AgentBadge agent={s.agent} />
                     </Link>
                   </TD>
                   <TD className="text-[var(--tt-fg)] max-w-[640px] truncate">
-                    <Link href={`/sessions/${s.id}?agent=${s.agent}`} className="block truncate">
+                    <Link href={`/sessions/${s.id}?agent=${s.agent}&from=${encodeURIComponent(pathname)}`} className="block truncate">
                       {s.display || s.text || (
                         <span className="italic text-[var(--tt-fg-faint)]">No prompt content</span>
                       )}
@@ -69,7 +71,7 @@ export default function ActivityTab() {
                     </div>
                   </TD>
                   <TD className="text-right pr-5 tabular text-[11px] text-[var(--tt-fg-muted)] group-hover:text-[var(--tt-brand)] transition-colors">
-                    <Link href={`/sessions/${s.id}?agent=${s.agent}`} className="block">
+                    <Link href={`/sessions/${s.id}?agent=${s.agent}&from=${encodeURIComponent(pathname)}`} className="block">
                       <div>{format(new Date(s.timestamp), "HH:mm:ss")}</div>
                       <div className="text-[10px] uppercase tracking-wider text-[var(--tt-fg-faint)]">
                         {format(new Date(s.timestamp), "MMM d")}

--- a/frontend/src/app/projects/[path]/plans/page.tsx
+++ b/frontend/src/app/projects/[path]/plans/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { format } from "date-fns";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -10,6 +11,7 @@ import { Card, CardTitle, AgentBadge, EmptyState } from "@/components/ui";
 import { useProject } from "../_lib/project-context";
 
 export default function PlansTab() {
+  const pathname = usePathname();
   const { project } = useProject();
   const plans = project?.plans ?? [];
 
@@ -47,7 +49,7 @@ export default function PlansTab() {
 
           <div className="px-5 py-3 border-t border-[var(--tt-border)] bg-[var(--tt-sunken)] flex justify-end">
             <Link
-              href={`/sessions/${plan.session_id}?agent=${plan.agent}`}
+              href={`/sessions/${plan.session_id}?agent=${plan.agent}&from=${encodeURIComponent(pathname)}`}
               className="inline-flex items-center gap-1.5 text-[11px] font-medium text-[var(--tt-fg-muted)] hover:text-[var(--tt-brand)] transition-colors uppercase tracking-[0.16em]"
             >
               View full session <ArrowUpRight size={12} />

--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -11,6 +11,7 @@ import { AgentBadge, Badge, Button, Skeleton } from "@/components/ui";
 import SourceBadge from "@/components/SourceBadge";
 import SummaryPanel from "@/components/summarizer/SummaryPanel";
 import { API_BASE } from "@/lib/api";
+import { resolveSessionBackTarget } from "@/lib/navigation";
 
 interface Artifact {
   name: string;
@@ -30,7 +31,8 @@ interface Session {
   has_plan: boolean;
   plans: any[];
   model?: string;
-  tokens?: { input: number; output: number; cached: number; total: number };
+  tokens?: { input: number; output: number; cached: number; total: number; cost?: number };
+  cost?: number;
   artifacts?: Artifact[];
   /** Hermes-only */
   source_subtype?: string;
@@ -78,6 +80,7 @@ function eventKind(evt: Event): StepKind {
 
   if (type === "session_meta" || type === "event_msg" || type === "turn_context") return "meta";
   if (type === "agent_reasoning" || evt.thoughts || payloadType === "reasoning" || type === "assistant_thinking") return "reasoning";
+
   if (Array.isArray(evt.payload) && (evt.payload as any[]).some((p: any) => p.kind === "thinking" || p.type === "thinking")) return "reasoning";
   if (role === "assistant" && Array.isArray(evt.message?.content) && evt.message.content.some((c: any) => c.type === "thinking" || c.type === "thought")) return "reasoning";
   if (evt.toolCalls || payloadType === "function_call" || payloadType === "tool_use") return "tool";
@@ -136,6 +139,7 @@ export default function SessionDetailPage() {
   const id = params?.id as string;
   const searchParams = useSearchParams();
   const agent = searchParams.get("agent");
+  const fromParam = searchParams.get("from");
   const initialTab = (() => {
     const t = searchParams.get("tab");
     return t === "tools" || t === "artifacts" || t === "raw" || t === "context" ? t : "context";
@@ -146,6 +150,7 @@ export default function SessionDetailPage() {
   const [sessionInfo, setSessionInfo] = useState<Session | null>(null);
   const [hermesOverlay, setHermesOverlay] = useState<any | null>(null);
   const [allHermesSessions, setAllHermesSessions] = useState<Session[] | null>(null);
+  const [grokForensics, setGrokForensics] = useState<any | null>(null);
 
   // Trace View States
   const [splitView, setSplitView] = useState(false);
@@ -227,6 +232,14 @@ export default function SessionDetailPage() {
           .then(res => res.json())
           .then(data => setHermesOverlay(data))
           .catch(() => setHermesOverlay(null));
+      }
+
+      // 4. Grok Build rich forensics (token progression, permissions, tools, phases, plan mode)
+      if (agent === "grok") {
+        fetch(`${API_BASE}/sessions/${id}/grok-forensics`)
+          .then(res => res.json())
+          .then(data => setGrokForensics(data))
+          .catch(() => setGrokForensics(null));
       }
     }
   }, [id, agent]);
@@ -444,14 +457,7 @@ export default function SessionDetailPage() {
           <div className="flex items-start justify-between gap-4 flex-wrap">
             <div className="flex items-start gap-3 min-w-0">
               <button
-                onClick={() => {
-                  const hasHistory = typeof window !== "undefined" && document.referrer.includes(window.location.host);
-                  if (hasHistory) {
-                    router.back();
-                  } else {
-                    router.push(agent === "hermes" ? "/hermes" : "/");
-                  }
-                }}
+                onClick={() => router.push(resolveSessionBackTarget(searchParams.get("from"), agent))}
                 title="Back"
                 aria-label="Back"
                 className="h-9 w-9 grid place-items-center rounded-[var(--tt-radius)] border border-[var(--tt-border)] text-[var(--tt-fg-muted)] hover:text-[var(--tt-fg)] hover:tt-tint-1 transition-colors shrink-0 mt-0.5"
@@ -497,11 +503,27 @@ export default function SessionDetailPage() {
               </div>
               {sessionInfo?.tokens && (
                 <div className="hidden lg:flex items-center gap-3 bg-[var(--tt-sunken)] px-3 h-9 rounded-[var(--tt-radius)] border border-[var(--tt-border)]">
-                  <TokenStat label="Input"  value={sessionInfo.tokens.input.toLocaleString()} />
-                  <span className="w-px h-5 bg-[var(--tt-border)]" />
-                  <TokenStat label="Output" value={sessionInfo.tokens.output.toLocaleString()} />
-                  <span className="w-px h-5 bg-[var(--tt-border)]" />
-                  <TokenStat label="Cached" value={sessionInfo.tokens.cached.toLocaleString()} accent="text-[var(--tt-cyan-fg)]" />
+                  {agent === "grok" ? (
+                    // Grok Build only reports cumulative context (input-side) usage —
+                    // it never logs generated-output or cache-read tokens, so we label
+                    // the figure "Context" and show "—" (not reported) rather than a
+                    // misleading 0. See GrokForensicsCard for the context-window meter.
+                    <>
+                      <TokenStat label="Context" value={sessionInfo.tokens.input.toLocaleString()} />
+                      <span className="w-px h-5 bg-[var(--tt-border)]" />
+                      <TokenStat label="Output" value="—" />
+                      <span className="w-px h-5 bg-[var(--tt-border)]" />
+                      <TokenStat label="Cached" value="—" accent="text-[var(--tt-cyan-fg)]" />
+                    </>
+                  ) : (
+                    <>
+                      <TokenStat label="Input"  value={sessionInfo.tokens.input.toLocaleString()} />
+                      <span className="w-px h-5 bg-[var(--tt-border)]" />
+                      <TokenStat label="Output" value={sessionInfo.tokens.output.toLocaleString()} />
+                      <span className="w-px h-5 bg-[var(--tt-border)]" />
+                      <TokenStat label="Cached" value={sessionInfo.tokens.cached.toLocaleString()} accent="text-[var(--tt-cyan-fg)]" />
+                    </>
+                  )}
                 </div>
               )}
               <Button
@@ -612,10 +634,12 @@ export default function SessionDetailPage() {
              )}
              {/* Hermes session chain (compression / branched continuations) */}
              {agent === "hermes" && sessionInfo && allHermesSessions && (
-               <HermesChainBanner current={sessionInfo} all={allHermesSessions} />
+               <HermesChainBanner current={sessionInfo} all={allHermesSessions} from={fromParam} />
              )}
              {/* Hermes performance overlay */}
              {agent === "hermes" && hermesOverlay && <HermesOverlayCard overlay={hermesOverlay} />}
+             {/* Grok Build forensics — token growth, permissions, tool lifecycle, plan mode */}
+             {agent === "grok" && grokForensics && <GrokForensicsCard forensics={grokForensics} cost={sessionInfo?.tokens?.cost ?? sessionInfo?.cost} />}
              <div className={splitView ? "grid grid-cols-2 gap-8" : "space-y-8"}>
                 <div className="space-y-8">
                    {splitView && <h3 className="text-[10px] font-black text-[var(--tt-fg-dim)] uppercase tracking-[0.2em] ml-2 mb-2 flex items-center gap-2"><User size={14}/> User & Agent Dialogue</h3>}
@@ -636,6 +660,7 @@ export default function SessionDetailPage() {
                       
                       if (splitView && ((isReasoning || hasThinkingPart) && !hasText)) return null;
                       const kind = eventKind(event);
+
                       return (
                          <div key={idx} ref={(el) => { stepRefs.current[idx] = el; }} className={activeStep === idx ? `${stepRingClass[kind]} rounded-[var(--tt-radius-lg)]` : ""}>
                             <EventCard event={event} mode={splitView ? "dialogue" : "all"} agent={agent} />
@@ -1840,7 +1865,199 @@ function HermesOverlayCard({ overlay }: { overlay: any }) {
   );
 }
 
-function HermesChainBanner({ current, all }: { current: Session; all: Session[] }) {
+function GrokForensicsCard({ forensics, cost }: { forensics: any; cost?: number }) {
+  if (!forensics || forensics.error) return null;
+
+  const summary = forensics.summary || {};
+  const plan = forensics.plan_mode || {};
+  const tokenProg = forensics.token_progression || [];
+  const permEvents = forensics.permission_events || [];
+  const counts = forensics.counts || {};
+  const signals = forensics.signals || {};
+
+  const latestTokens = tokenProg.length > 0 ? Number(tokenProg[tokenProg.length - 1].totalTokens || 0) : null;
+
+  // Context usage
+  const ctxUsed = Number(signals.context_tokens_used ?? 0);
+  const ctxWindow = Number(signals.context_window_tokens ?? 0);
+  const ctxPctRaw = Number(
+    signals.context_window_usage_pct ??
+      (ctxWindow > 0 ? (ctxUsed / ctxWindow) * 100 : 0)
+  );
+  const ctxPct = Math.max(0, Math.min(100, ctxPctRaw));
+
+  // Duration formatting (e.g. "1m 49s")
+  const fmtDuration = (secs: number) => {
+    const s = Math.max(0, Math.round(secs));
+    if (s < 60) return `${s}s`;
+    const m = Math.floor(s / 60);
+    const rem = s % 60;
+    return `${m}m ${rem}s`;
+  };
+  // TTFT: ms or s
+  const fmtMs = (ms: number) => (ms >= 1000 ? `${(ms / 1000).toFixed(1)}s` : `${Math.round(ms)}ms`);
+
+  const toolsUsed: string[] = Array.isArray(signals.tools_used) ? signals.tools_used : [];
+
+  // Metric tiles — only render those with a meaningful source value.
+  const has = (k: string) => signals[k] != null && Number(signals[k]) > 0;
+  type Tile = { label: string; value: string; show: boolean };
+  const tiles: Tile[] = [
+    { label: "Tools", value: Number(signals.tool_call_count ?? 0).toLocaleString(), show: has("tool_call_count") },
+    { label: "Turns", value: Number(signals.turn_count ?? 0).toLocaleString(), show: has("turn_count") },
+    { label: "Duration", value: fmtDuration(Number(signals.session_duration_seconds ?? 0)), show: has("session_duration_seconds") },
+    { label: "Errors", value: Number(signals.error_count ?? 0).toLocaleString(), show: has("error_count") },
+    { label: "Tool failures", value: Number(signals.tool_failure_count ?? 0).toLocaleString(), show: has("tool_failure_count") },
+    { label: "Cancellations", value: Number(signals.cancellation_count ?? 0).toLocaleString(), show: has("cancellation_count") },
+    { label: "Compactions", value: Number(signals.compaction_count ?? 0).toLocaleString(), show: has("compaction_count") },
+    { label: "Doom-loops", value: Number(signals.doom_loop_detections ?? 0).toLocaleString(), show: has("doom_loop_detections") },
+    {
+      label: "Lines",
+      value: `+${Number(signals.agent_lines_added ?? 0).toLocaleString()} / −${Number(signals.agent_lines_removed ?? 0).toLocaleString()}`,
+      show: has("agent_lines_added") || has("agent_lines_removed"),
+    },
+    { label: "Files touched", value: Number(signals.agent_files_touched ?? 0).toLocaleString(), show: has("agent_files_touched") },
+    { label: "Avg TTFT", value: fmtMs(Number(signals.avg_time_to_first_token_ms ?? 0)), show: has("avg_time_to_first_token_ms") },
+  ];
+  const visibleTiles = tiles.filter((t) => t.show);
+
+  return (
+    <div className="mb-8 bg-[var(--tt-panel)]/60 border border-zinc-600/40 rounded-[var(--tt-radius-lg)] p-5">
+      <div className="flex items-center justify-between mb-3">
+        <div className="text-[10px] font-black uppercase tracking-[0.2em] text-zinc-300 flex items-center gap-2">
+          <Cpu size={12} strokeWidth={3} className="text-zinc-400" /> Grok Build Forensics
+        </div>
+        <div className="text-[10px] font-mono text-[var(--tt-fg-muted)]">
+          {summary.num_messages || 0} msgs · {counts.tools || 0} tool events
+        </div>
+      </div>
+
+      {/* Summary + Git context */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-4 text-[11px]">
+        <div className="bg-[var(--tt-sunken)] border border-[var(--tt-border)] rounded p-3">
+          <div className="text-[var(--tt-fg-dim)] mb-1">Session</div>
+          <div className="font-medium text-[var(--tt-fg)]">{summary.generated_title || summary.session_summary || "—"}</div>
+          <div className="text-[var(--tt-fg-muted)] mt-1">
+            Model: <span className="font-mono">{summary.current_model_id || "grok-build"}</span>
+          </div>
+          {typeof cost === "number" && cost > 0 && (
+            <div className="text-[var(--tt-fg-muted)] mt-0.5">
+              Est. cost: <span className="font-mono text-[var(--tt-fg)]">${cost.toFixed(4)}</span>
+              <span className="text-[var(--tt-fg-faint)] ml-1">· input-rate estimate (output not reported)</span>
+            </div>
+          )}
+        </div>
+        <div className="bg-[var(--tt-sunken)] border border-[var(--tt-border)] rounded p-3">
+          <div className="text-[var(--tt-fg-dim)] mb-1">Git Context</div>
+          <div className="font-mono text-[var(--tt-fg)] truncate">{summary.git_root_dir || "—"}</div>
+          <div className="text-[var(--tt-fg-muted)] mt-0.5">
+            {summary.head_branch ? <span className="text-emerald-400">{summary.head_branch}</span> : null}
+            {summary.head_commit ? <span className="ml-2 text-[var(--tt-fg-faint)]">{String(summary.head_commit).slice(0, 8)}</span> : null}
+          </div>
+        </div>
+      </div>
+
+      {/* Context Usage — authoritative context-window pressure */}
+      {ctxWindow > 0 && (
+        <div className="mb-4 bg-[var(--tt-sunken)] border border-[var(--tt-border)] rounded p-3">
+          <div className="flex items-center justify-between text-[11px] mb-1.5">
+            <span className="text-[10px] uppercase tracking-wider text-[var(--tt-fg-dim)]">Context Usage</span>
+            <span className="font-mono text-[var(--tt-fg)]">
+              {ctxUsed.toLocaleString()} / {ctxWindow.toLocaleString()}
+              <span className="text-zinc-400 ml-2">{ctxPct.toFixed(1)}%</span>
+            </span>
+          </div>
+          <div className="h-1.5 w-full bg-[var(--tt-border)] rounded-full overflow-hidden">
+            <div className="h-full bg-zinc-300 rounded-full" style={{ width: `${ctxPct}%` }} />
+          </div>
+        </div>
+      )}
+
+      {/* Signals metrics grid */}
+      {visibleTiles.length > 0 && (
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-2 mb-4">
+          {visibleTiles.map((t) => (
+            <div key={t.label} className="bg-[var(--tt-sunken)] border border-[var(--tt-border)] rounded px-2.5 py-1.5">
+              <div className="text-[9px] uppercase tracking-[0.16em] text-[var(--tt-fg-dim)]">{t.label}</div>
+              <div className="text-[12px] font-mono tabular text-[var(--tt-fg)] mt-0.5">{t.value}</div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Tools used — canonical names from signals */}
+      {toolsUsed.length > 0 && (
+        <div className="mb-4">
+          <div className="text-[10px] uppercase tracking-wider text-[var(--tt-fg-dim)] mb-1.5">Tools Used</div>
+          <div className="flex flex-wrap gap-1.5">
+            {toolsUsed.map((t, i) => (
+              <span
+                key={`${t}-${i}`}
+                className="text-[10px] font-mono px-2 py-0.5 rounded border border-zinc-600/40 bg-zinc-700/20 text-zinc-300"
+              >
+                {t}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Permission decisions — very useful forensics */}
+      {permEvents.length > 0 && (
+        <div className="mb-4">
+          <div className="text-[10px] uppercase tracking-wider text-[var(--tt-fg-dim)] mb-1">Permission Decisions</div>
+          <div className="space-y-1 text-[11px]">
+            {permEvents.slice(-6).map((p: any, i: number) => (
+              <div key={i} className="flex items-center gap-2 bg-[var(--tt-sunken)] border border-[var(--tt-border)] rounded px-2 py-1">
+                <span className="font-mono text-[var(--tt-fg-muted)]">{p.tool_name}</span>
+                {p.decision && (
+                  <span className={p.decision === "allow" ? "text-emerald-400" : "text-amber-400"}>
+                    {p.decision}
+                  </span>
+                )}
+                {p.wait_ms != null && <span className="text-[var(--tt-fg-faint)] text-[10px]">({p.wait_ms}ms)</span>}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Context Growth (streaming samples) — NOT billed input/output */}
+      {tokenProg.length > 0 && (
+        <div className="mb-4">
+          <div className="text-[10px] uppercase tracking-wider text-[var(--tt-fg-dim)] mb-1 flex items-center gap-2">
+            Context Growth (streaming samples) <span className="text-zinc-400">({tokenProg.length})</span>
+            {latestTokens != null && <span className="font-mono text-[var(--tt-fg)]">→ {latestTokens.toLocaleString()} total</span>}
+          </div>
+          <div className="text-[9px] text-[var(--tt-fg-faint)] mb-1.5">
+            Cumulative context observed during streaming — not billed input/output tokens.
+          </div>
+          <div className="bg-[var(--tt-sunken)] border border-[var(--tt-border)] rounded p-2 max-h-28 overflow-y-auto text-[10px] font-mono">
+            {tokenProg.slice(-12).map((t: any, i: number) => (
+              <div key={i} className="flex justify-between py-0.5">
+                <span className="text-[var(--tt-fg-muted)]">{t.updateType || "update"}</span>
+                <span className="text-[var(--tt-fg)]">{Number(t.totalTokens || 0).toLocaleString()}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Plan mode + high level counts */}
+      <div className="flex flex-wrap gap-3 text-[11px]">
+        <div className="px-3 py-1 rounded border border-[var(--tt-border)] bg-[var(--tt-sunken)]">
+          Plan mode: <span className={plan?.state === "Active" ? "text-zinc-200 font-medium" : "text-[var(--tt-fg-muted)]"}>{plan?.state || "Inactive"}</span>
+        </div>
+        <div className="px-3 py-1 rounded border border-[var(--tt-border)] bg-[var(--tt-sunken)] text-[var(--tt-fg-muted)]">
+          {counts.tools || 0} tool events · {counts.permissions || 0} permission prompts
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function HermesChainBanner({ current, all, from }: { current: Session; all: Session[]; from?: string | null }) {
+  const fromSuffix = from ? `&from=${encodeURIComponent(from)}` : "";
   // Compression-style continuation chain via parent_session_id.
   // delegate_task subagents are NOT in state.db (verified — see HERMES_INTERNALS.md §1.6).
   const parent = current.parent_session_id
@@ -1862,7 +2079,7 @@ function HermesChainBanner({ current, all }: { current: Session; all: Session[] 
       <div className="flex items-center gap-2 flex-wrap">
         {parent && (
           <Link
-            href={`/sessions/${parent.id}?agent=hermes`}
+            href={`/sessions/${parent.id}?agent=hermes${fromSuffix}`}
             className="inline-flex items-center gap-1.5 text-[11px] font-mono bg-[var(--tt-sunken)] border border-[var(--tt-border)] rounded px-2 py-1 hover:border-violet-500/50 hover:bg-violet-500/5 text-[var(--tt-fg-muted)] hover:text-[var(--tt-fg)] transition-colors"
           >
             <ChevronLeft size={11} />
@@ -1873,7 +2090,7 @@ function HermesChainBanner({ current, all }: { current: Session; all: Session[] 
         {children.map((c) => (
           <Link
             key={c.id}
-            href={`/sessions/${c.id}?agent=hermes`}
+            href={`/sessions/${c.id}?agent=hermes${fromSuffix}`}
             className="inline-flex items-center gap-1.5 text-[11px] font-mono bg-[var(--tt-sunken)] border border-[var(--tt-border)] rounded px-2 py-1 hover:border-violet-500/50 hover:bg-violet-500/5 text-[var(--tt-fg-muted)] hover:text-[var(--tt-fg)] transition-colors"
           >
             <span className="truncate max-w-[200px]">{c.display || c.id}</span>

--- a/frontend/src/components/icons/GrokIcon.tsx
+++ b/frontend/src/components/icons/GrokIcon.tsx
@@ -1,0 +1,24 @@
+import { forwardRef } from "react";
+import type { LucideIcon, LucideProps } from "lucide-react";
+
+// Grok (xAI) brand mark — the two angular "blade" strokes that form Grok's
+// stylized monogram. Rendered as a FILLED glyph (fill="currentColor") so it
+// inherits the agent's accent color and stays solid/visible on the dark theme.
+// Background container square is intentionally dropped so it reads as an icon.
+const GrokIcon = forwardRef<SVGSVGElement, LucideProps>(({ size, strokeWidth, ...props }, ref) => (
+  <svg
+    ref={ref}
+    xmlns="http://www.w3.org/2000/svg"
+    width={size ?? 24}
+    height={size ?? 24}
+    viewBox="0 0 512 509.641"
+    fill="currentColor"
+    stroke="none"
+    {...props}
+  >
+    <path d="M213.235 306.019l178.976-180.002v.169l51.695-51.763c-.924 1.32-1.86 2.605-2.785 3.89-39.281 54.164-58.46 80.649-43.07 146.922l-.09-.101c10.61 45.11-.744 95.137-37.398 131.836-46.216 46.306-120.167 56.611-181.063 14.928l42.462-19.675c38.863 15.278 81.392 8.57 111.947-22.03 30.566-30.6 37.432-75.159 22.065-112.252-2.92-7.025-11.67-8.795-17.792-4.263l-124.947 92.341zm-25.786 22.437l-.033.034L68.094 435.217c7.565-10.429 16.957-20.294 26.327-30.149 26.428-27.803 52.653-55.359 36.654-94.302-21.422-52.112-8.952-113.177 30.724-152.898 41.243-41.254 101.98-51.661 152.706-30.758 11.23 4.172 21.016 10.114 28.638 15.639l-42.359 19.584c-39.44-16.563-84.629-5.299-112.207 22.313-37.298 37.308-44.84 102.003-1.128 143.81z" />
+  </svg>
+));
+GrokIcon.displayName = "GrokIcon";
+
+export default GrokIcon as LucideIcon;

--- a/frontend/src/lib/agents.ts
+++ b/frontend/src/lib/agents.ts
@@ -3,10 +3,11 @@ import {
   GitBranch, Code2, type LucideIcon,
 } from "lucide-react";
 import HermesIcon from "@/components/icons/HermesIcon";
+import GrokIcon from "@/components/icons/GrokIcon";
 
 export type AgentKey =
   | "claude" | "codex" | "gemini" | "antigravity"
-  | "qwen" | "vibe" | "cursor" | "copilot" | "opencode" | "hermes";
+  | "qwen" | "vibe" | "cursor" | "copilot" | "opencode" | "hermes" | "grok";
 
 export interface AgentMeta {
   key: AgentKey;
@@ -27,6 +28,7 @@ export const AGENTS: Record<AgentKey, AgentMeta> = {
   copilot:     { key: "copilot",     label: "Copilot",     hex: "#6366f1", icon: GitBranch },
   opencode:    { key: "opencode",    label: "OpenCode",    hex: "#f59e0b", icon: Code2 },
   hermes:      { key: "hermes",      label: "Hermes Agent", hex: "#eab308", icon: HermesIcon },
+  grok:        { key: "grok",        label: "Grok Build",  hex: "#d4d4d8", icon: GrokIcon },
 };
 
 const FALLBACK: AgentMeta = {

--- a/frontend/src/lib/navigation.test.ts
+++ b/frontend/src/lib/navigation.test.ts
@@ -1,0 +1,62 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { resolveSessionBackTarget } from "./navigation";
+
+test("internal project path is honored (came from a project -> back to project, not dashboard)", () => {
+  assert.equal(
+    resolveSessionBackTarget("/projects/abc/activity", "claude"),
+    "/projects/abc/activity",
+  );
+  // Same for hermes agent: explicit internal `from` wins over the per-agent fallback.
+  assert.equal(
+    resolveSessionBackTarget("/projects/abc/activity", "hermes"),
+    "/projects/abc/activity",
+  );
+});
+
+test('from="/" with agent="claude" returns "/"', () => {
+  assert.equal(resolveSessionBackTarget("/", "claude"), "/");
+});
+
+test('from=null falls back per-agent', () => {
+  assert.equal(resolveSessionBackTarget(null, "hermes"), "/hermes");
+  assert.equal(resolveSessionBackTarget(null, "claude"), "/");
+});
+
+test("from=undefined falls back per-agent", () => {
+  assert.equal(resolveSessionBackTarget(undefined, "hermes"), "/hermes");
+  assert.equal(resolveSessionBackTarget(undefined, "claude"), "/");
+});
+
+test('from="" (empty string) falls back per-agent', () => {
+  assert.equal(resolveSessionBackTarget("", "hermes"), "/hermes");
+  assert.equal(resolveSessionBackTarget("", "claude"), "/");
+});
+
+test("open-redirect guard: protocol-relative //evil.com falls back, never the external host", () => {
+  assert.equal(resolveSessionBackTarget("//evil.com", "claude"), "/");
+  assert.equal(resolveSessionBackTarget("//evil.com", "hermes"), "/hermes");
+  // Also guard the path-style protocol-relative with a trailing path.
+  assert.equal(resolveSessionBackTarget("//evil.com/projects/x", "claude"), "/");
+});
+
+test("open-redirect guard: absolute external URL falls back", () => {
+  assert.equal(resolveSessionBackTarget("https://evil.com", "claude"), "/");
+  assert.equal(resolveSessionBackTarget("https://evil.com", "hermes"), "/hermes");
+  assert.equal(resolveSessionBackTarget("http://evil.com", "claude"), "/");
+});
+
+test("open-redirect guard: javascript: scheme falls back", () => {
+  assert.equal(resolveSessionBackTarget("javascript:alert(1)", "claude"), "/");
+  assert.equal(resolveSessionBackTarget("javascript:alert(1)", "hermes"), "/hermes");
+});
+
+test('from="/hermes" with agent=null returns "/hermes"', () => {
+  // Agent is null, but an internal absolute `from` is still honored.
+  assert.equal(resolveSessionBackTarget("/hermes", null), "/hermes");
+});
+
+test("agent=null/undefined with no usable from defaults to dashboard", () => {
+  assert.equal(resolveSessionBackTarget(null, null), "/");
+  assert.equal(resolveSessionBackTarget(null, undefined), "/");
+});

--- a/frontend/src/lib/navigation.ts
+++ b/frontend/src/lib/navigation.ts
@@ -1,0 +1,14 @@
+/**
+ * Resolve where a session-detail "Back" button should navigate.
+ * Prefers an explicit `from` origin (the route the session was opened from),
+ * falling back to a sensible per-agent landing page. Only internal absolute
+ * paths are honored (must start with a single "/") to avoid open-redirect via
+ * a crafted ?from= value; protocol-relative ("//evil.com") and external URLs
+ * are rejected in favor of the fallback.
+ */
+export function resolveSessionBackTarget(from: string | null | undefined, agent: string | null | undefined): string {
+  if (typeof from === "string" && from.startsWith("/") && !from.startsWith("//")) {
+    return from;
+  }
+  return agent === "hermes" ? "/hermes" : "/";
+}

--- a/llms.txt
+++ b/llms.txt
@@ -4,7 +4,7 @@
 
 ## What is TokenTelemetry?
 
-TokenTelemetry is a free, open-source observability dashboard that automatically tracks token usage, LLM costs, tool calls, session traces, reasoning steps, subagent delegations, scheduled-job (cron) health, and gateway health across AI coding agents AND autonomous agents — Claude Code, Gemini CLI, OpenAI Codex, Cursor, GitHub Copilot, Qwen, OpenCode, Vibe, Antigravity, and Nous Research's Hermes Agent.
+TokenTelemetry is a free, open-source observability dashboard that automatically tracks token usage, LLM costs, tool calls, session traces, reasoning steps, subagent delegations, scheduled-job (cron) health, and gateway health across AI coding agents AND autonomous agents — Claude Code, Gemini CLI, OpenAI Codex, Cursor, GitHub Copilot, Qwen, OpenCode, Vibe, Antigravity, Grok Build, and Nous Research's Hermes Agent.
 
 It reads session logs and SQLite state directly from the filesystem (no SDK, no instrumentation) and presents them in a unified local web dashboard at http://localhost:3000.
 
@@ -22,7 +22,7 @@ It reads session logs and SQLite state directly from the filesystem (no SDK, no 
 
 ## Supported Agents
 
-### Coding agents (9)
+### Coding agents (10)
 
 - Claude Code (Anthropic)
 - OpenAI Codex CLI
@@ -33,6 +33,7 @@ It reads session logs and SQLite state directly from the filesystem (no SDK, no 
 - OpenCode
 - Vibe
 - Antigravity (Google)
+- Grok Build (xAI)
 
 ### Autonomous agents (1)
 
@@ -55,7 +56,7 @@ Hermes Agent is structurally different from coding agents — it runs across CLI
 
 ## Hermes Dashboard Plugin
 
-TokenTelemetry ships a plugin for Hermes Agent's own web dashboard (port 9119). After a one-command install, a "TokenTelemetry" tab appears inside Hermes Dashboard with deep-link cards that open TT pages (Hermes Overview, Skills, Memory, Analytics, Projects, All Agents) in a new browser tab. Important: the plugin is a launcher, not the engine — TokenTelemetry itself must be installed and running for the launcher to do anything. When TT isn't running, the plugin shows an onboarding card explaining what TokenTelemetry is (a local observability dashboard for Hermes Agent AND 9 coding agents) with a copy-paste install command.
+TokenTelemetry ships a plugin for Hermes Agent's own web dashboard (port 9119). After a one-command install, a "TokenTelemetry" tab appears inside Hermes Dashboard with deep-link cards that open TT pages (Hermes Overview, Skills, Memory, Analytics, Projects, All Agents) in a new browser tab. Important: the plugin is a launcher, not the engine — TokenTelemetry itself must be installed and running for the launcher to do anything. When TT isn't running, the plugin shows an onboarding card explaining what TokenTelemetry is (a local observability dashboard for Hermes Agent AND 10 coding agents) with a copy-paste install command.
 
 Install (recommended, via Hermes's own plugin manager):
 

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -4,7 +4,7 @@
 
 ## What is TokenTelemetry?
 
-TokenTelemetry is a free, open-source observability dashboard that automatically tracks token usage, LLM costs, tool calls, session traces, reasoning steps, subagent delegations, scheduled-job (cron) health, and gateway health across AI coding agents AND autonomous agents — Claude Code, Gemini CLI, OpenAI Codex, Cursor, GitHub Copilot, Qwen, OpenCode, Vibe, Antigravity, and Nous Research's Hermes Agent.
+TokenTelemetry is a free, open-source observability dashboard that automatically tracks token usage, LLM costs, tool calls, session traces, reasoning steps, subagent delegations, scheduled-job (cron) health, and gateway health across AI coding agents AND autonomous agents — Claude Code, Gemini CLI, OpenAI Codex, Cursor, GitHub Copilot, Qwen, OpenCode, Vibe, Antigravity, Grok Build, and Nous Research's Hermes Agent.
 
 It reads session logs and SQLite state directly from the filesystem (no SDK, no instrumentation) and presents them in a unified local web dashboard at http://localhost:3000.
 
@@ -22,7 +22,7 @@ It reads session logs and SQLite state directly from the filesystem (no SDK, no 
 
 ## Supported Agents
 
-### Coding agents (9)
+### Coding agents (10)
 
 - Claude Code (Anthropic)
 - OpenAI Codex CLI
@@ -33,6 +33,7 @@ It reads session logs and SQLite state directly from the filesystem (no SDK, no 
 - OpenCode
 - Vibe
 - Antigravity (Google)
+- Grok Build (xAI)
 
 ### Autonomous agents (1)
 
@@ -55,7 +56,7 @@ Hermes Agent is structurally different from coding agents — it runs across CLI
 
 ## Hermes Dashboard Plugin
 
-TokenTelemetry ships a plugin for Hermes Agent's own web dashboard (port 9119). After a one-command install, a "TokenTelemetry" tab appears inside Hermes Dashboard with deep-link cards that open TT pages (Hermes Overview, Skills, Memory, Analytics, Projects, All Agents) in a new browser tab. Important: the plugin is a launcher, not the engine — TokenTelemetry itself must be installed and running for the launcher to do anything. When TT isn't running, the plugin shows an onboarding card explaining what TokenTelemetry is (a local observability dashboard for Hermes Agent AND 9 coding agents) with a copy-paste install command.
+TokenTelemetry ships a plugin for Hermes Agent's own web dashboard (port 9119). After a one-command install, a "TokenTelemetry" tab appears inside Hermes Dashboard with deep-link cards that open TT pages (Hermes Overview, Skills, Memory, Analytics, Projects, All Agents) in a new browser tab. Important: the plugin is a launcher, not the engine — TokenTelemetry itself must be installed and running for the launcher to do anything. When TT isn't running, the plugin shows an onboarding card explaining what TokenTelemetry is (a local observability dashboard for Hermes Agent AND 10 coding agents) with a copy-paste install command.
 
 Install (recommended, via Hermes's own plugin manager):
 

--- a/website/src/app/layout.tsx
+++ b/website/src/app/layout.tsx
@@ -12,7 +12,7 @@ const geistMono = Geist_Mono({ variable: "--font-geist-mono", subsets: ["latin"]
 const SITE_URL = "https://tokentelemetry.com";
 const TITLE = "Token Telemetry — Observability for coding & autonomous agents (Hermes, Claude Code, Codex …)";
 const DESCRIPTION =
-  "Token Telemetry is local, read-only observability for 9 coding agents (Claude Code, Codex, Gemini CLI, Cursor, Copilot, Qwen, OpenCode, Vibe, Antigravity) plus Hermes Agent (Nous Research) — with a dedicated dashboard for gateway health, cron jobs, skills, memory, and 38 source platforms. One command, 100% on your machine.";
+  "Token Telemetry is local, read-only observability for 10 coding agents (Claude Code, Codex, Gemini CLI, Cursor, Copilot, Qwen, OpenCode, Vibe, Antigravity, Grok Build) plus Hermes Agent (Nous Research) — with a dedicated dashboard for gateway health, cron jobs, skills, memory, and 38 source platforms. One command, 100% on your machine.";
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),

--- a/website/src/components/AgentsGrid.tsx
+++ b/website/src/components/AgentsGrid.tsx
@@ -6,7 +6,7 @@ export default function AgentsGrid() {
       <div className="text-center mb-10 sm:mb-12">
         <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--tt-fg-dim)] mb-3">Supported</p>
         <h2 className="text-[28px] sm:text-[44px] leading-[1.1] tracking-[-0.02em] font-semibold text-[var(--tt-fg)] mb-4">
-          Ten agents. <span className="text-[var(--tt-brand)]">Zero config.</span>
+          Eleven agents. <span className="text-[var(--tt-brand)]">Zero config.</span>
         </h2>
         <p className="text-[14px] sm:text-[15px] text-[var(--tt-fg-muted)] max-w-2xl mx-auto leading-relaxed">
           TokenTelemetry reads logs your agents already write. No proxies, no wrappers, no SDK to register.

--- a/website/src/components/FAQ.tsx
+++ b/website/src/components/FAQ.tsx
@@ -9,7 +9,7 @@ export const FAQ_ITEMS = [
   },
   {
     q: "How do I monitor Gemini CLI and Codex costs?",
-    a: "TokenTelemetry auto-reads logs from Gemini CLI, OpenAI Codex CLI, Cursor, GitHub Copilot, Qwen CLI, OpenCode, Vibe, and Antigravity. Token counts and dollar costs appear in the local dashboard automatically.",
+    a: "TokenTelemetry auto-reads logs from Gemini CLI, OpenAI Codex CLI, Cursor, GitHub Copilot, Qwen CLI, OpenCode, Vibe, Antigravity, and Grok Build (xAI). Token counts and dollar costs appear in the local dashboard automatically.",
   },
   {
     q: "Is there a free tool to monitor AI coding agent token usage?",
@@ -25,7 +25,7 @@ export const FAQ_ITEMS = [
   },
   {
     q: "Which agents does it support?",
-    a: "Nine coding agents (Claude Code, OpenAI Codex, Gemini CLI, Cursor, GitHub Copilot, Qwen CLI, OpenCode, Vibe, Antigravity) plus Hermes Agent — Nous Research's autonomous agent, which gets its own dedicated dashboard at /hermes with gateway health, scheduled-job monitoring, skills + memory observability, and 38 source platforms (CLI / Telegram / Discord / Feishu / DingTalk / cron / webhook / …).",
+    a: "Ten coding agents (Claude Code, OpenAI Codex, Gemini CLI, Cursor, GitHub Copilot, Qwen CLI, OpenCode, Vibe, Antigravity, Grok Build) plus Hermes Agent — Nous Research's autonomous agent, which gets its own dedicated dashboard at /hermes with gateway health, scheduled-job monitoring, skills + memory observability, and 38 source platforms (CLI / Telegram / Discord / Feishu / DingTalk / cron / webhook / …).",
   },
   {
     q: "Why does Hermes Agent get its own page?",

--- a/website/src/components/Hero.tsx
+++ b/website/src/components/Hero.tsx
@@ -74,7 +74,7 @@ export default function Hero() {
             {/* Subhead */}
             <p className="text-[15px] sm:text-[17px] text-[var(--tt-fg-muted)] max-w-2xl mx-auto lg:mx-0 leading-relaxed mb-3">
               Local, read-only observability for Claude Code, Codex, Gemini CLI, Cursor, Copilot, Antigravity,
-              Qwen CLI, OpenCode, Hermes Agent, and Vibe — one command, no signup, nothing leaves your machine.
+              Qwen CLI, OpenCode, Grok Build, Hermes Agent, and Vibe — one command, no signup, nothing leaves your machine.
             </p>
             <p className="text-[13px] sm:text-[14px] text-[var(--tt-fg-dim)] font-mono italic mb-9 transition-opacity">
               &ldquo;{PAINS[pain]}&rdquo;

--- a/website/src/data/agents.ts
+++ b/website/src/data/agents.ts
@@ -17,5 +17,6 @@ export const AGENTS: Agent[] = [
   { name: "Cursor",         vendor: "Cursor",    captures: ["tokens", "traces", "plans"],                          logPath: "~/.cursor/ + workspaceStorage/",  hex: "#60a5fa" },
   { name: "GitHub Copilot", vendor: "GitHub",    captures: ["tokens", "traces", "cost"],                           logPath: "VS Code chatSessions/",           hex: "#6366f1" },
   { name: "OpenCode",       vendor: "OpenCode",  captures: ["tokens", "traces"],                                   logPath: "~/.local/share/opencode/",        hex: "#f59e0b" },
+  { name: "Grok Build",     vendor: "xAI",       captures: ["tokens", "traces", "reasoning", "cost"],              logPath: "~/.grok/sessions/",               hex: "#d4d4d8" },
   { name: "Hermes Agent",   vendor: "Nous Research", captures: ["tokens", "traces", "cost", "subagents", "skills", "memory", "cron", "38 sources"], logPath: "~/.hermes/",                      hex: "#eab308" },
 ];


### PR DESCRIPTION
## Summary
- **Grok Build (xAI) — new 11th agent.** Scans `~/.grok/sessions`; surfaces sessions, context-token usage, tool/permission events, plan mode, and a dedicated forensics card (from `signals.json`). Honest token accounting — Grok only reports cumulative *context* usage, so output/cached render as "—" (not a fabricated 0), and cost is a clearly-labeled input-rate estimate using new `grok-build` pricing. Includes the xAI brand icon and a visible zinc accent.
- **GitHub Copilot tracking fix** (resolves #36). VS Code ~1.100+ switched chat session files from `<id>.json` to `<id>.jsonl` (an append-only delta log); the scanner only matched `.json`, so newer Copilot sessions read as zero. Both the list scan and detail endpoint now reconstruct the `.jsonl` form. Verified locally: 82 → 116 sessions.
- **Session "Back" navigation fix.** Replaced the unreliable `document.referrer` heuristic (which never updates on client-side nav, so Back always fell back to the dashboard) with explicit origin tracking via `?from=` + a guarded `resolveSessionBackTarget` helper. Back now returns to the originating page. Unit-tested (10/10).
- **Website + docs.** Website, both `llms.txt` copies, and README now list Grok Build and reflect 11 agents ("10 coding agents … plus Hermes Agent").
- **Release notes.** `UPDATE.json` entry for 2026-06-02.

## Test plan
- [ ] Backend: `python3 -m py_compile backend/main.py backend/pricing.py`
- [ ] Frontend: `npx tsc --noEmit` (in `frontend/`)
- [ ] Nav helper unit tests: `npx tsx --test frontend/src/lib/navigation.test.ts` (10/10)
- [ ] Open a Grok session → token row shows Context / — / —, forensics card shows context-window meter + labeled cost estimate, model `grok-build`
- [ ] Create a Copilot chat in current VS Code → session appears (not 0)
- [ ] Open a session from a project → Back returns to the project, not the dashboard
- [ ] Website renders "Eleven agents" with Grok Build in the grid; `llms.txt` reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)