### PR TITLE
fix: restrict /config project param to safe roots (#54)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -3814,6 +3814,35 @@ def _collect_all_plugins(project: Optional[Path]) -> List[dict]:
         seen.add(key); deduped.append(p)
     return deduped
 
+def _project_safe_roots() -> List[Path]:
+    """Directories a `?project=` path is allowed to resolve inside.
+
+    Defaults to the user's home (where agents and their per-project config
+    live in practice). Power users whose code lives elsewhere (external
+    volumes, /opt, …) can extend this via TT_PROJECT_ROOTS — an os-pathsep
+    separated list of additional roots.
+    """
+    roots = [HOME]
+    extra = os.environ.get("TT_PROJECT_ROOTS")
+    if extra:
+        roots += [Path(p).expanduser() for p in extra.split(os.pathsep) if p.strip()]
+    return roots
+
+
+def _project_within_safe_roots(project: str) -> bool:
+    """True iff `project` resolves inside an allowed root (#54).
+
+    Resolution collapses symlinks and `..`, so neither `?project=/etc` nor a
+    `../../` escape nor a symlink can point the project scope at files outside
+    the user's own tree.
+    """
+    try:
+        resolved = Path(project).resolve()
+    except (OSError, RuntimeError):
+        return False
+    return any(resolved.is_relative_to(r.resolve()) for r in _project_safe_roots())
+
+
 @app.get("/config")
 async def get_config(project: Optional[str] = None):
     """Return skills, MCPs, and memory files for user scope + optional project scope."""
@@ -3887,7 +3916,7 @@ async def get_config(project: Optional[str] = None):
 
     # ---- PROJECT scope ----
     project_valid = False
-    if project:
+    if project and _project_within_safe_roots(project):
         proj = Path(project)
         if proj.exists() and proj.is_dir():
             project_valid = True


### PR DESCRIPTION
Closes #54.

## Problem
`GET /config?project=<path>` used the caller-supplied path directly (only `exists()`/`is_dir()`), with no check that it resolves inside the user's own tree. A localhost caller (script, or an XSS payload) could point project scope at directories like `?project=/etc` and have the server read `CLAUDE.md`/`AGENTS.md` there or enumerate `.claude/` config dirs.

**Scope note:** the real read surface is narrower than "any file" — `/config` only reads files literally named `CLAUDE.md`/`AGENTS.md` (via `_memory_preview`) and globs `.claude/`-style subdirs, not arbitrary paths like `/etc/passwd`. Still a genuine containment gap worth closing.

## Fix
- Add `_project_within_safe_roots()`: `Path(project).resolve()` (collapses symlinks + `..`) must be relative to an allowed root.
- Default allowed root is `HOME`; extensible via `TT_PROJECT_ROOTS` (os-pathsep list) for users whose code lives on external volumes / `/opt`.
- Paths outside the roots degrade gracefully to **user-scope-only** config (`project_valid=False`) rather than a hard error — keeps the config panel working.

## Testing
- `python -m py_compile backend/main.py` ✓
- Behavior check: `/etc`, `/`, `/etc/passwd` → rejected; `$HOME` and subdirs → allowed; `TT_PROJECT_ROOTS` override honored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)