### PR TITLE
fix: use cache high-watermark for cost + relabel to 'API equiv.' (#42)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1741,7 +1741,7 @@ def _scan_sessions_sync():
                                     sess["tokens"]["cached"] = max(sess["tokens"]["cached"], cr)
                                     sess["tokens"]["_cached_sum"] = sess["tokens"].get("_cached_sum", 0) + cr
                                 sess["tokens"]["total"] = sess["tokens"]["input"] + sess["tokens"]["output"] + sess["tokens"]["cached"]
-                                sess["cost"] = calculate_cost(sess.get("model"), sess["tokens"]["input"], sess["tokens"]["output"], sess["tokens"].get("_cached_sum", sess["tokens"]["cached"]))
+                                sess["cost"] = calculate_cost(sess.get("model"), sess["tokens"]["input"], sess["tokens"]["output"], sess["tokens"]["cached"])
                                 for item in msg.get("content", []):
                                     if item.get("type") == "tool_use":
                                         tool = item.get("name")
@@ -2147,7 +2147,7 @@ def _scan_sessions_sync():
                                                     plans.append({"session_id": sid, "agent": "qwen", "timestamp": last_ts, "content": t_text})
                                 except Exception: continue
                         tokens["total"] = tokens["input"] + tokens["output"] + tokens["cached"]
-                        tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens.get("_cached_sum", tokens["cached"]))
+                        tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"])
                         sessions.append({"id": sid, "agent": "qwen", "project": project_path, "timestamp": last_ts, "display": first_msg[:100], "tokens": tokens, "mcp_tools": mcp_tools, "has_plan": has_plan, "plans": plans, "model": model, "artifacts": artifacts, "cost": tokens["cost"]})
                     except Exception: continue
 
@@ -2254,7 +2254,7 @@ def _scan_sessions_sync():
                                                         has_plan = True
                                                         plans.append({"session_id": sid, "agent": "cursor", "timestamp": mtime, "content": t_text})
                                 tokens["total"] = tokens["input"] + tokens["output"] + tokens["cached"]
-                                tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens.get("_cached_sum", tokens["cached"]))
+                                tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"])
                                 sessions.append({"id": sid, "agent": "cursor", "project": project_path, "timestamp": mtime, "display": first_msg[:100], "tokens": tokens, "mcp_tools": mcp_tools, "subagents": subagents, "has_plan": has_plan, "plans": plans, "model": model, "artifacts": artifacts, "cost": tokens["cost"]})
                             except Exception: continue
 
@@ -2472,7 +2472,7 @@ def _scan_sessions_sync():
                             # writes into input as the closest available approximation).
                             tokens["input"]  += (tk.get("input", 0) or 0) + cache_write
                             tokens["output"] += tk.get("output", 0) or 0
-                            tokens["cached"] += (cache.get("read", 0) or 0)
+                            tokens["cached"] = max(tokens["cached"], cache.get("read", 0) or 0)
                     tokens["total"] = tokens["input"] + tokens["output"] + tokens["cached"]
                     tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"])
                     project_path = srow["directory"] or "unknown"

