### PR TITLE
feat(privacy): disclose the update check + add in-app opt-out toggle (#64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,12 +185,29 @@ TokenTelemetry stores lightweight state in `~/.tokentelemetry/`:
 
 ```
 ~/.tokentelemetry/
-  aliases.json    # Rename/merge project folder paths
-  hidden.json     # Hide specific projects from dashboard
-  VERSION         # Current version
+  aliases.json       # Rename/merge project folder paths
+  hidden.json        # Hide specific projects from dashboard
+  preferences.json   # App preferences (e.g. update check on/off)
+  VERSION            # Current version
 ```
 
 All hand-editable JSON — no database, no config GUI needed.
+
+### Update check
+
+TokenTelemetry does **not** collect or transmit your logs, sessions, tokens, or
+costs — those never leave your machine. The one outbound call it makes is an
+**optional update check**: about once an hour the dashboard fetches the latest
+version and curated release notes from GitHub, so you know when new features
+land. It sends no usage data — only a version request, which (like any web
+request) exposes your IP and the app name to GitHub.
+
+Turn it off either way:
+
+- **In the app** — Settings → *Updates & privacy* → toggle off *Check for updates*.
+- **Via environment** — set `TT_NO_UPDATE_CHECK=1` before launching. This wins
+  over the in-app toggle, so admins can enforce it (e.g. in air-gapped or
+  egress-monitored environments).
 
 ---
 
@@ -210,7 +227,7 @@ tokentelemetry/
 ## FAQ
 
 **Q: Does TokenTelemetry send any data to the cloud?**  
-A: No. 100% local. It reads log files from your filesystem and serves a local web dashboard. Nothing leaves your machine.
+A: No usage data, ever. It reads log files from your filesystem and serves a local web dashboard — your logs, sessions, tokens, and costs never leave your machine. The only outbound call is an optional update check that fetches the latest version and release notes from GitHub (no usage data sent); disable it in Settings → *Updates & privacy* or with `TT_NO_UPDATE_CHECK=1`. See [Update check](#update-check).
 
 **Q: How does it track Claude Code token usage?**  
 A: Claude Code writes JSONL session logs to `~/.claude/`. TokenTelemetry watches those files and parses token counts, tool calls, and reasoning in real time.

--- a/UPDATE.json
+++ b/UPDATE.json
@@ -1,6 +1,21 @@
 {
   "releases": [
     {
+      "tag": "2026-06-07",
+      "title": "Update check — now visible and yours to control",
+      "highlights": [
+        {
+          "title": "Check-for-updates toggle",
+          "description": "TokenTelemetry's one outbound call — an optional check that tells you when new features ship — now has a switch in Settings → Updates & privacy. It sends no usage data; turn it off any time, or set TT_NO_UPDATE_CHECK=1 to enforce it off.",
+          "href": "/settings"
+        },
+        {
+          "title": "Clearer privacy wording",
+          "description": "Docs and site now state precisely what stays local (all your logs, sessions, tokens, and costs) and what the update check does, so the privacy promise matches the behavior."
+        }
+      ]
+    },
+    {
       "tag": "2026-06-05",
       "title": "Summarize with any OpenAI-compatible server",
       "highlights": [

--- a/backend/harness_config.py
+++ b/backend/harness_config.py
@@ -17,13 +17,22 @@ import json
 import os
 import tempfile
 from pathlib import Path
-from typing import Dict, List, Set
+from typing import Any, Dict, List, Set
 
 HARNESS_DIR = Path.home() / ".tokentelemetry"
 ALIASES_FILE = HARNESS_DIR / "aliases.json"
 HIDDEN_FILE = HARNESS_DIR / "hidden.json"
+PREFERENCES_FILE = HARNESS_DIR / "preferences.json"
 VERSION_FILE = HARNESS_DIR / "VERSION"
 SCHEMA_VERSION = 1
+
+# App preferences with their defaults. Only keys listed here are ever read from
+# or written to disk, so a stale/garbage file can't inject unknown settings.
+#   update_check: whether the dashboard may fetch the latest version + release
+#                 notes from GitHub (the only outbound call the app makes).
+DEFAULT_PREFERENCES: Dict[str, Any] = {
+    "update_check": True,
+}
 
 
 def _ensure_dir() -> None:
@@ -105,6 +114,40 @@ def unhide_project(path: str) -> Set[str]:
     current.discard(path)
     save_hidden(current)
     return current
+
+
+def load_preferences() -> Dict[str, Any]:
+    """Return app preferences, defaults filled in for anything missing/invalid.
+
+    Never raises: a missing or malformed file yields the defaults. Unknown keys
+    on disk are ignored so only recognised preferences ever take effect."""
+    prefs = dict(DEFAULT_PREFERENCES)
+    if not PREFERENCES_FILE.exists():
+        return prefs
+    try:
+        with open(PREFERENCES_FILE, "r", encoding="utf-8") as f:
+            raw = json.load(f)
+    except Exception:
+        return prefs
+    if not isinstance(raw, dict):
+        return prefs
+    for key, default in DEFAULT_PREFERENCES.items():
+        if key in raw and isinstance(raw[key], type(default)):
+            prefs[key] = raw[key]
+    return prefs
+
+
+def save_preferences(updates: Dict[str, Any]) -> Dict[str, Any]:
+    """Merge `updates` (known keys only) over current prefs and persist.
+
+    Returns the full preferences dict after the merge. Values whose type doesn't
+    match the default are skipped, so a bad payload can't corrupt a setting."""
+    prefs = load_preferences()
+    for key, default in DEFAULT_PREFERENCES.items():
+        if key in updates and isinstance(updates[key], type(default)):
+            prefs[key] = updates[key]
+    _atomic_write_json(PREFERENCES_FILE, prefs)
+    return prefs
 
 
 def list_aliases() -> Dict[str, str]:

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Body
 from fastapi.middleware.cors import CORSMiddleware
 import os
 import re
@@ -15,6 +15,7 @@ from harness_config import (
     load_aliases, apply_alias,
     load_hidden, hide_project, unhide_project,
     list_aliases, save_aliases,
+    load_preferences, save_preferences,
 )
 
 def _aware(dt):
@@ -1265,10 +1266,25 @@ def _fetch_remote() -> Optional[Dict[str, Any]]:
     return {"latest": latest_sha, "releases": releases, "release_url": release_url}
 
 
+def _update_check_enabled() -> bool:
+    """Whether the dashboard may contact GitHub for version/release info.
+
+    Two ways to turn it off, env var taking precedence so ops/enterprise can
+    enforce it regardless of the in-app setting:
+      - TT_NO_UPDATE_CHECK=1 (env) — hard off, not user-overridable; and
+      - the `update_check` preference (Settings toggle), default on.
+    This is the *only* outbound network call the app makes; it sends no logs,
+    sessions, or usage data — just a version/UPDATE.json fetch."""
+    if os.environ.get("TT_NO_UPDATE_CHECK"):
+        return False
+    return bool(load_preferences().get("update_check", True))
+
+
 @app.get("/version")
 async def get_version():
     """Banner data: how far behind the local checkout is + 1-3 curated bullets
-    about what's in the update. Set TT_NO_UPDATE_CHECK=1 to disable."""
+    about what's in the update. Disable via the Settings toggle or, to enforce
+    it for everyone, TT_NO_UPDATE_CHECK=1."""
     current = _local_commit()
     base: Dict[str, Any] = {
         "current": current,
@@ -1279,7 +1295,7 @@ async def get_version():
         "source": "none",
         "repo": f"{_REPO_OWNER}/{_REPO_NAME}",
     }
-    if os.environ.get("TT_NO_UPDATE_CHECK"):
+    if not _update_check_enabled():
         base["source"] = "disabled"
         return base
     if not current:
@@ -3302,6 +3318,30 @@ async def post_unhide(payload: PathPayload):
     updated = unhide_project(payload.path)
     _invalidate_sessions_cache()
     return {"ok": True, "hidden": sorted(updated)}
+
+
+@app.get("/config/update-check")
+async def get_update_check():
+    """Current update-check state for the Settings toggle.
+
+    `enabled` is the saved preference; `env_forced_off` is true when
+    TT_NO_UPDATE_CHECK is set, in which case the toggle is read-only (ops/policy
+    override). `effective` is what actually happens (env wins)."""
+    pref = bool(load_preferences().get("update_check", True))
+    env_off = bool(os.environ.get("TT_NO_UPDATE_CHECK"))
+    return {"enabled": pref, "env_forced_off": env_off, "effective": pref and not env_off}
+
+
+@app.post("/config/update-check")
+async def post_update_check(payload: dict = Body(...)):
+    """Persist the update-check preference. Body: {"enabled": bool}."""
+    from fastapi import HTTPException
+    enabled = payload.get("enabled")
+    if not isinstance(enabled, bool):
+        raise HTTPException(status_code=400, detail="'enabled' must be a boolean")
+    save_preferences({"update_check": enabled})
+    env_off = bool(os.environ.get("TT_NO_UPDATE_CHECK"))
+    return {"enabled": enabled, "env_forced_off": env_off, "effective": enabled and not env_off}
 
 
 @app.get("/config/aliases")

--- a/backend/test_update_check.py
+++ b/backend/test_update_check.py
@@ -1,0 +1,102 @@
+"""Tests for the update-check preference + /version gating (issue #64).
+
+The dashboard makes one outbound call — an optional update check to GitHub.
+Users must be able to turn it off in-app (a persisted preference) or enforce it
+off via the TT_NO_UPDATE_CHECK env var (which wins). These tests pin the
+preference store, the gating precedence, and the endpoint contract.
+
+No pytest in the venv — run directly:  python backend/test_update_check.py
+"""
+import asyncio
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(__file__))
+import harness_config  # noqa: E402
+
+
+def _isolate_prefs() -> None:
+    """Point harness_config at a throwaway dir so tests never touch real prefs."""
+    d = tempfile.mkdtemp()
+    harness_config.HARNESS_DIR = Path(d)
+    harness_config.PREFERENCES_FILE = Path(d) / "preferences.json"
+    harness_config.VERSION_FILE = Path(d) / "VERSION"
+
+
+def test_preferences_default_and_roundtrip():
+    _isolate_prefs()
+    assert harness_config.load_preferences() == {"update_check": True}
+    assert harness_config.save_preferences({"update_check": False})["update_check"] is False
+    assert harness_config.load_preferences()["update_check"] is False
+
+
+def test_preferences_rejects_unknown_keys_and_bad_types():
+    _isolate_prefs()
+    # Unknown keys never persist; wrong-typed values are skipped (stay default).
+    saved = harness_config.save_preferences({"bogus": 123, "update_check": "yes"})
+    assert "bogus" not in saved
+    assert saved["update_check"] is True  # string rejected -> default kept
+    # A malformed file degrades to defaults, never raises.
+    harness_config.PREFERENCES_FILE.write_text("not valid json {")
+    assert harness_config.load_preferences() == {"update_check": True}
+
+
+def test_version_gating_precedence():
+    _isolate_prefs()
+    import main
+    # main caches the imported symbol; point it at the isolated store too.
+    main.load_preferences = harness_config.load_preferences
+
+    os.environ.pop("TT_NO_UPDATE_CHECK", None)
+    harness_config.save_preferences({"update_check": True})
+    assert main._update_check_enabled() is True
+
+    harness_config.save_preferences({"update_check": False})
+    assert main._update_check_enabled() is False
+
+    # Env var wins over an enabled preference.
+    harness_config.save_preferences({"update_check": True})
+    os.environ["TT_NO_UPDATE_CHECK"] = "1"
+    try:
+        assert main._update_check_enabled() is False
+        # /version short-circuits to a disabled payload (no network).
+        v = asyncio.run(main.get_version())
+        assert v["source"] == "disabled" and v["behind"] is False
+    finally:
+        os.environ.pop("TT_NO_UPDATE_CHECK", None)
+
+
+def test_endpoint_contract():
+    _isolate_prefs()
+    import main
+    main.load_preferences = harness_config.load_preferences
+    from fastapi import HTTPException
+
+    os.environ.pop("TT_NO_UPDATE_CHECK", None)
+    assert asyncio.run(main.get_update_check()) == {
+        "enabled": True, "env_forced_off": False, "effective": True}
+    assert asyncio.run(main.post_update_check({"enabled": False})) == {
+        "enabled": False, "env_forced_off": False, "effective": False}
+    assert asyncio.run(main.get_update_check())["enabled"] is False
+    # Non-boolean payload is rejected.
+    try:
+        asyncio.run(main.post_update_check({"enabled": "nope"}))
+        raise AssertionError("expected 400 for non-boolean payload")
+    except HTTPException as e:
+        assert e.status_code == 400
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS  {t.__name__}")
+        except Exception as e:  # noqa: BLE001
+            failed += 1
+            print(f"FAIL  {t.__name__}: {e!r}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    sys.exit(1 if failed else 0)

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Settings2, Sparkles, Check, Loader2 } from "lucide-react";
+import { Settings2, Sparkles, Check, Loader2, RefreshCw } from "lucide-react";
+import { cn } from "@/lib/cn";
 import { PageHeader, Section, Card, CardHeader, CardTitle, Button, Badge, Skeleton } from "@/components/ui";
 import { BackendPicker } from "@/components/summarizer/BackendPicker";
 import {
@@ -9,6 +10,7 @@ import {
   DEFAULT_OPENAI_COMPAT,
   type SummarizerConfig, type SummarizerBackend, type OpenAICompatConfig,
 } from "@/lib/summarizer";
+import { getUpdateCheck, setUpdateCheck, type UpdateCheckState } from "@/lib/version";
 
 // Backends that carry a per-backend model selection.
 const MODEL_BACKENDS = new Set(["ollama", "codex", "openai_compat"]);
@@ -25,6 +27,31 @@ export default function SettingsPage() {
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Update-check preference (independent of the summarizer config above).
+  const [updateCheck, setUpdateCheckState] = useState<UpdateCheckState | null>(null);
+  const [togglingUpdate, setTogglingUpdate] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    getUpdateCheck()
+      .then((s) => { if (!cancelled) setUpdateCheckState(s); })
+      .catch(() => { /* non-fatal: section just stays in its loading state */ });
+    return () => { cancelled = true; };
+  }, []);
+
+  const toggleUpdateCheck = async () => {
+    if (!updateCheck || updateCheck.env_forced_off) return;
+    setTogglingUpdate(true);
+    const next = !updateCheck.enabled;
+    try {
+      setUpdateCheckState(await setUpdateCheck(next));
+    } catch {
+      /* leave previous state; the toggle simply won't flip */
+    } finally {
+      setTogglingUpdate(false);
+    }
+  };
 
   useEffect(() => {
     let cancelled = false;
@@ -140,6 +167,64 @@ export default function SettingsPage() {
                 <Button variant="primary" onClick={save} disabled={saving || !dirty}>
                   {saving ? <><Loader2 size={13} className="animate-spin" /> Saving…</> : "Save changes"}
                 </Button>
+              </div>
+            </div>
+          )}
+        </Card>
+      </Section>
+
+      <Section
+        title="Updates & privacy"
+        description="TokenTelemetry never sends your logs, sessions, tokens, or costs anywhere — those stay on your machine. The only outbound network call is this optional update check."
+      >
+        <Card>
+          <CardHeader>
+            <CardTitle>
+              <RefreshCw size={14} className="text-[var(--tt-brand)]" />
+              Check for updates
+            </CardTitle>
+            {updateCheck && (
+              <Badge variant={updateCheck.effective ? "success" : "neutral"} size="sm">
+                {updateCheck.env_forced_off ? "Off · env" : updateCheck.enabled ? "On" : "Off"}
+              </Badge>
+            )}
+          </CardHeader>
+
+          {!updateCheck ? (
+            <Skeleton className="h-14 w-full" />
+          ) : (
+            <div className="space-y-4">
+              <div className="flex items-start justify-between gap-4">
+                <p className="text-[13px] leading-relaxed text-[var(--tt-fg-dim)] max-w-[560px]">
+                  When on, the dashboard fetches the latest version and release notes from GitHub
+                  (about once an hour) so you know when new features land. This sends no usage data —
+                  only a version request, which exposes your IP and app name to GitHub like any web
+                  request. {updateCheck.env_forced_off
+                    ? "It is currently forced off by the TT_NO_UPDATE_CHECK environment variable."
+                    : "You can also disable it with TT_NO_UPDATE_CHECK=1."}
+                </p>
+                <button
+                  onClick={toggleUpdateCheck}
+                  role="switch"
+                  aria-checked={updateCheck.enabled}
+                  aria-label="Toggle automatic update checks"
+                  disabled={togglingUpdate || updateCheck.env_forced_off}
+                  className={cn(
+                    "relative inline-flex h-5 w-9 shrink-0 items-center rounded-full border transition-colors mt-0.5",
+                    "border-[var(--tt-border)]",
+                    updateCheck.enabled ? "tt-tint-1" : "",
+                    updateCheck.env_forced_off ? "opacity-50 cursor-not-allowed" : "cursor-pointer",
+                  )}
+                >
+                  <span
+                    className={cn(
+                      "absolute h-3.5 w-3.5 rounded-full transition-transform",
+                      updateCheck.enabled
+                        ? "translate-x-[18px] bg-[var(--tt-brand)]"
+                        : "translate-x-0.5 bg-[var(--tt-fg-muted)]",
+                    )}
+                  />
+                </button>
               </div>
             </div>
           )}

--- a/frontend/src/lib/version.ts
+++ b/frontend/src/lib/version.ts
@@ -30,3 +30,22 @@ export interface VersionInfo {
 }
 
 export const getVersion = () => api<VersionInfo>("/version");
+
+/** State of the update-check preference (`GET/POST /config/update-check`). */
+export interface UpdateCheckState {
+  /** The saved preference (what the toggle reflects). */
+  enabled: boolean;
+  /** True when TT_NO_UPDATE_CHECK is set — toggle is read-only (policy override). */
+  env_forced_off: boolean;
+  /** What actually happens: enabled && !env_forced_off. */
+  effective: boolean;
+}
+
+export const getUpdateCheck = () => api<UpdateCheckState>("/config/update-check");
+
+export const setUpdateCheck = (enabled: boolean) =>
+  api<UpdateCheckState>("/config/update-check", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ enabled }),
+  });

--- a/website/src/app/privacy/page.tsx
+++ b/website/src/app/privacy/page.tsx
@@ -65,8 +65,15 @@ export default function PrivacyPage() {
 
       <Section title="What we never collect">
         <p>
-          Your prompts, code, agent logs, token counts, and costs stay on your own machine. The TokenTelemetry
-          application has no telemetry endpoint — there is nowhere for that data to go.
+          Your prompts, code, agent logs, token counts, and costs stay on your own machine. TokenTelemetry has no
+          usage-telemetry endpoint — your data is never collected or transmitted anywhere.
+        </p>
+        <p>
+          The application makes a single outbound network request: an <strong className="text-[var(--tt-fg)]">optional
+          update check</strong> that fetches the latest version and release notes from GitHub (about once an hour) so
+          you know when new features are available. It sends no usage data — only a version request, which, like any
+          web request, exposes your IP address and the app name to GitHub. Disable it in the app under
+          Settings → Updates &amp; privacy, or by setting <code>TT_NO_UPDATE_CHECK=1</code> before launching.
         </p>
       </Section>
 

--- a/website/src/components/FAQ.tsx
+++ b/website/src/components/FAQ.tsx
@@ -17,7 +17,7 @@ export const FAQ_ITEMS = [
   },
   {
     q: "Does TokenTelemetry send my data to the cloud?",
-    a: "No. Everything runs on your machine. The dashboard reads session log files from your local filesystem and serves a UI on localhost. Nothing leaves your computer.",
+    a: "No usage data, ever. The dashboard reads session log files from your local filesystem and serves a UI on localhost — your logs, sessions, tokens, and costs never leave your computer. The only outbound call is an optional update check that fetches the latest version and release notes from GitHub (no usage data sent); turn it off in Settings → Updates & privacy, or with TT_NO_UPDATE_CHECK=1.",
   },
   {
     q: "How does TokenTelemetry compare to Langfuse or Helicone?",

--- a/website/src/components/Hero.tsx
+++ b/website/src/components/Hero.tsx
@@ -74,7 +74,7 @@ export default function Hero() {
             {/* Subhead */}
             <p className="text-[15px] sm:text-[17px] text-[var(--tt-fg-muted)] max-w-2xl mx-auto lg:mx-0 leading-relaxed mb-3">
               Local, read-only observability for Claude Code, Codex, Gemini CLI, Cursor, Copilot, Antigravity,
-              Qwen CLI, OpenCode, Grok Build, Hermes Agent, and Vibe — one command, no signup, nothing leaves your machine.
+              Qwen CLI, OpenCode, Grok Build, Hermes Agent, and Vibe — one command, no signup, your logs never leave your machine.
             </p>
             <p className="text-[13px] sm:text-[14px] text-[var(--tt-fg-dim)] font-mono italic mb-9 transition-opacity">
               &ldquo;{PAINS[pain]}&rdquo;

--- a/website/src/components/TrustStrip.tsx
+++ b/website/src/components/TrustStrip.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { Lock, FileCode, Zap, GitBranch } from "lucide-react";
 
 const ITEMS = [
-  { icon: Lock,     title: "100% local",      body: "Logs never leave your machine. No telemetry endpoints. No accounts." },
+  { icon: Lock,     title: "100% local",      body: "Your logs never leave your machine. No usage tracking. No accounts. Only an optional update check pings GitHub." },
   { icon: FileCode, title: "MIT open source", body: "Read every line. Fork it. Replace it with something better — up to you." },
   { icon: Zap,      title: "No signup",       body: "One command, browser opens. That is the entire onboarding." },
 ];

--- a/website/src/data/features.ts
+++ b/website/src/data/features.ts
@@ -50,7 +50,7 @@ export const FEATURES: Feature[] = [
     bullets: [
       "Stacked daily area chart shows where your budget is actually going.",
       "Model leaderboard ranked by usage, cost, and cache hit rate.",
-      "All math local. No data leaves your machine.",
+      "All math runs locally — your analytics data never leaves your machine.",
     ],
     screenshot: "/screenshots/analytics.png",
   },


### PR DESCRIPTION
Fixes #64.

## Problem (verified)

The README/FAQ/website claimed *"Nothing leaves your machine"* / *"No telemetry endpoints"*, but the dashboard makes **one** outbound call: an optional update check to GitHub on `/version` (latest commit + `UPDATE.json`), cached 1h. Two corrections to the report, in our favor — it only runs for **git checkouts**, and it sends **no usage data** (no logs/sessions/tokens/costs; only what any HTTP GET reveals: IP, User-Agent, timestamp). But the absolute wording was inaccurate and the `TT_NO_UPDATE_CHECK` opt-out was **undocumented**.

The fix isn't to remove the feature — it's how users learn about new releases. It's to make it **honest and consciously controllable**.

## Changes

**Backend**
- `harness_config`: typed preferences store (`~/.tokentelemetry/preferences.json`) — `load`/`save` ignore unknown keys and type-mismatched values.
- `/version` gates on `_update_check_enabled()`: `TT_NO_UPDATE_CHECK` (env, **wins**) **OR** the `update_check` preference (default on). Env precedence lets ops/enterprise enforce off.
- `GET`/`POST /config/update-check` for the toggle; POST validates a boolean body (400 otherwise).

**Frontend**
- Settings → **Updates & privacy**: a switch (default on) + plain-English disclosure of exactly what the check does and that it sends no usage data. Renders read-only **"Off · env"** when `TT_NO_UPDATE_CHECK` forces it off.

**Docs**
- README: corrected FAQ wording + new **Update check** section documenting both opt-outs; `preferences.json` added to the config layout.
- website: `FAQ` / `Hero` / `TrustStrip` / `privacy` / `features` reworded from absolute *"nothing leaves"* → precise *"your logs never leave"* + update-check note.

## Testing

- New `backend/test_update_check.py` (4/4): preference store defaults/roundtrip, unknown-key & bad-type rejection, gating precedence (env wins), endpoint contract incl. 400. Existing `test_antigravity_cli.py` still 4/4.
- HTTP e2e (curl): toggle persists to disk, `/version` → `source=disabled` when off, 400 on bad body.
- `tsc --noEmit` clean; the **Updates & privacy** section renders in-app (screenshot verified).

**Note:** the in-browser *interactive* toggle couldn't be exercised via automation — the automation browser didn't hydrate the client (no XHR fired; the pre-existing summarizer section was stuck on its skeleton identically), so this is environmental, not a code defect. Render + backend + types are verified. The website has no local `node_modules` (deployed separately); its changes are copy-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)