### PR TITLE
fix(antigravity): permanent project resolution + hide "unassigned" from Projects

### DIFF
--- a/UPDATE.json
+++ b/UPDATE.json
@@ -10,8 +10,8 @@
           "href": "/"
         },
         {
-          "title": "Accurate project for Antigravity CLI sessions",
-          "description": "CLI sessions are now grouped under the exact project folder they ran in, taken from the CLI's own prompt history rather than guessed from the task text — so they stop landing in \"unassigned\".",
+          "title": "Accurate, stable project for Antigravity CLI sessions",
+          "description": "CLI sessions are now grouped under the exact folder they worked in, read from each session's own saved record — so the grouping stays correct over time instead of guessing from task text. Sessions that genuinely never entered a project (pure chat/research) stay under \"unassigned\".",
           "href": "/"
         }
       ]

--- a/backend/main.py
+++ b/backend/main.py
@@ -320,48 +320,104 @@ _AG_MODEL_DISPLAY_RE = re.compile(
     rb'(?:Pro|Flash|Ultra|Nano|Opus|Sonnet|Haiku)(?:[ ]\([A-Za-z]+\))?)'
 )
 
-def _antigravity_db_model(db_path: Path) -> Optional[str]:
-    """Pull the model display name from an Antigravity CLI SQLite trajectory.
+# Tool-call steps in an Antigravity CLI trajectory embed a clean JSON arg blob.
+# Its Cwd/SearchPath fields are the session's real workspace root; the file-path
+# fields point at files it touched. These are the authoritative, always-present
+# record of *where* a session worked — unlike history.jsonl, a rolling log that
+# ages out. Paths under the agent's own home (~/.gemini/...) are internal
+# (brain/scratch/mcp), not user projects, and are ignored.
+_AG_WORKSPACE_RE = re.compile(rb'"(?:Cwd|SearchPath)"\s*:\s*"((?:[^"\\]|\\.)+)"')
+_AG_FILEPATH_RE = re.compile(rb'"(?:AbsolutePath|TargetFile|DirectoryPath)"\s*:\s*"((?:[^"\\]|\\.)+)"')
 
-    `agy` stores the model as a protobuf field inside the gen_metadata.data
-    blobs (one row per model generation). We scan those blobs and take the most
-    common display-name match. Read-only and best-effort: returns None on any
-    DB/IO error or when no model string is present (e.g. older .pb sessions,
-    which don't embed the display name)."""
+
+def _antigravity_db_meta(db_path: Path) -> Dict[str, Optional[str]]:
+    """Read model + project for one Antigravity CLI session from its SQLite trajectory.
+
+    Single read-only pass over the DB:
+      - **model**: most common display name in the gen_metadata blobs (None for
+        older .pb-only sessions, which don't embed it).
+      - **project**: the workspace the session actually worked in, taken from the
+        Cwd/SearchPath of its tool calls (falling back to the project root of a
+        touched file). Paths under ~/.gemini are the agent's own internals and
+        are skipped, so a pure chat/research session that never entered a project
+        stays unattributed (project=None) instead of being mislabeled.
+
+    Best-effort: returns {"model": None, "project": None} on any DB/IO error."""
     from collections import Counter
-    counts: "Counter[str]" = Counter()
+    models: "Counter[str]" = Counter()
+    roots: "Counter[str]" = Counter()
+    files: "Counter[str]" = Counter()
+    gemini_home = str(GEMINI_DIR)
     try:
         con = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
         try:
             for (blob,) in con.execute("SELECT data FROM gen_metadata WHERE data IS NOT NULL"):
-                if not blob:
+                if blob:
+                    for m in _AG_MODEL_DISPLAY_RE.findall(blob):
+                        models[m.decode("ascii", "ignore")] += 1
+            for (payload,) in con.execute("SELECT step_payload FROM steps WHERE step_payload IS NOT NULL"):
+                if not payload:
                     continue