--- a/frontend/src/app/analytics/page.tsx
+++ b/frontend/src/app/analytics/page.tsx
@@ -163,7 +163,7 @@ export default function AnalyticsPage() {
           <StatTile
             label="Cache efficiency"
             value={`${cacheEff.toFixed(1)}%`}
-            hint={`${compact(data.total.cached)} cached · est. $${data.total.cost.toFixed(2)} cost`}
+            hint={`${compact(data.total.cached)} cached · est. $${data.total.cost.toFixed(2)} API equiv.`}
             icon={<Zap size={16} />}
             accent="var(--tt-warn)"
           />
@@ -275,7 +275,7 @@ export default function AnalyticsPage() {
                 <TH className="text-right">Output</TH>
                 <TH className="text-right">Cached</TH>
                 <TH className="text-right">Total</TH>
-                <TH className="text-right pr-5 text-amber-300">Cost</TH>
+                <TH className="text-right pr-5 text-amber-300">API equiv.</TH>
               </TR>
             </THead>
             <TBody>
@@ -384,7 +384,7 @@ export default function AnalyticsPage() {
                     <TH className="text-right">Output</TH>
                     <TH className="text-right">Cached</TH>
                     <TH className="text-right">Total</TH>
-                    <TH className="text-right pr-5 text-amber-300">Cost</TH>
+                    <TH className="text-right pr-5 text-amber-300">API equiv.</TH>
                   </TR>
                 </THead>
                 <TBody>

--- a/frontend/src/app/hermes/page.tsx
+++ b/frontend/src/app/hermes/page.tsx
@@ -154,7 +154,7 @@ export default function HermesPage() {
         />
         <StatTile
           icon={<DollarSign size={14} />}
-          label="Total cost"
+          label="API equiv."
           value={loading ? "—" : formatCost(totalCost)}
         />
         <StatTile

--- a/frontend/src/app/hermes/page.tsx
+++ b/frontend/src/app/hermes/page.tsx
@@ -408,7 +408,7 @@ export default function HermesPage() {
                 <TH className="pl-5">Source</TH>
                 <TH>Model</TH>
                 <TH>Message</TH>
-                <TH className="text-right">Cost</TH>
+                <TH className="text-right">API equiv.</TH>
                 <TH className="text-right pr-5">Time</TH>
               </TR>
             </THead>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -115,9 +115,9 @@ export default function Home() {
             accent="var(--tt-info)"
           />
           <StatTile
-            label="Cost (est.)"
+            label="API equiv. (est.)"
             value={loading ? <Skeleton className="h-8 w-20" /> : formatCost(totalCost)}
-            hint={pricingUpdated ? `Rates updated ${pricingUpdated}` : undefined}
+            hint="Estimated at API list prices. Subscription users pay a flat monthly fee — this is not your actual spend."
             icon={<DollarSign size={16} />}
             accent="var(--tt-warn)"
           />

--- a/frontend/src/app/projects/page.tsx
+++ b/frontend/src/app/projects/page.tsx
@@ -34,7 +34,7 @@ type SortKey = "sessions" | "tokens" | "cost" | "name";
 const SORTS: { key: SortKey; label: string }[] = [
   { key: "sessions", label: "Sessions" },
   { key: "tokens",   label: "Tokens"   },
-  { key: "cost",     label: "Cost"     },
+  { key: "cost",     label: "API equiv."     },
   { key: "name",     label: "Name"     },
 ];
 
@@ -166,7 +166,7 @@ export default function ProjectsPage() {
                 <TH className="text-right">Subagents</TH>
                 <TH className="text-right">Plans</TH>
                 <TH className="text-right">Tokens</TH>
-                <TH className="text-right pr-5">Cost</TH>
+                <TH className="text-right pr-5">API equiv.</TH>
               </TR>
             </THead>
             <TBody>
@@ -268,7 +268,7 @@ function ProjectCard({ project }: { project: Project }) {
           <Stat label="Sessions" value={project.session_count} />
           <Stat label="Subs"     value={subs}      tone="purple" />
           <Stat label="Plans"    value={project.plan_count || 0} tone="emerald" />
-          <Stat label="Cost"     value={formatCost(cost)} tone="amber"
+          <Stat label="API equiv." value={formatCost(cost)} tone="amber"
                 hint={tokens ? formatTokens(tokens) : undefined} />
         </div>
       </Card>

--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -1950,8 +1950,8 @@ function GrokForensicsCard({ forensics, cost }: { forensics: any; cost?: number 
           </div>
           {typeof cost === "number" && cost > 0 && (
             <div className="text-[var(--tt-fg-muted)] mt-0.5">
-              Est. cost: <span className="font-mono text-[var(--tt-fg)]">${cost.toFixed(4)}</span>
-              <span className="text-[var(--tt-fg-faint)] ml-1">· input-rate estimate (output not reported)</span>
+              API equiv.: <span className="font-mono text-[var(--tt-fg)]">${cost.toFixed(4)}</span>
+              <span className="text-[var(--tt-fg-faint)] ml-1">· API list-price estimate</span>
             </div>
           )}
         </div>

--- a/frontend/src/components/summarizer/SummaryPanel.tsx
+++ b/frontend/src/components/summarizer/SummaryPanel.tsx
@@ -217,7 +217,7 @@ export default function SummaryPanel({ sessionId, agent }: SummaryPanelProps) {
                 <Stat label="Input" value={formatTokens(brief.tokens.input)} />
                 <Stat label="Output" value={formatTokens(brief.tokens.output)} />
                 <Stat label="Total" value={formatTokens(brief.tokens.total)} accent />
-                <Stat label="Cost" value={formatCost(brief.cost)} icon={<Coins size={11} />} accent />
+                <Stat label="API equiv." value={formatCost(brief.cost)} icon={<Coins size={11} />} accent />
                 <Stat label="User turns" value={brief.user_turns} />
                 {brief.model && (
                   <Badge variant="success" size="xs" className="font-mono normal-case" title={brief.model}>{brief.model}</Badge>


### PR DESCRIPTION
Two-part fix for inflated cost estimates:

1. Use high-watermark (max across turns) instead of cumulative
   _cached_sum for cache-read cost calculation across Claude, Qwen,
   Cursor, and OpenCode parsers. The cumulative sum counts every
   re-read of the same cached prefix across turns, inflating the
   estimate by orders of magnitude on long sessions. Session-level
   cost now reflects the unique cached-prefix size.

2. Relabel all 'Cost' / 'Cost (est.)' / 'Est. cost' displays to
   'API equiv. (est.)' with a tooltip clarifying this is an API
   list-price estimate — subscription users pay a flat fee.

Fixes #42.
