### PR TITLE
fix: sanitize remote-sourced hrefs in WhatsChangedDrawer (#56)

### DIFF
--- a/frontend/src/components/WhatsChangedDrawer.tsx
+++ b/frontend/src/components/WhatsChangedDrawer.tsx
@@ -16,6 +16,21 @@ interface Props {
 }
 
 /**
+ * Neutralize hrefs whose data originates from the remote /version feed (which
+ * can be poisoned via a compromised update cache or MITM). Only http(s) and
+ * in-app absolute paths pass through; `javascript:`, `data:`, and any other
+ * scheme collapse to "#" so a crafted release_url / highlight href can't
+ * execute script when clicked (#56).
+ */
+function safeHref(url: string | null | undefined): string {
+  if (!url) return "#";
+  if (url.startsWith("/") || url.startsWith("https://") || url.startsWith("http://")) {
+    return url;
+  }
+  return "#";
+}
+
+/**
  * Side-drawer that lists all curated releases from UPDATE.json — newest first.
  * The first release gets a "Latest" pill; older releases are shown as history
  * so users who fell behind by several updates can read everything they missed
@@ -106,7 +121,7 @@ export default function WhatsChangedDrawer({
             <span className="ml-2 text-[var(--tt-fg-faint)]">on {repo}</span>
           </span>
           <a
-            href={releaseUrl}
+            href={safeHref(releaseUrl)}
             target="_blank" rel="noopener noreferrer"
             className="inline-flex items-center gap-1 text-[var(--tt-fg-muted)] hover:text-[var(--tt-fg)] transition-colors"
           >
@@ -201,7 +216,7 @@ function HighlightCard({
           </Link>
         ) : (
           <a
-            href={h.href}
+            href={safeHref(h.href)}
             target="_blank" rel="noopener noreferrer"
             className="mt-2.5 inline-flex items-center gap-1 text-[12px] font-medium text-[var(--tt-brand)] hover:text-[var(--tt-brand-strong)] transition-colors"
           >


### PR DESCRIPTION
Closes #56.

## Problem
`release_url` and highlight `href` values come from the remote `/version` feed (`_fetch_remote()` / cached `UPDATE.json`), which can be poisoned via a compromised update cache or MITM. They were placed verbatim into `<a href={...}>`, so a `javascript:` URI would execute arbitrary script when the user clicks the link (cookie/token exfiltration).

## Fix
- Add `safeHref()` — an allow-list (`http://`, `https://`, in-app `/…` only; everything else → `#`).
- Apply to the footer "Commit history on GitHub" link (`releaseUrl`) and the external highlight link (`h.href`).
- The internal `<Link>` branch is already gated on a leading `/`, so it can't carry a `javascript:` scheme — left as-is.
- `rel="noopener noreferrer"` was already present on both external anchors; retained.

## Testing
- `npx tsc --noEmit` — no errors in `WhatsChangedDrawer.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)