-                for m in _AG_MODEL_DISPLAY_RE.findall(blob):
-                    counts[m.decode("ascii", "ignore")] += 1
+                for m in _AG_WORKSPACE_RE.findall(payload):
+                    v = m.decode("utf-8", "ignore")
+                    if not v.startswith(gemini_home):
+                        roots[v] += 1
+                for m in _AG_FILEPATH_RE.findall(payload):
+                    v = m.decode("utf-8", "ignore")
+                    if not v.startswith(gemini_home):
+                        files[v] += 1
         finally:
             con.close()
     except (sqlite3.Error, OSError):
-        return None
-    if not counts:
-        return None
-    return counts.most_common(1)[0][0]
+        return {"model": None, "project": None}
+
+    model = models.most_common(1)[0][0] if models else None
+    project: Optional[str] = None
+    if roots:
+        project = roots.most_common(1)[0][0]
+    elif files:
+        inferred = _antigravity_infer_project(files.most_common(1)[0][0])
+        if "unassigned" not in inferred:  # only accept a real derived root
+            project = inferred
+    return {"model": model, "project": project}
+
 
 def _antigravity_cli_meta(cli_dir: Path = ANTIGRAVITY_CLI_DIR) -> Dict[str, Dict[str, Any]]:
     """Enrich Antigravity CLI (`agy`) sessions from its own stores.
 
-    The brain/ scanner only sees derived markdown, so it labels every CLI
-    session with a generic model ("gemini (antigravity)") and a heuristic
-    project guessed from the task/plan text. Here we recover the ground truth:
+    The brain/ scanner only sees derived markdown, so it labels every CLI session
+    with a generic model ("gemini (antigravity)") and a project heuristically
+    guessed from the task/plan text. Here we recover the ground truth, preferring
+    the per-session SQLite trajectory (permanent) over history.jsonl (a rolling
+    log that ages out):
 
-      - **project cwd** from history.jsonl, which maps conversationId -> workspace
-        directly (no guessing); and
-      - **model display name** from each conversations/<uuid>.db gen_metadata table.
+      1. model + project from each conversations/<uuid>.db (see _antigravity_db_meta);
+      2. project from history.jsonl (conversationId -> workspace) as a fallback for
+         sessions whose trajectory recorded no workspace (e.g. older .pb sessions).
 
     Session ids in brain/ are the conversation UUIDs, so the returned map keys
     line up 1:1. Returns {session_id: {"model": str, "project": str}} with each
     field present only when found. Best-effort — never raises."""
     meta: Dict[str, Dict[str, Any]] = {}
-    # 1. Exact project cwd from the flat prompt log (last line wins => latest cwd).
+    # 1. Authoritative, permanent: each session's own SQLite trajectory.
+    conv = cli_dir / "conversations"
+    try:
+        db_files = sorted(conv.glob("*.db")) if conv.exists() else []
+    except OSError:
+        db_files = []
+    for db in db_files:
+        dm = _antigravity_db_meta(db)
+        entry: Dict[str, Any] = {}
+        if dm.get("model"):
+            entry["model"] = dm["model"]
+        if dm.get("project"):
+            entry["project"] = dm["project"]
+        if entry:
+            meta[db.stem] = entry
+    # 2. Fallback project source: the flat prompt log. Build a last-wins map
+    #    (newest cwd per conversation), then fill only sessions the .db didn't
+    #    resolve — so a project from the authoritative .db always wins.
+    hist_project: Dict[str, str] = {}
     hist = cli_dir / "history.jsonl"
     try:
         if hist.exists():
