### PR TITLE
feat(summarizer): config-driven OpenAI-compatible backend (#38)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -84,3 +84,36 @@ The hook is intentionally narrow. Cases:
 - **Backend default port: 8000** (matches `bin/cli.js`). If you start uvicorn elsewhere, frontend's `NEXT_PUBLIC_API_BASE` must follow.
 - **`UPDATE.json` is committed.** It's not generated, not gitignored. Treat it as source code.
 - **Test pollution: clear `~/.tokentelemetry/.update-check.json`** if you manually seed it for testing; the SHA validator added in PR #34 catches obvious garbage but doesn't catch all dev mistakes.
+
+## Summarizer error handling (never dump raw errors in the UI)
+
+Any failure from a summarizer backend (CLI non-zero exit, HTTP 4xx/5xx, timeout,
+empty output) **must be classified, not surfaced raw**. A user should never see a
+bare stack trace, `HTTP 4xx …`, or a provider's JSON blob as the error message.
+
+The pipeline is:
+
+1. **Adapters raise `SummarizerError`** with the underlying detail kept in the
+   message (status code + provider body), so the classifier has something to
+   match on. HTTP adapters keep the numeric status in the string (e.g.
+   `HTTP 413 from …: {…}`).
+2. **`backend/summarizers/errors.py::classify()`** buckets it into a `category`
+   and returns `{category, title, message, hint, raw}` — a short human title, a
+   plain-English message, an actionable hint, and the truncated raw text (shown
+   only behind a "Show raw error" disclosure). Patterns are ordered, first match
+   wins; order matters (e.g. `too_large` before `quota` because token-budget
+   413s also carry rate-limit wording).
+3. **The endpoint returns `error_info`**, and the frontend renders it via
+   `SummaryErrorCard` (`SummaryPanel.tsx`) / the Test-connection result.
+
+**When you add a new error category** you must touch all three layers or it
+won't compile / won't render:
+- add the pattern + `title`/`message`/`hint` branch in `errors.py`;
+- add it to the `SummaryErrorInfo["category"]` union in `frontend/src/lib/summarizer.ts`;
+- add an icon to `ERROR_ICONS` in `SummaryPanel.tsx` (it's a total `Record`, so
+  TS fails the build if a category is missing).
+
+Hints should tell the user what to *do* (switch model, check `ollama serve`,
+set an env var), not just restate the error. Prefer graceful degradation over a
+hard error where possible — e.g. the `openai_compat` adapter retries once with a
+clean OpenAI-only payload when a strict gateway 400s on a non-standard field.

--- a/UPDATE.json
+++ b/UPDATE.json
@@ -1,6 +1,17 @@
 {
   "releases": [
     {
+      "tag": "2026-06-05",
+      "title": "Summarize with any OpenAI-compatible server",
+      "highlights": [
+        {
+          "title": "OpenAI-compatible summarizer backend",
+          "description": "Point TokenTelemetry at any server speaking the OpenAI /v1/chat/completions API — llama.cpp, vLLM, LM Studio, LocalAI, or Ollama's OpenAI endpoint — to generate trace summaries. No extra CLI to install: set the endpoint, model, and (optionally) an API key, tune sampling, and hit Test connection.",
+          "href": "/settings"
+        }
+      ]
+    },
+    {
       "tag": "2026-06-04",
       "title": "Antigravity — tokens, IDE coverage, surface labels",
       "highlights": [

--- a/backend/main.py
+++ b/backend/main.py
@@ -4011,6 +4011,29 @@ async def list_codex_models():
     from summarizers.codex import SUGGESTED_MODELS
     return {"models": SUGGESTED_MODELS}
 
+
+@app.post("/summarizer/openai-compat/test")
+async def test_openai_compat(cfg: dict = Body(...)):
+    """Ping the configured OpenAI-compatible endpoint with a trivial prompt so
+    the settings UI can confirm the server is reachable before saving. Accepts
+    the same shape as the config (top-level ``model`` + ``openai_compat`` block,
+    or a bare openai_compat dict)."""
+    from summarizers.openai_compat import OpenAICompatSummarizer
+    from summarizers.errors import classify as _classify_err
+
+    options = cfg.get("openai_compat") if isinstance(cfg.get("openai_compat"), dict) else cfg
+    sm = OpenAICompatSummarizer(model=cfg.get("model"), config=options)
+    try:
+        sample = sm.summarize("Reply with the single word: ok", timeout=30)
+        return {"ok": True, "sample": sample[:200], "endpoint": sm.endpoint}
+    except SummarizerError as e:
+        return {
+            "ok": False,
+            "error": str(e),
+            "error_info": _classify_err(str(e), backend_name="openai_compat"),
+        }
+
+
 @app.get("/sessions/{session_id}/summary")
 async def get_summary(session_id: str):
     cached = _summaries.get_cached(session_id)
@@ -4038,7 +4061,7 @@ async def make_summary(session_id: str, agent: str, force: bool = False):
     narrative = None
     gen_error = None
     if cfg.get("enabled") and backend_name:
-        sm = get_summarizer(backend_name, cfg.get("model"))
+        sm = get_summarizer(backend_name, cfg.get("model"), cfg.get("openai_compat"))
         if sm and sm.is_available():
             try:
                 raw = sm.summarize(_summaries.build_prompt(brief))

--- a/backend/summaries.py
+++ b/backend/summaries.py
@@ -364,6 +364,33 @@ def _row_to_dict(row: sqlite3.Row) -> Dict[str, Any]:
 # --------------------------------------------------------------------------- #
 # Config — which backend summarizes, persisted in ~/.tokentelemetry.
 # --------------------------------------------------------------------------- #
+def _coerce_openai_compat(raw: Any) -> Dict[str, Any]:
+    """Merge a user-supplied openai_compat sub-config over the canonical
+    defaults, coercing each field to its expected type. Unknown keys are
+    dropped so the persisted file stays clean."""
+    from summarizers.openai_compat import default_config
+
+    defaults = default_config()
+    merged = dict(defaults)
+    if isinstance(raw, dict):
+        for key, default in defaults.items():
+            if key not in raw or raw[key] is None:
+                continue
+            val = raw[key]
+            try:
+                if isinstance(default, bool):
+                    merged[key] = bool(val)
+                elif isinstance(default, int) and not isinstance(default, bool):
+                    merged[key] = int(val)
+                elif isinstance(default, float):
+                    merged[key] = float(val)
+                else:
+                    merged[key] = str(val)
+            except (TypeError, ValueError):
+                merged[key] = default
+    return merged
+
+
 def load_config() -> Dict[str, Any]:
     try:
         return json.loads(_CONFIG_PATH.read_text())
@@ -373,10 +400,15 @@ def load_config() -> Dict[str, Any]:
 
 def save_config(cfg: Dict[str, Any]) -> Dict[str, Any]:
     TT_HOME.mkdir(parents=True, exist_ok=True)
-    out = {
+    out: Dict[str, Any] = {
         "enabled": bool(cfg.get("enabled")),
         "backend": cfg.get("backend") or None,
         "model": cfg.get("model") or None,
     }
+    # Persist the openai_compat sub-config whenever it's supplied — keeping it
+    # around even when another backend is active means the user's endpoint /
+    # tuning survives a backend switch.
+    if cfg.get("openai_compat") is not None or out["backend"] == "openai_compat":
+        out["openai_compat"] = _coerce_openai_compat(cfg.get("openai_compat"))
     _CONFIG_PATH.write_text(json.dumps(out, indent=2))
     return out

--- a/backend/summarizers/__init__.py
+++ b/backend/summarizers/__init__.py
@@ -5,7 +5,7 @@ frontend, so the onboarding picker shows exactly what the user can actually run.
 """
 from __future__ import annotations
 
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from .base import BaseSummarizer, SummarizerError
 from .claude import ClaudeSummarizer
@@ -13,9 +13,12 @@ from .codex import CodexSummarizer
 from .gemini import GeminiSummarizer
 from .antigravity import AntigravitySummarizer
 from .ollama import OllamaSummarizer
+from .openai_compat import OpenAICompatSummarizer
 from .qwen import QwenSummarizer
 
 # Only adapters whose CLI is installed are offered to the frontend.
+# openai_compat is the exception — it has no CLI to install, so it always shows
+# as the universal "point it at any OpenAI-compatible server" option.
 _ALL: List[BaseSummarizer] = [
     ClaudeSummarizer(),
     CodexSummarizer(),
@@ -23,19 +26,27 @@ _ALL: List[BaseSummarizer] = [
     AntigravitySummarizer(),
     QwenSummarizer(),
     OllamaSummarizer(),
+    OpenAICompatSummarizer(),
 ]
 
 _BY_NAME: Dict[str, BaseSummarizer] = {s.name: s for s in _ALL}
 
 
-def get_summarizer(name: str, model: Optional[str] = None) -> Optional[BaseSummarizer]:
+def get_summarizer(
+    name: str,
+    model: Optional[str] = None,
+    options: Optional[Dict[str, Any]] = None,
+) -> Optional[BaseSummarizer]:
     """Look up a backend by name. If a ``model`` is supplied, return a fresh
     instance bound to that model (Ollama / Codex support this) rather than
-    the registry singleton."""
+    the registry singleton. ``options`` carries backend-specific config — for
+    openai_compat that's the endpoint + sampling params."""
     if name == "ollama" and model:
         return OllamaSummarizer(model=model)
     if name == "codex" and model:
         return CodexSummarizer(model=model)
+    if name == "openai_compat":
+        return OpenAICompatSummarizer(model=model, config=options or {})
     return _BY_NAME.get(name)
 
 

--- a/backend/summarizers/errors.py
+++ b/backend/summarizers/errors.py
@@ -8,6 +8,7 @@ the underlying error when reporting bugs.
 
 from __future__ import annotations
 
+import json
 from typing import Optional
 
 _MAX_RAW = 3000
@@ -27,10 +28,56 @@ def _first_line(text: str) -> str:
     return text.strip()
 
 
-# (substring, category) — checked in order, first match wins.
+def _provider_message(raw: str) -> str:
+    """Best-effort: pull a human sentence out of a provider's JSON error body.
+
+    Backend HTTP errors arrive as e.g. ``HTTP 500 from …: {"error":{"message":
+    "…"}}``. We parse the embedded JSON and return its ``error.message`` (or
+    ``message`` / ``detail``) so the UI can show a sentence instead of a brace
+    soup. Returns "" when there's no usable JSON message."""
+    start, end = raw.find("{"), raw.rfind("}")
+    if start == -1 or end <= start:
+        return ""
+    try:
+        doc = json.loads(raw[start : end + 1])
+    except (ValueError, TypeError):
+        return ""
+    node = doc.get("error", doc) if isinstance(doc, dict) else doc
+    if isinstance(node, dict):
+        for key in ("message", "detail", "error"):
+            val = node.get(key)
+            if isinstance(val, str) and val.strip():
+                return val.strip()
+    elif isinstance(node, str) and node.strip():
+        return node.strip()
+    return ""
+
+
+def _humanize(raw: str) -> str:
+    """A presentable one-line message for an otherwise-unclassified error —
+    never a JSON blob. Prefers a provider's JSON message, then a clean first
+    line, else a generic fallback (the full text stays in ``raw``)."""
+    msg = _provider_message(raw)
+    if msg:
+        return msg[:300]
+    first = _first_line(raw)
+    if first and not first.lstrip().startswith(("{", "[")) and len(first) <= 200:
+        return first
+    return "The summarizer returned an unexpected error. See the raw details below."
+
+
+# (substring, category) — checked in order, first match wins. "too_large" is
+# listed before "quota" because token-budget 413s (Groq's per-minute TPM cap,
+# context-length overflows) often *also* carry rate-limit wording, but the
+# actionable advice is "shrink the request / bigger model", not "wait".
 _PATTERNS: list[tuple[tuple[str, ...], str]] = [
     (("401", "unauthorized", "invalid_api_key", "incorrect api key"), "auth"),
-    (("429", "rate limit", "quota", "exceeded your current quota"), "quota"),
+    (("413", "too large", "request too large", "request_too_large",
+      "maximum context", "context length", "context_length_exceeded",
+      "reduce your message", "tokens per minute", "too many tokens",
+      "input is too long", "prompt is too long"), "too_large"),
+    (("429", "rate limit", "rate_limit_exceeded", "quota",
+      "exceeded your current quota"), "quota"),
     (("model_not_found", "does not exist", "model not found", "no such model"), "model"),
     (("timed out", "timeout"), "timeout"),
     (("connection refused", "could not connect", "network", "dns"), "network"),
@@ -50,18 +97,34 @@ def _auth_hint(backend_name: str) -> str:
         return "Run `qwen auth` or set `DASHSCOPE_API_KEY`."
     if b == "antigravity":
         return "Re-authenticate the Antigravity agent (check `agy auth status`)."
+    if b == "openai_compat":
+        return "Set the API key in Settings → Summarizer, or via OPENAI_COMPAT_API_KEY."
     return "Check the CLI's auth configuration."
 
 
 def _network_hint(backend_name: str) -> str:
-    if (backend_name or "").lower() == "ollama":
+    b = (backend_name or "").lower()
+    if b == "ollama":
         return "Is `ollama serve` running?"
+    if b == "openai_compat":
+        return "Is your server running and is the endpoint URL correct (e.g. http://localhost:8080/v1)?"
     return "Check your internet connection."
 
 
 def _timeout_hint(backend_name: str) -> str:
     suffix = (backend_name or "BACKEND").upper() or "BACKEND"
     return f"Try a faster/smaller model, or override the timeout via TT_{suffix}_TIMEOUT."
+
+
+def _too_large_hint(backend_name: str) -> str:
+    if (backend_name or "").lower() == "openai_compat":
+        return (
+            "This trace is bigger than the model/tier allows. Pick a model with a "
+            "larger context window or higher rate-limit tier, switch to a local "
+            "backend (Ollama, llama.cpp) with no per-minute cap, or upgrade the "
+            "provider plan."
+        )
+    return "Use a model with a larger context window, or summarize a shorter session."
 
 
 def classify(stderr_text: str, *, backend_name: str = "") -> dict:
@@ -84,6 +147,10 @@ def classify(stderr_text: str, *, backend_name: str = "") -> dict:
         title = "API key invalid"
         message = "The summarizer CLI rejected your credentials (HTTP 401 / invalid key)."
         hint = _auth_hint(backend_name)
+    elif category == "too_large":
+        title = "Trace too large for this model"
+        message = "The request exceeded the model's context window or the provider's per-minute token budget."
+        hint = _too_large_hint(backend_name)
     elif category == "quota":
         title = "Rate limit or quota exceeded"
         message = "The model provider throttled the request or your quota is exhausted."
@@ -106,7 +173,7 @@ def classify(stderr_text: str, *, backend_name: str = "") -> dict:
         hint = "The backend completed but returned nothing — try a different model or regenerate."
     else:
         title = "Summarizer failed"
-        message = _first_line(raw) or "Unknown error."
+        message = _humanize(raw) or "Unknown error."
         hint = None
 
     return {

--- a/backend/summarizers/openai_compat.py
+++ b/backend/summarizers/openai_compat.py
@@ -1,0 +1,238 @@
+"""OpenAI-compatible HTTP summarizer adapter.
+
+Unlike every other backend, this one shells out to *nothing*. It POSTs the
+prompt to any server that speaks the OpenAI ``/v1/chat/completions`` API —
+llama.cpp, vLLM, LM Studio, LocalAI, Ollama's OpenAI endpoint, or a hosted
+gateway — and reads the reply back. That lets users reuse a model server they
+already run without installing yet another CLI (the ask in discussion #38).
+
+Design notes:
+  * Pure stdlib (``urllib``): no new runtime dependency, keeping the
+    "no signup, no key, 100 % local-first" promise intact.
+  * Synchronous, matching ``BaseSummarizer.summarize`` — the dispatcher calls
+    it without ``await``.
+  * Error messages embed the HTTP status / failure mode verbatim so
+    ``errors.classify`` can bucket them (401 → auth, 429 → quota, connection
+    refused → network, timed out → timeout, empty → no_output).
+  * An optional bearer token is supported (some local servers and all hosted
+    gateways require one). ``OPENAI_COMPAT_API_KEY`` overrides the stored value
+    so secrets need not live in ``summarizer.json``.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import urllib.error
+import urllib.request
+from typing import Any, Dict, Optional
+
+from .base import BaseSummarizer, SummarizerError
+
+_DEFAULT_ENDPOINT = "http://localhost:8080/v1"
+# Local inference can be slow; override via env for heavy models / cold loads.
+_DEFAULT_TIMEOUT = int(os.environ.get("TT_OPENAI_COMPAT_TIMEOUT", "120"))
+
+# stdlib urllib otherwise sends "User-Agent: Python-urllib/3.x". Cloudflare —
+# which fronts hosted gateways like Groq / OpenRouter — keeps a denylist of known
+# automation signatures (Python-urllib, python-requests, curl, Go-http-client…)
+# and blocks them with Error 1010 before the request reaches the model. An
+# honest product UA is not on that denylist, so it passes — exactly how the
+# official `openai` SDK's "OpenAI/Python x.y.z" UA gets through. We deliberately
+# do NOT impersonate a browser or hard-code an OS string: this ships to Windows,
+# macOS, and Linux users, and a faked "Macintosh … Chrome/124" UA would be both
+# dishonest and quick to rot. Override via OPENAI_COMPAT_USER_AGENT if a specific
+# gateway demands a different signature.
+_DEFAULT_USER_AGENT = os.environ.get(
+    "OPENAI_COMPAT_USER_AGENT",
+    "TokenTelemetry/1.0 (+https://github.com/VasiHemanth/tokentelemetry)",
+)
+
+# Reasoning models may prepend a <think>…</think> block; strip it so the
+# downstream JSON parse sees the answer, not the chain-of-thought.
+_THINK_RE = re.compile(r"<think>.*?</think>", re.DOTALL | re.IGNORECASE)
+
+
+class _BadRequest(Exception):
+    """Internal: the server answered HTTP 400. Used to trigger a one-shot retry
+    with a clean OpenAI-only payload (strict gateways reject non-OpenAI extras
+    like top_k / chat_template_kwargs). Never escapes the module."""
+
+    def __init__(self, detail: str) -> None:
+        super().__init__(detail)
+        self.detail = detail
+
+
+def default_config() -> Dict[str, Any]:
+    """Canonical defaults for the ``openai_compat`` sub-config.
+
+    Mirrored by the schema in discussion #38. Kept here so the backend has a
+    single source of truth that ``summaries.save_config`` coerces against.
+    """
+    return {
+        "endpoint": _DEFAULT_ENDPOINT,
+        "api_key": "",
+        "max_tokens": 512,
+        "temperature": 0.7,
+        "top_p": 0.95,
+        "top_k": 20,
+        "min_p": 0.0,
+        "presence_penalty": 1.5,
+        "repetition_penalty": 1.0,
+        "enable_thinking": False,
+    }
+
+
+class OpenAICompatSummarizer(BaseSummarizer):
+    name = "openai_compat"
+    display_name = "OpenAI-compatible server"
+    binary = ""  # HTTP, not a CLI — see is_available().
+
+    def __init__(
+        self,
+        model: Optional[str] = None,
+        config: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        cfg = {**default_config(), **(config or {})}
+        # Model id is carried at the top level of summarizer.json (reusing the
+        # existing per-backend model plumbing), but accept it from the sub-cfg
+        # too for the standalone test endpoint.
+        self._model = model or cfg.get("model")
+        self.endpoint = str(cfg.get("endpoint") or _DEFAULT_ENDPOINT).rstrip("/")
+        # Env wins so a key needn't be persisted to disk.
+        self.api_key = os.environ.get("OPENAI_COMPAT_API_KEY") or cfg.get("api_key") or ""
+        self.max_tokens = int(cfg.get("max_tokens", 512))
+        self.temperature = float(cfg.get("temperature", 0.7))
+        self.top_p = float(cfg.get("top_p", 0.95))
+        self.top_k = int(cfg.get("top_k", 20))
+        self.min_p = float(cfg.get("min_p", 0.0))
+        self.presence_penalty = float(cfg.get("presence_penalty", 1.5))
+        self.repetition_penalty = float(cfg.get("repetition_penalty", 1.0))
+        self.enable_thinking = bool(cfg.get("enable_thinking", False))
+
+    def is_available(self) -> bool:
+        # No CLI to probe — it's always "installable", so it always shows in the
+        # picker as the universal fallback. Whether the configured endpoint is
+        # actually reachable surfaces at summarize() time as a network error.
+        return True
+
+    def _payload(self, prompt: str, *, include_extensions: bool) -> Dict[str, Any]:
+        # Standard OpenAI chat-completions fields — accepted by every compliant
+        # server, including strict gateways (Groq, OpenAI itself).
+        body: Dict[str, Any] = {
+            "model": self._model or "default",
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": self.max_tokens,
+            "temperature": self.temperature,
+            "top_p": self.top_p,
+            "presence_penalty": self.presence_penalty,
+            "stream": False,
+        }
+        if include_extensions:
+            # Non-OpenAI sampling knobs. llama.cpp / vLLM read these at the top
+            # level and honour them; strict gateways reject unknown properties
+            # with HTTP 400, which triggers the clean-payload retry in
+            # summarize(). top_k / min_p / repetition_penalty come from
+            # discussion #38's schema.
+            body["top_k"] = self.top_k
+            body["min_p"] = self.min_p
+            body["repetition_penalty"] = self.repetition_penalty
+            # Only emit the reasoning toggle when the user actually turned it on:
+            # it's meaningful to Qwen3 / vLLM and rejected outright elsewhere.
+            if self.enable_thinking:
+                body["chat_template_kwargs"] = {"enable_thinking": True}
+        return body
+
+    def summarize(self, prompt: str, *, timeout: Optional[int] = None) -> str:
+        tmo = timeout if timeout is not None else _DEFAULT_TIMEOUT
+        url = f"{self.endpoint}/chat/completions"
+        # Try the full payload (with non-OpenAI extras) first. If a strict server
+        # rejects an unknown property with 400, retry once with an OpenAI-only
+        # payload so the summary still goes through — the extras it couldn't
+        # honour are simply dropped.
+        try:
+            raw = self._post(url, self._payload(prompt, include_extensions=True), tmo)
+        except _BadRequest:
+            try:
+                raw = self._post(url, self._payload(prompt, include_extensions=False), tmo)
+            except _BadRequest as e:
+                raise SummarizerError(f"HTTP 400 from {url}: {e.detail}") from e
+        return _extract_text(raw, url)
+
+    def _post(self, url: str, payload: Dict[str, Any], tmo: int) -> str:
+        """POST one payload. Returns raw body, raises ``_BadRequest`` on HTTP 400
+        (retryable), or ``SummarizerError`` on any other failure."""
+        data = json.dumps(payload).encode("utf-8")
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": _DEFAULT_USER_AGENT,
+        }
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+
+        try:
+            with urllib.request.urlopen(req, timeout=tmo) as resp:
+                return resp.read().decode("utf-8", "replace")
+        except urllib.error.HTTPError as e:
+            detail = ""
+            try:
+                detail = e.read().decode("utf-8", "replace")[:500]
+            except Exception:
+                pass
+            if e.code == 400:
+                raise _BadRequest(detail or str(e.reason)) from e
+            # Keep the numeric status in the message so classify() can bucket it.
+            raise SummarizerError(f"HTTP {e.code} from {url}: {detail or e.reason}") from e
+        except urllib.error.URLError as e:
+            reason = getattr(e, "reason", e)
+            if isinstance(reason, TimeoutError) or "timed out" in str(reason).lower():
+                raise SummarizerError(f"request to {url} timed out after {tmo}s") from e
+            raise SummarizerError(
+                f"could not connect to {url}: connection refused — {reason}"
+            ) from e
+        except (TimeoutError, OSError) as e:
+            raise SummarizerError(f"request to {url} timed out after {tmo}s: {e}") from e
+
+
+def _coerce_content(content: Any) -> str:
+    """Reduce a message ``content`` to text. Most servers return a string; some
+    (vision-style) return a list of typed parts — join the textual ones."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = [
+            p.get("text", "")
+            for p in content
+            if isinstance(p, dict) and p.get("type") in (None, "text")
+        ]
+        return "".join(parts)
+    return ""
+
+
+def _extract_text(raw: str, url: str) -> str:
+    try:
+        doc = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise SummarizerError(f"non-JSON response from {url}: {raw[:300]}") from e
+
+    choices = doc.get("choices") or []
+    if choices:
+        first = choices[0] or {}
+        message = first.get("message") or {}
+        content = _coerce_content(message.get("content"))
+        if not content:
+            # Completions-style fallback (some servers fill .text not .message).
+            content = _coerce_content(first.get("text"))
+        content = _THINK_RE.sub("", content).strip()
+        if content:
+            return content
+
+    # Surface an upstream error object if the server returned one.
+    err = doc.get("error")
+    if err:
+        emsg = err.get("message") if isinstance(err, dict) else str(err)
+        raise SummarizerError(f"server error: {emsg}")
+
+    raise SummarizerError(f"{url} produced no output")

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -6,8 +6,12 @@ import { PageHeader, Section, Card, CardHeader, CardTitle, Button, Badge, Skelet
 import { BackendPicker } from "@/components/summarizer/BackendPicker";
 import {
   getSummarizerConfig, getAvailableBackends, putSummarizerConfig,
-  type SummarizerConfig, type SummarizerBackend,
+  DEFAULT_OPENAI_COMPAT,
+  type SummarizerConfig, type SummarizerBackend, type OpenAICompatConfig,
 } from "@/lib/summarizer";
+
+// Backends that carry a per-backend model selection.
+const MODEL_BACKENDS = new Set(["ollama", "codex", "openai_compat"]);
 
 export default function SettingsPage() {
   const [config, setConfig] = useState<SummarizerConfig | null>(null);
@@ -15,6 +19,8 @@ export default function SettingsPage() {
   const [selected, setSelected] = useState<string | null>(null);
   // Only meaningful when selected === "ollama"; null = "auto-pick first model".
   const [model, setModel] = useState<string | null>(null);
+  // Only meaningful when selected === "openai_compat".
+  const [openaiCompat, setOpenaiCompat] = useState<OpenAICompatConfig>(DEFAULT_OPENAI_COMPAT);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
@@ -29,6 +35,7 @@ export default function SettingsPage() {
         setBackends(list);
         setSelected(cfg.enabled ? cfg.backend : null);
         setModel(cfg.model);
+        if (cfg.openai_compat) setOpenaiCompat(cfg.openai_compat);
         setLoading(false);
       })
       .catch((e) => {
@@ -48,12 +55,15 @@ export default function SettingsPage() {
         enabled: selected !== null,
         backend: selected,
         // Model field is meaningful for backends that support per-backend
-        // model selection (currently ollama + codex); null otherwise.
-        model: (selected === "ollama" || selected === "codex") ? model : null,
+        // model selection (ollama + codex + openai_compat); null otherwise.
+        model: selected && MODEL_BACKENDS.has(selected) ? model : null,
+        // Persist endpoint/tuning whenever openai_compat is the active backend.
+        ...(selected === "openai_compat" ? { openai_compat: openaiCompat } : {}),
       });
       setConfig(next);
       setSelected(next.enabled ? next.backend : null);
       setModel(next.model);
+      if (next.openai_compat) setOpenaiCompat(next.openai_compat);
       setSaved(true);
       setTimeout(() => setSaved(false), 2500);
     } catch (e) {
@@ -65,7 +75,9 @@ export default function SettingsPage() {
 
   const dirty = config
     ? (selected !== (config.enabled ? config.backend : null))
-        || ((selected === "ollama" || selected === "codex") && model !== config.model)
+        || (!!selected && MODEL_BACKENDS.has(selected) && model !== config.model)
+        || (selected === "openai_compat"
+            && JSON.stringify(openaiCompat) !== JSON.stringify(config.openai_compat ?? DEFAULT_OPENAI_COMPAT))
     : false;
 
   return (
@@ -109,10 +121,12 @@ export default function SettingsPage() {
                   // Drop the model when switching to a backend that doesn't
                   // use one — keeps the dirty-check honest and avoids saving
                   // an irrelevant model name into config.
-                  if (name !== "ollama" && name !== "codex") setModel(null);
+                  if (!name || !MODEL_BACKENDS.has(name)) setModel(null);
                 }}
                 model={model}
                 onModelChange={setModel}
+                openaiCompat={openaiCompat}
+                onOpenAICompatChange={setOpenaiCompat}
               />
 
               {error && <p className="text-[12px] text-[var(--tt-danger-fg)]">{error}</p>}

--- a/frontend/src/components/summarizer/BackendPicker.tsx
+++ b/frontend/src/components/summarizer/BackendPicker.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Check, Ban } from "lucide-react";
+import { Check, Ban, Loader2, Plug, AlertCircle } from "lucide-react";
 import { getAgent } from "@/lib/agents";
 import { cn } from "@/lib/cn";
 import {
-  listCodexModels, listOllamaModels,
+  listCodexModels, listOllamaModels, testOpenAICompat,
+  DEFAULT_OPENAI_COMPAT,
   type CodexModel, type OllamaModel, type SummarizerBackend,
+  type OpenAICompatConfig,
 } from "@/lib/summarizer";
 
 interface BackendPickerProps {
@@ -16,10 +18,14 @@ interface BackendPickerProps {
   onSelect: (backend: string | null) => void;
   /** Whether to render the "no AI summaries" opt-out tile. */
   allowSkip?: boolean;
-  /** Currently chosen model (meaningful for Ollama + Codex). */
+  /** Currently chosen model (meaningful for Ollama + Codex + openai_compat). */
   model?: string | null;
   /** Notified when the user picks a different model. */
   onModelChange?: (model: string | null) => void;
+  /** openai_compat tuning (endpoint + sampling params). */
+  openaiCompat?: OpenAICompatConfig;
+  /** Notified when any openai_compat field changes. */
+  onOpenAICompatChange?: (cfg: OpenAICompatConfig) => void;
 }
 
 /**
@@ -34,6 +40,7 @@ interface BackendPickerProps {
 export function BackendPicker({
   backends, selected, onSelect, allowSkip = true,
   model = null, onModelChange,
+  openaiCompat, onOpenAICompatChange,
 }: BackendPickerProps) {
   const [ollamaModels, setOllamaModels] = useState<OllamaModel[] | null>(null);
   const [ollamaErr, setOllamaErr] = useState<string | null>(null);
@@ -89,7 +96,9 @@ export function BackendPicker({
                 <div className="min-w-0 flex-1">
                   <div className="text-[13px] font-semibold text-[var(--tt-fg)] truncate">{b.display_name}</div>
                   <div className="text-[11px] text-[var(--tt-fg-dim)] truncate">
-                    Summaries generated locally via {b.display_name}.
+                    {b.name === "openai_compat"
+                      ? "POST traces to any OpenAI-compatible server you run."
+                      : `Summaries generated locally via ${b.display_name}.`}
                   </div>
                 </div>
                 {active && (
@@ -135,6 +144,15 @@ export function BackendPicker({
                   }))}
                   autoOption="Auto — use Codex default (~/.codex/config.toml)"
                   hint="Pick a cheaper model if you don't have ChatGPT Pro/Plus or hit 'incorrect API key' / quota errors on the default."
+                />
+              )}
+
+              {active && b.name === "openai_compat" && (
+                <OpenAICompatForm
+                  model={model}
+                  onModelChange={onModelChange}
+                  config={openaiCompat ?? DEFAULT_OPENAI_COMPAT}
+                  onChange={onOpenAICompatChange}
                 />
               )}
             </div>
@@ -219,6 +237,167 @@ function ModelDropdown({
       {hint && (
         <p className="text-[10.5px] text-[var(--tt-fg-dim)] mt-1.5">{hint}</p>
       )}
+    </div>
+  );
+}
+
+const FIELD_CLS =
+  "w-full h-9 px-3 rounded-md bg-[var(--tt-sunken)] border border-[var(--tt-border-strong)] text-[13px] text-[var(--tt-fg)] focus:outline-none focus:border-[var(--tt-border-focus)] transition-colors";
+const LABEL_CLS =
+  "block text-[10.5px] font-medium uppercase tracking-[0.1em] text-[var(--tt-fg-muted)] mb-1.5";
+
+interface OpenAICompatFormProps {
+  model: string | null;
+  onModelChange?: (model: string | null) => void;
+  config: OpenAICompatConfig;
+  onChange?: (cfg: OpenAICompatConfig) => void;
+}
+
+/**
+ * Config form for the openai_compat backend: endpoint + model + optional bearer
+ * token up front, sampling params behind an "Advanced" toggle, and a
+ * Test-connection button that pings the server before the user saves.
+ */
+function OpenAICompatForm({ model, onModelChange, config, onChange }: OpenAICompatFormProps) {
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [result, setResult] = useState<{ ok: boolean; msg: string } | null>(null);
+
+  const set = <K extends keyof OpenAICompatConfig>(key: K, value: OpenAICompatConfig[K]) =>
+    onChange?.({ ...config, [key]: value });
+
+  const num = (key: keyof OpenAICompatConfig, label: string, step = "0.05") => (
+    <div>
+      <label className={LABEL_CLS}>{label}</label>
+      <input
+        type="number"
+        step={step}
+        value={config[key] as number}
+        onChange={(e) => set(key, (e.target.value === "" ? 0 : Number(e.target.value)) as never)}
+        className={FIELD_CLS}
+      />
+    </div>
+  );
+
+  const runTest = async () => {
+    setTesting(true);
+    setResult(null);
+    try {
+      const r = await testOpenAICompat(model, config);
+      setResult(
+        r.ok
+          ? { ok: true, msg: `Connected — server replied "${(r.sample || "").trim().slice(0, 60)}"` }
+          // Prefer the classified hint/message (always human-readable) over the
+          // raw error string so a JSON error body never leaks into the UI.
+          : { ok: false, msg: r.error_info?.hint || r.error_info?.message || r.error || "Connection failed." },
+      );
+    } catch (e) {
+      setResult({ ok: false, msg: e instanceof Error ? e.message : String(e) });
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  return (
+    <div className="mt-2 ml-11 mr-1 space-y-3">
+      <div>
+        <label className={LABEL_CLS}>Endpoint</label>
+        <input
+          type="text"
+          spellCheck={false}
+          placeholder="http://localhost:8080/v1"
+          value={config.endpoint}
+          onChange={(e) => set("endpoint", e.target.value)}
+          className={FIELD_CLS}
+        />
+        <p className="text-[10.5px] text-[var(--tt-fg-dim)] mt-1.5">
+          Base URL of any OpenAI-compatible server (llama.cpp, vLLM, LM Studio, LocalAI…).
+          We POST to <code className="font-mono">/chat/completions</code> under it.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <label className={LABEL_CLS}>Model</label>
+          <input
+            type="text"
+            spellCheck={false}
+            placeholder="server model id"
+            value={model ?? ""}
+            onChange={(e) => onModelChange?.(e.target.value || null)}
+            className={FIELD_CLS}
+          />
+        </div>
+        <div>
+          <label className={LABEL_CLS}>API key (optional)</label>
+          <input
+            type="password"
+            autoComplete="off"
+            placeholder="sk-… (blank if unused)"
+            value={config.api_key}
+            onChange={(e) => set("api_key", e.target.value)}
+            className={FIELD_CLS}
+          />
+        </div>
+      </div>
+
+      <button
+        type="button"
+        onClick={() => setShowAdvanced((v) => !v)}
+        className="text-[11px] font-medium text-[var(--tt-fg-dim)] hover:text-[var(--tt-fg)] transition-colors"
+      >
+        {showAdvanced ? "▾ Hide advanced sampling" : "▸ Advanced sampling"}
+      </button>
+
+      {showAdvanced && (
+        <div className="space-y-3">
+          <div className="grid grid-cols-2 gap-2">
+            {num("max_tokens", "Max tokens", "1")}
+            {num("temperature", "Temperature")}
+            {num("top_p", "Top P")}
+            {num("top_k", "Top K", "1")}
+            {num("min_p", "Min P")}
+            {num("presence_penalty", "Presence penalty")}
+            {num("repetition_penalty", "Repetition penalty")}
+          </div>
+          <label className="flex items-center gap-2 text-[12px] text-[var(--tt-fg)] cursor-pointer">
+            <input
+              type="checkbox"
+              checked={config.enable_thinking}
+              onChange={(e) => set("enable_thinking", e.target.checked)}
+              className="h-3.5 w-3.5 accent-[var(--tt-brand)]"
+            />
+            Enable thinking (reasoning models — Qwen3 / vLLM)
+          </label>
+          <p className="text-[10.5px] text-[var(--tt-fg-dim)]">
+            Top-K / Min-P / Repetition penalty are non-OpenAI extras; local servers
+            honor them and others ignore them.
+          </p>
+        </div>
+      )}
+
+      <div className="flex items-center gap-3 pt-0.5">
+        <button
+          type="button"
+          onClick={runTest}
+          disabled={testing || !config.endpoint}
+          className="inline-flex items-center gap-1.5 h-8 px-3 rounded-md border border-[var(--tt-border-strong)] bg-[var(--tt-panel)] text-[12px] font-medium text-[var(--tt-fg)] hover:bg-[var(--tt-sunken)] disabled:opacity-50 transition-colors"
+        >
+          {testing ? <Loader2 size={12} className="animate-spin" /> : <Plug size={12} />}
+          Test connection
+        </button>
+        {result && (
+          <span
+            className={cn(
+              "inline-flex items-center gap-1.5 text-[11.5px]",
+              result.ok ? "text-[var(--tt-success-fg)]" : "text-[var(--tt-danger-fg)]",
+            )}
+          >
+            {result.ok ? <Check size={12} /> : <AlertCircle size={12} />}
+            {result.msg}
+          </span>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/summarizer/OnboardingModal.tsx
+++ b/frontend/src/components/summarizer/OnboardingModal.tsx
@@ -10,8 +10,13 @@ import {
   putSummarizerConfig,
   isConfigUnset,
   ONBOARDING_FLAG,
+  DEFAULT_OPENAI_COMPAT,
   type SummarizerBackend,
+  type OpenAICompatConfig,
 } from "@/lib/summarizer";
+
+// Backends that carry a per-backend model selection.
+const MODEL_BACKENDS = new Set(["ollama", "codex", "openai_compat"]);
 
 /**
  * First-run onboarding. On app load it reads /config/summarizer; if the config
@@ -24,6 +29,8 @@ export default function OnboardingModal() {
   const [selected, setSelected] = useState<string | null>(null);
   // Only meaningful when selected === "ollama".
   const [model, setModel] = useState<string | null>(null);
+  // Only meaningful when selected === "openai_compat".
+  const [openaiCompat, setOpenaiCompat] = useState<OpenAICompatConfig>(DEFAULT_OPENAI_COMPAT);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -60,7 +67,8 @@ export default function OnboardingModal() {
       await putSummarizerConfig({
         enabled: selected !== null,
         backend: selected,
-        model: (selected === "ollama" || selected === "codex") ? model : null,
+        model: selected && MODEL_BACKENDS.has(selected) ? model : null,
+        ...(selected === "openai_compat" ? { openai_compat: openaiCompat } : {}),
       });
       dismiss();
     } catch (e) {
@@ -119,10 +127,12 @@ export default function OnboardingModal() {
             selected={selected}
             onSelect={(name) => {
               setSelected(name);
-              if (name !== "ollama" && name !== "codex") setModel(null);
+              if (!name || !MODEL_BACKENDS.has(name)) setModel(null);
             }}
             model={model}
             onModelChange={setModel}
+            openaiCompat={openaiCompat}
+            onOpenAICompatChange={setOpenaiCompat}
           />
 
           {error && (

--- a/frontend/src/components/summarizer/SummaryPanel.tsx
+++ b/frontend/src/components/summarizer/SummaryPanel.tsx
@@ -316,6 +316,7 @@ const ERROR_ICONS: Record<SummaryErrorInfo["category"], React.ComponentType<{ si
   timeout: Clock,
   network: ServerOff,
   quota: Ban,
+  too_large: Gauge,
   model: AlertOctagon,
   no_output: AlertCircle,
   unknown: AlertCircle,

--- a/frontend/src/lib/agents.ts
+++ b/frontend/src/lib/agents.ts
@@ -1,13 +1,14 @@
 import {
   Terminal, Database, Sparkles, Orbit, Cpu, Zap, MousePointer2,
-  GitBranch, Code2, type LucideIcon,
+  GitBranch, Code2, Server, type LucideIcon,
 } from "lucide-react";
 import HermesIcon from "@/components/icons/HermesIcon";
 import GrokIcon from "@/components/icons/GrokIcon";
 
 export type AgentKey =
   | "claude" | "codex" | "gemini" | "antigravity"
-  | "qwen" | "vibe" | "cursor" | "copilot" | "opencode" | "hermes" | "grok";
+  | "qwen" | "vibe" | "cursor" | "copilot" | "opencode" | "hermes" | "grok"
+  | "openai_compat";
 
 export interface AgentMeta {
   key: AgentKey;
@@ -29,6 +30,7 @@ export const AGENTS: Record<AgentKey, AgentMeta> = {
   opencode:    { key: "opencode",    label: "OpenCode",    hex: "#f59e0b", icon: Code2 },
   hermes:      { key: "hermes",      label: "Hermes Agent", hex: "#eab308", icon: HermesIcon },
   grok:        { key: "grok",        label: "Grok Build",  hex: "#d4d4d8", icon: GrokIcon },
+  openai_compat: { key: "openai_compat", label: "OpenAI-compatible server", hex: "#14b8a6", icon: Server },
 };
 
 const FALLBACK: AgentMeta = {

--- a/frontend/src/lib/summarizer.ts
+++ b/frontend/src/lib/summarizer.ts
@@ -9,10 +9,43 @@ export interface SummarizerBackend {
   display_name: string;
 }
 
+/**
+ * Tuning for the openai_compat backend — POSTed to any server speaking the
+ * OpenAI /v1/chat/completions API. Mirrors the backend default_config().
+ */
+export interface OpenAICompatConfig {
+  endpoint: string;
+  /** Optional bearer token; most local servers ignore it. */
+  api_key: string;
+  max_tokens: number;
+  temperature: number;
+  top_p: number;
+  top_k: number;
+  min_p: number;
+  presence_penalty: number;
+  repetition_penalty: number;
+  enable_thinking: boolean;
+}
+
+export const DEFAULT_OPENAI_COMPAT: OpenAICompatConfig = {
+  endpoint: "http://localhost:8080/v1",
+  api_key: "",
+  max_tokens: 512,
+  temperature: 0.7,
+  top_p: 0.95,
+  top_k: 20,
+  min_p: 0.0,
+  presence_penalty: 1.5,
+  repetition_penalty: 1.0,
+  enable_thinking: false,
+};
+
 export interface SummarizerConfig {
   enabled: boolean;
   backend: string | null;
   model: string | null;
+  /** Present only when the openai_compat backend has been configured. */
+  openai_compat?: OpenAICompatConfig;
 }
 
 export interface SummaryBrief {
@@ -51,7 +84,7 @@ export interface Summary {
 }
 
 export interface SummaryErrorInfo {
-  category: "auth" | "quota" | "model" | "timeout" | "network" | "no_output" | "unknown";
+  category: "auth" | "quota" | "too_large" | "model" | "timeout" | "network" | "no_output" | "unknown";
   title: string;
   message: string;
   hint: string | null;
@@ -93,6 +126,22 @@ export const putSummarizerConfig = (cfg: SummarizerConfig) =>
     method: "PUT",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(cfg),
+  });
+
+export interface OpenAICompatTestResult {
+  ok: boolean;
+  sample?: string;
+  endpoint?: string;
+  error?: string;
+  error_info?: SummaryErrorInfo | null;
+}
+
+/** Ping the configured OpenAI-compatible endpoint to confirm it's reachable. */
+export const testOpenAICompat = (model: string | null, openai_compat: OpenAICompatConfig) =>
+  api<OpenAICompatTestResult>("/summarizer/openai-compat/test", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ model, openai_compat }),
   });
 
 export const getCachedSummary = (sessionId: string) =>


### PR DESCRIPTION
Implements the request from discussion #38: a config-driven summarizer backend that talks to **any** OpenAI-compatible server — llama.cpp, vLLM, LM Studio, LocalAI, Ollama's OpenAI endpoint, or hosted gateways (Groq, OpenRouter) — so users can reuse a model server they already run **without installing another CLI**.

## What's in it

**New `openai_compat` adapter** (`backend/summarizers/openai_compat.py`, pure stdlib `urllib` — no new deps)
- Full sampling schema from #38: endpoint, model, `max_tokens`, `temperature`, `top_p`, `top_k`, `min_p`, `presence_penalty`, `repetition_penalty`, `enable_thinking`, plus an optional API key.
- Registered in the adapter registry; always offered (no CLI to probe).
- Config persisted under `summarizer.json`'s `openai_compat` block (type-coerced).
- `POST /summarizer/openai-compat/test` powers the settings **Test connection** button.

**Robustness hardened through real-world testing** (validated live against Ollama + Groq):
- **Honest, OS-agnostic User-Agent** (`TokenTelemetry/1.0`) so Cloudflare-fronted gateways don't `1010`-block the default `Python-urllib` signature. Env-overridable via `OPENAI_COMPAT_USER_AGENT`.
- **Graceful degradation:** non-OpenAI extras (`top_k`/`min_p`/`repetition_penalty`/`chat_template_kwargs`) are retried-without on a strict-server **400**, so Groq/OpenAI fall back to a compliant payload while llama.cpp/vLLM keep the extras.
- **Error classification:** new `too_large` category for **413** / context-overflow / per-minute token caps; unclassified errors are *humanized* (extract the provider's JSON `error.message`) so the UI never shows a raw JSON blob.

**Frontend**
- `OpenAICompatConfig` type + `testOpenAICompat` helper; agent meta; config form in `BackendPicker` (endpoint/model/key, advanced sampling, Test connection) wired through Settings + onboarding.
- `SummaryErrorInfo` gains `too_large`; `ERROR_ICONS` updated.

**Docs:** `CLAUDE.md` "Summarizer error handling" convention. `UPDATE.json` release entry.

## Testing
- Backend unit tests (mock servers): payload/auth/think-strip, strict-vs-lenient retry, 413/unknown classification, UA on the wire, config persistence — all green.
- Live UI: configured + **Test connection** ✅ against Ollama (`qwen3:0.6b`, `nemotron-3-nano:4b`); real session summaries generated through the production path.
- Unknown-error fallback verified in the UI (HTTP 500 + JSON body → clean sentence, not raw JSON).
- Frontend `tsc --noEmit` clean.

Addresses #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)