### PR TITLE
fix: pass prompts via stdin (#50) and retain summary on error (#51)

### DIFF
--- a/backend/summarizers/antigravity.py
+++ b/backend/summarizers/antigravity.py
@@ -28,10 +28,10 @@ class AntigravitySummarizer(BaseSummarizer):
         out = run_cli(
             [
                 self.binary,
-                "-p", prompt,
                 "--dangerously-skip-permissions",
                 "--print-timeout", f"{timeout}s",
             ],
+            stdin=prompt,
             cwd=_ensure_cwd(),
             # Give the process a little slack past its own print-timeout so the
             # binary's timeout fires first with a cleaner message.

--- a/backend/summarizers/gemini.py
+++ b/backend/summarizers/gemini.py
@@ -21,7 +21,8 @@ class GeminiSummarizer(BaseSummarizer):
 
     def summarize(self, prompt: str, *, timeout: int = 120) -> str:
         out = run_cli(
-            [self.binary, "-p", prompt, "-o", "json"],
+            [self.binary, "-o", "json"],
+            stdin=prompt,
             cwd=_ensure_cwd(),
             timeout=timeout,
         )

--- a/backend/summarizers/qwen.py
+++ b/backend/summarizers/qwen.py
@@ -23,7 +23,8 @@ class QwenSummarizer(BaseSummarizer):
 
     def summarize(self, prompt: str, *, timeout: int = 120) -> str:
         out = run_cli(
-            [self.binary, prompt, "-o", "json"],
+            [self.binary, "-o", "json"],
+            stdin=prompt,
             cwd=_ensure_cwd(),
             timeout=timeout,
         )

--- a/frontend/src/components/summarizer/SummaryPanel.tsx
+++ b/frontend/src/components/summarizer/SummaryPanel.tsx
@@ -56,9 +56,12 @@ export default function SummaryPanel({ sessionId, agent }: SummaryPanelProps) {
     setErrorInfo(null);
     try {
       const res = await generateSummary(sessionId, agent, force);
-      setSummary(res.summary);
-      if (res.error) setError(res.error);
-      if (res.error_info) setErrorInfo(res.error_info);
+      if (res.error) {
+        setError(res.error);
+        if (res.error_info) setErrorInfo(res.error_info);
+      } else {
+        setSummary(res.summary);
+      }
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to generate summary.");
     } finally {


### PR DESCRIPTION
Fixes #50 and #51 which were left out of #60.

- **#50:** Passes the prompt to `qwen`, `gemini`, and `antigravity` CLI backends via stdin instead of argv to prevent flag injection and `ARG_MAX` limit breaches.
- **#51:** Modifies `SummaryPanel.tsx` to retain the previously displayed summary when a regenerate request returns an error, preventing the UI from wiping out the user's view.