@@ -376,19 +432,11 @@ def _antigravity_cli_meta(cli_dir: Path = ANTIGRAVITY_CLI_DIR) -> Dict[str, Dict
                         continue
                     cid, ws = rec.get("conversationId"), rec.get("workspace")
                     if cid and ws:
-                        meta.setdefault(cid, {})["project"] = ws
+                        hist_project[cid] = ws  # last line wins => latest cwd
     except OSError:
         pass
-    # 2. Real model name from the per-session SQLite trajectory.
-    conv = cli_dir / "conversations"
-    try:
-        db_files = sorted(conv.glob("*.db")) if conv.exists() else []
-    except OSError:
-        db_files = []
-    for db in db_files:
-        model = _antigravity_db_model(db)
-        if model:
-            meta.setdefault(db.stem, {})["model"] = model
+    for cid, ws in hist_project.items():
+        meta.setdefault(cid, {}).setdefault("project", ws)
     return meta
 
 class TokenUsage(BaseModel):

--- a/backend/main.py
+++ b/backend/main.py
@@ -235,6 +235,12 @@ def _load_project_aliases() -> Dict[str, str]:
         except Exception: pass
     return {}
 
+# Sentinel project for Antigravity sessions whose real workspace can't be
+# recovered (pure chat/research runs that never entered a project dir). It groups
+# such sessions but is NOT a real workspace, so get_projects hides it from the
+# Projects view — the sessions still appear in the dashboard and session lists.
+ANTIGRAVITY_UNASSIGNED = "Antigravity / unassigned"
+
 def _antigravity_infer_project(text: str) -> str:
     import re
     # Match absolute paths starting with the home directory or common root prefixes
@@ -263,8 +269,8 @@ def _antigravity_infer_project(text: str) -> str:
             if len(parts) >= 4:
                 return "/".join(parts[:4])
             return path
-            
-    return "Antigravity / unassigned"
+
+    return ANTIGRAVITY_UNASSIGNED
 
 def _estimate_antigravity_tokens(sess_dir: Path) -> dict:
     import logging
@@ -3376,6 +3382,11 @@ async def get_projects(include_hidden: bool = False):
     hidden = load_hidden()
     for s in sessions:
         proj = s["project"]
+        # The Antigravity "unassigned" sentinel isn't a real workspace — skip it
+        # so it never shows as a project card. These sessions remain visible in
+        # the dashboard and session lists, just not grouped as a project.
+        if proj == ANTIGRAVITY_UNASSIGNED:
+            continue
         if proj not in projects:
             # Basename that handles both POSIX (/) and Windows (\) separators
             proj_name = (os.path.basename((proj or "").replace("\\", "/").rstrip("/")) or proj or "unknown").strip()

--- a/backend/test_antigravity_cli.py
+++ b/backend/test_antigravity_cli.py
@@ -106,6 +106,28 @@ def test_db_meta_regex_and_error_handling():
         assert main._antigravity_cli_meta(Path(d) / "does-not-exist") == {}
 
 
+def test_projects_excludes_unassigned_sentinel():
+    # The Antigravity "unassigned" bucket must never render as a project card,
+    # while real workspaces still do. Sessions themselves remain in /sessions.
+    async def fake_sessions():
+        common = {"agent": "antigravity", "mcp_tools": [], "subagents": [],
+                  "tokens": {}, "cost": 0.0, "plans": [], "has_plan": False}
+        return [
+            {"project": "/Users/me/Documents/Developer/realproj", **common},
+            {"project": main.ANTIGRAVITY_UNASSIGNED, **common},
+            {"project": main.ANTIGRAVITY_UNASSIGNED, **common},
+        ]
+    orig = main.get_sessions_cached
+    main.get_sessions_cached = fake_sessions
+    try:
+        out = asyncio.run(main.get_projects())
+    finally:
+        main.get_sessions_cached = orig
+    paths = [p["path"] for p in out]
+    assert main.ANTIGRAVITY_UNASSIGNED not in paths
+    assert "/Users/me/Documents/Developer/realproj" in paths
+
+
 def _call_artifact(path):
     try:
         resp = asyncio.run(main.get_artifact(path))

--- a/backend/test_antigravity_cli.py
+++ b/backend/test_antigravity_cli.py
@@ -28,46 +28,80 @@ def _make_cli_dir(root: Path) -> Path:
     conv = root / "conversations"
     conv.mkdir(parents=True)
     # history.jsonl: last-wins per conversationId; tolerate junk + missing fields.
+    # sid-db's history workspace must LOSE to the .db-derived project below.
     (root / "history.jsonl").write_text(
-        json.dumps({"conversationId": "sid-db", "workspace": "/proj/alpha"}) + "\n"
+        json.dumps({"conversationId": "sid-db", "workspace": "/proj/stale-history"}) + "\n"
         + "this is not json\n"
-        + json.dumps({"conversationId": "sid-db", "workspace": "/proj/alpha2"}) + "\n"
         + json.dumps({"display": "no conversation id"}) + "\n"
-        + json.dumps({"conversationId": "sid-pb", "workspace": "/proj/beta"}) + "\n",
+        + json.dumps({"conversationId": "sid-pb", "workspace": "/proj/beta"}) + "\n"
+        + json.dumps({"conversationId": "sid-chat", "workspace": "/proj/from-history"}) + "\n",
         encoding="utf-8",
     )
-    # .db session with the model embedded in gen_metadata blobs (+ prose noise).
-    db = conv / "sid-db.db"
-    con = sqlite3.connect(db)
-    con.execute("CREATE TABLE gen_metadata (idx integer, data blob)")
-    con.execute("INSERT INTO gen_metadata VALUES (?,?)",
-                (0, b"\x0aGemini 3.1 Pro (High)\x12 Gemini API) prose \x1aClaude Code"))
-    con.execute("INSERT INTO gen_metadata VALUES (?,?)", (1, b"xxGemini 3.1 Pro (High)yy"))
-    con.execute("INSERT INTO gen_metadata VALUES (?,?)", (2, None))
-    con.commit()
-    con.close()
-    # .pb-only session: no model embedded -> model unresolved, project still found.
-    (conv / "sid-pb.pb").write_bytes(b"raw protobuf bytes with no model display name")
+
+    def _make_db(name, gen_blobs, step_blobs):
+        db = conv / name
+        con = sqlite3.connect(db)
+        con.execute("CREATE TABLE gen_metadata (idx integer, data blob)")
+        for i, b in enumerate(gen_blobs):
+            con.execute("INSERT INTO gen_metadata VALUES (?,?)", (i, b))
+        con.execute("CREATE TABLE steps (idx integer, step_payload blob)")
+        for i, b in enumerate(step_blobs):
+            con.execute("INSERT INTO steps VALUES (?,?)", (i, b))
+        con.commit()
+        con.close()
+
+    # sid-db: model in gen_metadata (+ prose noise); workspace in tool-call Cwd,
+    # appearing more often than a one-off side path so it's the most common.
+    _make_db(
+        "sid-db.db",
+        [b"\x0aGemini 3.1 Pro (High)\x12 Gemini API) prose \x1aClaude Code",
+         b"xxGemini 3.1 Pro (High)yy", None],
+        [b'{"Cwd":"/work/realproj","toolAction":"x"}',
+         b'{"SearchPath":"/work/realproj","Query":"y"}',
+         b'{"Cwd":"/work/realproj"}',
+         b'{"AbsolutePath":"/work/other/one-off.py"}', None],
+    )
+    # sid-chat: a pure research session — its only path is under the agent's own
+    # ~/.gemini home, so the .db yields no project; history.jsonl fills it.
+    _make_db(
+        "sid-chat.db",
+        [None],
+        [(b'{"Cwd":"' + str(main.GEMINI_DIR).encode() + b'/antigravity-cli/scratch"}'),
+         b'{"Query":"how do tariffs work"}'],
+    )
+    # .pb-only session: no model and no extractable cwd -> project from history.
+    (conv / "sid-pb.pb").write_bytes(b"raw protobuf bytes with no model or path")
     return root
 
 
-def test_cli_meta_recovers_model_and_project():
+def test_cli_meta_prefers_db_project_over_history():
     with tempfile.TemporaryDirectory() as d:
         cli = _make_cli_dir(Path(d))
         meta = main._antigravity_cli_meta(cli)
-        assert meta["sid-db"]["project"] == "/proj/alpha2"  # last line wins
+        # .db workspace (permanent) wins over the rolling history.jsonl entry.
+        assert meta["sid-db"]["project"] == "/work/realproj"
         assert meta["sid-db"]["model"] == "Gemini 3.1 Pro (High)"
+
+
+def test_cli_meta_history_fallback_and_internal_paths_ignored():
+    with tempfile.TemporaryDirectory() as d:
+        cli = _make_cli_dir(Path(d))
+        meta = main._antigravity_cli_meta(cli)
+        # .pb session has no .db signal -> project comes from history.jsonl.
         assert meta["sid-pb"]["project"] == "/proj/beta"
-        assert "model" not in meta["sid-pb"]  # .pb has no embedded display name
+        assert "model" not in meta["sid-pb"]
+        # Research session: ~/.gemini-internal cwd ignored, so history fills it
+        # rather than the session being mislabeled with the agent's own path.
+        assert meta["sid-chat"]["project"] == "/proj/from-history"
 
 
-def test_model_regex_ignores_prose_and_handles_errors():
-    # Strict pattern must not match prose like "Gemini API" or skill names.
+def test_db_meta_regex_and_error_handling():
+    # Strict model pattern must not match prose like "Gemini API" or skill names.
     assert main._AG_MODEL_DISPLAY_RE.findall(b"Gemini API) into web apps; Claude Code") == []
     with tempfile.TemporaryDirectory() as d:
         bad = Path(d) / "corrupt.db"
         bad.write_bytes(b"this is not a sqlite database")
-        assert main._antigravity_db_model(bad) is None
+        assert main._antigravity_db_meta(bad) == {"model": None, "project": None}
         # Missing dir must yield an empty map, never raise.
         assert main._antigravity_cli_meta(Path(d) / "does-not-exist") == {}
 


### PR DESCRIPTION
Follow-up to #63. Two related fixes so Antigravity CLI (`agy`) sessions group correctly and the Projects view stays clean.

## 1. Resolve project from the session's own `.db` (permanent)

#63 tied CLI sessions to a project via `history.jsonl` — a **rolling prompt log that ages out**, so sessions silently regress to "unassigned" once their entry rotates. Now the project is read from each session's own SQLite trajectory (`conversations/<id>.db`), which never rotates:

- Replace the model-only `_antigravity_db_model` with `_antigravity_db_meta` — one read-only pass that pulls **both** the model (`gen_metadata`) and the project (the `Cwd`/`SearchPath` of the session's tool calls — a clean, version-stable JSON field, falling back to a touched file's root).
- Paths under the agent's own `~/.gemini` home (brain/scratch/mcp) are skipped, so a pure chat/research session that never entered a project stays `project=None` rather than being mislabeled.
- `history.jsonl` is kept only as a fallback for older `.pb`-only sessions.

## 2. Hide the "unassigned" sentinel from the Projects view

Sessions with no recoverable workspace are grouped under `Antigravity / unassigned`. That's a real grouping but **not a real workspace**, and rendering it as a Projects card is noise (it opens to nothing useful). Named it `ANTIGRAVITY_UNASSIGNED` and skip it in `get_projects`, so it never appears as a card. The sessions themselves are untouched — still in the dashboard and session lists.

## Result (verified on real data)

- CLI sessions tie to their real project from the `.db` and **stay correct after `history.jsonl` rotates**.
- Projects list: the "unassigned" card is gone (103 → 102 cards); 254 antigravity sessions correctly grouped under real projects.

## Testing

`backend/test_antigravity_cli.py` — **6/6**: `.db`-wins-over-history, history fallback, `~/.gemini`-internal paths ignored, error handling, and the new `get_projects` sentinel-exclusion. Verified live: restarted backend, `/projects` no longer returns an "unassigned" entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)