### PR TITLE
fix: minor batch — SQLite leak, cron validation, summarizer backend validation (#52, #53, #57)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -3966,7 +3966,7 @@ async def get_config(project: Optional[str] = None):
 # Trace summaries
 # --------------------------------------------------------------------------- #
 from fastapi import Body, HTTPException
-from summarizers import get_summarizer, available_summarizers, SummarizerError
+from summarizers import get_summarizer, available_summarizers, SummarizerError, KNOWN_BACKENDS
 import summaries as _summaries
 
 async def _session_meta(session_id: str, agent: str):
@@ -3992,6 +3992,16 @@ async def get_summarizer_config():
 
 @app.put("/config/summarizer")
 async def put_summarizer_config(cfg: dict = Body(...)):
+    # Reject an unknown backend up front rather than persisting garbage that
+    # silently disables every future summarizer call (#57). Validated against
+    # the live registry so all real backends (gemini/antigravity/qwen/
+    # openai_compat/…) stay accepted — not a stale hardcoded list.
+    backend = cfg.get("backend") or None
+    if backend is not None and backend not in KNOWN_BACKENDS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"unknown summarizer backend {backend!r}; expected one of {sorted(KNOWN_BACKENDS)}",
+        )
     return _summaries.save_config(cfg)
 
 

--- a/backend/summaries.py
+++ b/backend/summaries.py
@@ -275,21 +275,28 @@ def content_hash(session_id: str, events: List[Dict[str, Any]]) -> str:
 def _conn() -> sqlite3.Connection:
     TT_HOME.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(_DB_PATH)
-    conn.row_factory = sqlite3.Row
-    conn.execute(
-        """CREATE TABLE IF NOT EXISTS summaries (
-            session_id   TEXT PRIMARY KEY,
-            agent        TEXT,
-            content_hash TEXT,
-            backend      TEXT,
-            model        TEXT,
-            brief_json   TEXT,
-            narrative_json TEXT,
-            summary_cost REAL,
-            generated_at TEXT
-        )"""
-    )
-    return conn
+    try:
+        conn.row_factory = sqlite3.Row
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS summaries (
+                session_id   TEXT PRIMARY KEY,
+                agent        TEXT,
+                content_hash TEXT,
+                backend      TEXT,
+                model        TEXT,
+                brief_json   TEXT,
+                narrative_json TEXT,
+                summary_cost REAL,
+                generated_at TEXT
+            )"""
+        )
+        return conn
+    except Exception:
+        # The DDL can fail on a corrupt DB, a read-only dir, or an incompatible
+        # schema. Close the just-opened handle before propagating so repeated
+        # failures don't leak file descriptors until the OS limit is hit (#52).
+        conn.close()
+        raise
 
 
 def get_cached(session_id: str) -> Optional[Dict[str, Any]]:

--- a/backend/summarizers/__init__.py
+++ b/backend/summarizers/__init__.py
@@ -31,6 +31,11 @@ _ALL: List[BaseSummarizer] = [
 
 _BY_NAME: Dict[str, BaseSummarizer] = {s.name: s for s in _ALL}
 
+# Every backend name the registry knows about, installed or not. Used to
+# validate persisted config so an unknown ``backend`` value can't be saved and
+# then silently disable summaries (#57).
+KNOWN_BACKENDS: frozenset[str] = frozenset(_BY_NAME)
+
 
 def get_summarizer(
     name: str,
@@ -60,4 +65,5 @@ __all__ = [
     "SummarizerError",
     "get_summarizer",
     "available_summarizers",
+    "KNOWN_BACKENDS",
 ]

--- a/frontend/src/lib/hermesCron.ts
+++ b/frontend/src/lib/hermesCron.ts
@@ -138,9 +138,20 @@ export function encodeSchedule(b: BuilderState): string | null {
     case "weekly": {
       const [hh, mm] = b.weeklyTime.split(":");
       const day = parseInt(b.weeklyDay, 10);
-      if (Number.isNaN(day) || !hh || !mm) return null;
+      const hhN = parseInt(hh, 10);
+      const mmN = parseInt(mm, 10);
+      // parseInt("ab") is NaN — a falsy `!hh` check let malformed times like
+      // "ab:cd" through and emitted "NaN NaN * * 1" (#53). Validate the parsed
+      // numbers and their ranges instead.
+      if (
+        Number.isNaN(day) ||
+        Number.isNaN(hhN) || hhN < 0 || hhN > 23 ||
+        Number.isNaN(mmN) || mmN < 0 || mmN > 59
+      ) {
+        return null;
+      }
       // Cron: minute hour * * day-of-week
-      return `${parseInt(mm, 10)} ${parseInt(hh, 10)} * * ${day}`;
+      return `${mmN} ${hhN} * * ${day}`;
     }
     case "custom":
       return b.customCron.trim() || null;


### PR DESCRIPTION
Batches three small, independent fixes. Closes #52, #53, #57.

> Note: #50 and #51 were intentionally left out of this batch.

---

### #52 — SQLite connection leak in `summaries._conn()` on DDL failure
`_conn()` ran `CREATE TABLE IF NOT EXISTS` outside any try/finally, so the handle leaked whenever the DDL raised (corrupt DB, read-only dir, incompatible schema). Repeated failures exhaust the FD limit. **Fix:** wrap the DDL in `try/except`, `conn.close()` before re-raising.

### #53 — `hermesCron.encodeSchedule` emits `NaN NaN * * 1`
The weekly branch guarded the time with a falsy `!hh` check — `false` for non-numeric strings like `"ab"` — so `"ab:cd"` slipped through and produced `"NaN NaN * * 1"`. **Fix:** parse `hh`/`mm` to numbers and validate both NaN **and** ranges (`0–23` / `0–59`), returning `null` on bad input. Verified: `"ab:cd"`, `"25:00"`, `"09:75"`, `""` → `null`; `"09:30"` → `30 9 * * 1`.

### #57 — `PUT /config/summarizer` accepts an unvalidated `backend`
**Scope correction vs the issue:** `save_config` already whitelists keys (so it does *not* persist arbitrary JSON verbatim), and `get_summarizer()` is a dict lookup — a path-like `backend` just returns `None`, it's never used as a path/exec sink, so the described path-traversal doesn't materialize. The *real* residual gap is that an unknown `backend` is persisted and silently disables all future summaries.

**Fix:** reject an unknown `backend` with `400`, validated against the live registry (`KNOWN_BACKENDS`). The issue's suggested `Literal["ollama","codex","claude"]` was **not** used — it would have rejected the valid `gemini`/`antigravity`/`qwen`/`openai_compat` backends. Validating against the registry keeps all real backends accepted and the openai_compat sub-config passthrough intact.

## Testing
- `python -m py_compile` on all changed backend modules ✓
- `import summarizers` → `KNOWN_BACKENDS` = all 7 backends ✓
- `npx tsc --noEmit` — no errors in `hermesCron.ts` ✓
- Behavior tests for #53 (above) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)