### PR TITLE
feat(antigravity): real model + accurate project for agy CLI sessions

### DIFF
--- a/UPDATE.json
+++ b/UPDATE.json
@@ -1,6 +1,22 @@
 {
   "releases": [
     {
+      "tag": "2026-06-07",
+      "title": "Antigravity CLI — real model & accurate projects",
+      "highlights": [
+        {
+          "title": "Real model for Antigravity CLI sessions",
+          "description": "Sessions from the Antigravity CLI (agy) now show the actual model they ran (e.g. \"Gemini 3.1 Pro (High)\") instead of a generic \"gemini (antigravity)\" label, read straight from each session's own trajectory.",
+          "href": "/"
+        },
+        {
+          "title": "Accurate project for Antigravity CLI sessions",
+          "description": "CLI sessions are now grouped under the exact project folder they ran in, taken from the CLI's own prompt history rather than guessed from the task text — so they stop landing in \"unassigned\".",
+          "href": "/"
+        }
+      ]
+    },
+    {
       "tag": "2026-06-05",
       "title": "Summarize with any OpenAI-compatible server",
       "highlights": [

--- a/backend/main.py
+++ b/backend/main.py
@@ -216,6 +216,13 @@ ANTIGRAVITY_BRAIN_SOURCES = [
     (GEMINI_DIR / "antigravity" / "brain", "app"),
 ]
 ANTIGRAVITY_BRAIN_DIRS = [d for d, _ in ANTIGRAVITY_BRAIN_SOURCES]
+# `agy` (the Antigravity CLI) additionally persists each session's full trajectory
+# under antigravity-cli/conversations/<uuid>.db (SQLite; newer sessions) or
+# <uuid>.pb (protobuf; older), plus a flat prompt log in history.jsonl. The brain/
+# scanner above only reads derived markdown, so it falls back to a generic model
+# name and a heuristic project. We mine these CLI-only stores for the real model
+# display name and the exact project cwd — see _antigravity_cli_meta().
+ANTIGRAVITY_CLI_DIR = GEMINI_DIR / "antigravity-cli"
 PROJECT_ALIASES_FILE = HOME / ".tokentelemetry" / "aliases.json"
 
 def _load_project_aliases() -> Dict[str, str]:
@@ -303,6 +310,86 @@ def _estimate_antigravity_tokens(sess_dir: Path) -> dict:
         logging.debug(f"Failed to access transcript for {sess_dir}: {e}")
 
     return tkns
+
+# Model display name as embedded (protobuf string field) in Antigravity CLI
+# trajectories, e.g. "Gemini 3.1 Pro (High)". Deliberately strict — requires a
+# version number + tier word — so it never matches prose like "Gemini API ..."
+# or skill/plugin names ("Claude Code") that also appear in the blobs.
+_AG_MODEL_DISPLAY_RE = re.compile(
+    rb'\b((?:Gemini|Claude|GPT)[ ]\d[0-9.]*[ ]'
+    rb'(?:Pro|Flash|Ultra|Nano|Opus|Sonnet|Haiku)(?:[ ]\([A-Za-z]+\))?)'
+)
+
+def _antigravity_db_model(db_path: Path) -> Optional[str]:
+    """Pull the model display name from an Antigravity CLI SQLite trajectory.
+
+    `agy` stores the model as a protobuf field inside the gen_metadata.data
+    blobs (one row per model generation). We scan those blobs and take the most
+    common display-name match. Read-only and best-effort: returns None on any
+    DB/IO error or when no model string is present (e.g. older .pb sessions,
+    which don't embed the display name)."""
+    from collections import Counter
+    counts: "Counter[str]" = Counter()
+    try:
+        con = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        try:
+            for (blob,) in con.execute("SELECT data FROM gen_metadata WHERE data IS NOT NULL"):
+                if not blob:
+                    continue
+                for m in _AG_MODEL_DISPLAY_RE.findall(blob):
+                    counts[m.decode("ascii", "ignore")] += 1
+        finally:
+            con.close()
+    except (sqlite3.Error, OSError):
+        return None
+    if not counts:
+        return None
+    return counts.most_common(1)[0][0]
+
+def _antigravity_cli_meta(cli_dir: Path = ANTIGRAVITY_CLI_DIR) -> Dict[str, Dict[str, Any]]:
+    """Enrich Antigravity CLI (`agy`) sessions from its own stores.
+
+    The brain/ scanner only sees derived markdown, so it labels every CLI
+    session with a generic model ("gemini (antigravity)") and a heuristic
+    project guessed from the task/plan text. Here we recover the ground truth:
+
+      - **project cwd** from history.jsonl, which maps conversationId -> workspace
+        directly (no guessing); and
+      - **model display name** from each conversations/<uuid>.db gen_metadata table.
+
+    Session ids in brain/ are the conversation UUIDs, so the returned map keys
+    line up 1:1. Returns {session_id: {"model": str, "project": str}} with each
+    field present only when found. Best-effort — never raises."""
+    meta: Dict[str, Dict[str, Any]] = {}
+    # 1. Exact project cwd from the flat prompt log (last line wins => latest cwd).
+    hist = cli_dir / "history.jsonl"
+    try:
+        if hist.exists():
+            with open(hist, "r", encoding="utf-8", errors="replace") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        rec = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    cid, ws = rec.get("conversationId"), rec.get("workspace")
+                    if cid and ws:
+                        meta.setdefault(cid, {})["project"] = ws
+    except OSError:
+        pass
+    # 2. Real model name from the per-session SQLite trajectory.
+    conv = cli_dir / "conversations"
+    try:
+        db_files = sorted(conv.glob("*.db")) if conv.exists() else []
+    except OSError:
+        db_files = []
+    for db in db_files:
+        model = _antigravity_db_model(db)
+        if model:
+            meta.setdefault(db.stem, {})["model"] = model
+    return meta
 
 class TokenUsage(BaseModel):
     input: int = 0
@@ -2055,6 +2142,8 @@ def _scan_sessions_sync():
 
     # 3b. Antigravity brain/ folder — richer per-session artifacts (task/plan/walkthrough)
     _seen_brain_sids: set = set()
+    # CLI (`agy`) ground truth: real model + exact project, keyed by session id.
+    _ag_cli_meta = _antigravity_cli_meta()
     for _brain_dir in ANTIGRAVITY_BRAIN_DIRS:
         if not _brain_dir.exists(): continue
         for sess_dir in _brain_dir.iterdir():
@@ -2129,7 +2218,10 @@ def _scan_sessions_sync():
                 # mirror dir must not block the dir that holds this session's content.
                 _seen_antigravity.add(sid)
                 _seen_brain_sids.add(sid)
-                project = apply_alias(_antigravity_infer_project((task or "") + "\n" + (plan or "")))
+                # Prefer the CLI's own records (exact cwd from history.jsonl, real
+                # model from the SQLite trajectory); fall back to brain heuristics.
+                _cli = _ag_cli_meta.get(sid, {})
+                project = apply_alias(_cli.get("project") or _antigravity_infer_project((task or "") + "\n" + (plan or "")))
                 first_line = next((ln.strip() for ln in (task or plan or walkthrough).splitlines() if ln.strip() and not ln.strip().startswith("#")), "")
                 display = (first_line or "Antigravity session")[:100]
                 plans: List[dict] = []
@@ -2145,7 +2237,7 @@ def _scan_sessions_sync():
                     "mcp_tools": [],
                     "has_plan": bool(plan),
                     "plans": plans,
-                    "model": "gemini (antigravity)",
+                    "model": _cli.get("model") or "gemini (antigravity)",
                     "artifacts": artifacts,
                     "antigravity_source": _ag_surface.get(sid),
                     "cost": 0.0,
@@ -2702,20 +2794,33 @@ async def get_artifact(path: str):
     """Stream a local artifact file securely."""
     from fastapi.responses import FileResponse
     p = Path(path)
-    # Security: only serve files from known agent directories
-    allowed = [CLAUDE_DIR, CODEX_DIR, GEMINI_DIR, QWEN_DIR, VIBE_DIR, CURSOR_DIR, VSCODE_BASE, CURSOR_BASE]
+    # Security: only serve files from known agent directories. We compare the
+    # *resolved* path (symlinks collapsed) against each resolved allow-root, so a
+    # symlink planted inside an allowed dir that points outside it is rejected.
+    # Antigravity's brain/CLI stores live under GEMINI_DIR already, but we list
+    # them explicitly so the allow-list survives any future narrowing of that
+    # root (and documents that those artifacts are intentionally served).
+    allowed = [CLAUDE_DIR, CODEX_DIR, GEMINI_DIR, QWEN_DIR, VIBE_DIR, CURSOR_DIR,
+               VSCODE_BASE, CURSOR_BASE, *ANTIGRAVITY_BRAIN_DIRS, ANTIGRAVITY_CLI_DIR]
+    try:
+        resolved = p.resolve()
+    except Exception:
+        resolved = None
     is_safe = False
-    for a in allowed:
-        try:
-            if p.resolve().is_relative_to(a.resolve()):
-                is_safe = True; break
-        except Exception: continue
+    if resolved is not None:
+        for a in allowed:
+            try:
+                if resolved.is_relative_to(a.resolve()):
+                    is_safe = True; break
+            except Exception: continue
 
-    if not is_safe or not p.exists() or not p.is_file():
+    if not is_safe or resolved is None or not resolved.exists() or not resolved.is_file():
         from fastapi import HTTPException
         raise HTTPException(status_code=403, detail="Unauthorized or not found")
 
-    return FileResponse(path)
+    # Serve the validated, resolved path (not the raw input) so the file we
+    # checked is exactly the file we return — closes any symlink-swap window.
+    return FileResponse(str(resolved))
 
 
 @app.get("/cache/status")

--- a/backend/test_antigravity_cli.py
+++ b/backend/test_antigravity_cli.py
@@ -1,0 +1,126 @@
+"""Tests for Antigravity CLI (`agy`) session enrichment and /artifacts safety.
+
+`agy` saves each session under ~/.gemini/antigravity-cli/ as
+conversations/<uuid>.db (SQLite; newer) or <uuid>.pb (protobuf; older), plus a
+flat history.jsonl prompt log. The brain/ scanner only reads derived markdown,
+so we recover the real model name (from the SQLite trajectory) and the exact
+project cwd (from history.jsonl). These tests pin that behaviour and the
+/artifacts allow-list hardening.
+
+No pytest in the venv — run directly:  python backend/test_antigravity_cli.py
+(also importable by pytest if installed).
+"""
+import asyncio
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(__file__))
+import main  # noqa: E402
+from fastapi import HTTPException  # noqa: E402
+
+
+def _make_cli_dir(root: Path) -> Path:
+    """Build a synthetic antigravity-cli store: one .db session, one .pb-only."""
+    conv = root / "conversations"
+    conv.mkdir(parents=True)
+    # history.jsonl: last-wins per conversationId; tolerate junk + missing fields.
+    (root / "history.jsonl").write_text(
+        json.dumps({"conversationId": "sid-db", "workspace": "/proj/alpha"}) + "\n"
+        + "this is not json\n"
+        + json.dumps({"conversationId": "sid-db", "workspace": "/proj/alpha2"}) + "\n"
+        + json.dumps({"display": "no conversation id"}) + "\n"
+        + json.dumps({"conversationId": "sid-pb", "workspace": "/proj/beta"}) + "\n",
+        encoding="utf-8",
+    )
+    # .db session with the model embedded in gen_metadata blobs (+ prose noise).
+    db = conv / "sid-db.db"
+    con = sqlite3.connect(db)
+    con.execute("CREATE TABLE gen_metadata (idx integer, data blob)")
+    con.execute("INSERT INTO gen_metadata VALUES (?,?)",
+                (0, b"\x0aGemini 3.1 Pro (High)\x12 Gemini API) prose \x1aClaude Code"))
+    con.execute("INSERT INTO gen_metadata VALUES (?,?)", (1, b"xxGemini 3.1 Pro (High)yy"))
+    con.execute("INSERT INTO gen_metadata VALUES (?,?)", (2, None))
+    con.commit()
+    con.close()
+    # .pb-only session: no model embedded -> model unresolved, project still found.
+    (conv / "sid-pb.pb").write_bytes(b"raw protobuf bytes with no model display name")
+    return root
+
+
+def test_cli_meta_recovers_model_and_project():
+    with tempfile.TemporaryDirectory() as d:
+        cli = _make_cli_dir(Path(d))
+        meta = main._antigravity_cli_meta(cli)
+        assert meta["sid-db"]["project"] == "/proj/alpha2"  # last line wins
+        assert meta["sid-db"]["model"] == "Gemini 3.1 Pro (High)"
+        assert meta["sid-pb"]["project"] == "/proj/beta"
+        assert "model" not in meta["sid-pb"]  # .pb has no embedded display name
+
+
+def test_model_regex_ignores_prose_and_handles_errors():
+    # Strict pattern must not match prose like "Gemini API" or skill names.
+    assert main._AG_MODEL_DISPLAY_RE.findall(b"Gemini API) into web apps; Claude Code") == []
+    with tempfile.TemporaryDirectory() as d:
+        bad = Path(d) / "corrupt.db"
+        bad.write_bytes(b"this is not a sqlite database")
+        assert main._antigravity_db_model(bad) is None
+        # Missing dir must yield an empty map, never raise.
+        assert main._antigravity_cli_meta(Path(d) / "does-not-exist") == {}
+
+
+def _call_artifact(path):
+    try:
+        resp = asyncio.run(main.get_artifact(path))
+        return ("ok", getattr(resp, "path", None))
+    except HTTPException as e:
+        return ("denied", e.status_code)
+
+
+def test_artifacts_rejects_symlink_escape_and_outside_paths():
+    # Outside the allow-list -> 403.
+    assert _call_artifact("/etc/hosts")[0] == "denied"
+    # Symlink planted inside an allowed dir but pointing out -> 403 (resolved check).
+    evil = main.CLAUDE_DIR / "tt_symlink_escape_test"
+    try:
+        if not evil.exists():
+            os.symlink("/etc", evil)
+        assert _call_artifact(str(evil / "hosts"))[0] == "denied"
+    finally:
+        try:
+            evil.unlink()
+        except OSError:
+            pass
+
+
+def test_artifacts_serves_legit_under_allowlist():
+    with tempfile.TemporaryDirectory() as d:
+        # GEMINI_DIR is on the allow-list; create a file under it via the real root.
+        f = main.GEMINI_DIR / "tt_artifact_serve_test.txt"
+        try:
+            f.write_text("hello")
+            status, served = _call_artifact(str(f))
+            assert status == "ok"
+            assert served == str(f.resolve())  # serves the resolved path
+        finally:
+            try:
+                f.unlink()
+            except OSError:
+                pass
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS  {t.__name__}")
+        except Exception as e:  # noqa: BLE001
+            failed += 1
+            print(f"FAIL  {t.__name__}: {e!r}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
## Summary

Antigravity CLI (`agy`) sessions surfaced through the `brain/` scanner, which only reads Antigravity's **derived markdown**. So every CLI session showed a generic **`gemini (antigravity)`** model and a project **guessed** from task text (often `Antigravity / unassigned`).

`agy` actually stores each session's trajectory under `~/.gemini/antigravity-cli/`:

| File | Format | Holds |
|---|---|---|
| `conversations/<uuid>.db` | SQLite | trajectory (newer) |
| `conversations/<uuid>.pb` | protobuf | trajectory (older) |
| `history.jsonl` | JSON Lines | `conversationId → workspace` |

This PR mines those CLI stores (session id == conversation UUID == brain dir name):

- **`_antigravity_db_model()`** — model display name (e.g. `Gemini 3.1 Pro (High)`) from SQLite `gen_metadata` protobuf blobs via a strict regex that ignores prose/skill names. Read-only, best-effort; `.pb` sessions fall back gracefully.
- **`_antigravity_cli_meta()`** — `session_id → {model, project}`, project read **exactly** from `history.jsonl`.

Brain scanner prefers these, falls back to prior heuristics. Dedup + surface labels unchanged. Tokens/cost left as estimates (real counts are protobuf varints; mixing with a real model would mislead cost, cf. #42).

## Security hardening (relates to #55)

The reported `/artifacts` traversal and "Antigravity always 403" **did not reproduce on current `main`** (`p.resolve()` already blocks the escape; `GEMINI_DIR` already covers brain dirs). Shipped as defense-in-depth: serve the *resolved* path, and list the Antigravity dirs explicitly.

## Testing

- New `backend/test_antigravity_cli.py` (4/4 pass): model/project recovery, regex prose rejection, corrupt-DB/missing-dir paths, `/artifacts` symlink-escape + legit-serve.
- Full `_scan_sessions_sync()` on real data: 8 CLI sessions resolve to `Gemini 3.1 Pro (High)` with exact projects; no double-counting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)