### PR TITLE
fix: extract modelID directly from OpenCode DB messages

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2197,8 +2197,11 @@ def _scan_sessions_sync():
                             if not model:
                                 model = mdata.get("modelID") or mdata.get("providerID")
                                 if not model:
-                                    mi = mdata.get("model") or {}
-                                    model = mi.get("modelID") or mi.get("providerID")
+                                    mi = mdata.get("model")
+                                    if isinstance(mi, dict):
+                                        model = mi.get("modelID") or mi.get("providerID")
+                                    elif isinstance(mi, str):
+                                        model = mi
                             if mdata.get("mode") == "plan":
                                 has_plan = True
                     # Parts: first user text, tool names, token totals from step-finish

--- a/backend/main.py
+++ b/backend/main.py
@@ -2195,8 +2195,10 @@ def _scan_sessions_sync():
                         except Exception: continue
                         if mdata.get("role") == "assistant":
                             if not model:
-                                mi = mdata.get("model") or {}
-                                model = mi.get("modelID") or mi.get("providerID")
+                                model = mdata.get("modelID") or mdata.get("providerID")
+                                if not model:
+                                    mi = mdata.get("model") or {}
+                                    model = mi.get("modelID") or mi.get("providerID")
                             if mdata.get("mode") == "plan":
                                 has_plan = True
                     # Parts: first user text, tool names, token totals from step-finish


### PR DESCRIPTION
## Description
Fixes an issue where `opencode` models were not displaying in the UI because the ingestion engine expected `modelID` to be nested inside a `model` object in the JSON payload. The SQLite DB actually stores `modelID` at the root of the assistant message data.

## Changes
- Modified `backend/main.py` to check for `modelID` or `providerID` at the root of `mdata` before falling back to the nested `model` object.
- Ensures compatibility with newer `opencode-go` artifacts (e.g., `glm-5.1`).