### PR TITLE
feat(copilot): add Copilot CLI source + surface sub-label

### DIFF
--- a/UPDATE.json
+++ b/UPDATE.json
@@ -1,6 +1,22 @@
 {
   "releases": [
     {
+      "tag": "2026-06-04",
+      "title": "GitHub Copilot CLI support",
+      "highlights": [
+        {
+          "title": "GitHub Copilot CLI sessions tracked",
+          "description": "TokenTelemetry now reads GitHub Copilot CLI / agent sessions from ~/.copilot/session-state, so your terminal Copilot usage shows up alongside everything else — model, tokens, project, and full trace.",
+          "href": "/"
+        },
+        {
+          "title": "Copilot surface sub-label",
+          "description": "Copilot sessions now carry a small CLI or VS Code tag so you can tell at a glance which surface a session came from. They still roll up under one Copilot total.",
+          "href": "/"
+        }
+      ]
+    },
+    {
       "tag": "2026-06-02",
       "title": "Grok Build support + tracking fixes",
       "highlights": [

--- a/backend/main.py
+++ b/backend/main.py
@@ -38,6 +38,65 @@ def _file_mtime_utc(path) -> datetime:
     except Exception:
         return _now()
 
+def _load_copilot_cli_events(events_file: Path) -> List[dict]:
+    """Load a GitHub Copilot CLI session's append-only event log (#36)."""
+    rows: List[dict] = []
+    try:
+        with open(events_file, "r", encoding="utf-8", errors="replace") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rows.append(json.loads(line))
+                except Exception:
+                    continue
+    except OSError:
+        pass
+    return rows
+
+def _parse_copilot_iso(ts) -> Optional[datetime]:
+    """Copilot CLI timestamps are ISO-8601 with a trailing Z (e.g.
+    '2026-06-04T11:45:07.548Z'). Returns None for anything unparseable."""
+    if not isinstance(ts, str):
+        return None
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except Exception:
+        return None
+
+def _copilot_cli_tokens_from_metrics(metrics) -> Optional[dict]:
+    """Best-effort precise token totals from a closed session's
+    `session.shutdown.modelMetrics`. The exact shape varies by Copilot
+    version, so we defensively sum any recognizable input/output/cache token
+    counts found anywhere in the structure. Returns None when nothing usable
+    is present (caller then falls back to the per-message estimate)."""
+    if not isinstance(metrics, (dict, list)):
+        return None
+    tot = {"input": 0, "output": 0, "cached": 0}
+    found = False
+
+    def grab(obj):
+        nonlocal found
+        if isinstance(obj, dict):
+            for k, v in obj.items():
+                kl = str(k).lower()
+                if isinstance(v, (int, float)) and not isinstance(v, bool) and "token" in kl:
+                    if "cache" in kl:
+                        tot["cached"] += int(v); found = True
+                    elif "out" in kl or "completion" in kl or "output" in kl:
+                        tot["output"] += int(v); found = True
+                    elif "in" in kl or "prompt" in kl:
+                        tot["input"] += int(v); found = True
+                else:
+                    grab(v)
+        elif isinstance(obj, list):
+            for x in obj:
+                grab(x)
+
+    grab(metrics)
+    return tot if found else None
+
 def _pid_alive(pid: int) -> bool:
     """Cross-platform process liveness probe.
 
@@ -128,6 +187,9 @@ GROK_SIGNALS = "signals.json"
 # Specialized storage paths
 VSCODE_STORAGE = VSCODE_BASE / "User/workspaceStorage"
 CURSOR_STORAGE = CURSOR_BASE / "User/workspaceStorage"
+# GitHub Copilot CLI / agent writes an append-only event log per session here,
+# separate from the VS Code Copilot chat store above (#36).
+COPILOT_CLI_DIR = HOME / ".copilot" / "session-state"
 ANTIGRAVITY_BRAIN_DIR = GEMINI_DIR / "antigravity" / "brain"
 PROJECT_ALIASES_FILE = HOME / ".tokentelemetry" / "aliases.json"
 
@@ -1191,7 +1253,7 @@ async def get_available_agents():
     if QWEN_DIR.exists(): agents.append("qwen")
     if VIBE_DIR.exists(): agents.append("vibe")
     if CURSOR_DIR.exists(): agents.append("cursor")
-    if VSCODE_STORAGE.exists(): agents.append("copilot")
+    if VSCODE_STORAGE.exists() or COPILOT_CLI_DIR.exists(): agents.append("copilot")
     if OPENCODE_DB.exists(): agents.append("opencode")
     if _hermes_dbs(): agents.append("hermes")
     if GROK_SESSIONS_DIR.exists(): agents.append("grok")
@@ -2166,8 +2228,71 @@ def _scan_sessions_sync():
                                 for part in req["response"]: tokens["output"] += part.get("tokens", 0) or 0
                         tokens["total"] = tokens["input"] + tokens["output"] + tokens["cached"]
                         tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"])
-                        sessions.append({"id": sid, "agent": "copilot", "project": project_path, "timestamp": last_ts, "display": first_msg[:100], "tokens": tokens, "mcp_tools": [], "has_plan": len(plans) > 0, "plans": plans, "model": model, "artifacts": [], "cost": tokens["cost"]})
+                        sessions.append({"id": sid, "agent": "copilot", "project": project_path, "timestamp": last_ts, "display": first_msg[:100], "tokens": tokens, "mcp_tools": [], "has_plan": len(plans) > 0, "plans": plans, "model": model, "artifacts": [], "copilot_source": "vscode", "cost": tokens["cost"]})
                     except Exception: continue
+            except Exception: continue
+
+    # 7b. GitHub Copilot CLI / agent — ~/.copilot/session-state/<id>/events.jsonl.
+    # A separate store from the VS Code Copilot chat sessions above; the CLI
+    # writes an append-only event log per session (#36). Token usage comes from
+    # session.shutdown.modelMetrics when the session has ended, otherwise we sum
+    # per-message outputTokens and estimate input from prompt length.
+    if COPILOT_CLI_DIR.exists():
+        for sess_dir in COPILOT_CLI_DIR.iterdir():
+            try:
+                if not sess_dir.is_dir(): continue
+                ev_file = sess_dir / "events.jsonl"
+                if not ev_file.exists(): continue
+                rows = _load_copilot_cli_events(ev_file)
+                if not rows: continue
+                sid = sess_dir.name
+                project_path = "unknown"; first_msg = ""; model = None
+                models_used: List[str] = []
+                out_tokens = 0; in_estimate = 0
+                start_ts = None; last_ts = None; shutdown_metrics = None
+                for r in rows:
+                    et = r.get("type"); d = r.get("data") or {}
+                    rts = _parse_copilot_iso(r.get("timestamp"))
+                    if rts and (last_ts is None or rts > last_ts): last_ts = rts
+                    if et == "session.start":
+                        cwd = (d.get("context") or {}).get("cwd")
+                        if cwd: project_path = cwd
+                        start_ts = _parse_copilot_iso(d.get("startTime")) or rts
+                    elif et == "user.message":
+                        c = d.get("content") or ""
+                        if c and not first_msg: first_msg = c
+                        in_estimate += len(c) // 4
+                    elif et == "assistant.message":
+                        m = d.get("model")
+                        if m:
+                            if not model: model = m
+                            if m not in models_used: models_used.append(m)
+                        ot = d.get("outputTokens")
+                        if isinstance(ot, (int, float)) and not isinstance(ot, bool):
+                            out_tokens += int(ot)
+                    elif et == "session.model_change":
+                        nm = d.get("newModel")
+                        if nm and nm not in models_used: models_used.append(nm)
+                    elif et == "session.shutdown":
+                        shutdown_metrics = d.get("modelMetrics")
+                tokens = {"input": 0, "output": 0, "cached": 0, "total": 0}
+                metr = _copilot_cli_tokens_from_metrics(shutdown_metrics)
+                if metr:
+                    tokens.update(metr)
+                else:
+                    tokens["input"] = in_estimate
+                    tokens["output"] = out_tokens
+                tokens["total"] = tokens["input"] + tokens["output"] + tokens["cached"]
+                tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"])
+                if model and model not in models_used: models_used.insert(0, model)
+                ts = last_ts or start_ts or _file_mtime_utc(ev_file)
+                sessions.append({
+                    "id": sid, "agent": "copilot", "project": apply_alias(project_path),
+                    "timestamp": ts, "display": first_msg[:100], "tokens": tokens,
+                    "mcp_tools": [], "has_plan": False, "plans": [],
+                    "model": model, "models_used": models_used, "artifacts": [],
+                    "copilot_source": "cli", "cost": tokens["cost"],
+                })
             except Exception: continue
 
     # 8. OpenCode (SQLite: session / message / part)
@@ -2754,6 +2879,31 @@ async def get_session_detail(session_id: str, agent: str):
                 except Exception: continue
         return events
     elif agent == "copilot":
+        # GitHub Copilot CLI session (~/.copilot/session-state/<id>/events.jsonl)
+        # takes priority — its ids are dir-named UUIDs distinct from VS Code (#36).
+        cli_file = COPILOT_CLI_DIR / session_id / "events.jsonl"
+        if cli_file.exists():
+            events = []
+            for r in _load_copilot_cli_events(cli_file):
+                et = r.get("type"); d = r.get("data") or {}
+                _p = _parse_copilot_iso(r.get("timestamp"))
+                norm = int(_p.timestamp() * 1000) if _p else None
+                base = {"timestamp": norm, "normalized_timestamp": norm}
+                if et == "user.message":
+                    events.append({"type": "user", "payload": {"content": d.get("content", "")}, **base})
+                elif et == "assistant.message":
+                    rt = d.get("reasoningText") or ""
+                    if rt:
+                        events.append({"type": "assistant_thinking", "payload": {"text": rt}, **base})
+                    txt = d.get("content") or ""
+                    if txt:
+                        events.append({"type": "assistant", "payload": {"content": txt, "model": d.get("model")}, **base})
+                    for tr in (d.get("toolRequests") or []):
+                        events.append({"type": "tool_call", "payload": {
+                            "tool": tr.get("name"), "callID": tr.get("toolCallId"),
+                            "arguments": tr.get("arguments"),
+                        }, **base})
+            return events
         # VS Code ~1.100+ stores sessions as <id>.jsonl (delta log) instead of
         # <id>.json (single object); match both and reconstruct the .jsonl form.
         files = list(VSCODE_STORAGE.glob(f"**/chatSessions/{session_id}.json")) \

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -10,6 +10,7 @@ import {
 import { useResource } from "@/lib/api";
 import { AGENTS, getAgent, type AgentKey } from "@/lib/agents";
 import SourceBadge from "@/components/SourceBadge";
+import CopilotSourceBadge from "@/components/CopilotSourceBadge";
 import { formatTokens, formatCost } from "@/lib/format";
 import {
   PageHeader, StatTile, Section, Card, CardHeader, CardTitle, CardEyebrow,
@@ -25,6 +26,8 @@ interface Session {
   text?: string;
   tokens?: { input: number; output: number; cached: number; total: number };
   cost?: number;
+  /** Copilot-only: cli / vscode */
+  copilot_source?: string;
   /** Hermes-only: cli / telegram / cron / etc. */
   source_subtype?: string;
 }
@@ -228,8 +231,9 @@ export default function Home() {
                   {sessions.slice(0, 50).map((s, i) => (
                     <TR key={`${s.agent}-${s.id}-${i}`} interactive>
                       <TD className="pl-5">
-                        <Link href={`/sessions/${s.id}?agent=${s.agent}&from=${encodeURIComponent(pathname)}`} className="block">
+                        <Link href={`/sessions/${s.id}?agent=${s.agent}&from=${encodeURIComponent(pathname)}`} className="flex items-center gap-1.5">
                           <AgentBadge agent={s.agent} />
+                          {s.agent === "copilot" && <CopilotSourceBadge source={s.copilot_source} size="xs" />}
                         </Link>
                       </TD>
                       <TD className="font-mono text-[12px] text-[var(--tt-fg-muted)] max-w-[160px] truncate" title={s.agent === "hermes" ? `Hermes source: ${s.source_subtype || "unknown"}` : s.project}>

--- a/frontend/src/app/projects/[path]/_lib/project-context.tsx
+++ b/frontend/src/app/projects/[path]/_lib/project-context.tsx
@@ -19,6 +19,7 @@ export interface SessionRow {
   mcp_tools: string[];
   subagents: string[];
   has_plan: boolean;
+  copilot_source?: string;
   tokens?: { input: number; output: number; cached: number; total: number };
 }
 

--- a/frontend/src/app/projects/[path]/activity/page.tsx
+++ b/frontend/src/app/projects/[path]/activity/page.tsx
@@ -10,6 +10,7 @@ import {
   Table, THead, TBody, TR, TH, TD,
 } from "@/components/ui";
 import { useProject } from "../_lib/project-context";
+import CopilotSourceBadge from "@/components/CopilotSourceBadge";
 
 export default function ActivityTab() {
   const pathname = usePathname();
@@ -47,8 +48,9 @@ export default function ActivityTab() {
               {sessions.map((s, i) => (
                 <TR key={`${s.agent}-${s.id}-${i}`} interactive>
                   <TD className="pl-5">
-                    <Link href={`/sessions/${s.id}?agent=${s.agent}&from=${encodeURIComponent(pathname)}`} className="block">
+                    <Link href={`/sessions/${s.id}?agent=${s.agent}&from=${encodeURIComponent(pathname)}`} className="flex items-center gap-1.5">
                       <AgentBadge agent={s.agent} />
+                      {s.agent === "copilot" && <CopilotSourceBadge source={s.copilot_source} size="xs" />}
                     </Link>
                   </TD>
                   <TD className="text-[var(--tt-fg)] max-w-[640px] truncate">

--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -9,6 +9,7 @@ import Link from "next/link";
 import { format } from "date-fns";
 import { AgentBadge, Badge, Button, Skeleton } from "@/components/ui";
 import SourceBadge from "@/components/SourceBadge";
+import CopilotSourceBadge from "@/components/CopilotSourceBadge";
 import SummaryPanel from "@/components/summarizer/SummaryPanel";
 import { API_BASE } from "@/lib/api";
 import { resolveSessionBackTarget } from "@/lib/navigation";
@@ -34,6 +35,8 @@ interface Session {
   tokens?: { input: number; output: number; cached: number; total: number; cost?: number };
   cost?: number;
   artifacts?: Artifact[];
+  /** Copilot-only: which surface (cli vs vscode) */
+  copilot_source?: string;
   /** Hermes-only */
   source_subtype?: string;
   parent_session_id?: string | null;
@@ -471,6 +474,7 @@ export default function SessionDetailPage() {
                 </div>
                 <div className="flex items-center gap-2 flex-wrap">
                   {agent && <AgentBadge agent={agent} />}
+                  {agent === "copilot" && <CopilotSourceBadge source={sessionInfo?.copilot_source} size="sm" />}
                   {agent === "hermes" && <SourceBadge source={sessionInfo?.source_subtype} size="sm" />}
                   <button
                     onClick={() => navigator.clipboard?.writeText(id)}

--- a/frontend/src/components/CopilotSourceBadge.tsx
+++ b/frontend/src/components/CopilotSourceBadge.tsx
@@ -1,0 +1,36 @@
+// Copilot surface sub-label — distinguishes the GitHub Copilot CLI/agent
+// (~/.copilot/session-state) from the VS Code Copilot chat store. Both roll up
+// under the single "Copilot" agent; this chip just says which surface (#36).
+
+import { Terminal, Code } from "lucide-react";
+
+type CopilotSource = "cli" | "vscode";
+
+const META: Record<CopilotSource, { label: string; icon: typeof Terminal; cls: string }> = {
+  cli:    { label: "CLI",     icon: Terminal, cls: "text-amber-300 bg-amber-500/10 border-amber-500/30" },
+  vscode: { label: "VS CODE", icon: Code,     cls: "text-sky-300 bg-sky-500/10 border-sky-500/30" },
+};
+
+export default function CopilotSourceBadge({
+  source,
+  size = "sm",
+}: {
+  source: string | null | undefined;
+  size?: "xs" | "sm";
+}) {
+  const meta = source && (META as Record<string, typeof META.cli>)[source];
+  if (!meta) return null; // only render when we actually know the surface
+  const Icon = meta.icon;
+  const sizing =
+    size === "xs" ? "text-[9px] px-1.5 py-[1px] gap-1" : "text-[10px] px-2 py-[2px] gap-1";
+  const iconSize = size === "xs" ? 9 : 11;
+  return (
+    <span
+      className={`inline-flex items-center font-mono uppercase tracking-wider rounded border ${sizing} ${meta.cls}`}
+      title={`Copilot surface: ${meta.label.toLowerCase()}`}
+    >
+      <Icon size={iconSize} />
+      {meta.label}
+    </span>
+  );
+}


### PR DESCRIPTION
Fixes #36.

Adds **GitHub Copilot CLI / agent** as a first-class source (`~/.copilot/session-state/<id>/events.jsonl`) — the VS Code fix (#37) only covered the VS Code chat store. Reads:
- project/cwd from `session.start.context.cwd`
- per-message model + mid-session `session.model_change`
- tokens from `session.shutdown.modelMetrics` when present, else summed `assistant.message.outputTokens` + a prompt-length input estimate for active sessions

Both surfaces stay under one **Copilot** agent; a new `copilot_source` field (`cli` / `vscode`) drives a small `CopilotSourceBadge` sub-label in the session list, project activity, and detail header. Includes an `UPDATE.json` entry.

Verified against a real local Copilot CLI session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
