### PR TITLE
feat(pricing): build-time pricing data from models.dev (no runtime network)

### DIFF
--- a/.github/workflows/pricing-sync.yml
+++ b/.github/workflows/pricing-sync.yml
@@ -1,0 +1,48 @@
+name: Pricing sync (models.dev)
+
+# Refreshes backend/pricing_data.json from models.dev and opens a PR for review.
+# This is the ONLY place pricing data is fetched over the network — it runs in
+# CI, never on a user machine. TokenTelemetry stays local-first: users get fresh
+# prices through the normal version update, with no new outbound call.
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"  # weekly, Mondays 06:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Regenerate pricing_data.json
+        run: python backend/pricing_sync.py
+
+      - name: Open PR with refreshed pricing
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore(pricing): refresh pricing_data.json from models.dev"
+          title: "chore(pricing): weekly models.dev pricing refresh"
+          body: |
+            Automated weekly refresh of `backend/pricing_data.json` from
+            [models.dev](https://models.dev/api.json).
+
+            - No runtime/user-machine network calls are introduced — this data is
+              shipped with the package and read locally by `backend/pricing.py`.
+            - Inline curated entries in `pricing.py` remain authoritative; this
+              overlay only covers the long tail.
+
+            Please eyeball the diff for any wild price swings before merging.
+          branch: pricing-sync/models-dev
+          delete-branch: true
+          add-paths: |
+            backend/pricing_data.json

--- a/UPDATE.json
+++ b/UPDATE.json
@@ -1,6 +1,17 @@
 {
   "releases": [
     {
+      "tag": "2026-06-08",
+      "title": "Broader, fresher model pricing",
+      "highlights": [
+        {
+          "title": "2000+ models priced for accurate cost estimates",
+          "description": "Cost estimates now draw on a much larger, regularly-refreshed pricing dataset (sourced from models.dev), so far more models — and provider-specific rates — get an accurate price instead of a generic fallback. The data ships with each update and is read entirely on your machine: no new outbound calls, same local-first privacy.",
+          "href": "/"
+        }
+      ]
+    },
+    {
       "tag": "2026-06-07",
       "title": "Update check — now visible and yours to control",
       "highlights": [

--- a/backend/pricing.py
+++ b/backend/pricing.py
@@ -16,9 +16,23 @@
 #
 # Sources cited in PRICING_SOURCES.md alongside this file.
 
+import json
+from pathlib import Path
 from typing import Optional
 
 PRICING_UPDATED = "2026-05-17"
+
+# Build-time pricing dataset (models.dev), refreshed maintainer/CI-side and
+# committed alongside this module — see pricing_sync.py. We read ONLY this
+# bundled file from the package directory; pricing.py performs ZERO network I/O
+# at import or runtime. The inline PRICING / PRICING_BY_PROVIDER dicts below
+# stay as the curated, authoritative fallback (and the fallback if the bundled
+# file is absent or malformed). The overlay fills in the long tail of models the
+# inline tables don't cover, without clobbering the hand-tuned entries.
+_PRICING_DATA_PATH = Path(__file__).parent / "pricing_data.json"
+# Separator used by pricing_sync.py to flatten (provider, model) tuples into the
+# JSON string keys of the "by_provider" map.
+_PROVIDER_SEP = "\x00"
 
 # Direct first-party pricing — used as the flat-fallback when provider unknown.
 PRICING = {
@@ -180,6 +194,80 @@ PRICING_BY_PROVIDER = {
     ("groq", "llama-3.3-70b-versatile"):             {"in": 0.59, "out": 0.79, "cached_read": None},
     ("groq", "llama-3.1-8b-instant"):                {"in": 0.05, "out": 0.08, "cached_read": None},
 }
+
+
+def _coerce_rates(value) -> Optional[dict]:
+    """Validate one overlay entry → {in, out, cached_read} with float|None values.
+
+    Returns None for anything that isn't a usable rate dict, so malformed entries
+    are skipped rather than poisoning the table.
+    """
+    if not isinstance(value, dict):
+        return None
+    out = {}
+    for key in ("in", "out", "cached_read"):
+        raw = value.get(key)
+        if raw is None:
+            out[key] = None
+            continue
+        if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+            return None
+        out[key] = float(raw)
+    # Need at least one priced direction to be meaningful.
+    if out["in"] is None and out["out"] is None:
+        return None
+    return out
+
+
+def _load_bundled_pricing() -> None:
+    """Overlay the committed pricing_data.json onto the inline tables, in place.
+
+    Pure local file read — NO network I/O. Inline dict entries always win
+    (curated/authoritative); the overlay only adds models not already present,
+    giving us broad models.dev coverage without clobbering hand-tuned prices.
+    Any failure (missing file, bad JSON, wrong shape) is swallowed so the module
+    falls back cleanly to the static tables.
+    """
+    try:
+        raw = _PRICING_DATA_PATH.read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (OSError, ValueError):
+        return
+    if not isinstance(data, dict):
+        return
+
+    flat = data.get("pricing")
+    if isinstance(flat, dict):
+        for model_id, rates in flat.items():
+            if not isinstance(model_id, str):
+                continue
+            key = model_id.lower().strip()
+            if not key or key in PRICING:
+                continue  # inline entry is authoritative
+            coerced = _coerce_rates(rates)
+            if coerced is not None:
+                PRICING[key] = coerced
+
+    by_provider = data.get("by_provider")
+    if isinstance(by_provider, dict):
+        for combined, rates in by_provider.items():
+            if not isinstance(combined, str) or _PROVIDER_SEP not in combined:
+                continue
+            provider, model_id = combined.split(_PROVIDER_SEP, 1)
+            tup = (provider.lower().strip(), model_id.lower().strip())
+            if not tup[0] or not tup[1] or tup in PRICING_BY_PROVIDER:
+                continue  # inline entry is authoritative
+            coerced = _coerce_rates(rates)
+            if coerced is not None:
+                PRICING_BY_PROVIDER[tup] = coerced
+
+    updated = data.get("updated")
+    if isinstance(updated, str) and updated.strip():
+        global PRICING_UPDATED
+        PRICING_UPDATED = updated.strip()
+
+
+_load_bundled_pricing()
 
 
 def _normalize_model_id(model: str) -> str:

--- a/backend/pricing_data.json
+++ b/backend/pricing_data.json
@@ -1,0 +1,35849 @@
+{
+  "by_provider": {
+    "302ai\u0000chatgpt-4o-latest": {
+      "cached_read": null,
+      "in": 5.0,
+      "out": 15.0
+    },
+    "302ai\u0000claude-3-5-haiku-20241022": {
+      "cached_read": null,
+      "in": 0.8,
+      "out": 4.0
+    },
+    "302ai\u0000claude-3-5-haiku-latest": {
+      "cached_read": null,
+      "in": 0.8,
+      "out": 4.0
+    },
+    "302ai\u0000claude-haiku-4-5": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "302ai\u0000claude-haiku-4-5-20251001": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "302ai\u0000claude-opus-4-1-20250805": {
+      "cached_read": null,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "302ai\u0000claude-opus-4-1-20250805-thinking": {
+      "cached_read": null,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "302ai\u0000claude-opus-4-20250514": {
+      "cached_read": null,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "302ai\u0000claude-opus-4-5": {
+      "cached_read": null,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "302ai\u0000claude-opus-4-5-20251101": {
+      "cached_read": null,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "302ai\u0000claude-opus-4-5-20251101-thinking": {
+      "cached_read": null,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "302ai\u0000claude-opus-4-6": {
+      "cached_read": null,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "302ai\u0000claude-opus-4-6-thinking": {
+      "cached_read": null,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "302ai\u0000claude-opus-4-7": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "302ai\u0000claude-sonnet-4-20250514": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "302ai\u0000claude-sonnet-4-5": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "302ai\u0000claude-sonnet-4-5-20250929": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "302ai\u0000claude-sonnet-4-5-20250929-thinking": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "302ai\u0000claude-sonnet-4-6": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "302ai\u0000claude-sonnet-4-6-thinking": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "302ai\u0000deepseek-chat": {
+      "cached_read": null,
+      "in": 0.29,
+      "out": 0.43
+    },
+    "302ai\u0000deepseek-reasoner": {
+      "cached_read": null,
+      "in": 0.29,
+      "out": 0.43
+    },
+    "302ai\u0000deepseek-v3.2": {
+      "cached_read": null,
+      "in": 0.29,
+      "out": 0.43
+    },
+    "302ai\u0000deepseek-v3.2-thinking": {
+      "cached_read": null,
+      "in": 0.29,
+      "out": 0.43
+    },
+    "302ai\u0000doubao-seed-1-6-thinking-250715": {
+      "cached_read": null,
+      "in": 0.121,
+      "out": 1.21
+    },
+    "302ai\u0000doubao-seed-1-6-vision-250815": {
+      "cached_read": null,
+      "in": 0.114,
+      "out": 1.143
+    },
+    "302ai\u0000doubao-seed-1-8-251215": {
+      "cached_read": null,
+      "in": 0.114,
+      "out": 0.286
+    },
+    "302ai\u0000doubao-seed-code-preview-251028": {
+      "cached_read": null,
+      "in": 0.17,
+      "out": 1.14
+    },
+    "302ai\u0000gemini-2.0-flash-lite": {
+      "cached_read": null,
+      "in": 0.075,
+      "out": 0.3
+    },
+    "302ai\u0000gemini-2.5-flash": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "302ai\u0000gemini-2.5-flash-image": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 30.0
+    },
+    "302ai\u0000gemini-2.5-flash-lite-preview-09-2025": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "302ai\u0000gemini-2.5-flash-nothink": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "302ai\u0000gemini-2.5-flash-preview-09-2025": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "302ai\u0000gemini-2.5-pro": {
+      "cached_read": null,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "302ai\u0000gemini-3-flash-preview": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "302ai\u0000gemini-3-pro-image-preview": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 120.0
+    },
+    "302ai\u0000gemini-3-pro-preview": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "302ai\u0000gemini-3.1-flash-image-preview": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 60.0
+    },
+    "302ai\u0000glm-4.5": {
+      "cached_read": null,
+      "in": 0.286,
+      "out": 1.142
+    },
+    "302ai\u0000glm-4.5-air": {
+      "cached_read": null,
+      "in": 0.1143,
+      "out": 0.286
+    },
+    "302ai\u0000glm-4.5-airx": {
+      "cached_read": null,
+      "in": 0.572,
+      "out": 1.714
+    },
+    "302ai\u0000glm-4.5-x": {
+      "cached_read": null,
+      "in": 1.143,
+      "out": 2.29
+    },
+    "302ai\u0000glm-4.5v": {
+      "cached_read": null,
+      "in": 0.29,
+      "out": 0.86
+    },
+    "302ai\u0000glm-4.6": {
+      "cached_read": null,
+      "in": 0.286,
+      "out": 1.142
+    },
+    "302ai\u0000glm-4.6v": {
+      "cached_read": null,
+      "in": 0.145,
+      "out": 0.43
+    },
+    "302ai\u0000glm-4.7": {
+      "cached_read": null,
+      "in": 0.286,
+      "out": 1.142
+    },
+    "302ai\u0000glm-4.7-flashx": {
+      "cached_read": null,
+      "in": 0.0715,
+      "out": 0.429
+    },
+    "302ai\u0000glm-5": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.6
+    },
+    "302ai\u0000glm-5-turbo": {
+      "cached_read": null,
+      "in": 0.72,
+      "out": 3.2
+    },
+    "302ai\u0000glm-5.1": {
+      "cached_read": null,
+      "in": 0.86,
+      "out": 3.5
+    },
+    "302ai\u0000glm-5v-turbo": {
+      "cached_read": null,
+      "in": 0.72,
+      "out": 3.2
+    },
+    "302ai\u0000glm-for-coding": {
+      "cached_read": null,
+      "in": 0.086,
+      "out": 0.343
+    },
+    "302ai\u0000gpt-4.1": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "302ai\u0000gpt-4.1-mini": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 1.6
+    },
+    "302ai\u0000gpt-4.1-nano": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "302ai\u0000gpt-4o": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "302ai\u0000gpt-5": {
+      "cached_read": null,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "302ai\u0000gpt-5-mini": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "302ai\u0000gpt-5-pro": {
+      "cached_read": null,
+      "in": 15.0,
+      "out": 120.0
+    },
+    "302ai\u0000gpt-5-thinking": {
+      "cached_read": null,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "302ai\u0000gpt-5.1": {
+      "cached_read": null,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "302ai\u0000gpt-5.1-chat-latest": {
+      "cached_read": null,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "302ai\u0000gpt-5.2": {
+      "cached_read": null,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "302ai\u0000gpt-5.2-chat-latest": {
+      "cached_read": null,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "302ai\u0000gpt-5.4": {
+      "cached_read": 0.25,
+      "in": 2.5,
+      "out": 15.0
+    },
+    "302ai\u0000gpt-5.4-mini": {
+      "cached_read": null,
+      "in": 0.75,
+      "out": 4.5
+    },
+    "302ai\u0000gpt-5.4-mini-2026-03-17": {
+      "cached_read": null,
+      "in": 0.75,
+      "out": 4.5
+    },
+    "302ai\u0000gpt-5.4-nano": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 1.25
+    },
+    "302ai\u0000gpt-5.4-nano-2026-03-17": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 1.25
+    },
+    "302ai\u0000gpt-5.4-pro": {
+      "cached_read": 0.0,
+      "in": 30.0,
+      "out": 180.0
+    },
+    "302ai\u0000grok-4-1-fast-non-reasoning": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "302ai\u0000grok-4-1-fast-reasoning": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "302ai\u0000grok-4-fast-non-reasoning": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "302ai\u0000grok-4-fast-reasoning": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "302ai\u0000grok-4.1": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 10.0
+    },
+    "302ai\u0000grok-4.20-beta-0309-non-reasoning": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "302ai\u0000grok-4.20-beta-0309-reasoning": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "302ai\u0000grok-4.20-multi-agent-beta-0309": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "302ai\u0000kimi-k2-0905-preview": {
+      "cached_read": null,
+      "in": 0.632,
+      "out": 2.53
+    },
+    "302ai\u0000kimi-k2-thinking": {
+      "cached_read": null,
+      "in": 0.575,
+      "out": 2.3
+    },
+    "302ai\u0000kimi-k2-thinking-turbo": {
+      "cached_read": null,
+      "in": 1.265,
+      "out": 9.119
+    },
+    "302ai\u0000minimax-m1": {
+      "cached_read": null,
+      "in": 0.132,
+      "out": 1.254
+    },
+    "302ai\u0000minimax-m2": {
+      "cached_read": null,
+      "in": 0.33,
+      "out": 1.32
+    },
+    "302ai\u0000minimax-m2.1": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "302ai\u0000minimax-m2.7": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "302ai\u0000minimax-m2.7-highspeed": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 4.8
+    },
+    "302ai\u0000ministral-14b-2512": {
+      "cached_read": null,
+      "in": 0.33,
+      "out": 0.33
+    },
+    "302ai\u0000mistral-large-2512": {
+      "cached_read": null,
+      "in": 1.1,
+      "out": 3.3
+    },
+    "302ai\u0000qwen-flash": {
+      "cached_read": null,
+      "in": 0.022,
+      "out": 0.22
+    },
+    "302ai\u0000qwen-max-latest": {
+      "cached_read": null,
+      "in": 0.343,
+      "out": 1.372
+    },
+    "302ai\u0000qwen-plus": {
+      "cached_read": null,
+      "in": 0.12,
+      "out": 1.2
+    },
+    "302ai\u0000qwen3-235b-a22b": {
+      "cached_read": null,
+      "in": 0.29,
+      "out": 2.86
+    },
+    "302ai\u0000qwen3-235b-a22b-instruct-2507": {
+      "cached_read": null,
+      "in": 0.29,
+      "out": 1.143
+    },
+    "302ai\u0000qwen3-30b-a3b": {
+      "cached_read": null,
+      "in": 0.11,
+      "out": 1.08
+    },
+    "302ai\u0000qwen3-coder-480b-a35b-instruct": {
+      "cached_read": null,
+      "in": 0.86,
+      "out": 3.43
+    },
+    "302ai\u0000qwen3-max-2025-09-23": {
+      "cached_read": null,
+      "in": 0.86,
+      "out": 3.43
+    },
+    "abacus\u0000claude-3-7-sonnet-20250219": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "abacus\u0000claude-haiku-4-5-20251001": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "abacus\u0000claude-opus-4-1-20250805": {
+      "cached_read": null,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "abacus\u0000claude-opus-4-20250514": {
+      "cached_read": null,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "abacus\u0000claude-opus-4-5-20251101": {
+      "cached_read": null,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "abacus\u0000claude-opus-4-6": {
+      "cached_read": null,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "abacus\u0000claude-sonnet-4-20250514": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "abacus\u0000claude-sonnet-4-5-20250929": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "abacus\u0000claude-sonnet-4-6": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "abacus\u0000deepseek-ai/deepseek-r1": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 7.0
+    },
+    "abacus\u0000deepseek-ai/deepseek-v3.1-terminus": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 1.0
+    },
+    "abacus\u0000deepseek-ai/deepseek-v3.2": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 0.4
+    },
+    "abacus\u0000deepseek/deepseek-v3.1": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 1.66
+    },
+    "abacus\u0000gemini-2.5-flash": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "abacus\u0000gemini-2.5-pro": {
+      "cached_read": null,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "abacus\u0000gemini-3-flash-preview": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "abacus\u0000gemini-3.1-flash-lite-preview": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 1.5
+    },
+    "abacus\u0000gemini-3.1-pro-preview": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "abacus\u0000gpt-4.1": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "abacus\u0000gpt-4.1-mini": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 1.6
+    },
+    "abacus\u0000gpt-4.1-nano": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "abacus\u0000gpt-4o-2024-11-20": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "abacus\u0000gpt-4o-mini": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "abacus\u0000gpt-5": {
+      "cached_read": null,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "abacus\u0000gpt-5-codex": {
+      "cached_read": null,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "abacus\u0000gpt-5-mini": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "abacus\u0000gpt-5-nano": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.4
+    },
+    "abacus\u0000gpt-5.1": {
+      "cached_read": null,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "abacus\u0000gpt-5.1-chat-latest": {
+      "cached_read": null,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "abacus\u0000gpt-5.1-codex": {
+      "cached_read": null,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "abacus\u0000gpt-5.1-codex-max": {
+      "cached_read": null,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "abacus\u0000gpt-5.2": {
+      "cached_read": null,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "abacus\u0000gpt-5.2-chat-latest": {
+      "cached_read": null,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "abacus\u0000gpt-5.2-codex": {
+      "cached_read": null,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "abacus\u0000gpt-5.3-chat-latest": {
+      "cached_read": null,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "abacus\u0000gpt-5.3-codex": {
+      "cached_read": null,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "abacus\u0000gpt-5.3-codex-xhigh": {
+      "cached_read": null,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "abacus\u0000gpt-5.4": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 15.0
+    },
+    "abacus\u0000grok-4-0709": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "abacus\u0000grok-4-1-fast-non-reasoning": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "abacus\u0000grok-4-fast-non-reasoning": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "abacus\u0000grok-code-fast-1": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 1.5
+    },
+    "abacus\u0000kimi-k2-turbo-preview": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 8.0
+    },
+    "abacus\u0000kimi-k2.5": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 3.0
+    },
+    "abacus\u0000llama-3.3-70b-versatile": {
+      "cached_read": null,
+      "in": 0.59,
+      "out": 0.79
+    },
+    "abacus\u0000meta-llama/llama-4-maverick-17b-128e-instruct-fp8": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.59
+    },
+    "abacus\u0000meta-llama/meta-llama-3.1-405b-instruct-turbo": {
+      "cached_read": null,
+      "in": 3.5,
+      "out": 3.5
+    },
+    "abacus\u0000meta-llama/meta-llama-3.1-8b-instruct": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.05
+    },
+    "abacus\u0000o3": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "abacus\u0000o3-mini": {
+      "cached_read": null,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "abacus\u0000o3-pro": {
+      "cached_read": null,
+      "in": 20.0,
+      "out": 40.0
+    },
+    "abacus\u0000o4-mini": {
+      "cached_read": null,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "abacus\u0000openai/gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.08,
+      "out": 0.44
+    },
+    "abacus\u0000qwen-2.5-coder-32b": {
+      "cached_read": null,
+      "in": 0.79,
+      "out": 0.79
+    },
+    "abacus\u0000qwen/qwen2.5-72b-instruct": {
+      "cached_read": null,
+      "in": 0.11,
+      "out": 0.38
+    },
+    "abacus\u0000qwen/qwen3-235b-a22b-instruct-2507": {
+      "cached_read": null,
+      "in": 0.13,
+      "out": 0.6
+    },
+    "abacus\u0000qwen/qwen3-32b": {
+      "cached_read": null,
+      "in": 0.09,
+      "out": 0.29
+    },
+    "abacus\u0000qwen/qwen3-coder-480b-a35b-instruct": {
+      "cached_read": null,
+      "in": 0.29,
+      "out": 1.2
+    },
+    "abacus\u0000qwen/qwq-32b": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 0.4
+    },
+    "abacus\u0000qwen3-max": {
+      "cached_read": null,
+      "in": 1.2,
+      "out": 6.0
+    },
+    "abacus\u0000route-llm": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "abacus\u0000zai-org/glm-4.5": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "abacus\u0000zai-org/glm-4.6": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "abacus\u0000zai-org/glm-4.7": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "abacus\u0000zai-org/glm-5": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 3.2
+    },
+    "abliteration-ai\u0000abliterated-model": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 3.0
+    },
+    "aihubmix\u0000alicloud-deepseek-v4-flash": {
+      "cached_read": 0.028,
+      "in": 0.14,
+      "out": 0.28
+    },
+    "aihubmix\u0000alicloud-deepseek-v4-pro": {
+      "cached_read": 0.13,
+      "in": 1.69,
+      "out": 3.38
+    },
+    "aihubmix\u0000alicloud-glm-5.1": {
+      "cached_read": 0.169,
+      "in": 0.84,
+      "out": 3.38
+    },
+    "aihubmix\u0000claude-opus-4-6": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "aihubmix\u0000claude-opus-4-6-think": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "aihubmix\u0000claude-opus-4-7": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "aihubmix\u0000claude-opus-4-7-think": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "aihubmix\u0000claude-sonnet-4-6": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "aihubmix\u0000claude-sonnet-4-6-think": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "aihubmix\u0000coding-glm-5.1": {
+      "cached_read": 0.013,
+      "in": 0.06,
+      "out": 0.22
+    },
+    "aihubmix\u0000coding-glm-5.1-free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "aihubmix\u0000coding-minimax-m2.7": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "aihubmix\u0000coding-minimax-m2.7-free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "aihubmix\u0000coding-minimax-m2.7-highspeed": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "aihubmix\u0000coding-xiaomi-mimo-v2.5": {
+      "cached_read": 0.016,
+      "in": 0.08,
+      "out": 0.4
+    },
+    "aihubmix\u0000coding-xiaomi-mimo-v2.5-pro": {
+      "cached_read": 0.04,
+      "in": 0.2,
+      "out": 0.6
+    },
+    "aihubmix\u0000deep-deepseek-v4-flash": {
+      "cached_read": 0.0308,
+      "in": 0.154,
+      "out": 0.308
+    },
+    "aihubmix\u0000deep-deepseek-v4-pro": {
+      "cached_read": 0.004302,
+      "in": 0.478,
+      "out": 0.956
+    },
+    "aihubmix\u0000doubao-seed-2-0-code-preview": {
+      "cached_read": 0.09644,
+      "in": 0.48,
+      "out": 2.41
+    },
+    "aihubmix\u0000doubao-seed-2-0-lite-260428": {
+      "cached_read": 0.01692,
+      "in": 0.08,
+      "out": 0.51
+    },
+    "aihubmix\u0000doubao-seed-2-0-mini-260428": {
+      "cached_read": 0.00564,
+      "in": 0.03,
+      "out": 0.28
+    },
+    "aihubmix\u0000doubao-seed-2-0-pro": {
+      "cached_read": 0.09644,
+      "in": 0.48,
+      "out": 2.41
+    },
+    "aihubmix\u0000gemini-2.5-flash": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "aihubmix\u0000gemini-2.5-pro": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "aihubmix\u0000gemini-3-flash-preview": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "aihubmix\u0000gemini-3.1-flash-lite": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 1.5
+    },
+    "aihubmix\u0000gemini-3.1-pro-preview": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "aihubmix\u0000gemini-3.1-pro-preview-customtools": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "aihubmix\u0000glm-5v-turbo": {
+      "cached_read": 0.169008,
+      "in": 0.7042,
+      "out": 3.09848
+    },
+    "aihubmix\u0000gpt-5.1": {
+      "cached_read": 0.13,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "aihubmix\u0000gpt-5.1-codex": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "aihubmix\u0000gpt-5.1-codex-mini": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "aihubmix\u0000gpt-5.2": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "aihubmix\u0000gpt-5.2-codex": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "aihubmix\u0000gpt-5.3-codex": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "aihubmix\u0000gpt-5.4": {
+      "cached_read": 0.25,
+      "in": 2.5,
+      "out": 15.0
+    },
+    "aihubmix\u0000gpt-5.4-mini": {
+      "cached_read": 0.075,
+      "in": 0.75,
+      "out": 4.5
+    },
+    "aihubmix\u0000gpt-5.5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 30.0
+    },
+    "aihubmix\u0000grok-4.3": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "aihubmix\u0000kimi-k2.5": {
+      "cached_read": 0.1,
+      "in": 0.6,
+      "out": 3.0
+    },
+    "aihubmix\u0000kimi-k2.6": {
+      "cached_read": 0.16,
+      "in": 0.95,
+      "out": 4.0
+    },
+    "aihubmix\u0000minimax-m2.7": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "aihubmix\u0000qwen3.6-flash": {
+      "cached_read": 0.0169,
+      "in": 0.17,
+      "out": 1.01
+    },
+    "aihubmix\u0000qwen3.6-max-preview": {
+      "cached_read": 0.1268,
+      "in": 1.27,
+      "out": 7.61
+    },
+    "aihubmix\u0000qwen3.6-plus": {
+      "cached_read": 0.0282,
+      "in": 0.28,
+      "out": 1.69
+    },
+    "aihubmix\u0000xiaomi-mimo-v2.5": {
+      "cached_read": 0.088,
+      "in": 0.44,
+      "out": 2.2
+    },
+    "aihubmix\u0000xiaomi-mimo-v2.5-free": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "aihubmix\u0000xiaomi-mimo-v2.5-pro": {
+      "cached_read": 0.22,
+      "in": 1.1,
+      "out": 3.3
+    },
+    "aihubmix\u0000xiaomi-mimo-v2.5-pro-free": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "aihubmix\u0000zai-glm-5.1": {
+      "cached_read": 0.183112,
+      "in": 0.845,
+      "out": 3.38
+    },
+    "alibaba\u0000qvq-max": {
+      "cached_read": null,
+      "in": 1.2,
+      "out": 4.8
+    },
+    "alibaba\u0000qwen-flash": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.4
+    },
+    "alibaba\u0000qwen-max": {
+      "cached_read": null,
+      "in": 1.6,
+      "out": 6.4
+    },
+    "alibaba\u0000qwen-mt-plus": {
+      "cached_read": null,
+      "in": 2.46,
+      "out": 7.37
+    },
+    "alibaba\u0000qwen-mt-turbo": {
+      "cached_read": null,
+      "in": 0.16,
+      "out": 0.49
+    },
+    "alibaba\u0000qwen-omni-turbo": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.27
+    },
+    "alibaba\u0000qwen-omni-turbo-realtime": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 1.07
+    },
+    "alibaba\u0000qwen-plus": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 1.2
+    },
+    "alibaba\u0000qwen-plus-character-ja": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.4
+    },
+    "alibaba\u0000qwen-turbo": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.2
+    },
+    "alibaba\u0000qwen-vl-max": {
+      "cached_read": null,
+      "in": 0.8,
+      "out": 3.2
+    },
+    "alibaba\u0000qwen-vl-ocr": {
+      "cached_read": null,
+      "in": 0.72,
+      "out": 0.72
+    },
+    "alibaba\u0000qwen-vl-plus": {
+      "cached_read": null,
+      "in": 0.21,
+      "out": 0.63
+    },
+    "alibaba\u0000qwen2-5-14b-instruct": {
+      "cached_read": null,
+      "in": 0.35,
+      "out": 1.4
+    },
+    "alibaba\u0000qwen2-5-32b-instruct": {
+      "cached_read": null,
+      "in": 0.7,
+      "out": 2.8
+    },
+    "alibaba\u0000qwen2-5-72b-instruct": {
+      "cached_read": null,
+      "in": 1.4,
+      "out": 5.6
+    },
+    "alibaba\u0000qwen2-5-7b-instruct": {
+      "cached_read": null,
+      "in": 0.175,
+      "out": 0.7
+    },
+    "alibaba\u0000qwen2-5-omni-7b": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "alibaba\u0000qwen2-5-vl-72b-instruct": {
+      "cached_read": null,
+      "in": 2.8,
+      "out": 8.4
+    },
+    "alibaba\u0000qwen2-5-vl-7b-instruct": {
+      "cached_read": null,
+      "in": 0.35,
+      "out": 1.05
+    },
+    "alibaba\u0000qwen3-14b": {
+      "cached_read": null,
+      "in": 0.35,
+      "out": 1.4
+    },
+    "alibaba\u0000qwen3-235b-a22b": {
+      "cached_read": null,
+      "in": 0.7,
+      "out": 2.8
+    },
+    "alibaba\u0000qwen3-32b": {
+      "cached_read": null,
+      "in": 0.7,
+      "out": 2.8
+    },
+    "alibaba\u0000qwen3-8b": {
+      "cached_read": null,
+      "in": 0.18,
+      "out": 0.7
+    },
+    "alibaba\u0000qwen3-asr-flash": {
+      "cached_read": null,
+      "in": 0.035,
+      "out": 0.035
+    },
+    "alibaba\u0000qwen3-coder-30b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.45,
+      "out": 2.25
+    },
+    "alibaba\u0000qwen3-coder-480b-a35b-instruct": {
+      "cached_read": null,
+      "in": 1.5,
+      "out": 7.5
+    },
+    "alibaba\u0000qwen3-coder-flash": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.5
+    },
+    "alibaba\u0000qwen3-coder-plus": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "alibaba\u0000qwen3-livetranslate-flash-realtime": {
+      "cached_read": null,
+      "in": 10.0,
+      "out": 10.0
+    },
+    "alibaba\u0000qwen3-max": {
+      "cached_read": null,
+      "in": 1.2,
+      "out": 6.0
+    },
+    "alibaba\u0000qwen3-next-80b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 2.0
+    },
+    "alibaba\u0000qwen3-next-80b-a3b-thinking": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 6.0
+    },
+    "alibaba\u0000qwen3-omni-flash": {
+      "cached_read": null,
+      "in": 0.43,
+      "out": 1.66
+    },
+    "alibaba\u0000qwen3-omni-flash-realtime": {
+      "cached_read": null,
+      "in": 0.52,
+      "out": 1.99
+    },
+    "alibaba\u0000qwen3-vl-235b-a22b": {
+      "cached_read": null,
+      "in": 0.7,
+      "out": 2.8
+    },
+    "alibaba\u0000qwen3-vl-30b-a3b": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.8
+    },
+    "alibaba\u0000qwen3-vl-plus": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 1.6
+    },
+    "alibaba\u0000qwen3.5-122b-a10b": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 3.2
+    },
+    "alibaba\u0000qwen3.5-27b": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 2.4
+    },
+    "alibaba\u0000qwen3.5-35b-a3b": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "alibaba\u0000qwen3.5-397b-a17b": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 3.6
+    },
+    "alibaba\u0000qwen3.5-plus": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.4
+    },
+    "alibaba\u0000qwen3.6-27b": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 3.6
+    },
+    "alibaba\u0000qwen3.6-35b-a3b": {
+      "cached_read": null,
+      "in": 0.248,
+      "out": 1.485
+    },
+    "alibaba\u0000qwen3.6-flash": {
+      "cached_read": null,
+      "in": 0.1875,
+      "out": 1.125
+    },
+    "alibaba\u0000qwen3.6-max-preview": {
+      "cached_read": 0.13,
+      "in": 1.3,
+      "out": 7.8
+    },
+    "alibaba\u0000qwen3.6-plus": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "alibaba\u0000qwen3.7-max": {
+      "cached_read": 0.5,
+      "in": 2.5,
+      "out": 7.5
+    },
+    "alibaba\u0000qwen3.7-plus": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "alibaba\u0000qwq-plus": {
+      "cached_read": null,
+      "in": 0.8,
+      "out": 2.4
+    },
+    "alibaba-cn\u0000deepseek-r1": {
+      "cached_read": null,
+      "in": 0.574,
+      "out": 2.294
+    },
+    "alibaba-cn\u0000deepseek-r1-0528": {
+      "cached_read": null,
+      "in": 0.574,
+      "out": 2.294
+    },
+    "alibaba-cn\u0000deepseek-r1-distill-llama-70b": {
+      "cached_read": null,
+      "in": 0.287,
+      "out": 0.861
+    },
+    "alibaba-cn\u0000deepseek-r1-distill-llama-8b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "alibaba-cn\u0000deepseek-r1-distill-qwen-1-5b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "alibaba-cn\u0000deepseek-r1-distill-qwen-14b": {
+      "cached_read": null,
+      "in": 0.144,
+      "out": 0.431
+    },
+    "alibaba-cn\u0000deepseek-r1-distill-qwen-32b": {
+      "cached_read": null,
+      "in": 0.287,
+      "out": 0.861
+    },
+    "alibaba-cn\u0000deepseek-r1-distill-qwen-7b": {
+      "cached_read": null,
+      "in": 0.072,
+      "out": 0.144
+    },
+    "alibaba-cn\u0000deepseek-v3": {
+      "cached_read": null,
+      "in": 0.287,
+      "out": 1.147
+    },
+    "alibaba-cn\u0000deepseek-v3-1": {
+      "cached_read": null,
+      "in": 0.574,
+      "out": 1.721
+    },
+    "alibaba-cn\u0000deepseek-v3-2-exp": {
+      "cached_read": null,
+      "in": 0.287,
+      "out": 0.431
+    },
+    "alibaba-cn\u0000deepseek-v4-flash": {
+      "cached_read": 0.0028,
+      "in": 0.14,
+      "out": 0.28
+    },
+    "alibaba-cn\u0000deepseek-v4-pro": {
+      "cached_read": 0.003625,
+      "in": 0.435,
+      "out": 0.87
+    },
+    "alibaba-cn\u0000glm-5": {
+      "cached_read": null,
+      "in": 0.86,
+      "out": 3.15
+    },
+    "alibaba-cn\u0000glm-5.1": {
+      "cached_read": 0.17,
+      "in": 0.87,
+      "out": 3.48
+    },
+    "alibaba-cn\u0000kimi-k2-thinking": {
+      "cached_read": null,
+      "in": 0.574,
+      "out": 2.294
+    },
+    "alibaba-cn\u0000kimi-k2.5": {
+      "cached_read": null,
+      "in": 0.574,
+      "out": 2.411
+    },
+    "alibaba-cn\u0000kimi-k2.6": {
+      "cached_read": null,
+      "in": 0.929,
+      "out": 3.858
+    },
+    "alibaba-cn\u0000kimi/kimi-k2.5": {
+      "cached_read": 0.1,
+      "in": 0.6,
+      "out": 3.0
+    },
+    "alibaba-cn\u0000minimax-m2.5": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "alibaba-cn\u0000minimax/minimax-m2.7": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "alibaba-cn\u0000moonshot-kimi-k2-instruct": {
+      "cached_read": null,
+      "in": 0.574,
+      "out": 2.294
+    },
+    "alibaba-cn\u0000qvq-max": {
+      "cached_read": null,
+      "in": 1.147,
+      "out": 4.588
+    },
+    "alibaba-cn\u0000qwen-deep-research": {
+      "cached_read": null,
+      "in": 7.742,
+      "out": 23.367
+    },
+    "alibaba-cn\u0000qwen-doc-turbo": {
+      "cached_read": null,
+      "in": 0.087,
+      "out": 0.144
+    },
+    "alibaba-cn\u0000qwen-flash": {
+      "cached_read": null,
+      "in": 0.022,
+      "out": 0.216
+    },
+    "alibaba-cn\u0000qwen-long": {
+      "cached_read": null,
+      "in": 0.072,
+      "out": 0.287
+    },
+    "alibaba-cn\u0000qwen-math-plus": {
+      "cached_read": null,
+      "in": 0.574,
+      "out": 1.721
+    },
+    "alibaba-cn\u0000qwen-math-turbo": {
+      "cached_read": null,
+      "in": 0.287,
+      "out": 0.861
+    },
+    "alibaba-cn\u0000qwen-max": {
+      "cached_read": null,
+      "in": 0.345,
+      "out": 1.377
+    },
+    "alibaba-cn\u0000qwen-mt-plus": {
+      "cached_read": null,
+      "in": 0.259,
+      "out": 0.775
+    },
+    "alibaba-cn\u0000qwen-mt-turbo": {
+      "cached_read": null,
+      "in": 0.101,
+      "out": 0.28
+    },
+    "alibaba-cn\u0000qwen-omni-turbo": {
+      "cached_read": null,
+      "in": 0.058,
+      "out": 0.23
+    },
+    "alibaba-cn\u0000qwen-omni-turbo-realtime": {
+      "cached_read": null,
+      "in": 0.23,
+      "out": 0.918
+    },
+    "alibaba-cn\u0000qwen-plus": {
+      "cached_read": null,
+      "in": 0.115,
+      "out": 0.287
+    },
+    "alibaba-cn\u0000qwen-plus-character": {
+      "cached_read": null,
+      "in": 0.115,
+      "out": 0.287
+    },
+    "alibaba-cn\u0000qwen-turbo": {
+      "cached_read": null,
+      "in": 0.044,
+      "out": 0.087
+    },
+    "alibaba-cn\u0000qwen-vl-max": {
+      "cached_read": null,
+      "in": 0.23,
+      "out": 0.574
+    },
+    "alibaba-cn\u0000qwen-vl-ocr": {
+      "cached_read": null,
+      "in": 0.717,
+      "out": 0.717
+    },
+    "alibaba-cn\u0000qwen-vl-plus": {
+      "cached_read": null,
+      "in": 0.115,
+      "out": 0.287
+    },
+    "alibaba-cn\u0000qwen2-5-14b-instruct": {
+      "cached_read": null,
+      "in": 0.144,
+      "out": 0.431
+    },
+    "alibaba-cn\u0000qwen2-5-32b-instruct": {
+      "cached_read": null,
+      "in": 0.287,
+      "out": 0.861
+    },
+    "alibaba-cn\u0000qwen2-5-72b-instruct": {
+      "cached_read": null,
+      "in": 0.574,
+      "out": 1.721
+    },
+    "alibaba-cn\u0000qwen2-5-7b-instruct": {
+      "cached_read": null,
+      "in": 0.072,
+      "out": 0.144
+    },
+    "alibaba-cn\u0000qwen2-5-coder-32b-instruct": {
+      "cached_read": null,
+      "in": 0.287,
+      "out": 0.861
+    },
+    "alibaba-cn\u0000qwen2-5-coder-7b-instruct": {
+      "cached_read": null,
+      "in": 0.144,
+      "out": 0.287
+    },
+    "alibaba-cn\u0000qwen2-5-math-72b-instruct": {
+      "cached_read": null,
+      "in": 0.574,
+      "out": 1.721
+    },
+    "alibaba-cn\u0000qwen2-5-math-7b-instruct": {
+      "cached_read": null,
+      "in": 0.144,
+      "out": 0.287
+    },
+    "alibaba-cn\u0000qwen2-5-omni-7b": {
+      "cached_read": null,
+      "in": 0.087,
+      "out": 0.345
+    },
+    "alibaba-cn\u0000qwen2-5-vl-72b-instruct": {
+      "cached_read": null,
+      "in": 2.294,
+      "out": 6.881
+    },
+    "alibaba-cn\u0000qwen2-5-vl-7b-instruct": {
+      "cached_read": null,
+      "in": 0.287,
+      "out": 0.717
+    },
+    "alibaba-cn\u0000qwen3-14b": {
+      "cached_read": null,
+      "in": 0.144,
+      "out": 0.574
+    },
+    "alibaba-cn\u0000qwen3-235b-a22b": {
+      "cached_read": null,
+      "in": 0.287,
+      "out": 1.147
+    },
+    "alibaba-cn\u0000qwen3-32b": {
+      "cached_read": null,
+      "in": 0.287,
+      "out": 1.147
+    },
+    "alibaba-cn\u0000qwen3-8b": {
+      "cached_read": null,
+      "in": 0.072,
+      "out": 0.287
+    },
+    "alibaba-cn\u0000qwen3-asr-flash": {
+      "cached_read": null,
+      "in": 0.032,
+      "out": 0.032
+    },
+    "alibaba-cn\u0000qwen3-coder-30b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.216,
+      "out": 0.861
+    },
+    "alibaba-cn\u0000qwen3-coder-480b-a35b-instruct": {
+      "cached_read": null,
+      "in": 0.861,
+      "out": 3.441
+    },
+    "alibaba-cn\u0000qwen3-coder-flash": {
+      "cached_read": null,
+      "in": 0.144,
+      "out": 0.574
+    },
+    "alibaba-cn\u0000qwen3-coder-plus": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "alibaba-cn\u0000qwen3-max": {
+      "cached_read": null,
+      "in": 0.861,
+      "out": 3.441
+    },
+    "alibaba-cn\u0000qwen3-next-80b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.144,
+      "out": 0.574
+    },
+    "alibaba-cn\u0000qwen3-next-80b-a3b-thinking": {
+      "cached_read": null,
+      "in": 0.144,
+      "out": 1.434
+    },
+    "alibaba-cn\u0000qwen3-omni-flash": {
+      "cached_read": null,
+      "in": 0.058,
+      "out": 0.23
+    },
+    "alibaba-cn\u0000qwen3-omni-flash-realtime": {
+      "cached_read": null,
+      "in": 0.23,
+      "out": 0.918
+    },
+    "alibaba-cn\u0000qwen3-vl-235b-a22b": {
+      "cached_read": null,
+      "in": 0.286705,
+      "out": 1.14682
+    },
+    "alibaba-cn\u0000qwen3-vl-30b-a3b": {
+      "cached_read": null,
+      "in": 0.108,
+      "out": 0.431
+    },
+    "alibaba-cn\u0000qwen3-vl-plus": {
+      "cached_read": null,
+      "in": 0.143353,
+      "out": 1.433525
+    },
+    "alibaba-cn\u0000qwen3.5-397b-a17b": {
+      "cached_read": null,
+      "in": 0.43,
+      "out": 2.58
+    },
+    "alibaba-cn\u0000qwen3.5-flash": {
+      "cached_read": null,
+      "in": 0.172,
+      "out": 1.72
+    },
+    "alibaba-cn\u0000qwen3.5-plus": {
+      "cached_read": null,
+      "in": 0.573,
+      "out": 3.44
+    },
+    "alibaba-cn\u0000qwen3.6-flash": {
+      "cached_read": null,
+      "in": 0.1875,
+      "out": 1.125
+    },
+    "alibaba-cn\u0000qwen3.6-max-preview": {
+      "cached_read": 0.132,
+      "in": 1.32,
+      "out": 7.9
+    },
+    "alibaba-cn\u0000qwen3.6-plus": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "alibaba-cn\u0000qwen3.7-max": {
+      "cached_read": 0.5,
+      "in": 2.5,
+      "out": 7.5
+    },
+    "alibaba-cn\u0000qwen3.7-plus": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "alibaba-cn\u0000qwq-32b": {
+      "cached_read": null,
+      "in": 0.287,
+      "out": 0.861
+    },
+    "alibaba-cn\u0000qwq-plus": {
+      "cached_read": null,
+      "in": 0.23,
+      "out": 0.574
+    },
+    "alibaba-cn\u0000siliconflow/deepseek-r1-0528": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 2.18
+    },
+    "alibaba-cn\u0000siliconflow/deepseek-v3-0324": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 1.0
+    },
+    "alibaba-cn\u0000siliconflow/deepseek-v3.1-terminus": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 1.0
+    },
+    "alibaba-cn\u0000siliconflow/deepseek-v3.2": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 0.42
+    },
+    "alibaba-cn\u0000tongyi-intent-detect-v3": {
+      "cached_read": null,
+      "in": 0.058,
+      "out": 0.144
+    },
+    "alibaba-coding-plan\u0000glm-4.7": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "alibaba-coding-plan\u0000glm-5": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "alibaba-coding-plan\u0000kimi-k2.5": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "alibaba-coding-plan\u0000minimax-m2.5": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "alibaba-coding-plan\u0000qwen3-coder-next": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "alibaba-coding-plan\u0000qwen3-coder-plus": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "alibaba-coding-plan\u0000qwen3-max-2026-01-23": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "alibaba-coding-plan\u0000qwen3.5-plus": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "alibaba-coding-plan\u0000qwen3.6-flash": {
+      "cached_read": null,
+      "in": 0.1875,
+      "out": 1.125
+    },
+    "alibaba-coding-plan\u0000qwen3.6-plus": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "alibaba-coding-plan\u0000qwen3.7-max": {
+      "cached_read": 0.5,
+      "in": 2.5,
+      "out": 7.5
+    },
+    "alibaba-coding-plan-cn\u0000glm-4.7": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "alibaba-coding-plan-cn\u0000glm-5": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "alibaba-coding-plan-cn\u0000kimi-k2.5": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "alibaba-coding-plan-cn\u0000minimax-m2.5": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "alibaba-coding-plan-cn\u0000qwen3-coder-next": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "alibaba-coding-plan-cn\u0000qwen3-coder-plus": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "alibaba-coding-plan-cn\u0000qwen3-max-2026-01-23": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "alibaba-coding-plan-cn\u0000qwen3.5-plus": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "alibaba-coding-plan-cn\u0000qwen3.6-flash": {
+      "cached_read": null,
+      "in": 0.1875,
+      "out": 1.125
+    },
+    "alibaba-coding-plan-cn\u0000qwen3.6-plus": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "alibaba-coding-plan-cn\u0000qwen3.7-max": {
+      "cached_read": 0.5,
+      "in": 2.5,
+      "out": 7.5
+    },
+    "alibaba-token-plan\u0000deepseek-v3.2": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "alibaba-token-plan\u0000deepseek-v4-flash": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "alibaba-token-plan\u0000deepseek-v4-pro": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "alibaba-token-plan\u0000glm-5": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "alibaba-token-plan\u0000glm-5.1": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "alibaba-token-plan\u0000kimi-k2.5": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "alibaba-token-plan\u0000kimi-k2.6": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "alibaba-token-plan\u0000minimax-m2.5": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "alibaba-token-plan\u0000qwen-image-2.0": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "alibaba-token-plan\u0000qwen-image-2.0-pro": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "alibaba-token-plan\u0000qwen3.6-flash": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "alibaba-token-plan\u0000qwen3.6-plus": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "alibaba-token-plan\u0000qwen3.7-max": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "alibaba-token-plan\u0000wan2.7-image": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "alibaba-token-plan\u0000wan2.7-image-pro": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "amazon-bedrock\u0000amazon.nova-2-lite-v1:0": {
+      "cached_read": null,
+      "in": 0.33,
+      "out": 2.75
+    },
+    "amazon-bedrock\u0000amazon.nova-lite-v1:0": {
+      "cached_read": 0.015,
+      "in": 0.06,
+      "out": 0.24
+    },
+    "amazon-bedrock\u0000amazon.nova-micro-v1:0": {
+      "cached_read": 0.00875,
+      "in": 0.035,
+      "out": 0.14
+    },
+    "amazon-bedrock\u0000amazon.nova-pro-v1:0": {
+      "cached_read": 0.2,
+      "in": 0.8,
+      "out": 3.2
+    },
+    "amazon-bedrock\u0000anthropic.claude-haiku-4-5-20251001-v1:0": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "amazon-bedrock\u0000anthropic.claude-opus-4-1-20250805-v1:0": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "amazon-bedrock\u0000anthropic.claude-opus-4-5-20251101-v1:0": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "amazon-bedrock\u0000anthropic.claude-opus-4-6-v1": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "amazon-bedrock\u0000anthropic.claude-opus-4-7": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "amazon-bedrock\u0000anthropic.claude-opus-4-8": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "amazon-bedrock\u0000anthropic.claude-sonnet-4-5-20250929-v1:0": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "amazon-bedrock\u0000anthropic.claude-sonnet-4-6": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "amazon-bedrock\u0000au.anthropic.claude-haiku-4-5-20251001-v1:0": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "amazon-bedrock\u0000au.anthropic.claude-opus-4-6-v1": {
+      "cached_read": 1.65,
+      "in": 16.5,
+      "out": 82.5
+    },
+    "amazon-bedrock\u0000au.anthropic.claude-opus-4-8": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "amazon-bedrock\u0000au.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "amazon-bedrock\u0000au.anthropic.claude-sonnet-4-6": {
+      "cached_read": 0.33,
+      "in": 3.3,
+      "out": 16.5
+    },
+    "amazon-bedrock\u0000deepseek.r1-v1:0": {
+      "cached_read": null,
+      "in": 1.35,
+      "out": 5.4
+    },
+    "amazon-bedrock\u0000deepseek.v3-v1:0": {
+      "cached_read": null,
+      "in": 0.58,
+      "out": 1.68
+    },
+    "amazon-bedrock\u0000deepseek.v3.2": {
+      "cached_read": null,
+      "in": 0.62,
+      "out": 1.85
+    },
+    "amazon-bedrock\u0000eu.anthropic.claude-haiku-4-5-20251001-v1:0": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "amazon-bedrock\u0000eu.anthropic.claude-opus-4-5-20251101-v1:0": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "amazon-bedrock\u0000eu.anthropic.claude-opus-4-6-v1": {
+      "cached_read": 0.55,
+      "in": 5.5,
+      "out": 27.5
+    },
+    "amazon-bedrock\u0000eu.anthropic.claude-opus-4-7": {
+      "cached_read": 0.55,
+      "in": 5.5,
+      "out": 27.5
+    },
+    "amazon-bedrock\u0000eu.anthropic.claude-opus-4-8": {
+      "cached_read": 0.55,
+      "in": 5.5,
+      "out": 27.5
+    },
+    "amazon-bedrock\u0000eu.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+      "cached_read": 0.33,
+      "in": 3.3,
+      "out": 16.5
+    },
+    "amazon-bedrock\u0000eu.anthropic.claude-sonnet-4-6": {
+      "cached_read": 0.33,
+      "in": 3.3,
+      "out": 16.5
+    },
+    "amazon-bedrock\u0000global.anthropic.claude-haiku-4-5-20251001-v1:0": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "amazon-bedrock\u0000global.anthropic.claude-opus-4-5-20251101-v1:0": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "amazon-bedrock\u0000global.anthropic.claude-opus-4-6-v1": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "amazon-bedrock\u0000global.anthropic.claude-opus-4-7": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "amazon-bedrock\u0000global.anthropic.claude-opus-4-8": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "amazon-bedrock\u0000global.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "amazon-bedrock\u0000global.anthropic.claude-sonnet-4-6": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "amazon-bedrock\u0000google.gemma-3-12b-it": {
+      "cached_read": null,
+      "in": 0.049999999999999996,
+      "out": 0.09999999999999999
+    },
+    "amazon-bedrock\u0000google.gemma-3-27b-it": {
+      "cached_read": null,
+      "in": 0.12,
+      "out": 0.2
+    },
+    "amazon-bedrock\u0000google.gemma-3-4b-it": {
+      "cached_read": null,
+      "in": 0.04,
+      "out": 0.08
+    },
+    "amazon-bedrock\u0000jp.anthropic.claude-opus-4-7": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "amazon-bedrock\u0000jp.anthropic.claude-opus-4-8": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "amazon-bedrock\u0000jp.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "amazon-bedrock\u0000jp.anthropic.claude-sonnet-4-6": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "amazon-bedrock\u0000meta.llama3-1-70b-instruct-v1:0": {
+      "cached_read": null,
+      "in": 0.72,
+      "out": 0.72
+    },
+    "amazon-bedrock\u0000meta.llama3-1-8b-instruct-v1:0": {
+      "cached_read": null,
+      "in": 0.22,
+      "out": 0.22
+    },
+    "amazon-bedrock\u0000meta.llama3-3-70b-instruct-v1:0": {
+      "cached_read": null,
+      "in": 0.72,
+      "out": 0.72
+    },
+    "amazon-bedrock\u0000meta.llama4-maverick-17b-instruct-v1:0": {
+      "cached_read": null,
+      "in": 0.24,
+      "out": 0.97
+    },
+    "amazon-bedrock\u0000meta.llama4-scout-17b-instruct-v1:0": {
+      "cached_read": null,
+      "in": 0.17,
+      "out": 0.66
+    },
+    "amazon-bedrock\u0000minimax.minimax-m2": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "amazon-bedrock\u0000minimax.minimax-m2.1": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "amazon-bedrock\u0000minimax.minimax-m2.5": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "amazon-bedrock\u0000mistral.devstral-2-123b": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "amazon-bedrock\u0000mistral.magistral-small-2509": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "amazon-bedrock\u0000mistral.ministral-3-14b-instruct": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "amazon-bedrock\u0000mistral.ministral-3-3b-instruct": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "amazon-bedrock\u0000mistral.ministral-3-8b-instruct": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.15
+    },
+    "amazon-bedrock\u0000mistral.mistral-large-3-675b-instruct": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "amazon-bedrock\u0000mistral.pixtral-large-2502-v1:0": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "amazon-bedrock\u0000mistral.voxtral-mini-3b-2507": {
+      "cached_read": null,
+      "in": 0.04,
+      "out": 0.04
+    },
+    "amazon-bedrock\u0000mistral.voxtral-small-24b-2507": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.35
+    },
+    "amazon-bedrock\u0000moonshot.kimi-k2-thinking": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.5
+    },
+    "amazon-bedrock\u0000moonshotai.kimi-k2.5": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 3.0
+    },
+    "amazon-bedrock\u0000nvidia.nemotron-nano-12b-v2": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.6
+    },
+    "amazon-bedrock\u0000nvidia.nemotron-nano-3-30b": {
+      "cached_read": null,
+      "in": 0.06,
+      "out": 0.24
+    },
+    "amazon-bedrock\u0000nvidia.nemotron-nano-9b-v2": {
+      "cached_read": null,
+      "in": 0.06,
+      "out": 0.23
+    },
+    "amazon-bedrock\u0000nvidia.nemotron-super-3-120b": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.65
+    },
+    "amazon-bedrock\u0000openai.gpt-5.4": {
+      "cached_read": 0.275,
+      "in": 2.75,
+      "out": 16.5
+    },
+    "amazon-bedrock\u0000openai.gpt-5.5": {
+      "cached_read": 0.55,
+      "in": 5.5,
+      "out": 33.0
+    },
+    "amazon-bedrock\u0000openai.gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "amazon-bedrock\u0000openai.gpt-oss-120b-1:0": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "amazon-bedrock\u0000openai.gpt-oss-20b": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.3
+    },
+    "amazon-bedrock\u0000openai.gpt-oss-20b-1:0": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.3
+    },
+    "amazon-bedrock\u0000openai.gpt-oss-safeguard-120b": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "amazon-bedrock\u0000openai.gpt-oss-safeguard-20b": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.2
+    },
+    "amazon-bedrock\u0000qwen.qwen3-235b-a22b-2507-v1:0": {
+      "cached_read": null,
+      "in": 0.22,
+      "out": 0.88
+    },
+    "amazon-bedrock\u0000qwen.qwen3-32b-v1:0": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "amazon-bedrock\u0000qwen.qwen3-coder-30b-a3b-v1:0": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "amazon-bedrock\u0000qwen.qwen3-coder-480b-a35b-v1:0": {
+      "cached_read": null,
+      "in": 0.22,
+      "out": 1.8
+    },
+    "amazon-bedrock\u0000qwen.qwen3-coder-next": {
+      "cached_read": null,
+      "in": 0.22,
+      "out": 1.8
+    },
+    "amazon-bedrock\u0000qwen.qwen3-next-80b-a3b": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 1.4
+    },
+    "amazon-bedrock\u0000qwen.qwen3-vl-235b-a22b": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.5
+    },
+    "amazon-bedrock\u0000us.anthropic.claude-haiku-4-5-20251001-v1:0": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "amazon-bedrock\u0000us.anthropic.claude-opus-4-1-20250805-v1:0": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "amazon-bedrock\u0000us.anthropic.claude-opus-4-5-20251101-v1:0": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "amazon-bedrock\u0000us.anthropic.claude-opus-4-6-v1": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "amazon-bedrock\u0000us.anthropic.claude-opus-4-7": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "amazon-bedrock\u0000us.anthropic.claude-opus-4-8": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "amazon-bedrock\u0000us.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "amazon-bedrock\u0000us.anthropic.claude-sonnet-4-6": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "amazon-bedrock\u0000us.deepseek.r1-v1:0": {
+      "cached_read": null,
+      "in": 1.35,
+      "out": 5.4
+    },
+    "amazon-bedrock\u0000us.meta.llama4-maverick-17b-instruct-v1:0": {
+      "cached_read": null,
+      "in": 0.24,
+      "out": 0.97
+    },
+    "amazon-bedrock\u0000us.meta.llama4-scout-17b-instruct-v1:0": {
+      "cached_read": null,
+      "in": 0.17,
+      "out": 0.66
+    },
+    "amazon-bedrock\u0000writer.palmyra-x4-v1:0": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "amazon-bedrock\u0000writer.palmyra-x5-v1:0": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 6.0
+    },
+    "amazon-bedrock\u0000zai.glm-4.7": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "amazon-bedrock\u0000zai.glm-4.7-flash": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.4
+    },
+    "amazon-bedrock\u0000zai.glm-5": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 3.2
+    },
+    "ambient\u0000moonshotai/kimi-k2.6": {
+      "cached_read": 0.2,
+      "in": 0.95,
+      "out": 4.0
+    },
+    "ambient\u0000zai-org/glm-5.1-fp8": {
+      "cached_read": 0.0,
+      "in": 1.4,
+      "out": 4.4
+    },
+    "anthropic\u0000claude-3-5-haiku-20241022": {
+      "cached_read": 0.08,
+      "in": 0.8,
+      "out": 4.0
+    },
+    "anthropic\u0000claude-3-5-haiku-latest": {
+      "cached_read": 0.08,
+      "in": 0.8,
+      "out": 4.0
+    },
+    "anthropic\u0000claude-3-5-sonnet-20240620": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "anthropic\u0000claude-3-5-sonnet-20241022": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "anthropic\u0000claude-3-7-sonnet-20250219": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "anthropic\u0000claude-3-haiku-20240307": {
+      "cached_read": 0.03,
+      "in": 0.25,
+      "out": 1.25
+    },
+    "anthropic\u0000claude-3-opus-20240229": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "anthropic\u0000claude-3-sonnet-20240229": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "anthropic\u0000claude-haiku-4-5": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "anthropic\u0000claude-haiku-4-5-20251001": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "anthropic\u0000claude-opus-4-0": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "anthropic\u0000claude-opus-4-1": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "anthropic\u0000claude-opus-4-1-20250805": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "anthropic\u0000claude-opus-4-20250514": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "anthropic\u0000claude-opus-4-5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "anthropic\u0000claude-opus-4-5-20251101": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "anthropic\u0000claude-opus-4-6": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "anthropic\u0000claude-opus-4-7": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "anthropic\u0000claude-opus-4-8": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "anthropic\u0000claude-sonnet-4-0": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "anthropic\u0000claude-sonnet-4-20250514": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "anthropic\u0000claude-sonnet-4-5": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "anthropic\u0000claude-sonnet-4-5-20250929": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "anthropic\u0000claude-sonnet-4-6": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "atomic-chat\u0000gemma-4-e4b-it-iq4_xs": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "atomic-chat\u0000gemma-4-e4b-it-mlx-4bit": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "atomic-chat\u0000meta-llama-3_1-8b-instruct-gguf": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "atomic-chat\u0000qwen3_5-9b-mlx-4bit": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "atomic-chat\u0000qwen3_5-9b-q4_k_m": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "auriko\u0000claude-opus-4-6": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "auriko\u0000claude-opus-4-7": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "auriko\u0000claude-sonnet-4-6": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "auriko\u0000deepseek-v4-flash": {
+      "cached_read": 0.0028,
+      "in": 0.14,
+      "out": 0.28
+    },
+    "auriko\u0000deepseek-v4-pro": {
+      "cached_read": 0.003625,
+      "in": 0.435,
+      "out": 0.87
+    },
+    "auriko\u0000gemini-2.5-flash": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "auriko\u0000gemini-2.5-pro": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "auriko\u0000gemini-3.1-pro-preview": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "auriko\u0000glm-5.1": {
+      "cached_read": 0.26,
+      "in": 1.4,
+      "out": 4.4
+    },
+    "auriko\u0000grok-4.3": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "auriko\u0000kimi-k2.5": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 2.8
+    },
+    "auriko\u0000kimi-k2.6": {
+      "cached_read": 0.16,
+      "in": 0.95,
+      "out": 4.0
+    },
+    "auriko\u0000minimax-m2-7": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "auriko\u0000minimax-m2-7-highspeed": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.4
+    },
+    "auriko\u0000qwen-3.6-plus": {
+      "cached_read": 0.1,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "azure\u0000claude-haiku-4-5": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "azure\u0000claude-opus-4-1": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "azure\u0000claude-opus-4-5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "azure\u0000claude-opus-4-6": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "azure\u0000claude-sonnet-4-5": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "azure\u0000claude-sonnet-4-6": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "azure\u0000codestral-2501": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.9
+    },
+    "azure\u0000codex-mini": {
+      "cached_read": 0.375,
+      "in": 1.5,
+      "out": 6.0
+    },
+    "azure\u0000cohere-command-a": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "azure\u0000cohere-command-r-08-2024": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "azure\u0000cohere-command-r-plus-08-2024": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "azure\u0000cohere-embed-v-4-0": {
+      "cached_read": null,
+      "in": 0.12,
+      "out": 0.0
+    },
+    "azure\u0000cohere-embed-v3-english": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.0
+    },
+    "azure\u0000cohere-embed-v3-multilingual": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.0
+    },
+    "azure\u0000deepseek-r1": {
+      "cached_read": null,
+      "in": 1.35,
+      "out": 5.4
+    },
+    "azure\u0000deepseek-r1-0528": {
+      "cached_read": null,
+      "in": 1.35,
+      "out": 5.4
+    },
+    "azure\u0000deepseek-v3-0324": {
+      "cached_read": null,
+      "in": 1.14,
+      "out": 4.56
+    },
+    "azure\u0000deepseek-v3.1": {
+      "cached_read": null,
+      "in": 0.56,
+      "out": 1.68
+    },
+    "azure\u0000deepseek-v3.2": {
+      "cached_read": null,
+      "in": 0.58,
+      "out": 1.68
+    },
+    "azure\u0000deepseek-v3.2-speciale": {
+      "cached_read": null,
+      "in": 0.58,
+      "out": 1.68
+    },
+    "azure\u0000gpt-3.5-turbo-0125": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "azure\u0000gpt-3.5-turbo-0301": {
+      "cached_read": null,
+      "in": 1.5,
+      "out": 2.0
+    },
+    "azure\u0000gpt-3.5-turbo-0613": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 4.0
+    },
+    "azure\u0000gpt-3.5-turbo-1106": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 2.0
+    },
+    "azure\u0000gpt-3.5-turbo-instruct": {
+      "cached_read": null,
+      "in": 1.5,
+      "out": 2.0
+    },
+    "azure\u0000gpt-4": {
+      "cached_read": null,
+      "in": 60.0,
+      "out": 120.0
+    },
+    "azure\u0000gpt-4-32k": {
+      "cached_read": null,
+      "in": 60.0,
+      "out": 120.0
+    },
+    "azure\u0000gpt-4-turbo": {
+      "cached_read": null,
+      "in": 10.0,
+      "out": 30.0
+    },
+    "azure\u0000gpt-4-turbo-vision": {
+      "cached_read": null,
+      "in": 10.0,
+      "out": 30.0
+    },
+    "azure\u0000gpt-4.1": {
+      "cached_read": 0.5,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "azure\u0000gpt-4.1-mini": {
+      "cached_read": 0.1,
+      "in": 0.4,
+      "out": 1.6
+    },
+    "azure\u0000gpt-4.1-nano": {
+      "cached_read": 0.025,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "azure\u0000gpt-4o": {
+      "cached_read": 1.25,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "azure\u0000gpt-4o-mini": {
+      "cached_read": 0.075,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "azure\u0000gpt-5": {
+      "cached_read": 0.13,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "azure\u0000gpt-5-chat": {
+      "cached_read": 0.13,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "azure\u0000gpt-5-codex": {
+      "cached_read": 0.13,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "azure\u0000gpt-5-mini": {
+      "cached_read": 0.03,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "azure\u0000gpt-5-nano": {
+      "cached_read": 0.01,
+      "in": 0.05,
+      "out": 0.4
+    },
+    "azure\u0000gpt-5-pro": {
+      "cached_read": null,
+      "in": 15.0,
+      "out": 120.0
+    },
+    "azure\u0000gpt-5.1": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "azure\u0000gpt-5.1-chat": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "azure\u0000gpt-5.1-codex": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "azure\u0000gpt-5.1-codex-max": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "azure\u0000gpt-5.1-codex-mini": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "azure\u0000gpt-5.2": {
+      "cached_read": 0.125,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "azure\u0000gpt-5.2-chat": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "azure\u0000gpt-5.2-codex": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "azure\u0000gpt-5.3-chat": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "azure\u0000gpt-5.3-codex": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "azure\u0000gpt-5.4": {
+      "cached_read": 0.25,
+      "in": 2.5,
+      "out": 15.0
+    },
+    "azure\u0000gpt-5.4-mini": {
+      "cached_read": 0.075,
+      "in": 0.75,
+      "out": 4.5
+    },
+    "azure\u0000gpt-5.4-nano": {
+      "cached_read": 0.02,
+      "in": 0.2,
+      "out": 1.25
+    },
+    "azure\u0000gpt-5.4-pro": {
+      "cached_read": null,
+      "in": 30.0,
+      "out": 180.0
+    },
+    "azure\u0000gpt-5.5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 30.0
+    },
+    "azure\u0000grok-4-1-fast-non-reasoning": {
+      "cached_read": 0.05,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "azure\u0000grok-4-1-fast-reasoning": {
+      "cached_read": 0.05,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "azure\u0000grok-4-20-non-reasoning": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "azure\u0000grok-4-20-reasoning": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "azure\u0000grok-4-fast-reasoning": {
+      "cached_read": 0.05,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "azure\u0000kimi-k2-thinking": {
+      "cached_read": 0.15,
+      "in": 0.6,
+      "out": 2.5
+    },
+    "azure\u0000kimi-k2.5": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 3.0
+    },
+    "azure\u0000kimi-k2.6": {
+      "cached_read": null,
+      "in": 0.95,
+      "out": 4.0
+    },
+    "azure\u0000llama-3.2-11b-vision-instruct": {
+      "cached_read": null,
+      "in": 0.37,
+      "out": 0.37
+    },
+    "azure\u0000llama-3.2-90b-vision-instruct": {
+      "cached_read": null,
+      "in": 2.04,
+      "out": 2.04
+    },
+    "azure\u0000llama-3.3-70b-instruct": {
+      "cached_read": null,
+      "in": 0.71,
+      "out": 0.71
+    },
+    "azure\u0000llama-4-maverick-17b-128e-instruct-fp8": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 1.0
+    },
+    "azure\u0000llama-4-scout-17b-16e-instruct": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.78
+    },
+    "azure\u0000mai-ds-r1": {
+      "cached_read": null,
+      "in": 1.35,
+      "out": 5.4
+    },
+    "azure\u0000meta-llama-3-70b-instruct": {
+      "cached_read": null,
+      "in": 2.68,
+      "out": 3.54
+    },
+    "azure\u0000meta-llama-3-8b-instruct": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.61
+    },
+    "azure\u0000meta-llama-3.1-405b-instruct": {
+      "cached_read": null,
+      "in": 5.33,
+      "out": 16.0
+    },
+    "azure\u0000meta-llama-3.1-70b-instruct": {
+      "cached_read": null,
+      "in": 2.68,
+      "out": 3.54
+    },
+    "azure\u0000meta-llama-3.1-8b-instruct": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.61
+    },
+    "azure\u0000ministral-3b": {
+      "cached_read": null,
+      "in": 0.04,
+      "out": 0.04
+    },
+    "azure\u0000mistral-large-2411": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "azure\u0000mistral-medium-2505": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "azure\u0000mistral-nemo": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.15
+    },
+    "azure\u0000mistral-small-2503": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "azure\u0000model-router": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.0
+    },
+    "azure\u0000o1": {
+      "cached_read": 7.5,
+      "in": 15.0,
+      "out": 60.0
+    },
+    "azure\u0000o1-mini": {
+      "cached_read": 0.55,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "azure\u0000o1-preview": {
+      "cached_read": 8.25,
+      "in": 16.5,
+      "out": 66.0
+    },
+    "azure\u0000o3": {
+      "cached_read": 0.5,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "azure\u0000o3-mini": {
+      "cached_read": 0.55,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "azure\u0000o4-mini": {
+      "cached_read": 0.275,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "azure\u0000phi-3-medium-128k-instruct": {
+      "cached_read": null,
+      "in": 0.17,
+      "out": 0.68
+    },
+    "azure\u0000phi-3-medium-4k-instruct": {
+      "cached_read": null,
+      "in": 0.17,
+      "out": 0.68
+    },
+    "azure\u0000phi-3-mini-128k-instruct": {
+      "cached_read": null,
+      "in": 0.13,
+      "out": 0.52
+    },
+    "azure\u0000phi-3-mini-4k-instruct": {
+      "cached_read": null,
+      "in": 0.13,
+      "out": 0.52
+    },
+    "azure\u0000phi-3-small-128k-instruct": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "azure\u0000phi-3-small-8k-instruct": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "azure\u0000phi-3.5-mini-instruct": {
+      "cached_read": null,
+      "in": 0.13,
+      "out": 0.52
+    },
+    "azure\u0000phi-3.5-moe-instruct": {
+      "cached_read": null,
+      "in": 0.16,
+      "out": 0.64
+    },
+    "azure\u0000phi-4": {
+      "cached_read": null,
+      "in": 0.125,
+      "out": 0.5
+    },
+    "azure\u0000phi-4-mini": {
+      "cached_read": null,
+      "in": 0.075,
+      "out": 0.3
+    },
+    "azure\u0000phi-4-mini-reasoning": {
+      "cached_read": null,
+      "in": 0.075,
+      "out": 0.3
+    },
+    "azure\u0000phi-4-multimodal": {
+      "cached_read": null,
+      "in": 0.08,
+      "out": 0.32
+    },
+    "azure\u0000phi-4-reasoning": {
+      "cached_read": null,
+      "in": 0.125,
+      "out": 0.5
+    },
+    "azure\u0000phi-4-reasoning-plus": {
+      "cached_read": null,
+      "in": 0.125,
+      "out": 0.5
+    },
+    "azure\u0000text-embedding-3-large": {
+      "cached_read": null,
+      "in": 0.13,
+      "out": 0.0
+    },
+    "azure\u0000text-embedding-3-small": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.0
+    },
+    "azure\u0000text-embedding-ada-002": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.0
+    },
+    "azure-cognitive-services\u0000claude-haiku-4-5": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "azure-cognitive-services\u0000claude-opus-4-1": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "azure-cognitive-services\u0000claude-opus-4-5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "azure-cognitive-services\u0000claude-opus-4-6": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "azure-cognitive-services\u0000claude-sonnet-4-5": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "azure-cognitive-services\u0000codestral-2501": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.9
+    },
+    "azure-cognitive-services\u0000codex-mini": {
+      "cached_read": 0.375,
+      "in": 1.5,
+      "out": 6.0
+    },
+    "azure-cognitive-services\u0000cohere-command-a": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "azure-cognitive-services\u0000cohere-command-r-08-2024": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "azure-cognitive-services\u0000cohere-command-r-plus-08-2024": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "azure-cognitive-services\u0000cohere-embed-v-4-0": {
+      "cached_read": null,
+      "in": 0.12,
+      "out": 0.0
+    },
+    "azure-cognitive-services\u0000cohere-embed-v3-english": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.0
+    },
+    "azure-cognitive-services\u0000cohere-embed-v3-multilingual": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.0
+    },
+    "azure-cognitive-services\u0000deepseek-r1": {
+      "cached_read": null,
+      "in": 1.35,
+      "out": 5.4
+    },
+    "azure-cognitive-services\u0000deepseek-r1-0528": {
+      "cached_read": null,
+      "in": 1.35,
+      "out": 5.4
+    },
+    "azure-cognitive-services\u0000deepseek-v3-0324": {
+      "cached_read": null,
+      "in": 1.14,
+      "out": 4.56
+    },
+    "azure-cognitive-services\u0000deepseek-v3.1": {
+      "cached_read": null,
+      "in": 0.56,
+      "out": 1.68
+    },
+    "azure-cognitive-services\u0000deepseek-v3.2": {
+      "cached_read": null,
+      "in": 0.58,
+      "out": 1.68
+    },
+    "azure-cognitive-services\u0000deepseek-v3.2-speciale": {
+      "cached_read": null,
+      "in": 0.58,
+      "out": 1.68
+    },
+    "azure-cognitive-services\u0000gpt-3.5-turbo-0125": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "azure-cognitive-services\u0000gpt-3.5-turbo-0301": {
+      "cached_read": null,
+      "in": 1.5,
+      "out": 2.0
+    },
+    "azure-cognitive-services\u0000gpt-3.5-turbo-0613": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 4.0
+    },
+    "azure-cognitive-services\u0000gpt-3.5-turbo-1106": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 2.0
+    },
+    "azure-cognitive-services\u0000gpt-3.5-turbo-instruct": {
+      "cached_read": null,
+      "in": 1.5,
+      "out": 2.0
+    },
+    "azure-cognitive-services\u0000gpt-4": {
+      "cached_read": null,
+      "in": 60.0,
+      "out": 120.0
+    },
+    "azure-cognitive-services\u0000gpt-4-32k": {
+      "cached_read": null,
+      "in": 60.0,
+      "out": 120.0
+    },
+    "azure-cognitive-services\u0000gpt-4-turbo": {
+      "cached_read": null,
+      "in": 10.0,
+      "out": 30.0
+    },
+    "azure-cognitive-services\u0000gpt-4-turbo-vision": {
+      "cached_read": null,
+      "in": 10.0,
+      "out": 30.0
+    },
+    "azure-cognitive-services\u0000gpt-4.1": {
+      "cached_read": 0.5,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "azure-cognitive-services\u0000gpt-4.1-mini": {
+      "cached_read": 0.1,
+      "in": 0.4,
+      "out": 1.6
+    },
+    "azure-cognitive-services\u0000gpt-4.1-nano": {
+      "cached_read": 0.025,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "azure-cognitive-services\u0000gpt-4o": {
+      "cached_read": 1.25,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "azure-cognitive-services\u0000gpt-4o-mini": {
+      "cached_read": 0.075,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "azure-cognitive-services\u0000gpt-5": {
+      "cached_read": 0.13,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "azure-cognitive-services\u0000gpt-5-chat": {
+      "cached_read": 0.13,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "azure-cognitive-services\u0000gpt-5-codex": {
+      "cached_read": 0.13,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "azure-cognitive-services\u0000gpt-5-mini": {
+      "cached_read": 0.03,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "azure-cognitive-services\u0000gpt-5-nano": {
+      "cached_read": 0.01,
+      "in": 0.05,
+      "out": 0.4
+    },
+    "azure-cognitive-services\u0000gpt-5-pro": {
+      "cached_read": null,
+      "in": 15.0,
+      "out": 120.0
+    },
+    "azure-cognitive-services\u0000gpt-5.1": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "azure-cognitive-services\u0000gpt-5.1-chat": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "azure-cognitive-services\u0000gpt-5.1-codex": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "azure-cognitive-services\u0000gpt-5.1-codex-mini": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "azure-cognitive-services\u0000gpt-5.2": {
+      "cached_read": 0.125,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "azure-cognitive-services\u0000gpt-5.2-chat": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "azure-cognitive-services\u0000gpt-5.2-codex": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "azure-cognitive-services\u0000gpt-5.3-codex": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "azure-cognitive-services\u0000gpt-5.4": {
+      "cached_read": 0.25,
+      "in": 2.5,
+      "out": 15.0
+    },
+    "azure-cognitive-services\u0000gpt-5.4-mini": {
+      "cached_read": 0.075,
+      "in": 0.75,
+      "out": 4.5
+    },
+    "azure-cognitive-services\u0000gpt-5.4-nano": {
+      "cached_read": 0.02,
+      "in": 0.2,
+      "out": 1.25
+    },
+    "azure-cognitive-services\u0000gpt-5.4-pro": {
+      "cached_read": null,
+      "in": 30.0,
+      "out": 180.0
+    },
+    "azure-cognitive-services\u0000gpt-5.5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 30.0
+    },
+    "azure-cognitive-services\u0000grok-4-fast-reasoning": {
+      "cached_read": 0.05,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "azure-cognitive-services\u0000kimi-k2-thinking": {
+      "cached_read": 0.15,
+      "in": 0.6,
+      "out": 2.5
+    },
+    "azure-cognitive-services\u0000kimi-k2.5": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 3.0
+    },
+    "azure-cognitive-services\u0000kimi-k2.6": {
+      "cached_read": null,
+      "in": 0.95,
+      "out": 4.0
+    },
+    "azure-cognitive-services\u0000llama-3.2-11b-vision-instruct": {
+      "cached_read": null,
+      "in": 0.37,
+      "out": 0.37
+    },
+    "azure-cognitive-services\u0000llama-3.2-90b-vision-instruct": {
+      "cached_read": null,
+      "in": 2.04,
+      "out": 2.04
+    },
+    "azure-cognitive-services\u0000llama-3.3-70b-instruct": {
+      "cached_read": null,
+      "in": 0.71,
+      "out": 0.71
+    },
+    "azure-cognitive-services\u0000llama-4-maverick-17b-128e-instruct-fp8": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 1.0
+    },
+    "azure-cognitive-services\u0000llama-4-scout-17b-16e-instruct": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.78
+    },
+    "azure-cognitive-services\u0000mai-ds-r1": {
+      "cached_read": null,
+      "in": 1.35,
+      "out": 5.4
+    },
+    "azure-cognitive-services\u0000meta-llama-3-70b-instruct": {
+      "cached_read": null,
+      "in": 2.68,
+      "out": 3.54
+    },
+    "azure-cognitive-services\u0000meta-llama-3-8b-instruct": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.61
+    },
+    "azure-cognitive-services\u0000meta-llama-3.1-405b-instruct": {
+      "cached_read": null,
+      "in": 5.33,
+      "out": 16.0
+    },
+    "azure-cognitive-services\u0000meta-llama-3.1-70b-instruct": {
+      "cached_read": null,
+      "in": 2.68,
+      "out": 3.54
+    },
+    "azure-cognitive-services\u0000meta-llama-3.1-8b-instruct": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.61
+    },
+    "azure-cognitive-services\u0000ministral-3b": {
+      "cached_read": null,
+      "in": 0.04,
+      "out": 0.04
+    },
+    "azure-cognitive-services\u0000mistral-large-2411": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "azure-cognitive-services\u0000mistral-medium-2505": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "azure-cognitive-services\u0000mistral-nemo": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.15
+    },
+    "azure-cognitive-services\u0000mistral-small-2503": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "azure-cognitive-services\u0000model-router": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.0
+    },
+    "azure-cognitive-services\u0000o1": {
+      "cached_read": 7.5,
+      "in": 15.0,
+      "out": 60.0
+    },
+    "azure-cognitive-services\u0000o1-mini": {
+      "cached_read": 0.55,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "azure-cognitive-services\u0000o1-preview": {
+      "cached_read": 8.25,
+      "in": 16.5,
+      "out": 66.0
+    },
+    "azure-cognitive-services\u0000o3": {
+      "cached_read": 0.5,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "azure-cognitive-services\u0000o3-mini": {
+      "cached_read": 0.55,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "azure-cognitive-services\u0000o4-mini": {
+      "cached_read": 0.275,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "azure-cognitive-services\u0000phi-3-medium-128k-instruct": {
+      "cached_read": null,
+      "in": 0.17,
+      "out": 0.68
+    },
+    "azure-cognitive-services\u0000phi-3-medium-4k-instruct": {
+      "cached_read": null,
+      "in": 0.17,
+      "out": 0.68
+    },
+    "azure-cognitive-services\u0000phi-3-mini-128k-instruct": {
+      "cached_read": null,
+      "in": 0.13,
+      "out": 0.52
+    },
+    "azure-cognitive-services\u0000phi-3-mini-4k-instruct": {
+      "cached_read": null,
+      "in": 0.13,
+      "out": 0.52
+    },
+    "azure-cognitive-services\u0000phi-3-small-128k-instruct": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "azure-cognitive-services\u0000phi-3-small-8k-instruct": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "azure-cognitive-services\u0000phi-3.5-mini-instruct": {
+      "cached_read": null,
+      "in": 0.13,
+      "out": 0.52
+    },
+    "azure-cognitive-services\u0000phi-3.5-moe-instruct": {
+      "cached_read": null,
+      "in": 0.16,
+      "out": 0.64
+    },
+    "azure-cognitive-services\u0000phi-4": {
+      "cached_read": null,
+      "in": 0.125,
+      "out": 0.5
+    },
+    "azure-cognitive-services\u0000phi-4-mini": {
+      "cached_read": null,
+      "in": 0.075,
+      "out": 0.3
+    },
+    "azure-cognitive-services\u0000phi-4-mini-reasoning": {
+      "cached_read": null,
+      "in": 0.075,
+      "out": 0.3
+    },
+    "azure-cognitive-services\u0000phi-4-multimodal": {
+      "cached_read": null,
+      "in": 0.08,
+      "out": 0.32
+    },
+    "azure-cognitive-services\u0000phi-4-reasoning": {
+      "cached_read": null,
+      "in": 0.125,
+      "out": 0.5
+    },
+    "azure-cognitive-services\u0000phi-4-reasoning-plus": {
+      "cached_read": null,
+      "in": 0.125,
+      "out": 0.5
+    },
+    "azure-cognitive-services\u0000text-embedding-3-large": {
+      "cached_read": null,
+      "in": 0.13,
+      "out": 0.0
+    },
+    "azure-cognitive-services\u0000text-embedding-3-small": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.0
+    },
+    "azure-cognitive-services\u0000text-embedding-ada-002": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.0
+    },
+    "bailing\u0000ling-1t": {
+      "cached_read": null,
+      "in": 0.57,
+      "out": 2.29
+    },
+    "bailing\u0000ring-1t": {
+      "cached_read": null,
+      "in": 0.57,
+      "out": 2.29
+    },
+    "baseten\u0000deepseek-ai/deepseek-v3-0324": {
+      "cached_read": null,
+      "in": 0.77,
+      "out": 0.77
+    },
+    "baseten\u0000deepseek-ai/deepseek-v3.1": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "baseten\u0000deepseek-ai/deepseek-v3.2": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.45
+    },
+    "baseten\u0000deepseek-ai/deepseek-v4-pro": {
+      "cached_read": 0.15,
+      "in": 1.74,
+      "out": 3.48
+    },
+    "baseten\u0000minimaxai/minimax-m2.5": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "baseten\u0000moonshotai/kimi-k2-instruct-0905": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.5
+    },
+    "baseten\u0000moonshotai/kimi-k2-thinking": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.5
+    },
+    "baseten\u0000moonshotai/kimi-k2.5": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 3.0
+    },
+    "baseten\u0000moonshotai/kimi-k2.6": {
+      "cached_read": 0.16,
+      "in": 0.95,
+      "out": 4.0
+    },
+    "baseten\u0000nvidia/nemotron-120b-a12b": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.75
+    },
+    "baseten\u0000openai/gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.5
+    },
+    "baseten\u0000zai-org/glm-4.6": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "baseten\u0000zai-org/glm-4.7": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "baseten\u0000zai-org/glm-5": {
+      "cached_read": null,
+      "in": 0.95,
+      "out": 3.15
+    },
+    "berget\u0000google/gemma-4-31b-it": {
+      "cached_read": null,
+      "in": 0.275,
+      "out": 0.55
+    },
+    "berget\u0000meta-llama/llama-3.3-70b-instruct": {
+      "cached_read": null,
+      "in": 0.99,
+      "out": 0.99
+    },
+    "berget\u0000mistralai/mistral-medium-3.5-128b": {
+      "cached_read": null,
+      "in": 1.65,
+      "out": 5.5
+    },
+    "berget\u0000mistralai/mistral-small-3.2-24b-instruct-2506": {
+      "cached_read": null,
+      "in": 0.33,
+      "out": 0.33
+    },
+    "berget\u0000moonshotai/kimi-k2.6": {
+      "cached_read": 0.16,
+      "in": 0.83,
+      "out": 3.85
+    },
+    "berget\u0000openai/gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.44,
+      "out": 0.99
+    },
+    "berget\u0000zai-org/glm-4.7": {
+      "cached_read": null,
+      "in": 0.77,
+      "out": 2.75
+    },
+    "cerebras\u0000gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 0.69
+    },
+    "cerebras\u0000llama3.1-8b": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "cerebras\u0000zai-glm-4.7": {
+      "cached_read": 0.0,
+      "in": 2.25,
+      "out": 2.75
+    },
+    "chutes\u0000deepseek-ai/deepseek-r1-0528-tee": {
+      "cached_read": 0.225,
+      "in": 0.45,
+      "out": 2.15
+    },
+    "chutes\u0000deepseek-ai/deepseek-r1-distill-llama-70b": {
+      "cached_read": 0.0136,
+      "in": 0.0272,
+      "out": 0.1087
+    },
+    "chutes\u0000deepseek-ai/deepseek-v3-0324-tee": {
+      "cached_read": 0.125,
+      "in": 0.25,
+      "out": 1.0
+    },
+    "chutes\u0000deepseek-ai/deepseek-v3.1-tee": {
+      "cached_read": 0.135,
+      "in": 0.27,
+      "out": 1.0
+    },
+    "chutes\u0000deepseek-ai/deepseek-v3.2-tee": {
+      "cached_read": 0.14,
+      "in": 0.28,
+      "out": 0.42
+    },
+    "chutes\u0000google/gemma-4-31b-turbo-tee": {
+      "cached_read": 0.065,
+      "in": 0.13,
+      "out": 0.38
+    },
+    "chutes\u0000minimaxai/minimax-m2.5-tee": {
+      "cached_read": 0.075,
+      "in": 0.15,
+      "out": 1.2
+    },
+    "chutes\u0000moonshotai/kimi-k2.5-tee": {
+      "cached_read": 0.22,
+      "in": 0.44,
+      "out": 2.0
+    },
+    "chutes\u0000moonshotai/kimi-k2.6-tee": {
+      "cached_read": 0.475,
+      "in": 0.95,
+      "out": 4.0
+    },
+    "chutes\u0000nousresearch/deephermes-3-mistral-24b-preview": {
+      "cached_read": 0.01225,
+      "in": 0.0245,
+      "out": 0.0978
+    },
+    "chutes\u0000nousresearch/hermes-4-14b": {
+      "cached_read": 0.0068,
+      "in": 0.0136,
+      "out": 0.0543
+    },
+    "chutes\u0000openai/gpt-oss-120b-tee": {
+      "cached_read": 0.045,
+      "in": 0.09,
+      "out": 0.36
+    },
+    "chutes\u0000qwen/qwen2.5-72b-instruct": {
+      "cached_read": 0.14945,
+      "in": 0.2989,
+      "out": 1.1957
+    },
+    "chutes\u0000qwen/qwen2.5-coder-32b-instruct": {
+      "cached_read": 0.0136,
+      "in": 0.0272,
+      "out": 0.1087
+    },
+    "chutes\u0000qwen/qwen2.5-vl-32b-instruct": {
+      "cached_read": 0.02715,
+      "in": 0.0543,
+      "out": 0.2174
+    },
+    "chutes\u0000qwen/qwen3-235b-a22b-instruct-2507-tee": {
+      "cached_read": 0.05,
+      "in": 0.1,
+      "out": 0.6
+    },
+    "chutes\u0000qwen/qwen3-235b-a22b-thinking-2507": {
+      "cached_read": 0.055,
+      "in": 0.11,
+      "out": 0.6
+    },
+    "chutes\u0000qwen/qwen3-30b-a3b": {
+      "cached_read": 0.03,
+      "in": 0.06,
+      "out": 0.22
+    },
+    "chutes\u0000qwen/qwen3-32b-tee": {
+      "cached_read": 0.04,
+      "in": 0.08,
+      "out": 0.24
+    },
+    "chutes\u0000qwen/qwen3-coder-next-tee": {
+      "cached_read": 0.06,
+      "in": 0.12,
+      "out": 0.75
+    },
+    "chutes\u0000qwen/qwen3-next-80b-a3b-instruct": {
+      "cached_read": 0.05,
+      "in": 0.1,
+      "out": 0.8
+    },
+    "chutes\u0000qwen/qwen3.5-397b-a17b-tee": {
+      "cached_read": 0.195,
+      "in": 0.39,
+      "out": 2.34
+    },
+    "chutes\u0000qwen/qwen3.6-27b-tee": {
+      "cached_read": 0.0975,
+      "in": 0.195,
+      "out": 1.56
+    },
+    "chutes\u0000qwen/qwen3guard-gen-0.6b": {
+      "cached_read": 0.005,
+      "in": 0.01,
+      "out": 0.0109
+    },
+    "chutes\u0000rednote-hilab/dots.ocr": {
+      "cached_read": 0.005,
+      "in": 0.01,
+      "out": 0.0109
+    },
+    "chutes\u0000tngtech/deepseek-tng-r1t2-chimera-tee": {
+      "cached_read": 0.15,
+      "in": 0.3,
+      "out": 1.1
+    },
+    "chutes\u0000unsloth/gemma-3-12b-it": {
+      "cached_read": 0.015,
+      "in": 0.03,
+      "out": 0.1
+    },
+    "chutes\u0000unsloth/gemma-3-27b-it": {
+      "cached_read": 0.0136,
+      "in": 0.0272,
+      "out": 0.1087
+    },
+    "chutes\u0000unsloth/gemma-3-4b-it": {
+      "cached_read": 0.005,
+      "in": 0.01,
+      "out": 0.0272
+    },
+    "chutes\u0000unsloth/llama-3.2-1b-instruct": {
+      "cached_read": 0.005,
+      "in": 0.01,
+      "out": 0.0109
+    },
+    "chutes\u0000unsloth/llama-3.2-3b-instruct": {
+      "cached_read": 0.005,
+      "in": 0.01,
+      "out": 0.0136
+    },
+    "chutes\u0000unsloth/mistral-nemo-instruct-2407": {
+      "cached_read": 0.01,
+      "in": 0.02,
+      "out": 0.04
+    },
+    "chutes\u0000xiaomimimo/mimo-v2-flash-tee": {
+      "cached_read": 0.045,
+      "in": 0.09,
+      "out": 0.29
+    },
+    "chutes\u0000zai-org/glm-4.6v": {
+      "cached_read": 0.15,
+      "in": 0.3,
+      "out": 0.9
+    },
+    "chutes\u0000zai-org/glm-4.7-fp8": {
+      "cached_read": 0.14945,
+      "in": 0.2989,
+      "out": 1.1957
+    },
+    "chutes\u0000zai-org/glm-4.7-tee": {
+      "cached_read": 0.195,
+      "in": 0.39,
+      "out": 1.75
+    },
+    "chutes\u0000zai-org/glm-5-tee": {
+      "cached_read": 0.475,
+      "in": 0.95,
+      "out": 2.55
+    },
+    "chutes\u0000zai-org/glm-5-turbo": {
+      "cached_read": 0.24455,
+      "in": 0.4891,
+      "out": 1.9565
+    },
+    "chutes\u0000zai-org/glm-5.1-tee": {
+      "cached_read": 0.525,
+      "in": 1.05,
+      "out": 3.5
+    },
+    "clarifai\u0000arcee_ai/afm/models/trinity-mini": {
+      "cached_read": null,
+      "in": 0.045,
+      "out": 0.15
+    },
+    "clarifai\u0000clarifai/main/models/mm-poly-8b": {
+      "cached_read": null,
+      "in": 0.658,
+      "out": 1.11
+    },
+    "clarifai\u0000deepseek-ai/deepseek-ocr/models/deepseek-ocr": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.7
+    },
+    "clarifai\u0000minimaxai/chat-completion/models/minimax-m2_5-high-throughput": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "clarifai\u0000mistralai/completion/models/ministral-3-14b-reasoning-2512": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 1.7
+    },
+    "clarifai\u0000mistralai/completion/models/ministral-3-3b-reasoning-2512": {
+      "cached_read": null,
+      "in": 1.039,
+      "out": 0.54825
+    },
+    "clarifai\u0000moonshotai/chat-completion/models/kimi-k2_6": {
+      "cached_read": null,
+      "in": 0.95,
+      "out": 4.0
+    },
+    "clarifai\u0000openai/chat-completion/models/gpt-oss-120b-high-throughput": {
+      "cached_read": null,
+      "in": 0.09,
+      "out": 0.36
+    },
+    "clarifai\u0000openai/chat-completion/models/gpt-oss-20b": {
+      "cached_read": null,
+      "in": 0.045,
+      "out": 0.18
+    },
+    "clarifai\u0000qwen/qwencoder/models/qwen3-coder-30b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.11458,
+      "out": 0.74812
+    },
+    "clarifai\u0000qwen/qwenlm/models/qwen3-30b-a3b-instruct-2507": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.5
+    },
+    "clarifai\u0000qwen/qwenlm/models/qwen3-30b-a3b-thinking-2507": {
+      "cached_read": null,
+      "in": 0.36,
+      "out": 1.3
+    },
+    "claudinio\u0000claudinio": {
+      "cached_read": 0.15,
+      "in": 0.5,
+      "out": 2.0
+    },
+    "cloudferro-sherlock\u0000meta-llama/llama-3.3-70b-instruct": {
+      "cached_read": null,
+      "in": 2.92,
+      "out": 2.92
+    },
+    "cloudferro-sherlock\u0000minimaxai/minimax-m2.5": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "cloudferro-sherlock\u0000openai/gpt-oss-120b": {
+      "cached_read": null,
+      "in": 2.92,
+      "out": 2.92
+    },
+    "cloudferro-sherlock\u0000speakleash/bielik-11b-v2.6-instruct": {
+      "cached_read": null,
+      "in": 0.67,
+      "out": 0.67
+    },
+    "cloudferro-sherlock\u0000speakleash/bielik-11b-v3.0-instruct": {
+      "cached_read": null,
+      "in": 0.67,
+      "out": 0.67
+    },
+    "cloudflare-ai-gateway\u0000anthropic/claude-3-5-haiku": {
+      "cached_read": 0.08,
+      "in": 0.8,
+      "out": 4.0
+    },
+    "cloudflare-ai-gateway\u0000anthropic/claude-3-haiku": {
+      "cached_read": 0.03,
+      "in": 0.25,
+      "out": 1.25
+    },
+    "cloudflare-ai-gateway\u0000anthropic/claude-3-opus": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "cloudflare-ai-gateway\u0000anthropic/claude-3-sonnet": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "cloudflare-ai-gateway\u0000anthropic/claude-3.5-haiku": {
+      "cached_read": 0.08,
+      "in": 0.8,
+      "out": 4.0
+    },
+    "cloudflare-ai-gateway\u0000anthropic/claude-3.5-sonnet": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "cloudflare-ai-gateway\u0000anthropic/claude-haiku-4-5": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "cloudflare-ai-gateway\u0000anthropic/claude-opus-4": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "cloudflare-ai-gateway\u0000anthropic/claude-opus-4-1": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "cloudflare-ai-gateway\u0000anthropic/claude-opus-4-5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "cloudflare-ai-gateway\u0000anthropic/claude-opus-4-6": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "cloudflare-ai-gateway\u0000anthropic/claude-opus-4-7": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "cloudflare-ai-gateway\u0000anthropic/claude-opus-4-8": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "cloudflare-ai-gateway\u0000anthropic/claude-sonnet-4": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "cloudflare-ai-gateway\u0000anthropic/claude-sonnet-4-5": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "cloudflare-ai-gateway\u0000anthropic/claude-sonnet-4-6": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "cloudflare-ai-gateway\u0000openai/gpt-3.5-turbo": {
+      "cached_read": 1.25,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "cloudflare-ai-gateway\u0000openai/gpt-4": {
+      "cached_read": null,
+      "in": 30.0,
+      "out": 60.0
+    },
+    "cloudflare-ai-gateway\u0000openai/gpt-4-turbo": {
+      "cached_read": null,
+      "in": 10.0,
+      "out": 30.0
+    },
+    "cloudflare-ai-gateway\u0000openai/gpt-4o": {
+      "cached_read": 1.25,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "cloudflare-ai-gateway\u0000openai/gpt-4o-mini": {
+      "cached_read": 0.08,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "cloudflare-ai-gateway\u0000openai/gpt-5.1": {
+      "cached_read": 0.13,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "cloudflare-ai-gateway\u0000openai/gpt-5.1-codex": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "cloudflare-ai-gateway\u0000openai/gpt-5.2": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "cloudflare-ai-gateway\u0000openai/gpt-5.2-codex": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "cloudflare-ai-gateway\u0000openai/gpt-5.3-codex": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "cloudflare-ai-gateway\u0000openai/gpt-5.4": {
+      "cached_read": 0.25,
+      "in": 2.5,
+      "out": 15.0
+    },
+    "cloudflare-ai-gateway\u0000openai/gpt-5.5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 30.0
+    },
+    "cloudflare-ai-gateway\u0000openai/o1": {
+      "cached_read": 7.5,
+      "in": 15.0,
+      "out": 60.0
+    },
+    "cloudflare-ai-gateway\u0000openai/o3": {
+      "cached_read": 0.5,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "cloudflare-ai-gateway\u0000openai/o3-mini": {
+      "cached_read": 0.55,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "cloudflare-ai-gateway\u0000openai/o3-pro": {
+      "cached_read": null,
+      "in": 20.0,
+      "out": 80.0
+    },
+    "cloudflare-ai-gateway\u0000openai/o4-mini": {
+      "cached_read": 0.28,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/ai4bharat/indictrans2-en-indic-1b": {
+      "cached_read": null,
+      "in": 0.34,
+      "out": 0.34
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/aisingapore/gemma-sea-lion-v4-27b-it": {
+      "cached_read": null,
+      "in": 0.35,
+      "out": 0.56
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/baai/bge-base-en-v1.5": {
+      "cached_read": null,
+      "in": 0.067,
+      "out": 0.0
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/baai/bge-large-en-v1.5": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.0
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/baai/bge-m3": {
+      "cached_read": null,
+      "in": 0.012,
+      "out": 0.0
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/baai/bge-reranker-base": {
+      "cached_read": null,
+      "in": 0.0031,
+      "out": 0.0
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/baai/bge-small-en-v1.5": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.0
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/deepgram/aura-2-en": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/deepgram/aura-2-es": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/deepgram/nova-3": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/deepseek-ai/deepseek-r1-distill-qwen-32b": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 4.88
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/facebook/bart-large-cnn": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/google/gemma-3-12b-it": {
+      "cached_read": null,
+      "in": 0.35,
+      "out": 0.56
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/huggingface/distilbert-sst-2-int8": {
+      "cached_read": null,
+      "in": 0.026,
+      "out": 0.0
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/ibm-granite/granite-4.0-h-micro": {
+      "cached_read": null,
+      "in": 0.017,
+      "out": 0.11
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/meta/llama-2-7b-chat-fp16": {
+      "cached_read": null,
+      "in": 0.56,
+      "out": 6.67
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/meta/llama-3-8b-instruct": {
+      "cached_read": null,
+      "in": 0.28,
+      "out": 0.83
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/meta/llama-3-8b-instruct-awq": {
+      "cached_read": null,
+      "in": 0.12,
+      "out": 0.27
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/meta/llama-3.1-8b-instruct": {
+      "cached_read": null,
+      "in": 0.28,
+      "out": 0.8299999999999998
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/meta/llama-3.1-8b-instruct-awq": {
+      "cached_read": null,
+      "in": 0.12,
+      "out": 0.27
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/meta/llama-3.1-8b-instruct-fp8": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.29
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/meta/llama-3.2-11b-vision-instruct": {
+      "cached_read": null,
+      "in": 0.049,
+      "out": 0.68
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/meta/llama-3.2-1b-instruct": {
+      "cached_read": null,
+      "in": 0.027,
+      "out": 0.2
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/meta/llama-3.2-3b-instruct": {
+      "cached_read": null,
+      "in": 0.051,
+      "out": 0.34
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/meta/llama-3.3-70b-instruct-fp8-fast": {
+      "cached_read": null,
+      "in": 0.29,
+      "out": 2.25
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/meta/llama-4-scout-17b-16e-instruct": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 0.85
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/meta/llama-guard-3-8b": {
+      "cached_read": null,
+      "in": 0.48,
+      "out": 0.03
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/meta/m2m100-1.2b": {
+      "cached_read": null,
+      "in": 0.34,
+      "out": 0.34
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/mistral/mistral-7b-instruct-v0.1": {
+      "cached_read": null,
+      "in": 0.11,
+      "out": 0.19
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/mistralai/mistral-small-3.1-24b-instruct": {
+      "cached_read": null,
+      "in": 0.35,
+      "out": 0.56
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/moonshotai/kimi-k2.5": {
+      "cached_read": 0.1,
+      "in": 0.6,
+      "out": 3.0
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/moonshotai/kimi-k2.6": {
+      "cached_read": 0.16,
+      "in": 0.95,
+      "out": 4.0
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/myshell-ai/melotts": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/nvidia/nemotron-3-120b-a12b": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/openai/gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.35,
+      "out": 0.75
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/openai/gpt-oss-20b": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.3
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/pfnet/plamo-embedding-1b": {
+      "cached_read": null,
+      "in": 0.019,
+      "out": 0.0
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/pipecat-ai/smart-turn-v2": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/qwen/qwen2.5-coder-32b-instruct": {
+      "cached_read": null,
+      "in": 0.66,
+      "out": 1.0
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/qwen/qwen3-30b-a3b-fp8": {
+      "cached_read": null,
+      "in": 0.051,
+      "out": 0.34
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/qwen/qwen3-embedding-0.6b": {
+      "cached_read": null,
+      "in": 0.012,
+      "out": 0.0
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/qwen/qwq-32b": {
+      "cached_read": null,
+      "in": 0.66,
+      "out": 1.0
+    },
+    "cloudflare-ai-gateway\u0000workers-ai/@cf/zai-org/glm-4.7-flash": {
+      "cached_read": null,
+      "in": 0.06,
+      "out": 0.4
+    },
+    "cloudflare-workers-ai\u0000@cf/aisingapore/gemma-sea-lion-v4-27b-it": {
+      "cached_read": null,
+      "in": 0.351,
+      "out": 0.555
+    },
+    "cloudflare-workers-ai\u0000@cf/deepseek-ai/deepseek-r1-distill-qwen-32b": {
+      "cached_read": null,
+      "in": 0.497,
+      "out": 4.881
+    },
+    "cloudflare-workers-ai\u0000@cf/google/gemma-4-26b-a4b-it": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "cloudflare-workers-ai\u0000@cf/ibm-granite/granite-4.0-h-micro": {
+      "cached_read": null,
+      "in": 0.017,
+      "out": 0.112
+    },
+    "cloudflare-workers-ai\u0000@cf/meta/llama-3.1-8b-instruct-fp8": {
+      "cached_read": null,
+      "in": 0.152,
+      "out": 0.287
+    },
+    "cloudflare-workers-ai\u0000@cf/meta/llama-3.2-11b-vision-instruct": {
+      "cached_read": null,
+      "in": 0.0485,
+      "out": 0.676
+    },
+    "cloudflare-workers-ai\u0000@cf/meta/llama-3.2-1b-instruct": {
+      "cached_read": null,
+      "in": 0.027,
+      "out": 0.201
+    },
+    "cloudflare-workers-ai\u0000@cf/meta/llama-3.2-3b-instruct": {
+      "cached_read": null,
+      "in": 0.0509,
+      "out": 0.335
+    },
+    "cloudflare-workers-ai\u0000@cf/meta/llama-3.3-70b-instruct-fp8-fast": {
+      "cached_read": null,
+      "in": 0.293,
+      "out": 2.253
+    },
+    "cloudflare-workers-ai\u0000@cf/meta/llama-4-scout-17b-16e-instruct": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 0.85
+    },
+    "cloudflare-workers-ai\u0000@cf/meta/llama-guard-3-8b": {
+      "cached_read": null,
+      "in": 0.484,
+      "out": 0.03
+    },
+    "cloudflare-workers-ai\u0000@cf/mistralai/mistral-small-3.1-24b-instruct": {
+      "cached_read": null,
+      "in": 0.351,
+      "out": 0.555
+    },
+    "cloudflare-workers-ai\u0000@cf/moonshotai/kimi-k2.6": {
+      "cached_read": 0.16,
+      "in": 0.95,
+      "out": 4.0
+    },
+    "cloudflare-workers-ai\u0000@cf/nvidia/nemotron-3-120b-a12b": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "cloudflare-workers-ai\u0000@cf/openai/gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.35,
+      "out": 0.75
+    },
+    "cloudflare-workers-ai\u0000@cf/openai/gpt-oss-20b": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.3
+    },
+    "cloudflare-workers-ai\u0000@cf/qwen/qwen2.5-coder-32b-instruct": {
+      "cached_read": null,
+      "in": 0.66,
+      "out": 1.0
+    },
+    "cloudflare-workers-ai\u0000@cf/qwen/qwen3-30b-a3b-fp8": {
+      "cached_read": null,
+      "in": 0.0509,
+      "out": 0.335
+    },
+    "cloudflare-workers-ai\u0000@cf/qwen/qwq-32b": {
+      "cached_read": null,
+      "in": 0.66,
+      "out": 1.0
+    },
+    "cloudflare-workers-ai\u0000@cf/zai-org/glm-4.7-flash": {
+      "cached_read": null,
+      "in": 0.0605,
+      "out": 0.4
+    },
+    "cohere\u0000command-a-03-2025": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "cohere\u0000command-a-reasoning-08-2025": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "cohere\u0000command-a-translate-08-2025": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "cohere\u0000command-a-vision-07-2025": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "cohere\u0000command-r-08-2024": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "cohere\u0000command-r-plus-08-2024": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "cohere\u0000command-r7b-12-2024": {
+      "cached_read": null,
+      "in": 0.0375,
+      "out": 0.15
+    },
+    "cohere\u0000command-r7b-arabic-02-2025": {
+      "cached_read": null,
+      "in": 0.0375,
+      "out": 0.15
+    },
+    "cortecs\u0000claude-4-5-sonnet": {
+      "cached_read": null,
+      "in": 3.259,
+      "out": 16.296
+    },
+    "cortecs\u0000claude-4-6-sonnet": {
+      "cached_read": null,
+      "in": 3.59,
+      "out": 17.92
+    },
+    "cortecs\u0000claude-haiku-4-5": {
+      "cached_read": null,
+      "in": 1.09,
+      "out": 5.43
+    },
+    "cortecs\u0000claude-opus4-5": {
+      "cached_read": null,
+      "in": 5.98,
+      "out": 29.89
+    },
+    "cortecs\u0000claude-opus4-6": {
+      "cached_read": null,
+      "in": 5.98,
+      "out": 29.89
+    },
+    "cortecs\u0000claude-opus4-7": {
+      "cached_read": 0.56,
+      "in": 5.6,
+      "out": 27.99
+    },
+    "cortecs\u0000claude-sonnet-4": {
+      "cached_read": null,
+      "in": 3.307,
+      "out": 16.536
+    },
+    "cortecs\u0000codestral-2508": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 0.9
+    },
+    "cortecs\u0000deepseek-r1-0528": {
+      "cached_read": null,
+      "in": 0.585,
+      "out": 2.307
+    },
+    "cortecs\u0000deepseek-v3-0324": {
+      "cached_read": null,
+      "in": 0.551,
+      "out": 1.654
+    },
+    "cortecs\u0000deepseek-v3.2": {
+      "cached_read": null,
+      "in": 0.266,
+      "out": 0.444
+    },
+    "cortecs\u0000deepseek-v4-flash": {
+      "cached_read": 0.0028,
+      "in": 0.133,
+      "out": 0.266
+    },
+    "cortecs\u0000deepseek-v4-pro": {
+      "cached_read": 0.003625,
+      "in": 1.553,
+      "out": 3.106
+    },
+    "cortecs\u0000devstral-2512": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "cortecs\u0000devstral-small-2512": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "cortecs\u0000gemini-2.5-pro": {
+      "cached_read": null,
+      "in": 1.654,
+      "out": 11.024
+    },
+    "cortecs\u0000glm-4.5": {
+      "cached_read": null,
+      "in": 0.67,
+      "out": 2.46
+    },
+    "cortecs\u0000glm-4.5-air": {
+      "cached_read": null,
+      "in": 0.22,
+      "out": 1.34
+    },
+    "cortecs\u0000glm-4.7": {
+      "cached_read": null,
+      "in": 0.45,
+      "out": 2.23
+    },
+    "cortecs\u0000glm-4.7-flash": {
+      "cached_read": null,
+      "in": 0.09,
+      "out": 0.53
+    },
+    "cortecs\u0000glm-5": {
+      "cached_read": null,
+      "in": 1.08,
+      "out": 3.44
+    },
+    "cortecs\u0000glm-5.1": {
+      "cached_read": 0.24,
+      "in": 1.31,
+      "out": 4.1
+    },
+    "cortecs\u0000gpt-4.1": {
+      "cached_read": null,
+      "in": 2.354,
+      "out": 9.417
+    },
+    "cortecs\u0000gpt-5.4": {
+      "cached_read": 0.25,
+      "in": 3.0,
+      "out": 16.13
+    },
+    "cortecs\u0000gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "cortecs\u0000hermes-4-70b": {
+      "cached_read": null,
+      "in": 0.116,
+      "out": 0.358
+    },
+    "cortecs\u0000intellect-3": {
+      "cached_read": null,
+      "in": 0.219,
+      "out": 1.202
+    },
+    "cortecs\u0000kimi-k2-instruct": {
+      "cached_read": null,
+      "in": 0.551,
+      "out": 2.646
+    },
+    "cortecs\u0000kimi-k2-thinking": {
+      "cached_read": null,
+      "in": 0.656,
+      "out": 2.731
+    },
+    "cortecs\u0000kimi-k2.5": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 2.76
+    },
+    "cortecs\u0000kimi-k2.6": {
+      "cached_read": 0.2,
+      "in": 0.81,
+      "out": 3.54
+    },
+    "cortecs\u0000llama-3.1-405b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "cortecs\u0000llama-3.3-70b-instruct": {
+      "cached_read": null,
+      "in": 0.089,
+      "out": 0.275
+    },
+    "cortecs\u0000minimax-m2": {
+      "cached_read": null,
+      "in": 0.39,
+      "out": 1.57
+    },
+    "cortecs\u0000minimax-m2.1": {
+      "cached_read": null,
+      "in": 0.34,
+      "out": 1.34
+    },
+    "cortecs\u0000minimax-m2.5": {
+      "cached_read": null,
+      "in": 0.32,
+      "out": 1.18
+    },
+    "cortecs\u0000minimax-m2.7": {
+      "cached_read": null,
+      "in": 0.47,
+      "out": 1.4
+    },
+    "cortecs\u0000mistral-large-2512": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "cortecs\u0000mixtral-8x7b-instruct-v0.1": {
+      "cached_read": null,
+      "in": 0.438,
+      "out": 0.68
+    },
+    "cortecs\u0000nemotron-3-super-120b-a12b": {
+      "cached_read": null,
+      "in": 0.266,
+      "out": 0.799
+    },
+    "cortecs\u0000nova-pro-v1": {
+      "cached_read": null,
+      "in": 1.016,
+      "out": 4.061
+    },
+    "cortecs\u0000qwen-2.5-72b-instruct": {
+      "cached_read": null,
+      "in": 0.062,
+      "out": 0.231
+    },
+    "cortecs\u0000qwen3-235b-a22b-instruct-2507": {
+      "cached_read": null,
+      "in": 0.062,
+      "out": 0.408
+    },
+    "cortecs\u0000qwen3-32b": {
+      "cached_read": null,
+      "in": 0.099,
+      "out": 0.33
+    },
+    "cortecs\u0000qwen3-coder-30b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.053,
+      "out": 0.222
+    },
+    "cortecs\u0000qwen3-coder-480b-a35b-instruct": {
+      "cached_read": null,
+      "in": 0.441,
+      "out": 1.984
+    },
+    "cortecs\u0000qwen3-coder-next": {
+      "cached_read": null,
+      "in": 0.158,
+      "out": 0.84
+    },
+    "cortecs\u0000qwen3-next-80b-a3b-thinking": {
+      "cached_read": null,
+      "in": 0.164,
+      "out": 1.311
+    },
+    "cortecs\u0000qwen3.5-122b-a10b": {
+      "cached_read": null,
+      "in": 0.444,
+      "out": 3.106
+    },
+    "cortecs\u0000qwen3.5-397b-a17b": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 3.6
+    },
+    "crof\u0000deepseek-v3.2": {
+      "cached_read": 0.04,
+      "in": 0.18,
+      "out": 0.35
+    },
+    "crof\u0000deepseek-v4-flash": {
+      "cached_read": 0.003,
+      "in": 0.12,
+      "out": 0.21
+    },
+    "crof\u0000deepseek-v4-pro": {
+      "cached_read": 0.003,
+      "in": 0.35,
+      "out": 0.8
+    },
+    "crof\u0000deepseek-v4-pro-lightning": {
+      "cached_read": 0.02,
+      "in": 0.8,
+      "out": 1.6
+    },
+    "crof\u0000gemma-4-31b-it": {
+      "cached_read": 0.02,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "crof\u0000glm-4.7": {
+      "cached_read": 0.05,
+      "in": 0.25,
+      "out": 1.1
+    },
+    "crof\u0000glm-4.7-flash": {
+      "cached_read": 0.008,
+      "in": 0.04,
+      "out": 0.3
+    },
+    "crof\u0000glm-5": {
+      "cached_read": 0.1,
+      "in": 0.48,
+      "out": 1.9
+    },
+    "crof\u0000glm-5.1": {
+      "cached_read": 0.08,
+      "in": 0.45,
+      "out": 2.15
+    },
+    "crof\u0000greg-1": {
+      "cached_read": 0.02,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "crof\u0000greg-1-mini": {
+      "cached_read": 0.01,
+      "in": 0.07,
+      "out": 0.15
+    },
+    "crof\u0000greg-1-super": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "crof\u0000greg-rp": {
+      "cached_read": 0.02,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "crof\u0000kimi-k2.5": {
+      "cached_read": 0.07,
+      "in": 0.35,
+      "out": 1.7
+    },
+    "crof\u0000kimi-k2.5-lightning": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "crof\u0000kimi-k2.6": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 1.99
+    },
+    "crof\u0000mimo-v2.5-pro": {
+      "cached_read": 0.003,
+      "in": 0.4,
+      "out": 0.8
+    },
+    "crof\u0000minimax-m2.5": {
+      "cached_read": 0.02,
+      "in": 0.11,
+      "out": 0.95
+    },
+    "crof\u0000qwen3.5-397b-a17b": {
+      "cached_read": 0.07,
+      "in": 0.35,
+      "out": 1.75
+    },
+    "crof\u0000qwen3.5-9b": {
+      "cached_read": 0.008,
+      "in": 0.04,
+      "out": 0.15
+    },
+    "crof\u0000qwen3.6-27b": {
+      "cached_read": 0.04,
+      "in": 0.2,
+      "out": 1.5
+    },
+    "databricks\u0000databricks-claude-haiku-4-5": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "databricks\u0000databricks-claude-opus-4-1": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "databricks\u0000databricks-claude-opus-4-5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "databricks\u0000databricks-claude-opus-4-6": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "databricks\u0000databricks-claude-opus-4-7": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "databricks\u0000databricks-claude-sonnet-4": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "databricks\u0000databricks-claude-sonnet-4-5": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "databricks\u0000databricks-claude-sonnet-4-6": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "databricks\u0000databricks-gemini-2-5-flash": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "databricks\u0000databricks-gemini-2-5-pro": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "databricks\u0000databricks-gemini-3-1-flash-lite": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 1.5
+    },
+    "databricks\u0000databricks-gemini-3-1-pro": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "databricks\u0000databricks-gemini-3-flash": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "databricks\u0000databricks-gemini-3-pro": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "databricks\u0000databricks-gpt-5": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "databricks\u0000databricks-gpt-5-1": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "databricks\u0000databricks-gpt-5-2": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "databricks\u0000databricks-gpt-5-4": {
+      "cached_read": 0.25,
+      "in": 2.5,
+      "out": 15.0
+    },
+    "databricks\u0000databricks-gpt-5-4-mini": {
+      "cached_read": 0.075,
+      "in": 0.75,
+      "out": 4.5
+    },
+    "databricks\u0000databricks-gpt-5-4-nano": {
+      "cached_read": 0.02,
+      "in": 0.2,
+      "out": 1.25
+    },
+    "databricks\u0000databricks-gpt-5-5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 30.0
+    },
+    "databricks\u0000databricks-gpt-5-mini": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "databricks\u0000databricks-gpt-5-nano": {
+      "cached_read": 0.005,
+      "in": 0.05,
+      "out": 0.4
+    },
+    "databricks\u0000databricks-gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.072,
+      "out": 0.28
+    },
+    "databricks\u0000databricks-gpt-oss-20b": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.2
+    },
+    "deepinfra\u0000anthropic/claude-3-7-sonnet-latest": {
+      "cached_read": 0.33,
+      "in": 3.3,
+      "out": 16.5
+    },
+    "deepinfra\u0000anthropic/claude-4-opus": {
+      "cached_read": null,
+      "in": 16.5,
+      "out": 82.5
+    },
+    "deepinfra\u0000deepseek-ai/deepseek-r1-0528": {
+      "cached_read": 0.35,
+      "in": 0.5,
+      "out": 2.15
+    },
+    "deepinfra\u0000deepseek-ai/deepseek-v3.2": {
+      "cached_read": 0.13,
+      "in": 0.26,
+      "out": 0.38
+    },
+    "deepinfra\u0000deepseek-ai/deepseek-v4-flash": {
+      "cached_read": 0.02,
+      "in": 0.1,
+      "out": 0.2
+    },
+    "deepinfra\u0000deepseek-ai/deepseek-v4-pro": {
+      "cached_read": 0.1,
+      "in": 1.3,
+      "out": 2.6
+    },
+    "deepinfra\u0000google/gemma-4-26b-a4b-it": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.34
+    },
+    "deepinfra\u0000google/gemma-4-31b-it": {
+      "cached_read": null,
+      "in": 0.13,
+      "out": 0.38
+    },
+    "deepinfra\u0000meta-llama/llama-3.1-70b-instruct": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 0.4
+    },
+    "deepinfra\u0000meta-llama/llama-3.1-70b-instruct-turbo": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 0.4
+    },
+    "deepinfra\u0000meta-llama/llama-3.1-8b-instruct": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.05
+    },
+    "deepinfra\u0000meta-llama/llama-3.1-8b-instruct-turbo": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.03
+    },
+    "deepinfra\u0000meta-llama/llama-3.3-70b-instruct-turbo": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.32
+    },
+    "deepinfra\u0000meta-llama/llama-4-maverick-17b-128e-instruct-fp8": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "deepinfra\u0000meta-llama/llama-4-scout-17b-16e-instruct": {
+      "cached_read": null,
+      "in": 0.08,
+      "out": 0.3
+    },
+    "deepinfra\u0000minimaxai/minimax-m2": {
+      "cached_read": null,
+      "in": 0.254,
+      "out": 1.02
+    },
+    "deepinfra\u0000minimaxai/minimax-m2.1": {
+      "cached_read": null,
+      "in": 0.28,
+      "out": 1.2
+    },
+    "deepinfra\u0000minimaxai/minimax-m2.5": {
+      "cached_read": 0.03,
+      "in": 0.27,
+      "out": 0.95
+    },
+    "deepinfra\u0000moonshotai/kimi-k2-instruct": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 2.0
+    },
+    "deepinfra\u0000moonshotai/kimi-k2-instruct-0905": {
+      "cached_read": 0.15,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "deepinfra\u0000moonshotai/kimi-k2-thinking": {
+      "cached_read": null,
+      "in": 0.47,
+      "out": 2.0
+    },
+    "deepinfra\u0000moonshotai/kimi-k2.5": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 2.8
+    },
+    "deepinfra\u0000moonshotai/kimi-k2.6": {
+      "cached_read": 0.15,
+      "in": 0.75,
+      "out": 3.5
+    },
+    "deepinfra\u0000openai/gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.24
+    },
+    "deepinfra\u0000openai/gpt-oss-20b": {
+      "cached_read": null,
+      "in": 0.03,
+      "out": 0.14
+    },
+    "deepinfra\u0000qwen/qwen3-coder-480b-a35b-instruct": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 1.6
+    },
+    "deepinfra\u0000qwen/qwen3-coder-480b-a35b-instruct-turbo": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "deepinfra\u0000qwen/qwen3.5-35b-a3b": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.95
+    },
+    "deepinfra\u0000qwen/qwen3.5-397b-a17b": {
+      "cached_read": null,
+      "in": 0.54,
+      "out": 3.4
+    },
+    "deepinfra\u0000qwen/qwen3.6-35b-a3b": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 1.0
+    },
+    "deepinfra\u0000xiaomimimo/mimo-v2.5": {
+      "cached_read": 0.08,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "deepinfra\u0000xiaomimimo/mimo-v2.5-pro": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "deepinfra\u0000zai-org/glm-4.5": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "deepinfra\u0000zai-org/glm-4.6": {
+      "cached_read": 0.08,
+      "in": 0.43,
+      "out": 1.74
+    },
+    "deepinfra\u0000zai-org/glm-4.6v": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.9
+    },
+    "deepinfra\u0000zai-org/glm-4.7": {
+      "cached_read": 0.08,
+      "in": 0.43,
+      "out": 1.75
+    },
+    "deepinfra\u0000zai-org/glm-4.7-flash": {
+      "cached_read": null,
+      "in": 0.06,
+      "out": 0.4
+    },
+    "deepinfra\u0000zai-org/glm-5": {
+      "cached_read": 0.16,
+      "in": 0.8,
+      "out": 2.56
+    },
+    "deepinfra\u0000zai-org/glm-5.1": {
+      "cached_read": 0.26,
+      "in": 1.4,
+      "out": 4.4
+    },
+    "deepseek\u0000deepseek-chat": {
+      "cached_read": 0.0028,
+      "in": 0.14,
+      "out": 0.28
+    },
+    "deepseek\u0000deepseek-reasoner": {
+      "cached_read": 0.0028,
+      "in": 0.14,
+      "out": 0.28
+    },
+    "deepseek\u0000deepseek-v4-flash": {
+      "cached_read": 0.0028,
+      "in": 0.14,
+      "out": 0.28
+    },
+    "deepseek\u0000deepseek-v4-pro": {
+      "cached_read": 0.003625,
+      "in": 0.435,
+      "out": 0.87
+    },
+    "digitalocean\u0000alibaba-qwen3-32b": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 0.55
+    },
+    "digitalocean\u0000all-mini-lm-l6-v2": {
+      "cached_read": null,
+      "in": 0.009,
+      "out": 0.0
+    },
+    "digitalocean\u0000anthropic-claude-3-opus": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "digitalocean\u0000anthropic-claude-3.5-haiku": {
+      "cached_read": 0.08,
+      "in": 0.8,
+      "out": 4.0
+    },
+    "digitalocean\u0000anthropic-claude-3.5-sonnet": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "digitalocean\u0000anthropic-claude-3.7-sonnet": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "digitalocean\u0000anthropic-claude-4.1-opus": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "digitalocean\u0000anthropic-claude-4.5-haiku": {
+      "cached_read": 1.0,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "digitalocean\u0000anthropic-claude-4.5-sonnet": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "digitalocean\u0000anthropic-claude-4.6-sonnet": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "digitalocean\u0000anthropic-claude-haiku-4.5": {
+      "cached_read": 1.0,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "digitalocean\u0000anthropic-claude-opus-4": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "digitalocean\u0000anthropic-claude-opus-4.5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "digitalocean\u0000anthropic-claude-opus-4.6": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "digitalocean\u0000anthropic-claude-opus-4.7": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "digitalocean\u0000anthropic-claude-opus-4.8": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "digitalocean\u0000anthropic-claude-sonnet-4": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "digitalocean\u0000arcee-trinity-large-thinking": {
+      "cached_read": 0.06,
+      "in": 0.25,
+      "out": 0.9
+    },
+    "digitalocean\u0000bge-m3": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.0
+    },
+    "digitalocean\u0000bge-reranker-v2-m3": {
+      "cached_read": null,
+      "in": 0.01,
+      "out": 0.0
+    },
+    "digitalocean\u0000deepseek-3.2": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.6
+    },
+    "digitalocean\u0000deepseek-r1-distill-llama-70b": {
+      "cached_read": null,
+      "in": 0.99,
+      "out": 0.99
+    },
+    "digitalocean\u0000deepseek-v4-pro": {
+      "cached_read": null,
+      "in": 1.74,
+      "out": 3.48
+    },
+    "digitalocean\u0000e5-large-v2": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.0
+    },
+    "digitalocean\u0000gemma-4-31b-it": {
+      "cached_read": null,
+      "in": 0.18,
+      "out": 0.5
+    },
+    "digitalocean\u0000glm-5": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 3.2
+    },
+    "digitalocean\u0000gte-large-en-v1.5": {
+      "cached_read": null,
+      "in": 0.09,
+      "out": 0.0
+    },
+    "digitalocean\u0000kimi-k2.5": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 2.7
+    },
+    "digitalocean\u0000kimi-k2.6": {
+      "cached_read": null,
+      "in": 0.95,
+      "out": 4.0
+    },
+    "digitalocean\u0000llama-4-maverick": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 0.87
+    },
+    "digitalocean\u0000llama3-8b-instruct": {
+      "cached_read": null,
+      "in": 0.198,
+      "out": 0.198
+    },
+    "digitalocean\u0000llama3.3-70b-instruct": {
+      "cached_read": null,
+      "in": 0.65,
+      "out": 0.65
+    },
+    "digitalocean\u0000minimax-m2.5": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "digitalocean\u0000mistral-3-14b": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "digitalocean\u0000mistral-nemo-instruct-2407": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.3
+    },
+    "digitalocean\u0000multi-qa-mpnet-base-dot-v1": {
+      "cached_read": null,
+      "in": 0.009,
+      "out": 0.0
+    },
+    "digitalocean\u0000nemotron-3-nano-omni": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 0.9
+    },
+    "digitalocean\u0000nemotron-nano-12b-v2-vl": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.6
+    },
+    "digitalocean\u0000nvidia-nemotron-3-super-120b": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.65
+    },
+    "digitalocean\u0000openai-gpt-4.1": {
+      "cached_read": 0.5,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "digitalocean\u0000openai-gpt-4o": {
+      "cached_read": 1.25,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "digitalocean\u0000openai-gpt-4o-mini": {
+      "cached_read": 0.075,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "digitalocean\u0000openai-gpt-5": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "digitalocean\u0000openai-gpt-5-mini": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "digitalocean\u0000openai-gpt-5-nano": {
+      "cached_read": 0.005,
+      "in": 0.05,
+      "out": 0.4
+    },
+    "digitalocean\u0000openai-gpt-5.1-codex-max": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "digitalocean\u0000openai-gpt-5.2": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "digitalocean\u0000openai-gpt-5.2-pro": {
+      "cached_read": null,
+      "in": 21.0,
+      "out": 168.0
+    },
+    "digitalocean\u0000openai-gpt-5.3-codex": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "digitalocean\u0000openai-gpt-5.4": {
+      "cached_read": 0.25,
+      "in": 2.5,
+      "out": 15.0
+    },
+    "digitalocean\u0000openai-gpt-5.4-mini": {
+      "cached_read": 0.075,
+      "in": 0.75,
+      "out": 4.5
+    },
+    "digitalocean\u0000openai-gpt-5.4-nano": {
+      "cached_read": 0.02,
+      "in": 0.2,
+      "out": 1.25
+    },
+    "digitalocean\u0000openai-gpt-5.4-pro": {
+      "cached_read": null,
+      "in": 30.0,
+      "out": 180.0
+    },
+    "digitalocean\u0000openai-gpt-5.5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 30.0
+    },
+    "digitalocean\u0000openai-gpt-image-1": {
+      "cached_read": 1.25,
+      "in": 5.0,
+      "out": 40.0
+    },
+    "digitalocean\u0000openai-gpt-image-1.5": {
+      "cached_read": 1.0,
+      "in": 5.0,
+      "out": 10.0
+    },
+    "digitalocean\u0000openai-gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.7
+    },
+    "digitalocean\u0000openai-gpt-oss-20b": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.45
+    },
+    "digitalocean\u0000openai-o1": {
+      "cached_read": 7.5,
+      "in": 15.0,
+      "out": 60.0
+    },
+    "digitalocean\u0000openai-o3": {
+      "cached_read": 0.5,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "digitalocean\u0000openai-o3-mini": {
+      "cached_read": 0.55,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "digitalocean\u0000qwen3-coder-flash": {
+      "cached_read": null,
+      "in": 0.45,
+      "out": 1.7
+    },
+    "digitalocean\u0000qwen3-embedding-0.6b": {
+      "cached_read": null,
+      "in": 0.04,
+      "out": 0.0
+    },
+    "digitalocean\u0000qwen3.5-397b-a17b": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 3.5
+    },
+    "digitalocean\u0000stable-diffusion-3.5-large": {
+      "cached_read": null,
+      "in": 0.08,
+      "out": 0.0
+    },
+    "digitalocean\u0000wan2-2-t2v-a14b": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 0.0
+    },
+    "dinference\u0000glm-4.7": {
+      "cached_read": null,
+      "in": 0.45,
+      "out": 1.65
+    },
+    "dinference\u0000glm-5": {
+      "cached_read": null,
+      "in": 0.75,
+      "out": 2.4
+    },
+    "dinference\u0000glm-5.1": {
+      "cached_read": null,
+      "in": 1.25,
+      "out": 3.89
+    },
+    "dinference\u0000gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.0675,
+      "out": 0.27
+    },
+    "dinference\u0000minimax-m2.5": {
+      "cached_read": null,
+      "in": 0.22,
+      "out": 0.88
+    },
+    "drun\u0000public/deepseek-r1": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 2.2
+    },
+    "drun\u0000public/deepseek-v3": {
+      "cached_read": null,
+      "in": 0.28,
+      "out": 1.1
+    },
+    "drun\u0000public/minimax-m25": {
+      "cached_read": null,
+      "in": 0.29,
+      "out": 1.16
+    },
+    "evroc\u0000intfloat/multilingual-e5-large-instruct": {
+      "cached_read": null,
+      "in": 0.12,
+      "out": 0.12
+    },
+    "evroc\u0000kblab/kb-whisper-large": {
+      "cached_read": null,
+      "in": 0.00236,
+      "out": 0.00236
+    },
+    "evroc\u0000microsoft/phi-4-multimodal-instruct": {
+      "cached_read": null,
+      "in": 0.24,
+      "out": 0.47
+    },
+    "evroc\u0000mistralai/devstral-small-2-24b-instruct-2512": {
+      "cached_read": null,
+      "in": 0.12,
+      "out": 0.47
+    },
+    "evroc\u0000mistralai/magistral-small-2509": {
+      "cached_read": null,
+      "in": 0.59,
+      "out": 2.36
+    },
+    "evroc\u0000mistralai/voxtral-small-24b-2507": {
+      "cached_read": null,
+      "in": 0.00236,
+      "out": 0.00236
+    },
+    "evroc\u0000moonshotai/kimi-k2.5": {
+      "cached_read": null,
+      "in": 1.47,
+      "out": 5.9
+    },
+    "evroc\u0000nvidia/llama-3.3-70b-instruct-fp8": {
+      "cached_read": null,
+      "in": 1.18,
+      "out": 1.18
+    },
+    "evroc\u0000openai/gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.24,
+      "out": 0.94
+    },
+    "evroc\u0000openai/whisper-large-v3": {
+      "cached_read": null,
+      "in": 0.00236,
+      "out": 0.00236
+    },
+    "evroc\u0000qwen/qwen3-30b-a3b-instruct-2507-fp8": {
+      "cached_read": null,
+      "in": 0.35,
+      "out": 1.42
+    },
+    "evroc\u0000qwen/qwen3-embedding-8b": {
+      "cached_read": null,
+      "in": 0.12,
+      "out": 0.12
+    },
+    "evroc\u0000qwen/qwen3-vl-30b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.24,
+      "out": 0.94
+    },
+    "fastrouter\u0000anthropic/claude-opus-4.1": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "fastrouter\u0000anthropic/claude-sonnet-4": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "fastrouter\u0000deepseek-ai/deepseek-r1-distill-llama-70b": {
+      "cached_read": null,
+      "in": 0.03,
+      "out": 0.14
+    },
+    "fastrouter\u0000google/gemini-2.5-flash": {
+      "cached_read": 0.0375,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "fastrouter\u0000google/gemini-2.5-pro": {
+      "cached_read": 0.31,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "fastrouter\u0000moonshotai/kimi-k2": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 2.2
+    },
+    "fastrouter\u0000openai/gpt-4.1": {
+      "cached_read": 0.5,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "fastrouter\u0000openai/gpt-5": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "fastrouter\u0000openai/gpt-5-mini": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "fastrouter\u0000openai/gpt-5-nano": {
+      "cached_read": 0.005,
+      "in": 0.05,
+      "out": 0.4
+    },
+    "fastrouter\u0000openai/gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "fastrouter\u0000openai/gpt-oss-20b": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.2
+    },
+    "fastrouter\u0000qwen/qwen3-coder": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "fastrouter\u0000x-ai/grok-4": {
+      "cached_read": 0.75,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "fastrouter\u0000z-ai/glm-5": {
+      "cached_read": null,
+      "in": 0.95,
+      "out": 3.15
+    },
+    "firepass\u0000accounts/fireworks/routers/kimi-k2p6-turbo": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "fireworks\u0000accounts/fireworks/models/deepseek-v4-flash": {
+      "cached_read": 0.03,
+      "in": 0.14,
+      "out": 0.28
+    },
+    "fireworks\u0000accounts/fireworks/models/deepseek-v4-pro": {
+      "cached_read": 0.145,
+      "in": 1.74,
+      "out": 3.48
+    },
+    "fireworks\u0000accounts/fireworks/models/glm-5p1": {
+      "cached_read": 0.26,
+      "in": 1.4,
+      "out": 4.4
+    },
+    "fireworks\u0000accounts/fireworks/models/gpt-oss-120b": {
+      "cached_read": 0.015,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "fireworks\u0000accounts/fireworks/models/gpt-oss-20b": {
+      "cached_read": 0.035,
+      "in": 0.07,
+      "out": 0.3
+    },
+    "fireworks\u0000accounts/fireworks/models/kimi-k2p5": {
+      "cached_read": 0.1,
+      "in": 0.6,
+      "out": 3.0
+    },
+    "fireworks\u0000accounts/fireworks/models/kimi-k2p6": {
+      "cached_read": 0.16,
+      "in": 0.95,
+      "out": 4.0
+    },
+    "fireworks\u0000accounts/fireworks/models/minimax-m2p5": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "fireworks\u0000accounts/fireworks/models/minimax-m2p7": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "fireworks\u0000accounts/fireworks/models/qwen3p6-plus": {
+      "cached_read": 0.1,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "fireworks\u0000accounts/fireworks/routers/glm-5p1-fast": {
+      "cached_read": 0.52,
+      "in": 2.8,
+      "out": 8.8
+    },
+    "fireworks\u0000accounts/fireworks/routers/kimi-k2p6-fast": {
+      "cached_read": 0.3,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "fireworks\u0000accounts/fireworks/routers/kimi-k2p6-turbo": {
+      "cached_read": 0.3,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "freemodel\u0000claude-haiku-4-5-20251001": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "freemodel\u0000claude-opus-4-6": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "freemodel\u0000claude-opus-4-7": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "freemodel\u0000claude-opus-4-8": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "freemodel\u0000claude-sonnet-4-6": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "freemodel\u0000gpt-5.3-codex": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "freemodel\u0000gpt-5.4": {
+      "cached_read": 0.25,
+      "in": 2.5,
+      "out": 15.0
+    },
+    "freemodel\u0000gpt-5.4-mini": {
+      "cached_read": 0.075,
+      "in": 0.75,
+      "out": 4.5
+    },
+    "freemodel\u0000gpt-5.5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 30.0
+    },
+    "friendli\u0000meta-llama/llama-3.1-8b-instruct": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "friendli\u0000meta-llama/llama-3.3-70b-instruct": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 0.6
+    },
+    "friendli\u0000minimaxai/minimax-m2.5": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "friendli\u0000qwen/qwen3-235b-a22b-instruct-2507": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.8
+    },
+    "friendli\u0000zai-org/glm-5": {
+      "cached_read": 0.5,
+      "in": 1.0,
+      "out": 3.2
+    },
+    "friendli\u0000zai-org/glm-5.1": {
+      "cached_read": 0.26,
+      "in": 1.4,
+      "out": 4.4
+    },
+    "frogbot\u0000claude-haiku-4-5": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "frogbot\u0000claude-opus-4-6": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "frogbot\u0000claude-opus-4-7": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "frogbot\u0000claude-sonnet-4-6": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "frogbot\u0000deepseek-v4-pro": {
+      "cached_read": 0.14,
+      "in": 1.74,
+      "out": 3.48
+    },
+    "frogbot\u0000gemini-2.5-flash": {
+      "cached_read": 0.075,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "frogbot\u0000gemini-2.5-pro": {
+      "cached_read": 0.31,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "frogbot\u0000gemini-3-1-pro-preview": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "frogbot\u0000gemini-3-flash-preview": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "frogbot\u0000gpt-4o": {
+      "cached_read": 1.25,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "frogbot\u0000gpt-5-3-codex": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "frogbot\u0000gpt-5-4-mini": {
+      "cached_read": 0.075,
+      "in": 0.75,
+      "out": 4.5
+    },
+    "frogbot\u0000gpt-5-4-nano": {
+      "cached_read": 0.02,
+      "in": 0.2,
+      "out": 1.25
+    },
+    "frogbot\u0000gpt-5-5": {
+      "cached_read": 0.25,
+      "in": 2.5,
+      "out": 15.0
+    },
+    "frogbot\u0000gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "frogbot\u0000gpt-oss-20b": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.2
+    },
+    "frogbot\u0000grok-4-1-fast-non-reasoning": {
+      "cached_read": 0.05,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "frogbot\u0000grok-4-1-fast-reasoning": {
+      "cached_read": 0.05,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "frogbot\u0000grok-4-3": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "frogbot\u0000grok-code-fast-1": {
+      "cached_read": 0.02,
+      "in": 0.2,
+      "out": 1.5
+    },
+    "frogbot\u0000kimi-k2-6": {
+      "cached_read": 0.16,
+      "in": 0.95,
+      "out": 4.0
+    },
+    "frogbot\u0000kimi-k2.5": {
+      "cached_read": 0.1,
+      "in": 0.6,
+      "out": 3.0
+    },
+    "frogbot\u0000minimax-m2-5": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "frogbot\u0000minimax-m2-7": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "frogbot\u0000qwen-3-6-plus": {
+      "cached_read": 0.1,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "frogbot\u0000zai-glm-5-1": {
+      "cached_read": 0.26,
+      "in": 1.4,
+      "out": 4.4
+    },
+    "github-copilot\u0000claude-haiku-4.5": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "github-copilot\u0000claude-opus-4.5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "github-copilot\u0000claude-opus-4.6": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "github-copilot\u0000claude-opus-4.7": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "github-copilot\u0000claude-opus-4.8": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "github-copilot\u0000claude-sonnet-4": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "github-copilot\u0000claude-sonnet-4.5": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "github-copilot\u0000claude-sonnet-4.6": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "github-copilot\u0000gemini-2.5-pro": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "github-copilot\u0000gemini-3-flash-preview": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "github-copilot\u0000gemini-3.1-pro-preview": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "github-copilot\u0000gemini-3.5-flash": {
+      "cached_read": 0.15,
+      "in": 1.5,
+      "out": 9.0
+    },
+    "github-copilot\u0000gpt-4.1": {
+      "cached_read": 0.5,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "github-copilot\u0000gpt-5-mini": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "github-copilot\u0000gpt-5.2": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "github-copilot\u0000gpt-5.2-codex": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "github-copilot\u0000gpt-5.3-codex": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "github-copilot\u0000gpt-5.4": {
+      "cached_read": 0.25,
+      "in": 2.5,
+      "out": 15.0
+    },
+    "github-copilot\u0000gpt-5.4-mini": {
+      "cached_read": 0.075,
+      "in": 0.75,
+      "out": 4.5
+    },
+    "github-copilot\u0000gpt-5.4-nano": {
+      "cached_read": 0.02,
+      "in": 0.2,
+      "out": 1.25
+    },
+    "github-copilot\u0000gpt-5.5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 30.0
+    },
+    "github-copilot\u0000raptor-mini": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "github-models\u0000ai21-labs/ai21-jamba-1.5-large": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000ai21-labs/ai21-jamba-1.5-mini": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000cohere/cohere-command-a": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000cohere/cohere-command-r": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000cohere/cohere-command-r-08-2024": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000cohere/cohere-command-r-plus": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000cohere/cohere-command-r-plus-08-2024": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000core42/jais-30b-chat": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000deepseek/deepseek-r1": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000deepseek/deepseek-r1-0528": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000deepseek/deepseek-v3-0324": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000meta/llama-3.2-11b-vision-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000meta/llama-3.2-90b-vision-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000meta/llama-3.3-70b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000meta/llama-4-maverick-17b-128e-instruct-fp8": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000meta/llama-4-scout-17b-16e-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000meta/meta-llama-3-70b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000meta/meta-llama-3-8b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000meta/meta-llama-3.1-405b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000meta/meta-llama-3.1-70b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000meta/meta-llama-3.1-8b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000microsoft/mai-ds-r1": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000microsoft/phi-3-medium-128k-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000microsoft/phi-3-medium-4k-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000microsoft/phi-3-mini-128k-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000microsoft/phi-3-mini-4k-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000microsoft/phi-3-small-128k-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000microsoft/phi-3-small-8k-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000microsoft/phi-3.5-mini-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000microsoft/phi-3.5-moe-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000microsoft/phi-3.5-vision-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000microsoft/phi-4": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000microsoft/phi-4-mini-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000microsoft/phi-4-mini-reasoning": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000microsoft/phi-4-multimodal-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000microsoft/phi-4-reasoning": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000mistral-ai/codestral-2501": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000mistral-ai/ministral-3b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000mistral-ai/mistral-large-2411": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000mistral-ai/mistral-medium-2505": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000mistral-ai/mistral-nemo": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000mistral-ai/mistral-small-2503": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000openai/gpt-4.1": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000openai/gpt-4.1-mini": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000openai/gpt-4.1-nano": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000openai/gpt-4o": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000openai/gpt-4o-mini": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000openai/o1": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000openai/o1-mini": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000openai/o1-preview": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000openai/o3": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000openai/o3-mini": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000openai/o4-mini": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000xai/grok-3": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "github-models\u0000xai/grok-3-mini": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "gitlab\u0000duo-chat-gpt-5-1": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "gitlab\u0000duo-chat-gpt-5-2": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "gitlab\u0000duo-chat-gpt-5-2-codex": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "gitlab\u0000duo-chat-gpt-5-3-codex": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "gitlab\u0000duo-chat-gpt-5-4": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "gitlab\u0000duo-chat-gpt-5-4-mini": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "gitlab\u0000duo-chat-gpt-5-4-nano": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "gitlab\u0000duo-chat-gpt-5-5": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "gitlab\u0000duo-chat-gpt-5-codex": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "gitlab\u0000duo-chat-gpt-5-mini": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "gitlab\u0000duo-chat-haiku-4-5": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "gitlab\u0000duo-chat-opus-4-5": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "gitlab\u0000duo-chat-opus-4-6": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "gitlab\u0000duo-chat-opus-4-7": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "gitlab\u0000duo-chat-opus-4-8": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "gitlab\u0000duo-chat-sonnet-4-5": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "gitlab\u0000duo-chat-sonnet-4-6": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "gmicloud\u0000anthropic/claude-opus-4.6": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "gmicloud\u0000anthropic/claude-opus-4.7": {
+      "cached_read": 0.45,
+      "in": 4.5,
+      "out": 22.5
+    },
+    "gmicloud\u0000anthropic/claude-sonnet-4.6": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "gmicloud\u0000deepseek-ai/deepseek-v4-flash": {
+      "cached_read": 0.022,
+      "in": 0.112,
+      "out": 0.224
+    },
+    "gmicloud\u0000deepseek-ai/deepseek-v4-pro": {
+      "cached_read": 0.116,
+      "in": 1.392,
+      "out": 2.784
+    },
+    "gmicloud\u0000moonshotai/kimi-k2.6": {
+      "cached_read": 0.144,
+      "in": 0.855,
+      "out": 3.6
+    },
+    "gmicloud\u0000zai-org/glm-5-fp8": {
+      "cached_read": 0.12,
+      "in": 0.6,
+      "out": 1.92
+    },
+    "gmicloud\u0000zai-org/glm-5.1-fp8": {
+      "cached_read": 0.182,
+      "in": 0.98,
+      "out": 3.08
+    },
+    "google\u0000gemini-2.0-flash": {
+      "cached_read": 0.025,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "google\u0000gemini-2.0-flash-lite": {
+      "cached_read": null,
+      "in": 0.075,
+      "out": 0.3
+    },
+    "google\u0000gemini-2.5-flash": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "google\u0000gemini-2.5-flash-image": {
+      "cached_read": 0.075,
+      "in": 0.3,
+      "out": 30.0
+    },
+    "google\u0000gemini-2.5-flash-lite": {
+      "cached_read": 0.01,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "google\u0000gemini-2.5-flash-preview-tts": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 10.0
+    },
+    "google\u0000gemini-2.5-pro": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "google\u0000gemini-2.5-pro-preview-tts": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 20.0
+    },
+    "google\u0000gemini-3-flash-preview": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "google\u0000gemini-3-pro-image-preview": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 120.0
+    },
+    "google\u0000gemini-3-pro-preview": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "google\u0000gemini-3.1-flash-image-preview": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 60.0
+    },
+    "google\u0000gemini-3.1-flash-lite": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 1.5
+    },
+    "google\u0000gemini-3.1-flash-lite-preview": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 1.5
+    },
+    "google\u0000gemini-3.1-pro-preview": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "google\u0000gemini-3.1-pro-preview-customtools": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "google\u0000gemini-3.5-flash": {
+      "cached_read": 0.15,
+      "in": 1.5,
+      "out": 9.0
+    },
+    "google\u0000gemini-embedding-001": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.0
+    },
+    "google\u0000gemini-flash-latest": {
+      "cached_read": 0.075,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "google\u0000gemini-flash-lite-latest": {
+      "cached_read": 0.025,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "google-vertex\u0000claude-3-5-haiku@20241022": {
+      "cached_read": 0.08,
+      "in": 0.8,
+      "out": 4.0
+    },
+    "google-vertex\u0000claude-3-5-sonnet@20241022": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "google-vertex\u0000claude-3-7-sonnet@20250219": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "google-vertex\u0000claude-haiku-4-5@20251001": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "google-vertex\u0000claude-opus-4-1@20250805": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "google-vertex\u0000claude-opus-4-5@20251101": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "google-vertex\u0000claude-opus-4-6@default": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "google-vertex\u0000claude-opus-4-7@default": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "google-vertex\u0000claude-opus-4-8@default": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "google-vertex\u0000claude-opus-4@20250514": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "google-vertex\u0000claude-sonnet-4-5@20250929": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "google-vertex\u0000claude-sonnet-4-6@default": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "google-vertex\u0000claude-sonnet-4@20250514": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "google-vertex\u0000deepseek-ai/deepseek-v3.1-maas": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 1.7
+    },
+    "google-vertex\u0000deepseek-ai/deepseek-v3.2-maas": {
+      "cached_read": 0.056,
+      "in": 0.56,
+      "out": 1.68
+    },
+    "google-vertex\u0000gemini-2.0-flash": {
+      "cached_read": 0.025,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "google-vertex\u0000gemini-2.0-flash-lite": {
+      "cached_read": null,
+      "in": 0.075,
+      "out": 0.3
+    },
+    "google-vertex\u0000gemini-2.5-flash": {
+      "cached_read": 0.075,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "google-vertex\u0000gemini-2.5-flash-lite": {
+      "cached_read": 0.01,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "google-vertex\u0000gemini-2.5-flash-lite-preview-06-17": {
+      "cached_read": 0.025,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "google-vertex\u0000gemini-2.5-flash-preview-09-2025": {
+      "cached_read": 0.075,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "google-vertex\u0000gemini-2.5-flash-tts": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 10.0
+    },
+    "google-vertex\u0000gemini-2.5-pro": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "google-vertex\u0000gemini-2.5-pro-tts": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 20.0
+    },
+    "google-vertex\u0000gemini-3-flash-preview": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "google-vertex\u0000gemini-3-pro-preview": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "google-vertex\u0000gemini-3.1-flash-lite": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 1.5
+    },
+    "google-vertex\u0000gemini-3.1-flash-lite-preview": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 1.5
+    },
+    "google-vertex\u0000gemini-3.1-pro-preview": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "google-vertex\u0000gemini-3.1-pro-preview-customtools": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "google-vertex\u0000gemini-3.5-flash": {
+      "cached_read": 0.15,
+      "in": 1.5,
+      "out": 9.0
+    },
+    "google-vertex\u0000gemini-embedding-001": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.0
+    },
+    "google-vertex\u0000gemini-flash-latest": {
+      "cached_read": 0.075,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "google-vertex\u0000gemini-flash-lite-latest": {
+      "cached_read": 0.025,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "google-vertex\u0000meta/llama-3.3-70b-instruct-maas": {
+      "cached_read": null,
+      "in": 0.72,
+      "out": 0.72
+    },
+    "google-vertex\u0000meta/llama-4-maverick-17b-128e-instruct-maas": {
+      "cached_read": null,
+      "in": 0.35,
+      "out": 1.15
+    },
+    "google-vertex\u0000moonshotai/kimi-k2-thinking-maas": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.5
+    },
+    "google-vertex\u0000openai/gpt-oss-120b-maas": {
+      "cached_read": null,
+      "in": 0.09,
+      "out": 0.36
+    },
+    "google-vertex\u0000openai/gpt-oss-20b-maas": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.25
+    },
+    "google-vertex\u0000qwen/qwen3-235b-a22b-instruct-2507-maas": {
+      "cached_read": null,
+      "in": 0.22,
+      "out": 0.88
+    },
+    "google-vertex\u0000zai-org/glm-4.7-maas": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "google-vertex\u0000zai-org/glm-5-maas": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 3.2
+    },
+    "google-vertex-anthropic\u0000claude-3-5-haiku@20241022": {
+      "cached_read": 0.08,
+      "in": 0.8,
+      "out": 4.0
+    },
+    "google-vertex-anthropic\u0000claude-3-5-sonnet@20241022": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "google-vertex-anthropic\u0000claude-3-7-sonnet@20250219": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "google-vertex-anthropic\u0000claude-haiku-4-5@20251001": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "google-vertex-anthropic\u0000claude-opus-4-1@20250805": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "google-vertex-anthropic\u0000claude-opus-4-5@20251101": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "google-vertex-anthropic\u0000claude-opus-4-6@default": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "google-vertex-anthropic\u0000claude-opus-4-7@default": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "google-vertex-anthropic\u0000claude-opus-4-8@default": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "google-vertex-anthropic\u0000claude-opus-4@20250514": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "google-vertex-anthropic\u0000claude-sonnet-4-5@20250929": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "google-vertex-anthropic\u0000claude-sonnet-4-6@default": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "google-vertex-anthropic\u0000claude-sonnet-4@20250514": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "groq\u0000allam-2-7b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "groq\u0000canopylabs/orpheus-arabic-saudi": {
+      "cached_read": null,
+      "in": 40.0,
+      "out": 0.0
+    },
+    "groq\u0000canopylabs/orpheus-v1-english": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "groq\u0000deepseek-r1-distill-llama-70b": {
+      "cached_read": null,
+      "in": 0.75,
+      "out": 0.99
+    },
+    "groq\u0000gemma2-9b-it": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "groq\u0000groq/compound": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "groq\u0000groq/compound-mini": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "groq\u0000llama-3.1-8b-instant": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.08
+    },
+    "groq\u0000llama-3.3-70b-versatile": {
+      "cached_read": null,
+      "in": 0.59,
+      "out": 0.79
+    },
+    "groq\u0000llama-guard-3-8b": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "groq\u0000llama3-70b-8192": {
+      "cached_read": null,
+      "in": 0.59,
+      "out": 0.79
+    },
+    "groq\u0000llama3-8b-8192": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.08
+    },
+    "groq\u0000meta-llama/llama-4-maverick-17b-128e-instruct": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.6
+    },
+    "groq\u0000meta-llama/llama-4-scout-17b-16e-instruct": {
+      "cached_read": null,
+      "in": 0.11,
+      "out": 0.34
+    },
+    "groq\u0000meta-llama/llama-guard-4-12b": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "groq\u0000meta-llama/llama-prompt-guard-2-22m": {
+      "cached_read": null,
+      "in": 0.03,
+      "out": 0.03
+    },
+    "groq\u0000meta-llama/llama-prompt-guard-2-86m": {
+      "cached_read": null,
+      "in": 0.04,
+      "out": 0.04
+    },
+    "groq\u0000mistral-saba-24b": {
+      "cached_read": null,
+      "in": 0.79,
+      "out": 0.79
+    },
+    "groq\u0000moonshotai/kimi-k2-instruct": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "groq\u0000moonshotai/kimi-k2-instruct-0905": {
+      "cached_read": 0.5,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "groq\u0000openai/gpt-oss-120b": {
+      "cached_read": 0.075,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "groq\u0000openai/gpt-oss-20b": {
+      "cached_read": 0.0375,
+      "in": 0.075,
+      "out": 0.3
+    },
+    "groq\u0000openai/gpt-oss-safeguard-20b": {
+      "cached_read": 0.037,
+      "in": 0.075,
+      "out": 0.3
+    },
+    "groq\u0000qwen-qwq-32b": {
+      "cached_read": null,
+      "in": 0.29,
+      "out": 0.39
+    },
+    "groq\u0000qwen/qwen3-32b": {
+      "cached_read": null,
+      "in": 0.29,
+      "out": 0.59
+    },
+    "groq\u0000whisper-large-v3": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "groq\u0000whisper-large-v3-turbo": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "helicone\u0000chatgpt-4o-latest": {
+      "cached_read": 2.5,
+      "in": 5.0,
+      "out": 20.0
+    },
+    "helicone\u0000claude-3-haiku-20240307": {
+      "cached_read": 0.03,
+      "in": 0.25,
+      "out": 1.25
+    },
+    "helicone\u0000claude-3.5-haiku": {
+      "cached_read": 0.08,
+      "in": 0.7999999999999999,
+      "out": 4.0
+    },
+    "helicone\u0000claude-3.5-sonnet-v2": {
+      "cached_read": 0.30000000000000004,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "helicone\u0000claude-3.7-sonnet": {
+      "cached_read": 0.30000000000000004,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "helicone\u0000claude-4.5-haiku": {
+      "cached_read": 0.09999999999999999,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "helicone\u0000claude-4.5-opus": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "helicone\u0000claude-4.5-sonnet": {
+      "cached_read": 0.30000000000000004,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "helicone\u0000claude-haiku-4-5-20251001": {
+      "cached_read": 0.09999999999999999,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "helicone\u0000claude-opus-4": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "helicone\u0000claude-opus-4-1": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "helicone\u0000claude-opus-4-1-20250805": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "helicone\u0000claude-sonnet-4": {
+      "cached_read": 0.30000000000000004,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "helicone\u0000claude-sonnet-4-5-20250929": {
+      "cached_read": 0.30000000000000004,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "helicone\u0000deepseek-r1-distill-llama-70b": {
+      "cached_read": null,
+      "in": 0.03,
+      "out": 0.13
+    },
+    "helicone\u0000deepseek-reasoner": {
+      "cached_read": 0.07,
+      "in": 0.56,
+      "out": 1.68
+    },
+    "helicone\u0000deepseek-tng-r1t2-chimera": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "helicone\u0000deepseek-v3": {
+      "cached_read": 0.07,
+      "in": 0.56,
+      "out": 1.68
+    },
+    "helicone\u0000deepseek-v3.1-terminus": {
+      "cached_read": 0.21600000000000003,
+      "in": 0.27,
+      "out": 1.0
+    },
+    "helicone\u0000deepseek-v3.2": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 0.41
+    },
+    "helicone\u0000ernie-4.5-21b-a3b-thinking": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.28
+    },
+    "helicone\u0000gemini-2.5-flash": {
+      "cached_read": 0.075,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "helicone\u0000gemini-2.5-flash-lite": {
+      "cached_read": 0.024999999999999998,
+      "in": 0.09999999999999999,
+      "out": 0.39999999999999997
+    },
+    "helicone\u0000gemini-2.5-pro": {
+      "cached_read": 0.3125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "helicone\u0000gemini-3-pro-preview": {
+      "cached_read": 0.19999999999999998,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "helicone\u0000gemma-3-12b-it": {
+      "cached_read": null,
+      "in": 0.049999999999999996,
+      "out": 0.09999999999999999
+    },
+    "helicone\u0000gemma2-9b-it": {
+      "cached_read": null,
+      "in": 0.01,
+      "out": 0.03
+    },
+    "helicone\u0000glm-4.6": {
+      "cached_read": null,
+      "in": 0.44999999999999996,
+      "out": 1.5
+    },
+    "helicone\u0000gpt-4.1": {
+      "cached_read": 0.5,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "helicone\u0000gpt-4.1-mini": {
+      "cached_read": 0.09999999999999999,
+      "in": 0.39999999999999997,
+      "out": 1.5999999999999999
+    },
+    "helicone\u0000gpt-4.1-mini-2025-04-14": {
+      "cached_read": 0.09999999999999999,
+      "in": 0.39999999999999997,
+      "out": 1.5999999999999999
+    },
+    "helicone\u0000gpt-4.1-nano": {
+      "cached_read": 0.024999999999999998,
+      "in": 0.09999999999999999,
+      "out": 0.39999999999999997
+    },
+    "helicone\u0000gpt-4o": {
+      "cached_read": 1.25,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "helicone\u0000gpt-4o-mini": {
+      "cached_read": 0.075,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "helicone\u0000gpt-5": {
+      "cached_read": 0.12500000000000003,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "helicone\u0000gpt-5-chat-latest": {
+      "cached_read": 0.12500000000000003,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "helicone\u0000gpt-5-codex": {
+      "cached_read": 0.12500000000000003,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "helicone\u0000gpt-5-mini": {
+      "cached_read": 0.024999999999999998,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "helicone\u0000gpt-5-nano": {
+      "cached_read": 0.005,
+      "in": 0.049999999999999996,
+      "out": 0.39999999999999997
+    },
+    "helicone\u0000gpt-5-pro": {
+      "cached_read": null,
+      "in": 15.0,
+      "out": 120.0
+    },
+    "helicone\u0000gpt-5.1": {
+      "cached_read": 0.12500000000000003,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "helicone\u0000gpt-5.1-chat-latest": {
+      "cached_read": 0.12500000000000003,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "helicone\u0000gpt-5.1-codex": {
+      "cached_read": 0.12500000000000003,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "helicone\u0000gpt-5.1-codex-mini": {
+      "cached_read": 0.024999999999999998,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "helicone\u0000gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.04,
+      "out": 0.16
+    },
+    "helicone\u0000gpt-oss-20b": {
+      "cached_read": null,
+      "in": 0.049999999999999996,
+      "out": 0.19999999999999998
+    },
+    "helicone\u0000grok-3": {
+      "cached_read": 0.75,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "helicone\u0000grok-3-mini": {
+      "cached_read": 0.075,
+      "in": 0.3,
+      "out": 0.5
+    },
+    "helicone\u0000grok-4": {
+      "cached_read": 0.75,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "helicone\u0000grok-4-1-fast-non-reasoning": {
+      "cached_read": 0.049999999999999996,
+      "in": 0.19999999999999998,
+      "out": 0.5
+    },
+    "helicone\u0000grok-4-1-fast-reasoning": {
+      "cached_read": 0.049999999999999996,
+      "in": 0.19999999999999998,
+      "out": 0.5
+    },
+    "helicone\u0000grok-4-fast-non-reasoning": {
+      "cached_read": 0.049999999999999996,
+      "in": 0.19999999999999998,
+      "out": 0.5
+    },
+    "helicone\u0000grok-4-fast-reasoning": {
+      "cached_read": 0.049999999999999996,
+      "in": 0.19999999999999998,
+      "out": 0.5
+    },
+    "helicone\u0000grok-code-fast-1": {
+      "cached_read": 0.02,
+      "in": 0.19999999999999998,
+      "out": 1.5
+    },
+    "helicone\u0000hermes-2-pro-llama-3-8b": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.14
+    },
+    "helicone\u0000kimi-k2-0711": {
+      "cached_read": null,
+      "in": 0.5700000000000001,
+      "out": 2.3
+    },
+    "helicone\u0000kimi-k2-0905": {
+      "cached_read": 0.39999999999999997,
+      "in": 0.5,
+      "out": 2.0
+    },
+    "helicone\u0000kimi-k2-thinking": {
+      "cached_read": null,
+      "in": 0.48,
+      "out": 2.0
+    },
+    "helicone\u0000llama-3.1-8b-instant": {
+      "cached_read": null,
+      "in": 0.049999999999999996,
+      "out": 0.08
+    },
+    "helicone\u0000llama-3.1-8b-instruct": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.049999999999999996
+    },
+    "helicone\u0000llama-3.1-8b-instruct-turbo": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.03
+    },
+    "helicone\u0000llama-3.3-70b-instruct": {
+      "cached_read": null,
+      "in": 0.13,
+      "out": 0.39
+    },
+    "helicone\u0000llama-3.3-70b-versatile": {
+      "cached_read": null,
+      "in": 0.59,
+      "out": 0.7899999999999999
+    },
+    "helicone\u0000llama-4-maverick": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "helicone\u0000llama-4-scout": {
+      "cached_read": null,
+      "in": 0.08,
+      "out": 0.3
+    },
+    "helicone\u0000llama-guard-4": {
+      "cached_read": null,
+      "in": 0.21,
+      "out": 0.21
+    },
+    "helicone\u0000llama-prompt-guard-2-22m": {
+      "cached_read": null,
+      "in": 0.01,
+      "out": 0.01
+    },
+    "helicone\u0000llama-prompt-guard-2-86m": {
+      "cached_read": null,
+      "in": 0.01,
+      "out": 0.01
+    },
+    "helicone\u0000mistral-large-2411": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "helicone\u0000mistral-nemo": {
+      "cached_read": null,
+      "in": 20.0,
+      "out": 40.0
+    },
+    "helicone\u0000mistral-small": {
+      "cached_read": null,
+      "in": 0.075,
+      "out": 0.2
+    },
+    "helicone\u0000o1": {
+      "cached_read": 7.5,
+      "in": 15.0,
+      "out": 60.0
+    },
+    "helicone\u0000o1-mini": {
+      "cached_read": 0.55,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "helicone\u0000o3": {
+      "cached_read": 0.5,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "helicone\u0000o3-mini": {
+      "cached_read": 0.55,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "helicone\u0000o3-pro": {
+      "cached_read": null,
+      "in": 20.0,
+      "out": 80.0
+    },
+    "helicone\u0000o4-mini": {
+      "cached_read": 0.275,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "helicone\u0000qwen2.5-coder-7b-fast": {
+      "cached_read": null,
+      "in": 0.03,
+      "out": 0.09
+    },
+    "helicone\u0000qwen3-235b-a22b-thinking": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 2.9000000000000004
+    },
+    "helicone\u0000qwen3-30b-a3b": {
+      "cached_read": null,
+      "in": 0.08,
+      "out": 0.29
+    },
+    "helicone\u0000qwen3-32b": {
+      "cached_read": null,
+      "in": 0.29,
+      "out": 0.59
+    },
+    "helicone\u0000qwen3-coder": {
+      "cached_read": null,
+      "in": 0.22,
+      "out": 0.95
+    },
+    "helicone\u0000qwen3-coder-30b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.09999999999999999,
+      "out": 0.3
+    },
+    "helicone\u0000qwen3-next-80b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 1.4
+    },
+    "helicone\u0000qwen3-vl-235b-a22b-instruct": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.5
+    },
+    "helicone\u0000sonar": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 1.0
+    },
+    "helicone\u0000sonar-deep-research": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "helicone\u0000sonar-pro": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "helicone\u0000sonar-reasoning": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "helicone\u0000sonar-reasoning-pro": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "hpc-ai\u0000minimax/minimax-m2.5": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "hpc-ai\u0000moonshotai/kimi-k2.5": {
+      "cached_read": 0.05,
+      "in": 0.3,
+      "out": 1.5
+    },
+    "hpc-ai\u0000zai-org/glm-5.1": {
+      "cached_read": 0.133,
+      "in": 0.615,
+      "out": 2.46
+    },
+    "huggingface\u0000deepseek-ai/deepseek-r1-0528": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 5.0
+    },
+    "huggingface\u0000deepseek-ai/deepseek-v3.2": {
+      "cached_read": null,
+      "in": 0.28,
+      "out": 0.4
+    },
+    "huggingface\u0000deepseek-ai/deepseek-v4-pro": {
+      "cached_read": 0.003625,
+      "in": 0.435,
+      "out": 0.87
+    },
+    "huggingface\u0000minimaxai/minimax-m2.1": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "huggingface\u0000minimaxai/minimax-m2.5": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "huggingface\u0000minimaxai/minimax-m2.7": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "huggingface\u0000moonshotai/kimi-k2-instruct": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "huggingface\u0000moonshotai/kimi-k2-instruct-0905": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "huggingface\u0000moonshotai/kimi-k2-thinking": {
+      "cached_read": 0.15,
+      "in": 0.6,
+      "out": 2.5
+    },
+    "huggingface\u0000moonshotai/kimi-k2.5": {
+      "cached_read": 0.1,
+      "in": 0.6,
+      "out": 3.0
+    },
+    "huggingface\u0000moonshotai/kimi-k2.6": {
+      "cached_read": 0.16,
+      "in": 0.95,
+      "out": 4.0
+    },
+    "huggingface\u0000qwen/qwen3-235b-a22b-thinking-2507": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 3.0
+    },
+    "huggingface\u0000qwen/qwen3-coder-480b-a35b-instruct": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 2.0
+    },
+    "huggingface\u0000qwen/qwen3-coder-next": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 1.5
+    },
+    "huggingface\u0000qwen/qwen3-embedding-4b": {
+      "cached_read": null,
+      "in": 0.01,
+      "out": 0.0
+    },
+    "huggingface\u0000qwen/qwen3-embedding-8b": {
+      "cached_read": null,
+      "in": 0.01,
+      "out": 0.0
+    },
+    "huggingface\u0000qwen/qwen3-next-80b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 1.0
+    },
+    "huggingface\u0000qwen/qwen3-next-80b-a3b-thinking": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 2.0
+    },
+    "huggingface\u0000qwen/qwen3.5-397b-a17b": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 3.6
+    },
+    "huggingface\u0000xiaomimimo/mimo-v2-flash": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "huggingface\u0000zai-org/glm-4.7": {
+      "cached_read": 0.11,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "huggingface\u0000zai-org/glm-4.7-flash": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "huggingface\u0000zai-org/glm-5": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 3.2
+    },
+    "huggingface\u0000zai-org/glm-5.1": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 3.2
+    },
+    "iflowcn\u0000deepseek-r1": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "iflowcn\u0000deepseek-v3": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "iflowcn\u0000deepseek-v3.2": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "iflowcn\u0000glm-4.6": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "iflowcn\u0000kimi-k2": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "iflowcn\u0000kimi-k2-0905": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "iflowcn\u0000qwen3-235b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "iflowcn\u0000qwen3-235b-a22b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "iflowcn\u0000qwen3-235b-a22b-thinking-2507": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "iflowcn\u0000qwen3-32b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "iflowcn\u0000qwen3-coder-plus": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "iflowcn\u0000qwen3-max": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "iflowcn\u0000qwen3-max-preview": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "iflowcn\u0000qwen3-vl-plus": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "inception\u0000mercury-2": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 0.75
+    },
+    "inception\u0000mercury-edit-2": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 0.75
+    },
+    "inceptron\u0000minimaxai/minimax-m2.5": {
+      "cached_read": 0.03,
+      "in": 0.24,
+      "out": 0.9
+    },
+    "inceptron\u0000moonshotai/kimi-k2.6": {
+      "cached_read": 0.2,
+      "in": 0.78,
+      "out": 3.5
+    },
+    "inceptron\u0000nvidia/llama-3.3-70b-instruct-fp8": {
+      "cached_read": 0.0,
+      "in": 0.12,
+      "out": 0.38
+    },
+    "inceptron\u0000zai-org/glm-5.1-fp8": {
+      "cached_read": 0.26,
+      "in": 1.4,
+      "out": 4.4
+    },
+    "inference\u0000google/gemma-3": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.3
+    },
+    "inference\u0000meta/llama-3.1-8b-instruct": {
+      "cached_read": null,
+      "in": 0.025,
+      "out": 0.025
+    },
+    "inference\u0000meta/llama-3.2-11b-vision-instruct": {
+      "cached_read": null,
+      "in": 0.055,
+      "out": 0.055
+    },
+    "inference\u0000meta/llama-3.2-1b-instruct": {
+      "cached_read": null,
+      "in": 0.01,
+      "out": 0.01
+    },
+    "inference\u0000meta/llama-3.2-3b-instruct": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.02
+    },
+    "inference\u0000mistral/mistral-nemo-12b-instruct": {
+      "cached_read": null,
+      "in": 0.038,
+      "out": 0.1
+    },
+    "inference\u0000osmosis/osmosis-structure-0.6b": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.5
+    },
+    "inference\u0000qwen/qwen-2.5-7b-vision-instruct": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "inference\u0000qwen/qwen3-embedding-4b": {
+      "cached_read": null,
+      "in": 0.01,
+      "out": 0.0
+    },
+    "io-net\u0000deepseek-ai/deepseek-r1-0528": {
+      "cached_read": 1.0,
+      "in": 2.0,
+      "out": 8.75
+    },
+    "io-net\u0000intel/qwen3-coder-480b-a35b-instruct-int4-mixed-ar": {
+      "cached_read": 0.11,
+      "in": 0.22,
+      "out": 0.95
+    },
+    "io-net\u0000meta-llama/llama-3.2-90b-vision-instruct": {
+      "cached_read": 0.175,
+      "in": 0.35,
+      "out": 0.4
+    },
+    "io-net\u0000meta-llama/llama-3.3-70b-instruct": {
+      "cached_read": 0.065,
+      "in": 0.13,
+      "out": 0.38
+    },
+    "io-net\u0000meta-llama/llama-4-maverick-17b-128e-instruct-fp8": {
+      "cached_read": 0.075,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "io-net\u0000mistralai/devstral-small-2505": {
+      "cached_read": 0.025,
+      "in": 0.05,
+      "out": 0.22
+    },
+    "io-net\u0000mistralai/magistral-small-2506": {
+      "cached_read": 0.25,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "io-net\u0000mistralai/mistral-large-instruct-2411": {
+      "cached_read": 1.0,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "io-net\u0000mistralai/mistral-nemo-instruct-2407": {
+      "cached_read": 0.01,
+      "in": 0.02,
+      "out": 0.04
+    },
+    "io-net\u0000moonshotai/kimi-k2-instruct-0905": {
+      "cached_read": 0.195,
+      "in": 0.39,
+      "out": 1.9
+    },
+    "io-net\u0000moonshotai/kimi-k2-thinking": {
+      "cached_read": 0.275,
+      "in": 0.55,
+      "out": 2.25
+    },
+    "io-net\u0000openai/gpt-oss-120b": {
+      "cached_read": 0.02,
+      "in": 0.04,
+      "out": 0.4
+    },
+    "io-net\u0000openai/gpt-oss-20b": {
+      "cached_read": 0.015,
+      "in": 0.03,
+      "out": 0.14
+    },
+    "io-net\u0000qwen/qwen2.5-vl-32b-instruct": {
+      "cached_read": 0.025,
+      "in": 0.05,
+      "out": 0.22
+    },
+    "io-net\u0000qwen/qwen3-235b-a22b-thinking-2507": {
+      "cached_read": 0.055,
+      "in": 0.11,
+      "out": 0.6
+    },
+    "io-net\u0000qwen/qwen3-next-80b-a3b-instruct": {
+      "cached_read": 0.05,
+      "in": 0.1,
+      "out": 0.8
+    },
+    "io-net\u0000zai-org/glm-4.6": {
+      "cached_read": 0.2,
+      "in": 0.4,
+      "out": 1.75
+    },
+    "jiekou\u0000baidu/ernie-4.5-300b-a47b-paddle": {
+      "cached_read": null,
+      "in": 0.28,
+      "out": 1.1
+    },
+    "jiekou\u0000baidu/ernie-4.5-vl-424b-a47b": {
+      "cached_read": null,
+      "in": 0.42,
+      "out": 1.25
+    },
+    "jiekou\u0000claude-haiku-4-5-20251001": {
+      "cached_read": null,
+      "in": 0.9,
+      "out": 4.5
+    },
+    "jiekou\u0000claude-opus-4-1-20250805": {
+      "cached_read": null,
+      "in": 13.5,
+      "out": 67.5
+    },
+    "jiekou\u0000claude-opus-4-20250514": {
+      "cached_read": null,
+      "in": 13.5,
+      "out": 67.5
+    },
+    "jiekou\u0000claude-opus-4-5-20251101": {
+      "cached_read": null,
+      "in": 4.5,
+      "out": 22.5
+    },
+    "jiekou\u0000claude-opus-4-6": {
+      "cached_read": null,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "jiekou\u0000claude-sonnet-4-20250514": {
+      "cached_read": null,
+      "in": 2.7,
+      "out": 13.5
+    },
+    "jiekou\u0000claude-sonnet-4-5-20250929": {
+      "cached_read": null,
+      "in": 2.7,
+      "out": 13.5
+    },
+    "jiekou\u0000deepseek/deepseek-r1-0528": {
+      "cached_read": null,
+      "in": 0.7,
+      "out": 2.5
+    },
+    "jiekou\u0000deepseek/deepseek-v3-0324": {
+      "cached_read": null,
+      "in": 0.28,
+      "out": 1.14
+    },
+    "jiekou\u0000deepseek/deepseek-v3.1": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 1.0
+    },
+    "jiekou\u0000gemini-2.5-flash": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 2.25
+    },
+    "jiekou\u0000gemini-2.5-flash-lite": {
+      "cached_read": null,
+      "in": 0.09,
+      "out": 0.36
+    },
+    "jiekou\u0000gemini-2.5-flash-lite-preview-06-17": {
+      "cached_read": null,
+      "in": 0.09,
+      "out": 0.36
+    },
+    "jiekou\u0000gemini-2.5-flash-lite-preview-09-2025": {
+      "cached_read": null,
+      "in": 0.09,
+      "out": 0.36
+    },
+    "jiekou\u0000gemini-2.5-flash-preview-05-20": {
+      "cached_read": null,
+      "in": 0.135,
+      "out": 3.15
+    },
+    "jiekou\u0000gemini-2.5-pro": {
+      "cached_read": null,
+      "in": 1.125,
+      "out": 9.0
+    },
+    "jiekou\u0000gemini-2.5-pro-preview-06-05": {
+      "cached_read": null,
+      "in": 1.125,
+      "out": 9.0
+    },
+    "jiekou\u0000gemini-3-flash-preview": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "jiekou\u0000gemini-3-pro-preview": {
+      "cached_read": null,
+      "in": 1.8,
+      "out": 10.8
+    },
+    "jiekou\u0000gpt-5-chat-latest": {
+      "cached_read": null,
+      "in": 1.125,
+      "out": 9.0
+    },
+    "jiekou\u0000gpt-5-codex": {
+      "cached_read": null,
+      "in": 1.125,
+      "out": 9.0
+    },
+    "jiekou\u0000gpt-5-mini": {
+      "cached_read": null,
+      "in": 0.225,
+      "out": 1.8
+    },
+    "jiekou\u0000gpt-5-nano": {
+      "cached_read": null,
+      "in": 0.045,
+      "out": 0.36
+    },
+    "jiekou\u0000gpt-5-pro": {
+      "cached_read": null,
+      "in": 13.5,
+      "out": 108.0
+    },
+    "jiekou\u0000gpt-5.1": {
+      "cached_read": null,
+      "in": 1.125,
+      "out": 9.0
+    },
+    "jiekou\u0000gpt-5.1-codex": {
+      "cached_read": null,
+      "in": 1.125,
+      "out": 9.0
+    },
+    "jiekou\u0000gpt-5.1-codex-max": {
+      "cached_read": null,
+      "in": 1.125,
+      "out": 9.0
+    },
+    "jiekou\u0000gpt-5.1-codex-mini": {
+      "cached_read": null,
+      "in": 0.225,
+      "out": 1.8
+    },
+    "jiekou\u0000gpt-5.2": {
+      "cached_read": null,
+      "in": 1.575,
+      "out": 12.6
+    },
+    "jiekou\u0000gpt-5.2-codex": {
+      "cached_read": null,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "jiekou\u0000gpt-5.2-pro": {
+      "cached_read": null,
+      "in": 18.9,
+      "out": 151.2
+    },
+    "jiekou\u0000grok-4-0709": {
+      "cached_read": null,
+      "in": 2.7,
+      "out": 13.5
+    },
+    "jiekou\u0000grok-4-1-fast-non-reasoning": {
+      "cached_read": null,
+      "in": 0.18,
+      "out": 0.45
+    },
+    "jiekou\u0000grok-4-1-fast-reasoning": {
+      "cached_read": null,
+      "in": 0.18,
+      "out": 0.45
+    },
+    "jiekou\u0000grok-4-fast-non-reasoning": {
+      "cached_read": null,
+      "in": 0.18,
+      "out": 0.45
+    },
+    "jiekou\u0000grok-4-fast-reasoning": {
+      "cached_read": null,
+      "in": 0.18,
+      "out": 0.45
+    },
+    "jiekou\u0000grok-code-fast-1": {
+      "cached_read": null,
+      "in": 0.18,
+      "out": 1.35
+    },
+    "jiekou\u0000minimax/minimax-m2.1": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "jiekou\u0000minimaxai/minimax-m1-80k": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 2.2
+    },
+    "jiekou\u0000moonshotai/kimi-k2-0905": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.5
+    },
+    "jiekou\u0000moonshotai/kimi-k2-instruct": {
+      "cached_read": null,
+      "in": 0.57,
+      "out": 2.3
+    },
+    "jiekou\u0000moonshotai/kimi-k2.5": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 3.0
+    },
+    "jiekou\u0000o3": {
+      "cached_read": null,
+      "in": 10.0,
+      "out": 40.0
+    },
+    "jiekou\u0000o3-mini": {
+      "cached_read": null,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "jiekou\u0000o4-mini": {
+      "cached_read": null,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "jiekou\u0000qwen/qwen3-235b-a22b-fp8": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.8
+    },
+    "jiekou\u0000qwen/qwen3-235b-a22b-instruct-2507": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.8
+    },
+    "jiekou\u0000qwen/qwen3-235b-a22b-thinking-2507": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 3.0
+    },
+    "jiekou\u0000qwen/qwen3-30b-a3b-fp8": {
+      "cached_read": null,
+      "in": 0.09,
+      "out": 0.45
+    },
+    "jiekou\u0000qwen/qwen3-32b-fp8": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.45
+    },
+    "jiekou\u0000qwen/qwen3-coder-480b-a35b-instruct": {
+      "cached_read": null,
+      "in": 0.29,
+      "out": 1.2
+    },
+    "jiekou\u0000qwen/qwen3-coder-next": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 1.5
+    },
+    "jiekou\u0000qwen/qwen3-next-80b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 1.5
+    },
+    "jiekou\u0000qwen/qwen3-next-80b-a3b-thinking": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 1.5
+    },
+    "jiekou\u0000xiaomimimo/mimo-v2-flash": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "jiekou\u0000zai-org/glm-4.5": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "jiekou\u0000zai-org/glm-4.5v": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 1.8
+    },
+    "jiekou\u0000zai-org/glm-4.7": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "jiekou\u0000zai-org/glm-4.7-flash": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.4
+    },
+    "kilo\u0000ai21/jamba-large-1.7": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "kilo\u0000aion-labs/aion-1.0": {
+      "cached_read": null,
+      "in": 4.0,
+      "out": 8.0
+    },
+    "kilo\u0000aion-labs/aion-1.0-mini": {
+      "cached_read": null,
+      "in": 0.7,
+      "out": 1.4
+    },
+    "kilo\u0000aion-labs/aion-2.0": {
+      "cached_read": null,
+      "in": 0.8,
+      "out": 1.6
+    },
+    "kilo\u0000aion-labs/aion-rp-llama-3.1-8b": {
+      "cached_read": null,
+      "in": 0.8,
+      "out": 1.6
+    },
+    "kilo\u0000alfredpros/codellama-7b-instruct-solidity": {
+      "cached_read": null,
+      "in": 0.8,
+      "out": 1.2
+    },
+    "kilo\u0000allenai/olmo-3-32b-think": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.5
+    },
+    "kilo\u0000amazon/nova-2-lite-v1": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "kilo\u0000amazon/nova-lite-v1": {
+      "cached_read": null,
+      "in": 0.06,
+      "out": 0.24
+    },
+    "kilo\u0000amazon/nova-micro-v1": {
+      "cached_read": null,
+      "in": 0.035,
+      "out": 0.14
+    },
+    "kilo\u0000amazon/nova-premier-v1": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 12.5
+    },
+    "kilo\u0000amazon/nova-pro-v1": {
+      "cached_read": null,
+      "in": 0.8,
+      "out": 3.2
+    },
+    "kilo\u0000anthracite-org/magnum-v4-72b": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 5.0
+    },
+    "kilo\u0000anthropic/claude-3-haiku": {
+      "cached_read": 0.03,
+      "in": 0.25,
+      "out": 1.25
+    },
+    "kilo\u0000anthropic/claude-3.5-haiku": {
+      "cached_read": 0.08,
+      "in": 0.8,
+      "out": 4.0
+    },
+    "kilo\u0000anthropic/claude-haiku-4.5": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "kilo\u0000anthropic/claude-opus-4": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "kilo\u0000anthropic/claude-opus-4.1": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "kilo\u0000anthropic/claude-opus-4.5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "kilo\u0000anthropic/claude-opus-4.6": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "kilo\u0000anthropic/claude-opus-4.6-fast": {
+      "cached_read": 3.0,
+      "in": 30.0,
+      "out": 150.0
+    },
+    "kilo\u0000anthropic/claude-opus-4.7": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "kilo\u0000anthropic/claude-opus-4.7-fast": {
+      "cached_read": 3.0,
+      "in": 30.0,
+      "out": 150.0
+    },
+    "kilo\u0000anthropic/claude-sonnet-4": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "kilo\u0000anthropic/claude-sonnet-4.5": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "kilo\u0000anthropic/claude-sonnet-4.6": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "kilo\u0000arcee-ai/coder-large": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 0.8
+    },
+    "kilo\u0000arcee-ai/maestro-reasoning": {
+      "cached_read": null,
+      "in": 0.9,
+      "out": 3.3
+    },
+    "kilo\u0000arcee-ai/spotlight": {
+      "cached_read": null,
+      "in": 0.18,
+      "out": 0.18
+    },
+    "kilo\u0000arcee-ai/trinity-large-thinking": {
+      "cached_read": null,
+      "in": 0.22,
+      "out": 0.85
+    },
+    "kilo\u0000arcee-ai/trinity-mini": {
+      "cached_read": null,
+      "in": 0.045,
+      "out": 0.15
+    },
+    "kilo\u0000arcee-ai/virtuoso-large": {
+      "cached_read": null,
+      "in": 0.75,
+      "out": 1.2
+    },
+    "kilo\u0000baidu/cobuddy:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "kilo\u0000baidu/ernie-4.5-21b-a3b": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.28
+    },
+    "kilo\u0000baidu/ernie-4.5-21b-a3b-thinking": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.28
+    },
+    "kilo\u0000baidu/ernie-4.5-300b-a47b": {
+      "cached_read": null,
+      "in": 0.28,
+      "out": 1.1
+    },
+    "kilo\u0000baidu/ernie-4.5-vl-28b-a3b": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.56
+    },
+    "kilo\u0000baidu/ernie-4.5-vl-424b-a47b": {
+      "cached_read": null,
+      "in": 0.42,
+      "out": 1.25
+    },
+    "kilo\u0000baidu/qianfan-ocr-fast": {
+      "cached_read": null,
+      "in": 0.68,
+      "out": 2.81
+    },
+    "kilo\u0000bytedance-seed/seed-1.6": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "kilo\u0000bytedance-seed/seed-1.6-flash": {
+      "cached_read": null,
+      "in": 0.075,
+      "out": 0.3
+    },
+    "kilo\u0000bytedance-seed/seed-2.0-lite": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "kilo\u0000bytedance-seed/seed-2.0-mini": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "kilo\u0000bytedance/ui-tars-1.5-7b": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.2
+    },
+    "kilo\u0000cohere/command-a": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "kilo\u0000cohere/command-r-08-2024": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "kilo\u0000cohere/command-r-plus-08-2024": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "kilo\u0000cohere/command-r7b-12-2024": {
+      "cached_read": null,
+      "in": 0.0375,
+      "out": 0.15
+    },
+    "kilo\u0000deepcogito/cogito-v2.1-671b": {
+      "cached_read": null,
+      "in": 1.25,
+      "out": 1.25
+    },
+    "kilo\u0000deepseek/deepseek-chat": {
+      "cached_read": 0.15,
+      "in": 0.32,
+      "out": 0.89
+    },
+    "kilo\u0000deepseek/deepseek-chat-v3-0324": {
+      "cached_read": 0.095,
+      "in": 0.2,
+      "out": 0.77
+    },
+    "kilo\u0000deepseek/deepseek-chat-v3.1": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.75
+    },
+    "kilo\u0000deepseek/deepseek-r1": {
+      "cached_read": null,
+      "in": 0.7,
+      "out": 2.5
+    },
+    "kilo\u0000deepseek/deepseek-r1-0528": {
+      "cached_read": 0.2,
+      "in": 0.45,
+      "out": 2.15
+    },
+    "kilo\u0000deepseek/deepseek-r1-distill-llama-70b": {
+      "cached_read": 0.015,
+      "in": 0.7,
+      "out": 0.8
+    },
+    "kilo\u0000deepseek/deepseek-r1-distill-qwen-32b": {
+      "cached_read": null,
+      "in": 0.29,
+      "out": 0.29
+    },
+    "kilo\u0000deepseek/deepseek-v3.1-terminus": {
+      "cached_read": 0.13,
+      "in": 0.21,
+      "out": 0.79
+    },
+    "kilo\u0000deepseek/deepseek-v3.2": {
+      "cached_read": 0.125,
+      "in": 0.26,
+      "out": 0.38
+    },
+    "kilo\u0000deepseek/deepseek-v3.2-exp": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 0.41
+    },
+    "kilo\u0000deepseek/deepseek-v3.2-speciale": {
+      "cached_read": 0.135,
+      "in": 0.4,
+      "out": 1.2
+    },
+    "kilo\u0000deepseek/deepseek-v4-flash": {
+      "cached_read": 0.0028,
+      "in": 0.14,
+      "out": 0.28
+    },
+    "kilo\u0000deepseek/deepseek-v4-pro": {
+      "cached_read": 0.003625,
+      "in": 0.435,
+      "out": 0.87
+    },
+    "kilo\u0000essentialai/rnj-1-instruct": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.15
+    },
+    "kilo\u0000google/gemini-2.0-flash-001": {
+      "cached_read": 0.025,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "kilo\u0000google/gemini-2.0-flash-lite-001": {
+      "cached_read": null,
+      "in": 0.075,
+      "out": 0.3
+    },
+    "kilo\u0000google/gemini-2.5-flash": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "kilo\u0000google/gemini-2.5-flash-image": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "kilo\u0000google/gemini-2.5-flash-lite": {
+      "cached_read": 0.01,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "kilo\u0000google/gemini-2.5-flash-lite-preview-09-2025": {
+      "cached_read": 0.01,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "kilo\u0000google/gemini-2.5-pro": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "kilo\u0000google/gemini-2.5-pro-preview": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "kilo\u0000google/gemini-2.5-pro-preview-05-06": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "kilo\u0000google/gemini-3-flash-preview": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "kilo\u0000google/gemini-3-pro-image-preview": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "kilo\u0000google/gemini-3.1-flash-image-preview": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "kilo\u0000google/gemini-3.1-flash-lite": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 1.5
+    },
+    "kilo\u0000google/gemini-3.1-flash-lite-preview": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 1.5
+    },
+    "kilo\u0000google/gemini-3.1-pro-preview": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "kilo\u0000google/gemini-3.1-pro-preview-customtools": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "kilo\u0000google/gemini-3.5-flash": {
+      "cached_read": 0.15,
+      "in": 1.5,
+      "out": 9.0
+    },
+    "kilo\u0000google/gemma-2-27b-it": {
+      "cached_read": null,
+      "in": 0.65,
+      "out": 0.65
+    },
+    "kilo\u0000google/gemma-3-12b-it": {
+      "cached_read": 0.015,
+      "in": 0.04,
+      "out": 0.13
+    },
+    "kilo\u0000google/gemma-3-27b-it": {
+      "cached_read": 0.02,
+      "in": 0.03,
+      "out": 0.11
+    },
+    "kilo\u0000google/gemma-3-4b-it": {
+      "cached_read": null,
+      "in": 0.04,
+      "out": 0.08
+    },
+    "kilo\u0000google/gemma-3n-e4b-it": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.04
+    },
+    "kilo\u0000google/gemma-4-26b-a4b-it": {
+      "cached_read": null,
+      "in": 0.12,
+      "out": 0.4
+    },
+    "kilo\u0000google/gemma-4-31b-it": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.4
+    },
+    "kilo\u0000google/lyria-3-clip-preview": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "kilo\u0000google/lyria-3-pro-preview": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "kilo\u0000gryphe/mythomax-l2-13b": {
+      "cached_read": null,
+      "in": 0.06,
+      "out": 0.06
+    },
+    "kilo\u0000ibm-granite/granite-4.0-h-micro": {
+      "cached_read": null,
+      "in": 0.017,
+      "out": 0.11
+    },
+    "kilo\u0000ibm-granite/granite-4.1-8b": {
+      "cached_read": 0.05,
+      "in": 0.05,
+      "out": 0.1
+    },
+    "kilo\u0000inception/mercury-2": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 0.75
+    },
+    "kilo\u0000inclusionai/ling-2.6-1t": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "kilo\u0000inclusionai/ling-2.6-flash": {
+      "cached_read": 0.016,
+      "in": 0.08,
+      "out": 0.24
+    },
+    "kilo\u0000inclusionai/ring-2.6-1t": {
+      "cached_read": 0.015,
+      "in": 0.075,
+      "out": 0.625
+    },
+    "kilo\u0000inflection/inflection-3-pi": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "kilo\u0000inflection/inflection-3-productivity": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "kilo\u0000kilo-auto/balanced": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 3.0
+    },
+    "kilo\u0000kilo-auto/free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "kilo\u0000kilo-auto/frontier": {
+      "cached_read": null,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "kilo\u0000kilo-auto/small": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.4
+    },
+    "kilo\u0000kwaipilot/kat-coder-pro-v2": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "kilo\u0000liquid/lfm-2-24b-a2b": {
+      "cached_read": null,
+      "in": 0.03,
+      "out": 0.12
+    },
+    "kilo\u0000mancer/weaver": {
+      "cached_read": null,
+      "in": 0.75,
+      "out": 1.0
+    },
+    "kilo\u0000meta-llama/llama-3-70b-instruct": {
+      "cached_read": null,
+      "in": 0.51,
+      "out": 0.74
+    },
+    "kilo\u0000meta-llama/llama-3-8b-instruct": {
+      "cached_read": null,
+      "in": 0.03,
+      "out": 0.04
+    },
+    "kilo\u0000meta-llama/llama-3.1-70b-instruct": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 0.4
+    },
+    "kilo\u0000meta-llama/llama-3.1-8b-instruct": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.05
+    },
+    "kilo\u0000meta-llama/llama-3.2-11b-vision-instruct": {
+      "cached_read": null,
+      "in": 0.049,
+      "out": 0.049
+    },
+    "kilo\u0000meta-llama/llama-3.2-1b-instruct": {
+      "cached_read": null,
+      "in": 0.027,
+      "out": 0.2
+    },
+    "kilo\u0000meta-llama/llama-3.2-3b-instruct": {
+      "cached_read": null,
+      "in": 0.051,
+      "out": 0.34
+    },
+    "kilo\u0000meta-llama/llama-3.3-70b-instruct": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.32
+    },
+    "kilo\u0000meta-llama/llama-4-maverick": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "kilo\u0000meta-llama/llama-4-scout": {
+      "cached_read": null,
+      "in": 0.08,
+      "out": 0.3
+    },
+    "kilo\u0000meta-llama/llama-guard-3-8b": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.06
+    },
+    "kilo\u0000meta-llama/llama-guard-4-12b": {
+      "cached_read": null,
+      "in": 0.18,
+      "out": 0.18
+    },
+    "kilo\u0000microsoft/phi-4": {
+      "cached_read": null,
+      "in": 0.06,
+      "out": 0.14
+    },
+    "kilo\u0000microsoft/phi-4-mini-instruct": {
+      "cached_read": 0.08,
+      "in": 0.08,
+      "out": 0.35
+    },
+    "kilo\u0000microsoft/wizardlm-2-8x22b": {
+      "cached_read": null,
+      "in": 0.62,
+      "out": 0.62
+    },
+    "kilo\u0000minimax/minimax-01": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 1.1
+    },
+    "kilo\u0000minimax/minimax-m1": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.2
+    },
+    "kilo\u0000minimax/minimax-m2": {
+      "cached_read": 0.03,
+      "in": 0.255,
+      "out": 1.0
+    },
+    "kilo\u0000minimax/minimax-m2-her": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "kilo\u0000minimax/minimax-m2.1": {
+      "cached_read": 0.03,
+      "in": 0.27,
+      "out": 0.95
+    },
+    "kilo\u0000minimax/minimax-m2.5": {
+      "cached_read": 0.029,
+      "in": 0.25,
+      "out": 1.2
+    },
+    "kilo\u0000minimax/minimax-m2.7": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "kilo\u0000mistralai/codestral-2508": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.9
+    },
+    "kilo\u0000mistralai/devstral-2512": {
+      "cached_read": 0.025,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "kilo\u0000mistralai/devstral-medium": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "kilo\u0000mistralai/devstral-small": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "kilo\u0000mistralai/ministral-14b-2512": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "kilo\u0000mistralai/ministral-3b-2512": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "kilo\u0000mistralai/ministral-8b-2512": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.15
+    },
+    "kilo\u0000mistralai/mistral-7b-instruct-v0.1": {
+      "cached_read": null,
+      "in": 0.11,
+      "out": 0.19
+    },
+    "kilo\u0000mistralai/mistral-large": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "kilo\u0000mistralai/mistral-large-2407": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "kilo\u0000mistralai/mistral-large-2411": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "kilo\u0000mistralai/mistral-large-2512": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "kilo\u0000mistralai/mistral-medium-3": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "kilo\u0000mistralai/mistral-medium-3-5": {
+      "cached_read": null,
+      "in": 1.5,
+      "out": 7.5
+    },
+    "kilo\u0000mistralai/mistral-medium-3.1": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "kilo\u0000mistralai/mistral-nemo": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.04
+    },
+    "kilo\u0000mistralai/mistral-saba": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.6
+    },
+    "kilo\u0000mistralai/mistral-small-24b-instruct-2501": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.08
+    },
+    "kilo\u0000mistralai/mistral-small-2603": {
+      "cached_read": 0.015,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "kilo\u0000mistralai/mistral-small-3.1-24b-instruct": {
+      "cached_read": 0.015,
+      "in": 0.35,
+      "out": 0.56
+    },
+    "kilo\u0000mistralai/mistral-small-3.2-24b-instruct": {
+      "cached_read": 0.03,
+      "in": 0.06,
+      "out": 0.18
+    },
+    "kilo\u0000mistralai/mixtral-8x22b-instruct": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "kilo\u0000mistralai/pixtral-large-2411": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "kilo\u0000mistralai/voxtral-small-24b-2507": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "kilo\u0000moonshotai/kimi-k2": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 2.2
+    },
+    "kilo\u0000moonshotai/kimi-k2-0905": {
+      "cached_read": 0.15,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "kilo\u0000moonshotai/kimi-k2-thinking": {
+      "cached_read": 0.2,
+      "in": 0.47,
+      "out": 2.0
+    },
+    "kilo\u0000moonshotai/kimi-k2.5": {
+      "cached_read": null,
+      "in": 0.45,
+      "out": 2.2
+    },
+    "kilo\u0000moonshotai/kimi-k2.6": {
+      "cached_read": 0.375,
+      "in": 0.75,
+      "out": 3.5
+    },
+    "kilo\u0000morph/morph-v3-fast": {
+      "cached_read": null,
+      "in": 0.8,
+      "out": 1.2
+    },
+    "kilo\u0000morph/morph-v3-large": {
+      "cached_read": null,
+      "in": 0.9,
+      "out": 1.9
+    },
+    "kilo\u0000nex-agi/deepseek-v3.1-nex-n1": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 1.0
+    },
+    "kilo\u0000nousresearch/hermes-2-pro-llama-3-8b": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.14
+    },
+    "kilo\u0000nousresearch/hermes-3-llama-3.1-405b": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 1.0
+    },
+    "kilo\u0000nousresearch/hermes-3-llama-3.1-70b": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.3
+    },
+    "kilo\u0000nousresearch/hermes-4-405b": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "kilo\u0000nousresearch/hermes-4-70b": {
+      "cached_read": 0.055,
+      "in": 0.13,
+      "out": 0.4
+    },
+    "kilo\u0000nvidia/llama-3.3-nemotron-super-49b-v1.5": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "kilo\u0000nvidia/nemotron-3-nano-30b-a3b": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.2
+    },
+    "kilo\u0000nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "kilo\u0000nvidia/nemotron-3-super-120b-a12b": {
+      "cached_read": 0.1,
+      "in": 0.1,
+      "out": 0.5
+    },
+    "kilo\u0000nvidia/nemotron-3-super-120b-a12b:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "kilo\u0000nvidia/nemotron-nano-9b-v2": {
+      "cached_read": null,
+      "in": 0.04,
+      "out": 0.16
+    },
+    "kilo\u0000openai/gpt-3.5-turbo": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "kilo\u0000openai/gpt-3.5-turbo-0613": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 2.0
+    },
+    "kilo\u0000openai/gpt-3.5-turbo-16k": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 4.0
+    },
+    "kilo\u0000openai/gpt-3.5-turbo-instruct": {
+      "cached_read": null,
+      "in": 1.5,
+      "out": 2.0
+    },
+    "kilo\u0000openai/gpt-4": {
+      "cached_read": null,
+      "in": 30.0,
+      "out": 60.0
+    },
+    "kilo\u0000openai/gpt-4-0314": {
+      "cached_read": null,
+      "in": 30.0,
+      "out": 60.0
+    },
+    "kilo\u0000openai/gpt-4-1106-preview": {
+      "cached_read": null,
+      "in": 10.0,
+      "out": 30.0
+    },
+    "kilo\u0000openai/gpt-4-turbo": {
+      "cached_read": null,
+      "in": 10.0,
+      "out": 30.0
+    },
+    "kilo\u0000openai/gpt-4-turbo-preview": {
+      "cached_read": null,
+      "in": 10.0,
+      "out": 30.0
+    },
+    "kilo\u0000openai/gpt-4.1": {
+      "cached_read": 0.5,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "kilo\u0000openai/gpt-4.1-mini": {
+      "cached_read": 0.1,
+      "in": 0.4,
+      "out": 1.6
+    },
+    "kilo\u0000openai/gpt-4.1-nano": {
+      "cached_read": 0.025,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "kilo\u0000openai/gpt-4o": {
+      "cached_read": 1.25,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "kilo\u0000openai/gpt-4o-2024-05-13": {
+      "cached_read": null,
+      "in": 5.0,
+      "out": 15.0
+    },
+    "kilo\u0000openai/gpt-4o-2024-08-06": {
+      "cached_read": 1.25,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "kilo\u0000openai/gpt-4o-2024-11-20": {
+      "cached_read": 1.25,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "kilo\u0000openai/gpt-4o-audio-preview": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "kilo\u0000openai/gpt-4o-mini": {
+      "cached_read": 0.075,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "kilo\u0000openai/gpt-4o-mini-2024-07-18": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "kilo\u0000openai/gpt-4o-mini-search-preview": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "kilo\u0000openai/gpt-4o-search-preview": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "kilo\u0000openai/gpt-5": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "kilo\u0000openai/gpt-5-chat": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "kilo\u0000openai/gpt-5-codex": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "kilo\u0000openai/gpt-5-image": {
+      "cached_read": null,
+      "in": 10.0,
+      "out": 10.0
+    },
+    "kilo\u0000openai/gpt-5-image-mini": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 2.0
+    },
+    "kilo\u0000openai/gpt-5-mini": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "kilo\u0000openai/gpt-5-nano": {
+      "cached_read": 0.005,
+      "in": 0.05,
+      "out": 0.4
+    },
+    "kilo\u0000openai/gpt-5-pro": {
+      "cached_read": null,
+      "in": 15.0,
+      "out": 120.0
+    },
+    "kilo\u0000openai/gpt-5.1": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "kilo\u0000openai/gpt-5.1-chat": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "kilo\u0000openai/gpt-5.1-codex": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "kilo\u0000openai/gpt-5.1-codex-max": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "kilo\u0000openai/gpt-5.1-codex-mini": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "kilo\u0000openai/gpt-5.2": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "kilo\u0000openai/gpt-5.2-chat": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "kilo\u0000openai/gpt-5.2-codex": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "kilo\u0000openai/gpt-5.2-pro": {
+      "cached_read": null,
+      "in": 21.0,
+      "out": 168.0
+    },
+    "kilo\u0000openai/gpt-5.3-chat": {
+      "cached_read": null,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "kilo\u0000openai/gpt-5.3-codex": {
+      "cached_read": null,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "kilo\u0000openai/gpt-5.4": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 15.0
+    },
+    "kilo\u0000openai/gpt-5.4-image-2": {
+      "cached_read": 2.0,
+      "in": 8.0,
+      "out": 15.0
+    },
+    "kilo\u0000openai/gpt-5.4-mini": {
+      "cached_read": 0.075,
+      "in": 0.75,
+      "out": 4.5
+    },
+    "kilo\u0000openai/gpt-5.4-nano": {
+      "cached_read": 0.02,
+      "in": 0.2,
+      "out": 1.25
+    },
+    "kilo\u0000openai/gpt-5.4-pro": {
+      "cached_read": null,
+      "in": 30.0,
+      "out": 180.0
+    },
+    "kilo\u0000openai/gpt-5.5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 30.0
+    },
+    "kilo\u0000openai/gpt-5.5-pro": {
+      "cached_read": null,
+      "in": 30.0,
+      "out": 180.0
+    },
+    "kilo\u0000openai/gpt-audio": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "kilo\u0000openai/gpt-audio-mini": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.4
+    },
+    "kilo\u0000openai/gpt-chat-latest": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 30.0
+    },
+    "kilo\u0000openai/gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.039,
+      "out": 0.19
+    },
+    "kilo\u0000openai/gpt-oss-20b": {
+      "cached_read": null,
+      "in": 0.03,
+      "out": 0.14
+    },
+    "kilo\u0000openai/gpt-oss-safeguard-20b": {
+      "cached_read": 0.037,
+      "in": 0.075,
+      "out": 0.3
+    },
+    "kilo\u0000openai/o1": {
+      "cached_read": 7.5,
+      "in": 15.0,
+      "out": 60.0
+    },
+    "kilo\u0000openai/o1-pro": {
+      "cached_read": null,
+      "in": 150.0,
+      "out": 600.0
+    },
+    "kilo\u0000openai/o3": {
+      "cached_read": 0.5,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "kilo\u0000openai/o3-deep-research": {
+      "cached_read": 2.5,
+      "in": 10.0,
+      "out": 40.0
+    },
+    "kilo\u0000openai/o3-mini": {
+      "cached_read": 0.55,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "kilo\u0000openai/o3-mini-high": {
+      "cached_read": 0.55,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "kilo\u0000openai/o3-pro": {
+      "cached_read": null,
+      "in": 20.0,
+      "out": 80.0
+    },
+    "kilo\u0000openai/o4-mini": {
+      "cached_read": 0.275,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "kilo\u0000openai/o4-mini-deep-research": {
+      "cached_read": 0.5,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "kilo\u0000openai/o4-mini-high": {
+      "cached_read": null,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "kilo\u0000openrouter/auto": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "kilo\u0000openrouter/bodybuilder": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "kilo\u0000openrouter/free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "kilo\u0000openrouter/owl-alpha": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "kilo\u0000openrouter/pareto-code": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "kilo\u0000perceptron/perceptron-mk1": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 1.5
+    },
+    "kilo\u0000perplexity/sonar": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 1.0
+    },
+    "kilo\u0000perplexity/sonar-deep-research": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "kilo\u0000perplexity/sonar-pro": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "kilo\u0000perplexity/sonar-pro-search": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "kilo\u0000perplexity/sonar-reasoning-pro": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "kilo\u0000poolside/laguna-m.1:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "kilo\u0000poolside/laguna-xs.2:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "kilo\u0000prime-intellect/intellect-3": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 1.1
+    },
+    "kilo\u0000qwen/qwen-2.5-72b-instruct": {
+      "cached_read": null,
+      "in": 0.12,
+      "out": 0.39
+    },
+    "kilo\u0000qwen/qwen-2.5-7b-instruct": {
+      "cached_read": null,
+      "in": 0.04,
+      "out": 0.1
+    },
+    "kilo\u0000qwen/qwen-2.5-coder-32b-instruct": {
+      "cached_read": 0.015,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "kilo\u0000qwen/qwen-plus": {
+      "cached_read": 0.08,
+      "in": 0.4,
+      "out": 1.2
+    },
+    "kilo\u0000qwen/qwen-plus-2025-07-28": {
+      "cached_read": null,
+      "in": 0.26,
+      "out": 0.78
+    },
+    "kilo\u0000qwen/qwen-plus-2025-07-28:thinking": {
+      "cached_read": null,
+      "in": 0.26,
+      "out": 0.78
+    },
+    "kilo\u0000qwen/qwen2.5-vl-72b-instruct": {
+      "cached_read": 0.075,
+      "in": 0.8,
+      "out": 0.8
+    },
+    "kilo\u0000qwen/qwen3-14b": {
+      "cached_read": 0.025,
+      "in": 0.06,
+      "out": 0.24
+    },
+    "kilo\u0000qwen/qwen3-235b-a22b": {
+      "cached_read": 0.15,
+      "in": 0.455,
+      "out": 1.82
+    },
+    "kilo\u0000qwen/qwen3-235b-a22b-2507": {
+      "cached_read": null,
+      "in": 0.071,
+      "out": 0.1
+    },
+    "kilo\u0000qwen/qwen3-235b-a22b-thinking-2507": {
+      "cached_read": null,
+      "in": 0.11,
+      "out": 0.6
+    },
+    "kilo\u0000qwen/qwen3-30b-a3b": {
+      "cached_read": 0.03,
+      "in": 0.08,
+      "out": 0.28
+    },
+    "kilo\u0000qwen/qwen3-30b-a3b-instruct-2507": {
+      "cached_read": 0.04,
+      "in": 0.09,
+      "out": 0.3
+    },
+    "kilo\u0000qwen/qwen3-30b-a3b-thinking-2507": {
+      "cached_read": null,
+      "in": 0.051,
+      "out": 0.34
+    },
+    "kilo\u0000qwen/qwen3-32b": {
+      "cached_read": 0.04,
+      "in": 0.08,
+      "out": 0.24
+    },
+    "kilo\u0000qwen/qwen3-8b": {
+      "cached_read": 0.05,
+      "in": 0.05,
+      "out": 0.4
+    },
+    "kilo\u0000qwen/qwen3-coder": {
+      "cached_read": 0.022,
+      "in": 0.22,
+      "out": 1.0
+    },
+    "kilo\u0000qwen/qwen3-coder-30b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.27
+    },
+    "kilo\u0000qwen/qwen3-coder-flash": {
+      "cached_read": 0.06,
+      "in": 0.195,
+      "out": 0.975
+    },
+    "kilo\u0000qwen/qwen3-coder-next": {
+      "cached_read": 0.035,
+      "in": 0.12,
+      "out": 0.75
+    },
+    "kilo\u0000qwen/qwen3-coder-plus": {
+      "cached_read": 0.2,
+      "in": 0.65,
+      "out": 3.25
+    },
+    "kilo\u0000qwen/qwen3-max": {
+      "cached_read": 0.24,
+      "in": 1.2,
+      "out": 6.0
+    },
+    "kilo\u0000qwen/qwen3-max-thinking": {
+      "cached_read": null,
+      "in": 0.78,
+      "out": 3.9
+    },
+    "kilo\u0000qwen/qwen3-next-80b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.09,
+      "out": 1.1
+    },
+    "kilo\u0000qwen/qwen3-next-80b-a3b-thinking": {
+      "cached_read": null,
+      "in": 0.0975,
+      "out": 0.78
+    },
+    "kilo\u0000qwen/qwen3-vl-235b-a22b-instruct": {
+      "cached_read": 0.11,
+      "in": 0.2,
+      "out": 0.88
+    },
+    "kilo\u0000qwen/qwen3-vl-235b-a22b-thinking": {
+      "cached_read": null,
+      "in": 0.26,
+      "out": 2.6
+    },
+    "kilo\u0000qwen/qwen3-vl-30b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.13,
+      "out": 0.52
+    },
+    "kilo\u0000qwen/qwen3-vl-30b-a3b-thinking": {
+      "cached_read": null,
+      "in": 0.13,
+      "out": 1.56
+    },
+    "kilo\u0000qwen/qwen3-vl-32b-instruct": {
+      "cached_read": null,
+      "in": 0.104,
+      "out": 0.416
+    },
+    "kilo\u0000qwen/qwen3-vl-8b-instruct": {
+      "cached_read": null,
+      "in": 0.08,
+      "out": 0.5
+    },
+    "kilo\u0000qwen/qwen3-vl-8b-thinking": {
+      "cached_read": null,
+      "in": 0.117,
+      "out": 1.365
+    },
+    "kilo\u0000qwen/qwen3.5-122b-a10b": {
+      "cached_read": null,
+      "in": 0.26,
+      "out": 2.08
+    },
+    "kilo\u0000qwen/qwen3.5-27b": {
+      "cached_read": null,
+      "in": 0.195,
+      "out": 1.56
+    },
+    "kilo\u0000qwen/qwen3.5-35b-a3b": {
+      "cached_read": null,
+      "in": 0.1625,
+      "out": 1.3
+    },
+    "kilo\u0000qwen/qwen3.5-397b-a17b": {
+      "cached_read": null,
+      "in": 0.39,
+      "out": 2.34
+    },
+    "kilo\u0000qwen/qwen3.5-9b": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.15
+    },
+    "kilo\u0000qwen/qwen3.5-flash-02-23": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "kilo\u0000qwen/qwen3.5-plus-02-15": {
+      "cached_read": null,
+      "in": 0.26,
+      "out": 1.56
+    },
+    "kilo\u0000qwen/qwen3.5-plus-20260420": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.4
+    },
+    "kilo\u0000qwen/qwen3.6-27b": {
+      "cached_read": null,
+      "in": 0.325,
+      "out": 3.25
+    },
+    "kilo\u0000qwen/qwen3.6-35b-a3b": {
+      "cached_read": 0.1612,
+      "in": 0.1612,
+      "out": 0.96525
+    },
+    "kilo\u0000qwen/qwen3.6-flash": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 1.5
+    },
+    "kilo\u0000qwen/qwen3.6-max-preview": {
+      "cached_read": null,
+      "in": 1.04,
+      "out": 6.24
+    },
+    "kilo\u0000qwen/qwen3.6-plus": {
+      "cached_read": 0.0325,
+      "in": 0.325,
+      "out": 1.95
+    },
+    "kilo\u0000qwen/qwen3.7-max": {
+      "cached_read": 0.1625,
+      "in": 1.625,
+      "out": 4.875
+    },
+    "kilo\u0000rekaai/reka-edge": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "kilo\u0000rekaai/reka-flash-3": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.2
+    },
+    "kilo\u0000relace/relace-apply-3": {
+      "cached_read": null,
+      "in": 0.85,
+      "out": 1.25
+    },
+    "kilo\u0000relace/relace-search": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "kilo\u0000sao10k/l3-euryale-70b": {
+      "cached_read": null,
+      "in": 1.48,
+      "out": 1.48
+    },
+    "kilo\u0000sao10k/l3-lunaris-8b": {
+      "cached_read": null,
+      "in": 0.04,
+      "out": 0.05
+    },
+    "kilo\u0000sao10k/l3.1-70b-hanami-x1": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 3.0
+    },
+    "kilo\u0000sao10k/l3.1-euryale-70b": {
+      "cached_read": null,
+      "in": 0.85,
+      "out": 0.85
+    },
+    "kilo\u0000sao10k/l3.3-euryale-70b": {
+      "cached_read": null,
+      "in": 0.65,
+      "out": 0.75
+    },
+    "kilo\u0000stealth/claude-opus-4.6": {
+      "cached_read": 0.4,
+      "in": 4.0,
+      "out": 20.0
+    },
+    "kilo\u0000stealth/claude-opus-4.7": {
+      "cached_read": 0.4,
+      "in": 4.0,
+      "out": 20.0
+    },
+    "kilo\u0000stealth/claude-sonnet-4.6": {
+      "cached_read": 0.24,
+      "in": 2.4,
+      "out": 12.0
+    },
+    "kilo\u0000stepfun/step-3.5-flash": {
+      "cached_read": 0.02,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "kilo\u0000switchpoint/router": {
+      "cached_read": null,
+      "in": 0.85,
+      "out": 3.4
+    },
+    "kilo\u0000tencent/hunyuan-a13b-instruct": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.57
+    },
+    "kilo\u0000tencent/hy3-preview": {
+      "cached_read": 0.029,
+      "in": 0.066,
+      "out": 0.26
+    },
+    "kilo\u0000thedrummer/cydonia-24b-v4.1": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.5
+    },
+    "kilo\u0000thedrummer/rocinante-12b": {
+      "cached_read": null,
+      "in": 0.17,
+      "out": 0.43
+    },
+    "kilo\u0000thedrummer/skyfall-36b-v2": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 0.8
+    },
+    "kilo\u0000thedrummer/unslopnemo-12b": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 0.4
+    },
+    "kilo\u0000undi95/remm-slerp-l2-13b": {
+      "cached_read": null,
+      "in": 0.45,
+      "out": 0.65
+    },
+    "kilo\u0000upstage/solar-pro-3": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "kilo\u0000writer/palmyra-x5": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 6.0
+    },
+    "kilo\u0000x-ai/grok-4.20": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "kilo\u0000x-ai/grok-4.20-multi-agent": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "kilo\u0000x-ai/grok-4.3": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "kilo\u0000x-ai/grok-build-0.1": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 2.0
+    },
+    "kilo\u0000xiaomi/mimo-v2-flash": {
+      "cached_read": 0.045,
+      "in": 0.09,
+      "out": 0.29
+    },
+    "kilo\u0000xiaomi/mimo-v2-omni": {
+      "cached_read": 0.08,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "kilo\u0000xiaomi/mimo-v2-pro": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "kilo\u0000xiaomi/mimo-v2.5": {
+      "cached_read": 0.08,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "kilo\u0000xiaomi/mimo-v2.5-pro": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "kilo\u0000z-ai/glm-4-32b": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "kilo\u0000z-ai/glm-4.5": {
+      "cached_read": 0.175,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "kilo\u0000z-ai/glm-4.5-air": {
+      "cached_read": 0.025,
+      "in": 0.13,
+      "out": 0.85
+    },
+    "kilo\u0000z-ai/glm-4.5v": {
+      "cached_read": 0.11,
+      "in": 0.6,
+      "out": 1.8
+    },
+    "kilo\u0000z-ai/glm-4.6": {
+      "cached_read": 0.175,
+      "in": 0.39,
+      "out": 1.9
+    },
+    "kilo\u0000z-ai/glm-4.6v": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.9
+    },
+    "kilo\u0000z-ai/glm-4.7": {
+      "cached_read": 0.2,
+      "in": 0.38,
+      "out": 1.98
+    },
+    "kilo\u0000z-ai/glm-4.7-flash": {
+      "cached_read": 0.01,
+      "in": 0.06,
+      "out": 0.4
+    },
+    "kilo\u0000z-ai/glm-5": {
+      "cached_read": null,
+      "in": 0.72,
+      "out": 2.3
+    },
+    "kilo\u0000z-ai/glm-5-turbo": {
+      "cached_read": 0.24,
+      "in": 1.2,
+      "out": 4.0
+    },
+    "kilo\u0000z-ai/glm-5.1": {
+      "cached_read": null,
+      "in": 1.26,
+      "out": 3.96
+    },
+    "kilo\u0000z-ai/glm-5v-turbo": {
+      "cached_read": 0.24,
+      "in": 1.2,
+      "out": 4.0
+    },
+    "kilo\u0000~anthropic/claude-haiku-latest": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "kilo\u0000~anthropic/claude-opus-latest": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "kilo\u0000~anthropic/claude-sonnet-latest": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "kilo\u0000~google/gemini-flash-latest": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "kilo\u0000~google/gemini-pro-latest": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "kilo\u0000~moonshotai/kimi-latest": {
+      "cached_read": 0.14,
+      "in": 0.74,
+      "out": 3.49
+    },
+    "kilo\u0000~openai/gpt-latest": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 30.0
+    },
+    "kilo\u0000~openai/gpt-mini-latest": {
+      "cached_read": 0.075,
+      "in": 0.75,
+      "out": 4.5
+    },
+    "kimi-for-coding\u0000k2p5": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "kimi-for-coding\u0000k2p6": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "kimi-for-coding\u0000kimi-k2-thinking": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "kuae-cloud-coding-plan\u0000glm-4.7": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "lilac\u0000google/gemma-4-31b-it": {
+      "cached_read": null,
+      "in": 0.11,
+      "out": 0.35
+    },
+    "lilac\u0000minimaxai/minimax-m2.7": {
+      "cached_read": 0.055,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "lilac\u0000moonshotai/kimi-k2.6": {
+      "cached_read": 0.2,
+      "in": 0.7,
+      "out": 3.5
+    },
+    "lilac\u0000zai-org/glm-5.1": {
+      "cached_read": 0.27,
+      "in": 0.9,
+      "out": 3.0
+    },
+    "llama\u0000cerebras-llama-4-maverick-17b-128e-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "llama\u0000cerebras-llama-4-scout-17b-16e-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "llama\u0000groq-llama-4-maverick-17b-128e-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "llama\u0000llama-3.3-70b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "llama\u0000llama-3.3-8b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "llama\u0000llama-4-maverick-17b-128e-instruct-fp8": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "llama\u0000llama-4-scout-17b-16e-instruct-fp8": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "llmgateway\u0000auto": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "llmgateway\u0000claude-3-5-haiku": {
+      "cached_read": 0.08,
+      "in": 0.8,
+      "out": 4.0
+    },
+    "llmgateway\u0000claude-3-5-sonnet-20241022": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "llmgateway\u0000claude-3-7-sonnet": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "llmgateway\u0000claude-3-7-sonnet-20250219": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "llmgateway\u0000claude-3-opus": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "llmgateway\u0000claude-haiku-4-5": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "llmgateway\u0000claude-haiku-4-5-20251001": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "llmgateway\u0000claude-opus-4-1-20250805": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "llmgateway\u0000claude-opus-4-20250514": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "llmgateway\u0000claude-opus-4-5-20251101": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "llmgateway\u0000claude-opus-4-6": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "llmgateway\u0000claude-opus-4-7": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "llmgateway\u0000claude-opus-4-8": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "llmgateway\u0000claude-sonnet-4-20250514": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "llmgateway\u0000claude-sonnet-4-5": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "llmgateway\u0000claude-sonnet-4-5-20250929": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "llmgateway\u0000claude-sonnet-4-6": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "llmgateway\u0000codestral-2508": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.9
+    },
+    "llmgateway\u0000custom": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "llmgateway\u0000deepseek-r1-0528": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 2.19
+    },
+    "llmgateway\u0000deepseek-v3.1": {
+      "cached_read": 0.07,
+      "in": 0.56,
+      "out": 1.68
+    },
+    "llmgateway\u0000deepseek-v3.2": {
+      "cached_read": 0.056,
+      "in": 0.28,
+      "out": 0.42
+    },
+    "llmgateway\u0000deepseek-v4-flash": {
+      "cached_read": 0.0028,
+      "in": 0.14,
+      "out": 0.28
+    },
+    "llmgateway\u0000deepseek-v4-pro": {
+      "cached_read": 0.003625,
+      "in": 0.435,
+      "out": 0.87
+    },
+    "llmgateway\u0000devstral-2512": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "llmgateway\u0000devstral-small-2507": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "llmgateway\u0000gemini-2.0-flash": {
+      "cached_read": 0.025,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "llmgateway\u0000gemini-2.0-flash-lite": {
+      "cached_read": null,
+      "in": 0.075,
+      "out": 0.3
+    },
+    "llmgateway\u0000gemini-2.5-flash": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "llmgateway\u0000gemini-2.5-flash-lite": {
+      "cached_read": 0.01,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "llmgateway\u0000gemini-2.5-pro": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "llmgateway\u0000gemini-3-flash-preview": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "llmgateway\u0000gemini-3.1-flash-lite": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 1.5
+    },
+    "llmgateway\u0000gemini-3.1-flash-lite-preview": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 1.5
+    },
+    "llmgateway\u0000gemini-3.1-pro-preview": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "llmgateway\u0000gemini-3.5-flash": {
+      "cached_read": 0.15,
+      "in": 1.5,
+      "out": 9.0
+    },
+    "llmgateway\u0000gemini-pro-latest": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "llmgateway\u0000gemma-2-27b-it-together": {
+      "cached_read": null,
+      "in": 0.08,
+      "out": 0.08
+    },
+    "llmgateway\u0000gemma-3-1b-it": {
+      "cached_read": null,
+      "in": 0.08,
+      "out": 0.3
+    },
+    "llmgateway\u0000gemma-3-27b": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 0.27
+    },
+    "llmgateway\u0000glm-4-32b-0414-128k": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "llmgateway\u0000glm-4.5": {
+      "cached_read": 0.11,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "llmgateway\u0000glm-4.5-air": {
+      "cached_read": 0.03,
+      "in": 0.2,
+      "out": 1.1
+    },
+    "llmgateway\u0000glm-4.5-airx": {
+      "cached_read": 0.22,
+      "in": 1.1,
+      "out": 4.5
+    },
+    "llmgateway\u0000glm-4.5-flash": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "llmgateway\u0000glm-4.5-x": {
+      "cached_read": 0.45,
+      "in": 2.2,
+      "out": 8.9
+    },
+    "llmgateway\u0000glm-4.5v": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 1.8
+    },
+    "llmgateway\u0000glm-4.6": {
+      "cached_read": 0.11,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "llmgateway\u0000glm-4.6v": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.9
+    },
+    "llmgateway\u0000glm-4.6v-flash": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "llmgateway\u0000glm-4.6v-flashx": {
+      "cached_read": 0.004,
+      "in": 0.04,
+      "out": 0.4
+    },
+    "llmgateway\u0000glm-4.7": {
+      "cached_read": 0.11,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "llmgateway\u0000glm-4.7-flash": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "llmgateway\u0000glm-4.7-flashx": {
+      "cached_read": 0.01,
+      "in": 0.07,
+      "out": 0.4
+    },
+    "llmgateway\u0000glm-5": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 3.2
+    },
+    "llmgateway\u0000glm-5.1": {
+      "cached_read": 1.3,
+      "in": 6.0,
+      "out": 24.0
+    },
+    "llmgateway\u0000gpt-3.5-turbo": {
+      "cached_read": 0.0,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "llmgateway\u0000gpt-4": {
+      "cached_read": null,
+      "in": 30.0,
+      "out": 60.0
+    },
+    "llmgateway\u0000gpt-4-turbo": {
+      "cached_read": null,
+      "in": 10.0,
+      "out": 30.0
+    },
+    "llmgateway\u0000gpt-4.1": {
+      "cached_read": 0.5,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "llmgateway\u0000gpt-4.1-mini": {
+      "cached_read": 0.1,
+      "in": 0.4,
+      "out": 1.6
+    },
+    "llmgateway\u0000gpt-4.1-nano": {
+      "cached_read": 0.025,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "llmgateway\u0000gpt-4o": {
+      "cached_read": 1.25,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "llmgateway\u0000gpt-4o-mini": {
+      "cached_read": 0.075,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "llmgateway\u0000gpt-4o-mini-search-preview": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "llmgateway\u0000gpt-4o-search-preview": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "llmgateway\u0000gpt-5": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "llmgateway\u0000gpt-5-chat-latest": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "llmgateway\u0000gpt-5-mini": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "llmgateway\u0000gpt-5-nano": {
+      "cached_read": 0.005,
+      "in": 0.05,
+      "out": 0.4
+    },
+    "llmgateway\u0000gpt-5-pro": {
+      "cached_read": null,
+      "in": 15.0,
+      "out": 120.0
+    },
+    "llmgateway\u0000gpt-5.1": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "llmgateway\u0000gpt-5.1-codex": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "llmgateway\u0000gpt-5.1-codex-mini": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "llmgateway\u0000gpt-5.2": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "llmgateway\u0000gpt-5.2-chat-latest": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "llmgateway\u0000gpt-5.2-codex": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "llmgateway\u0000gpt-5.2-pro": {
+      "cached_read": null,
+      "in": 21.0,
+      "out": 168.0
+    },
+    "llmgateway\u0000gpt-5.3-chat-latest": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "llmgateway\u0000gpt-5.3-codex": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "llmgateway\u0000gpt-5.4": {
+      "cached_read": 0.25,
+      "in": 2.5,
+      "out": 15.0
+    },
+    "llmgateway\u0000gpt-5.4-mini": {
+      "cached_read": 0.075,
+      "in": 0.75,
+      "out": 4.5
+    },
+    "llmgateway\u0000gpt-5.4-nano": {
+      "cached_read": 0.02,
+      "in": 0.2,
+      "out": 1.25
+    },
+    "llmgateway\u0000gpt-5.4-pro": {
+      "cached_read": null,
+      "in": 30.0,
+      "out": 180.0
+    },
+    "llmgateway\u0000gpt-5.5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 30.0
+    },
+    "llmgateway\u0000gpt-5.5-pro": {
+      "cached_read": null,
+      "in": 30.0,
+      "out": 180.0
+    },
+    "llmgateway\u0000gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.25
+    },
+    "llmgateway\u0000gpt-oss-20b": {
+      "cached_read": null,
+      "in": 0.04,
+      "out": 0.15
+    },
+    "llmgateway\u0000grok-4-0709": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "llmgateway\u0000grok-4-1-fast-reasoning": {
+      "cached_read": 0.05,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "llmgateway\u0000grok-4-20-beta-0309-non-reasoning": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "llmgateway\u0000grok-4-20-beta-0309-reasoning": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "llmgateway\u0000grok-4-20-non-reasoning": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "llmgateway\u0000grok-4-20-reasoning": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "llmgateway\u0000grok-4-3": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "llmgateway\u0000grok-4-fast-reasoning": {
+      "cached_read": 0.05,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "llmgateway\u0000hermes-2-pro-llama-3-8b": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.14
+    },
+    "llmgateway\u0000kimi-k2": {
+      "cached_read": 0.12,
+      "in": 0.6,
+      "out": 2.5
+    },
+    "llmgateway\u0000kimi-k2-thinking": {
+      "cached_read": 0.15,
+      "in": 0.6,
+      "out": 2.5
+    },
+    "llmgateway\u0000kimi-k2-thinking-turbo": {
+      "cached_read": 0.15,
+      "in": 1.15,
+      "out": 8.0
+    },
+    "llmgateway\u0000kimi-k2.5": {
+      "cached_read": 0.1,
+      "in": 0.6,
+      "out": 3.0
+    },
+    "llmgateway\u0000kimi-k2.6": {
+      "cached_read": 0.16,
+      "in": 0.95,
+      "out": 4.0
+    },
+    "llmgateway\u0000llama-3-70b-instruct": {
+      "cached_read": null,
+      "in": 0.51,
+      "out": 0.74
+    },
+    "llmgateway\u0000llama-3-8b-instruct": {
+      "cached_read": null,
+      "in": 0.04,
+      "out": 0.04
+    },
+    "llmgateway\u0000llama-3.1-70b-instruct": {
+      "cached_read": null,
+      "in": 0.72,
+      "out": 0.72
+    },
+    "llmgateway\u0000llama-3.1-8b-instruct": {
+      "cached_read": null,
+      "in": 0.22,
+      "out": 0.22
+    },
+    "llmgateway\u0000llama-3.1-nemotron-ultra-253b": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 1.8
+    },
+    "llmgateway\u0000llama-3.2-11b-instruct": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.33
+    },
+    "llmgateway\u0000llama-3.2-3b-instruct": {
+      "cached_read": null,
+      "in": 0.03,
+      "out": 0.05
+    },
+    "llmgateway\u0000llama-3.3-70b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "llmgateway\u0000llama-4-maverick-17b-instruct": {
+      "cached_read": null,
+      "in": 0.24,
+      "out": 0.97
+    },
+    "llmgateway\u0000llama-4-scout": {
+      "cached_read": null,
+      "in": 0.18,
+      "out": 0.59
+    },
+    "llmgateway\u0000llama-4-scout-17b-instruct": {
+      "cached_read": null,
+      "in": 0.17,
+      "out": 0.66
+    },
+    "llmgateway\u0000mimo-v2-flash": {
+      "cached_read": 0.01,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "llmgateway\u0000mimo-v2-omni": {
+      "cached_read": 0.08,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "llmgateway\u0000mimo-v2-pro": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "llmgateway\u0000mimo-v2.5": {
+      "cached_read": 0.08,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "llmgateway\u0000mimo-v2.5-pro": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "llmgateway\u0000minimax-m2": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "llmgateway\u0000minimax-m2.1": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "llmgateway\u0000minimax-m2.1-lightning": {
+      "cached_read": null,
+      "in": 0.12,
+      "out": 0.48
+    },
+    "llmgateway\u0000minimax-m2.5": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "llmgateway\u0000minimax-m2.5-highspeed": {
+      "cached_read": 0.06,
+      "in": 0.6,
+      "out": 2.4
+    },
+    "llmgateway\u0000minimax-m2.7": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "llmgateway\u0000minimax-m2.7-highspeed": {
+      "cached_read": 0.06,
+      "in": 0.6,
+      "out": 2.4
+    },
+    "llmgateway\u0000minimax-m3": {
+      "cached_read": 0.12,
+      "in": 0.6,
+      "out": 2.4
+    },
+    "llmgateway\u0000minimax-text-01": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 1.1
+    },
+    "llmgateway\u0000ministral-14b-2512": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "llmgateway\u0000ministral-3b-2512": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "llmgateway\u0000ministral-8b-2512": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.15
+    },
+    "llmgateway\u0000mistral-large-2512": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "llmgateway\u0000mistral-large-latest": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "llmgateway\u0000mistral-small-2506": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "llmgateway\u0000o1": {
+      "cached_read": 7.5,
+      "in": 15.0,
+      "out": 60.0
+    },
+    "llmgateway\u0000o3": {
+      "cached_read": 0.5,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "llmgateway\u0000o3-mini": {
+      "cached_read": 0.55,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "llmgateway\u0000o4-mini": {
+      "cached_read": 0.275,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "llmgateway\u0000pixtral-large-latest": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "llmgateway\u0000qwen-coder-plus": {
+      "cached_read": null,
+      "in": 0.502,
+      "out": 1.004
+    },
+    "llmgateway\u0000qwen-flash": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.4
+    },
+    "llmgateway\u0000qwen-max": {
+      "cached_read": null,
+      "in": 1.6,
+      "out": 6.4
+    },
+    "llmgateway\u0000qwen-max-latest": {
+      "cached_read": null,
+      "in": 0.345,
+      "out": 1.377
+    },
+    "llmgateway\u0000qwen-omni-turbo": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.27
+    },
+    "llmgateway\u0000qwen-plus": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 1.2
+    },
+    "llmgateway\u0000qwen-plus-latest": {
+      "cached_read": null,
+      "in": 0.115,
+      "out": 0.287
+    },
+    "llmgateway\u0000qwen-turbo": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.2
+    },
+    "llmgateway\u0000qwen-vl-max": {
+      "cached_read": null,
+      "in": 0.8,
+      "out": 3.2
+    },
+    "llmgateway\u0000qwen-vl-plus": {
+      "cached_read": null,
+      "in": 0.21,
+      "out": 0.63
+    },
+    "llmgateway\u0000qwen2-5-vl-32b-instruct": {
+      "cached_read": null,
+      "in": 1.4,
+      "out": 4.2
+    },
+    "llmgateway\u0000qwen2-5-vl-72b-instruct": {
+      "cached_read": null,
+      "in": 2.8,
+      "out": 8.4
+    },
+    "llmgateway\u0000qwen25-coder-7b": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.05
+    },
+    "llmgateway\u0000qwen3-235b-a22b-fp8": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.8
+    },
+    "llmgateway\u0000qwen3-235b-a22b-instruct-2507": {
+      "cached_read": null,
+      "in": 0.09,
+      "out": 0.58
+    },
+    "llmgateway\u0000qwen3-235b-a22b-thinking-2507": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.6
+    },
+    "llmgateway\u0000qwen3-30b-a3b-fp8": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "llmgateway\u0000qwen3-30b-a3b-instruct-2507": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "llmgateway\u0000qwen3-30b-a3b-thinking-2507": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "llmgateway\u0000qwen3-32b": {
+      "cached_read": null,
+      "in": 0.7,
+      "out": 2.8
+    },
+    "llmgateway\u0000qwen3-32b-fp8": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "llmgateway\u0000qwen3-4b-fp8": {
+      "cached_read": null,
+      "in": 0.03,
+      "out": 0.03
+    },
+    "llmgateway\u0000qwen3-coder-30b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.45,
+      "out": 2.25
+    },
+    "llmgateway\u0000qwen3-coder-480b-a35b-instruct": {
+      "cached_read": null,
+      "in": 1.5,
+      "out": 7.5
+    },
+    "llmgateway\u0000qwen3-coder-flash": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.5
+    },
+    "llmgateway\u0000qwen3-coder-next": {
+      "cached_read": null,
+      "in": 0.108,
+      "out": 0.675
+    },
+    "llmgateway\u0000qwen3-coder-plus": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "llmgateway\u0000qwen3-max": {
+      "cached_read": null,
+      "in": 1.2,
+      "out": 6.0
+    },
+    "llmgateway\u0000qwen3-max-2026-01-23": {
+      "cached_read": 0.072,
+      "in": 0.359,
+      "out": 1.434
+    },
+    "llmgateway\u0000qwen3-next-80b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 2.0
+    },
+    "llmgateway\u0000qwen3-next-80b-a3b-thinking": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 6.0
+    },
+    "llmgateway\u0000qwen3-vl-235b-a22b-instruct": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.5
+    },
+    "llmgateway\u0000qwen3-vl-235b-a22b-thinking": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 2.0
+    },
+    "llmgateway\u0000qwen3-vl-30b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.7
+    },
+    "llmgateway\u0000qwen3-vl-30b-a3b-thinking": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 1.0
+    },
+    "llmgateway\u0000qwen3-vl-8b-instruct": {
+      "cached_read": null,
+      "in": 0.08,
+      "out": 0.5
+    },
+    "llmgateway\u0000qwen3-vl-flash": {
+      "cached_read": 0.0044,
+      "in": 0.022,
+      "out": 0.215
+    },
+    "llmgateway\u0000qwen3-vl-plus": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 1.6
+    },
+    "llmgateway\u0000qwen3.6-35b-a3b": {
+      "cached_read": null,
+      "in": 0.248,
+      "out": 1.485
+    },
+    "llmgateway\u0000qwen3.6-max-preview": {
+      "cached_read": 0.13,
+      "in": 1.3,
+      "out": 7.8
+    },
+    "llmgateway\u0000qwen3.6-plus": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "llmgateway\u0000qwen3.7-max": {
+      "cached_read": 0.5,
+      "in": 2.5,
+      "out": 7.5
+    },
+    "llmgateway\u0000qwen3.7-plus": {
+      "cached_read": 0.08,
+      "in": 0.4,
+      "out": 1.6
+    },
+    "llmgateway\u0000qwen35-397b-a17b": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 3.6
+    },
+    "llmgateway\u0000qwq-plus": {
+      "cached_read": null,
+      "in": 0.8,
+      "out": 2.4
+    },
+    "llmgateway\u0000seed-1-6-250615": {
+      "cached_read": 0.05,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "llmgateway\u0000seed-1-6-250915": {
+      "cached_read": 0.05,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "llmgateway\u0000seed-1-6-flash-250715": {
+      "cached_read": 0.015,
+      "in": 0.07,
+      "out": 0.3
+    },
+    "llmgateway\u0000seed-1-8-251228": {
+      "cached_read": 0.05,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "llmgateway\u0000sonar": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 1.0
+    },
+    "llmgateway\u0000sonar-pro": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "llmgateway\u0000sonar-reasoning-pro": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "lmstudio\u0000openai/gpt-oss-20b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "lmstudio\u0000qwen/qwen3-30b-a3b-2507": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "lmstudio\u0000qwen/qwen3-coder-30b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "lucidquery\u0000lucidnova-rf1-100b": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 5.0
+    },
+    "lucidquery\u0000lucidquery-nexus-coder": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 5.0
+    },
+    "meganova\u0000deepseek-ai/deepseek-r1-0528": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 2.15
+    },
+    "meganova\u0000deepseek-ai/deepseek-v3-0324": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 0.88
+    },
+    "meganova\u0000deepseek-ai/deepseek-v3.1": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 1.0
+    },
+    "meganova\u0000deepseek-ai/deepseek-v3.2": {
+      "cached_read": null,
+      "in": 0.26,
+      "out": 0.38
+    },
+    "meganova\u0000deepseek-ai/deepseek-v3.2-exp": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 0.4
+    },
+    "meganova\u0000meta-llama/llama-3.3-70b-instruct": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "meganova\u0000minimaxai/minimax-m2.1": {
+      "cached_read": null,
+      "in": 0.28,
+      "out": 1.2
+    },
+    "meganova\u0000minimaxai/minimax-m2.5": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "meganova\u0000mistralai/mistral-nemo-instruct-2407": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.04
+    },
+    "meganova\u0000mistralai/mistral-small-3.2-24b-instruct-2506": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "meganova\u0000moonshotai/kimi-k2-thinking": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.6
+    },
+    "meganova\u0000moonshotai/kimi-k2.5": {
+      "cached_read": null,
+      "in": 0.45,
+      "out": 2.8
+    },
+    "meganova\u0000qwen/qwen2.5-vl-32b-instruct": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.6
+    },
+    "meganova\u0000qwen/qwen3-235b-a22b-instruct-2507": {
+      "cached_read": null,
+      "in": 0.09,
+      "out": 0.6
+    },
+    "meganova\u0000qwen/qwen3.5-plus": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.4
+    },
+    "meganova\u0000xiaomimimo/mimo-v2-flash": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "meganova\u0000zai-org/glm-4.6": {
+      "cached_read": null,
+      "in": 0.45,
+      "out": 1.9
+    },
+    "meganova\u0000zai-org/glm-4.7": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.8
+    },
+    "meganova\u0000zai-org/glm-5": {
+      "cached_read": null,
+      "in": 0.8,
+      "out": 2.56
+    },
+    "merge-gateway\u0000anthropic/claude-haiku-4-5-20251001": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "merge-gateway\u0000anthropic/claude-opus-4-1-20250805": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "merge-gateway\u0000anthropic/claude-opus-4-20250514": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "merge-gateway\u0000anthropic/claude-opus-4-5-20251101": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "merge-gateway\u0000anthropic/claude-opus-4-6": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "merge-gateway\u0000anthropic/claude-opus-4-7": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "merge-gateway\u0000anthropic/claude-sonnet-4-20250514": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "merge-gateway\u0000anthropic/claude-sonnet-4-5-20250929": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "merge-gateway\u0000anthropic/claude-sonnet-4-6": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "merge-gateway\u0000cohere/command-a-03-2025": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "merge-gateway\u0000cohere/command-r-08-2024": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "merge-gateway\u0000cohere/command-r-plus-08-2024": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "merge-gateway\u0000cohere/command-r7b-12-2024": {
+      "cached_read": null,
+      "in": 0.0375,
+      "out": 0.15
+    },
+    "merge-gateway\u0000deepseek/deepseek-v4-flash": {
+      "cached_read": 0.0028,
+      "in": 0.14,
+      "out": 0.28
+    },
+    "merge-gateway\u0000deepseek/deepseek-v4-pro": {
+      "cached_read": 0.003625,
+      "in": 0.435,
+      "out": 0.87
+    },
+    "merge-gateway\u0000google/gemini-2.5-flash": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "merge-gateway\u0000google/gemini-2.5-flash-lite": {
+      "cached_read": 0.01,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "merge-gateway\u0000google/gemini-2.5-pro": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "merge-gateway\u0000google/gemini-3-flash-preview": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "merge-gateway\u0000google/gemini-3-pro-preview": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "merge-gateway\u0000google/gemini-3.1-flash-lite": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 1.5
+    },
+    "merge-gateway\u0000google/gemini-3.1-flash-lite-preview": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 1.5
+    },
+    "merge-gateway\u0000google/gemini-3.1-pro-preview": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "merge-gateway\u0000google/gemini-3.1-pro-preview-customtools": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "merge-gateway\u0000google/gemini-3.5-flash": {
+      "cached_read": 0.15,
+      "in": 1.5,
+      "out": 9.0
+    },
+    "merge-gateway\u0000google/gemini-flash-latest": {
+      "cached_read": 0.075,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "merge-gateway\u0000google/gemini-flash-lite-latest": {
+      "cached_read": 0.025,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "merge-gateway\u0000minimax/minimax-m2": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "merge-gateway\u0000minimax/minimax-m2.1": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "merge-gateway\u0000minimax/minimax-m2.5": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "merge-gateway\u0000minimax/minimax-m2.5-highspeed": {
+      "cached_read": 0.06,
+      "in": 0.6,
+      "out": 2.4
+    },
+    "merge-gateway\u0000minimax/minimax-m2.7": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "merge-gateway\u0000minimax/minimax-m2.7-highspeed": {
+      "cached_read": 0.06,
+      "in": 0.6,
+      "out": 2.4
+    },
+    "merge-gateway\u0000mistral/codestral-latest": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.9
+    },
+    "merge-gateway\u0000mistral/devstral-2512": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "merge-gateway\u0000mistral/devstral-medium-2507": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "merge-gateway\u0000mistral/devstral-medium-latest": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "merge-gateway\u0000mistral/devstral-small-2507": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "merge-gateway\u0000mistral/magistral-medium-latest": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 5.0
+    },
+    "merge-gateway\u0000mistral/mistral-large-2411": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "merge-gateway\u0000mistral/mistral-large-2512": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "merge-gateway\u0000mistral/mistral-large-latest": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "merge-gateway\u0000mistral/mistral-medium-2505": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "merge-gateway\u0000mistral/mistral-medium-latest": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "merge-gateway\u0000mistral/mistral-small-latest": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "merge-gateway\u0000mistral/pixtral-large-latest": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "merge-gateway\u0000openai/gpt-4.1": {
+      "cached_read": 0.5,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "merge-gateway\u0000openai/gpt-4.1-mini": {
+      "cached_read": 0.1,
+      "in": 0.4,
+      "out": 1.6
+    },
+    "merge-gateway\u0000openai/gpt-4.1-nano": {
+      "cached_read": 0.025,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "merge-gateway\u0000openai/gpt-4o": {
+      "cached_read": 1.25,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "merge-gateway\u0000openai/gpt-4o-2024-05-13": {
+      "cached_read": null,
+      "in": 5.0,
+      "out": 15.0
+    },
+    "merge-gateway\u0000openai/gpt-4o-2024-08-06": {
+      "cached_read": 1.25,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "merge-gateway\u0000openai/gpt-4o-2024-11-20": {
+      "cached_read": 1.25,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "merge-gateway\u0000openai/gpt-4o-mini": {
+      "cached_read": 0.075,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "merge-gateway\u0000openai/gpt-5": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "merge-gateway\u0000openai/gpt-5-chat-latest": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "merge-gateway\u0000openai/gpt-5-mini": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "merge-gateway\u0000openai/gpt-5-nano": {
+      "cached_read": 0.005,
+      "in": 0.05,
+      "out": 0.4
+    },
+    "merge-gateway\u0000openai/gpt-5.1": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "merge-gateway\u0000openai/gpt-5.1-chat-latest": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "merge-gateway\u0000openai/gpt-5.2": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "merge-gateway\u0000openai/gpt-5.2-chat-latest": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "merge-gateway\u0000openai/gpt-5.3-chat-latest": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "merge-gateway\u0000openai/gpt-5.4": {
+      "cached_read": 0.25,
+      "in": 2.5,
+      "out": 15.0
+    },
+    "merge-gateway\u0000openai/gpt-5.4-mini": {
+      "cached_read": 0.075,
+      "in": 0.75,
+      "out": 4.5
+    },
+    "merge-gateway\u0000openai/gpt-5.4-nano": {
+      "cached_read": 0.02,
+      "in": 0.2,
+      "out": 1.25
+    },
+    "merge-gateway\u0000openai/gpt-5.5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 30.0
+    },
+    "merge-gateway\u0000openai/o1": {
+      "cached_read": 7.5,
+      "in": 15.0,
+      "out": 60.0
+    },
+    "merge-gateway\u0000openai/o3": {
+      "cached_read": 0.5,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "merge-gateway\u0000openai/o3-mini": {
+      "cached_read": 0.55,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "merge-gateway\u0000openai/o4-mini": {
+      "cached_read": 0.275,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "merge-gateway\u0000xai/grok-4.20-0309-reasoning": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "merge-gateway\u0000xai/grok-4.3": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "merge-gateway\u0000zai/glm-4.5": {
+      "cached_read": 0.11,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "merge-gateway\u0000zai/glm-4.5-air": {
+      "cached_read": 0.03,
+      "in": 0.2,
+      "out": 1.1
+    },
+    "merge-gateway\u0000zai/glm-4.6": {
+      "cached_read": 0.11,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "merge-gateway\u0000zai/glm-4.7": {
+      "cached_read": 0.11,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "merge-gateway\u0000zai/glm-4.7-flashx": {
+      "cached_read": 0.01,
+      "in": 0.07,
+      "out": 0.4
+    },
+    "merge-gateway\u0000zai/glm-5": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 3.2
+    },
+    "merge-gateway\u0000zai/glm-5-turbo": {
+      "cached_read": 0.24,
+      "in": 1.2,
+      "out": 4.0
+    },
+    "merge-gateway\u0000zai/glm-5.1": {
+      "cached_read": 0.26,
+      "in": 1.4,
+      "out": 4.4
+    },
+    "minimax\u0000minimax-m2": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "minimax\u0000minimax-m2.1": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "minimax\u0000minimax-m2.5": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "minimax\u0000minimax-m2.5-highspeed": {
+      "cached_read": 0.06,
+      "in": 0.6,
+      "out": 2.4
+    },
+    "minimax\u0000minimax-m2.7": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "minimax\u0000minimax-m2.7-highspeed": {
+      "cached_read": 0.06,
+      "in": 0.6,
+      "out": 2.4
+    },
+    "minimax\u0000minimax-m3": {
+      "cached_read": 0.12,
+      "in": 0.6,
+      "out": 2.4
+    },
+    "minimax-cn\u0000minimax-m2": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "minimax-cn\u0000minimax-m2.1": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "minimax-cn\u0000minimax-m2.5": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "minimax-cn\u0000minimax-m2.5-highspeed": {
+      "cached_read": 0.06,
+      "in": 0.6,
+      "out": 2.4
+    },
+    "minimax-cn\u0000minimax-m2.7": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "minimax-cn\u0000minimax-m2.7-highspeed": {
+      "cached_read": 0.06,
+      "in": 0.6,
+      "out": 2.4
+    },
+    "minimax-cn\u0000minimax-m3": {
+      "cached_read": 0.12,
+      "in": 0.6,
+      "out": 2.4
+    },
+    "minimax-cn-coding-plan\u0000minimax-m2": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "minimax-cn-coding-plan\u0000minimax-m2.1": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "minimax-cn-coding-plan\u0000minimax-m2.5": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "minimax-cn-coding-plan\u0000minimax-m2.5-highspeed": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "minimax-cn-coding-plan\u0000minimax-m2.7": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "minimax-cn-coding-plan\u0000minimax-m2.7-highspeed": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "minimax-cn-coding-plan\u0000minimax-m3": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "minimax-coding-plan\u0000minimax-m2": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "minimax-coding-plan\u0000minimax-m2.1": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "minimax-coding-plan\u0000minimax-m2.5": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "minimax-coding-plan\u0000minimax-m2.5-highspeed": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "minimax-coding-plan\u0000minimax-m2.7": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "minimax-coding-plan\u0000minimax-m2.7-highspeed": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "minimax-coding-plan\u0000minimax-m3": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "mistral\u0000codestral-latest": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.9
+    },
+    "mistral\u0000devstral-2512": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "mistral\u0000devstral-latest": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "mistral\u0000devstral-medium-2507": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "mistral\u0000devstral-medium-latest": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "mistral\u0000devstral-small-2505": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "mistral\u0000devstral-small-2507": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "mistral\u0000labs-devstral-small-2512": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "mistral\u0000magistral-medium-latest": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 5.0
+    },
+    "mistral\u0000magistral-small": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "mistral\u0000ministral-3b-latest": {
+      "cached_read": null,
+      "in": 0.04,
+      "out": 0.04
+    },
+    "mistral\u0000ministral-8b-latest": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "mistral\u0000mistral-embed": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.0
+    },
+    "mistral\u0000mistral-large-2411": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "mistral\u0000mistral-large-2512": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "mistral\u0000mistral-large-latest": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "mistral\u0000mistral-medium-2505": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "mistral\u0000mistral-medium-2508": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "mistral\u0000mistral-medium-2604": {
+      "cached_read": null,
+      "in": 1.5,
+      "out": 7.5
+    },
+    "mistral\u0000mistral-medium-latest": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "mistral\u0000mistral-nemo": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.15
+    },
+    "mistral\u0000mistral-small-2506": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "mistral\u0000mistral-small-2603": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "mistral\u0000mistral-small-latest": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "mistral\u0000open-mistral-7b": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 0.25
+    },
+    "mistral\u0000open-mistral-nemo": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.15
+    },
+    "mistral\u0000open-mixtral-8x22b": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "mistral\u0000open-mixtral-8x7b": {
+      "cached_read": null,
+      "in": 0.7,
+      "out": 0.7
+    },
+    "mistral\u0000pixtral-12b": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.15
+    },
+    "mistral\u0000pixtral-large-latest": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "mixlayer\u0000qwen/qwen3.5-122b-a10b": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 3.2
+    },
+    "mixlayer\u0000qwen/qwen3.5-27b": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 2.4
+    },
+    "mixlayer\u0000qwen/qwen3.5-35b-a3b": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 1.3
+    },
+    "mixlayer\u0000qwen/qwen3.5-397b-a17b": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 3.6
+    },
+    "mixlayer\u0000qwen/qwen3.5-9b": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "moark\u0000glm-4.7": {
+      "cached_read": null,
+      "in": 3.5,
+      "out": 14.0
+    },
+    "moark\u0000minimax-m2.1": {
+      "cached_read": null,
+      "in": 2.1,
+      "out": 8.4
+    },
+    "modelscope\u0000qwen/qwen3-235b-a22b-instruct-2507": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "modelscope\u0000qwen/qwen3-235b-a22b-thinking-2507": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "modelscope\u0000qwen/qwen3-30b-a3b-instruct-2507": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "modelscope\u0000qwen/qwen3-30b-a3b-thinking-2507": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "modelscope\u0000qwen/qwen3-coder-30b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "modelscope\u0000zhipuai/glm-4.5": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "modelscope\u0000zhipuai/glm-4.6": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "moonshotai\u0000kimi-k2-0711-preview": {
+      "cached_read": 0.15,
+      "in": 0.6,
+      "out": 2.5
+    },
+    "moonshotai\u0000kimi-k2-0905-preview": {
+      "cached_read": 0.15,
+      "in": 0.6,
+      "out": 2.5
+    },
+    "moonshotai\u0000kimi-k2-thinking": {
+      "cached_read": 0.15,
+      "in": 0.6,
+      "out": 2.5
+    },
+    "moonshotai\u0000kimi-k2-thinking-turbo": {
+      "cached_read": 0.15,
+      "in": 1.15,
+      "out": 8.0
+    },
+    "moonshotai\u0000kimi-k2-turbo-preview": {
+      "cached_read": 0.6,
+      "in": 2.4,
+      "out": 10.0
+    },
+    "moonshotai\u0000kimi-k2.5": {
+      "cached_read": 0.1,
+      "in": 0.6,
+      "out": 3.0
+    },
+    "moonshotai\u0000kimi-k2.6": {
+      "cached_read": 0.16,
+      "in": 0.95,
+      "out": 4.0
+    },
+    "moonshotai-cn\u0000kimi-k2-0711-preview": {
+      "cached_read": 0.15,
+      "in": 0.6,
+      "out": 2.5
+    },
+    "moonshotai-cn\u0000kimi-k2-0905-preview": {
+      "cached_read": 0.15,
+      "in": 0.6,
+      "out": 2.5
+    },
+    "moonshotai-cn\u0000kimi-k2-thinking": {
+      "cached_read": 0.15,
+      "in": 0.6,
+      "out": 2.5
+    },
+    "moonshotai-cn\u0000kimi-k2-thinking-turbo": {
+      "cached_read": 0.15,
+      "in": 1.15,
+      "out": 8.0
+    },
+    "moonshotai-cn\u0000kimi-k2-turbo-preview": {
+      "cached_read": 0.6,
+      "in": 2.4,
+      "out": 10.0
+    },
+    "moonshotai-cn\u0000kimi-k2.5": {
+      "cached_read": 0.1,
+      "in": 0.6,
+      "out": 3.0
+    },
+    "moonshotai-cn\u0000kimi-k2.6": {
+      "cached_read": 0.16,
+      "in": 0.95,
+      "out": 4.0
+    },
+    "morph\u0000auto": {
+      "cached_read": null,
+      "in": 0.85,
+      "out": 1.55
+    },
+    "morph\u0000morph-v3-fast": {
+      "cached_read": null,
+      "in": 0.8,
+      "out": 1.2
+    },
+    "morph\u0000morph-v3-large": {
+      "cached_read": null,
+      "in": 0.9,
+      "out": 1.9
+    },
+    "nano-gpt\u0000abacusai/dracarys-72b-instruct": {
+      "cached_read": null,
+      "in": 0.49299999999999994,
+      "out": 0.49299999999999994
+    },
+    "nano-gpt\u0000aion-labs/aion-1.0": {
+      "cached_read": null,
+      "in": 3.995,
+      "out": 7.99
+    },
+    "nano-gpt\u0000aion-labs/aion-1.0-mini": {
+      "cached_read": null,
+      "in": 0.7989999999999999,
+      "out": 1.394
+    },
+    "nano-gpt\u0000aion-labs/aion-2.0": {
+      "cached_read": null,
+      "in": 0.8,
+      "out": 1.6
+    },
+    "nano-gpt\u0000aion-labs/aion-2.5": {
+      "cached_read": 0.35,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "nano-gpt\u0000aion-labs/aion-rp-llama-3.1-8b": {
+      "cached_read": null,
+      "in": 0.2006,
+      "out": 0.2006
+    },
+    "nano-gpt\u0000alibaba-nlp/tongyi-deepresearch-30b-a3b": {
+      "cached_read": null,
+      "in": 0.08,
+      "out": 0.24000000000000002
+    },
+    "nano-gpt\u0000alibaba/qwen3.6-27b": {
+      "cached_read": null,
+      "in": 0.203,
+      "out": 2.24
+    },
+    "nano-gpt\u0000alibaba/qwen3.6-27b:thinking": {
+      "cached_read": null,
+      "in": 0.203,
+      "out": 2.24
+    },
+    "nano-gpt\u0000alibaba/qwen3.6-flash": {
+      "cached_read": null,
+      "in": 0.19,
+      "out": 1.16
+    },
+    "nano-gpt\u0000allenai/olmo-3-32b-think": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.44999999999999996
+    },
+    "nano-gpt\u0000amazon/nova-2-lite-v1": {
+      "cached_read": null,
+      "in": 0.5099999999999999,
+      "out": 4.25
+    },
+    "nano-gpt\u0000amazon/nova-lite-v1": {
+      "cached_read": null,
+      "in": 0.0595,
+      "out": 0.238
+    },
+    "nano-gpt\u0000amazon/nova-micro-v1": {
+      "cached_read": null,
+      "in": 0.0357,
+      "out": 0.1394
+    },
+    "nano-gpt\u0000amazon/nova-pro-v1": {
+      "cached_read": null,
+      "in": 0.7989999999999999,
+      "out": 3.1959999999999997
+    },
+    "nano-gpt\u0000anthracite-org/magnum-v2-72b": {
+      "cached_read": null,
+      "in": 2.006,
+      "out": 2.992
+    },
+    "nano-gpt\u0000anthracite-org/magnum-v4-72b": {
+      "cached_read": null,
+      "in": 2.006,
+      "out": 2.992
+    },
+    "nano-gpt\u0000anthropic/claude-haiku-latest": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "nano-gpt\u0000anthropic/claude-opus-4.6": {
+      "cached_read": null,
+      "in": 4.998,
+      "out": 25.007
+    },
+    "nano-gpt\u0000anthropic/claude-opus-4.6:thinking": {
+      "cached_read": null,
+      "in": 4.998,
+      "out": 25.007
+    },
+    "nano-gpt\u0000anthropic/claude-opus-4.6:thinking:low": {
+      "cached_read": null,
+      "in": 4.998,
+      "out": 25.007
+    },
+    "nano-gpt\u0000anthropic/claude-opus-4.6:thinking:max": {
+      "cached_read": null,
+      "in": 4.998,
+      "out": 25.007
+    },
+    "nano-gpt\u0000anthropic/claude-opus-4.6:thinking:medium": {
+      "cached_read": null,
+      "in": 4.998,
+      "out": 25.007
+    },
+    "nano-gpt\u0000anthropic/claude-opus-4.7": {
+      "cached_read": 0.4998,
+      "in": 4.998,
+      "out": 25.007
+    },
+    "nano-gpt\u0000anthropic/claude-opus-4.7:thinking": {
+      "cached_read": 0.4998,
+      "in": 4.998,
+      "out": 25.007
+    },
+    "nano-gpt\u0000anthropic/claude-opus-4.8": {
+      "cached_read": 0.4998,
+      "in": 4.998,
+      "out": 25.007
+    },
+    "nano-gpt\u0000anthropic/claude-opus-4.8:thinking": {
+      "cached_read": 0.4998,
+      "in": 4.998,
+      "out": 25.007
+    },
+    "nano-gpt\u0000anthropic/claude-opus-latest": {
+      "cached_read": 0.4998,
+      "in": 4.998,
+      "out": 25.007
+    },
+    "nano-gpt\u0000anthropic/claude-sonnet-4.6": {
+      "cached_read": null,
+      "in": 2.992,
+      "out": 14.993999999999998
+    },
+    "nano-gpt\u0000anthropic/claude-sonnet-4.6:thinking": {
+      "cached_read": null,
+      "in": 2.992,
+      "out": 14.993999999999998
+    },
+    "nano-gpt\u0000anthropic/claude-sonnet-latest": {
+      "cached_read": 0.2992,
+      "in": 2.992,
+      "out": 14.994
+    },
+    "nano-gpt\u0000arcee-ai/trinity-large-thinking": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 0.9
+    },
+    "nano-gpt\u0000arcee-ai/trinity-mini": {
+      "cached_read": null,
+      "in": 0.045000000000000005,
+      "out": 0.15
+    },
+    "nano-gpt\u0000asi1-mini": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 1.0
+    },
+    "nano-gpt\u0000auto-model": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nano-gpt\u0000auto-model-basic": {
+      "cached_read": null,
+      "in": 9.996,
+      "out": 19.992
+    },
+    "nano-gpt\u0000auto-model-premium": {
+      "cached_read": null,
+      "in": 9.996,
+      "out": 19.992
+    },
+    "nano-gpt\u0000auto-model-standard": {
+      "cached_read": null,
+      "in": 9.996,
+      "out": 19.992
+    },
+    "nano-gpt\u0000azure-gpt-4-turbo": {
+      "cached_read": null,
+      "in": 9.996,
+      "out": 30.005
+    },
+    "nano-gpt\u0000azure-gpt-4o": {
+      "cached_read": null,
+      "in": 2.499,
+      "out": 9.996
+    },
+    "nano-gpt\u0000azure-gpt-4o-mini": {
+      "cached_read": null,
+      "in": 0.1496,
+      "out": 0.595
+    },
+    "nano-gpt\u0000azure-o1": {
+      "cached_read": null,
+      "in": 14.994,
+      "out": 59.993
+    },
+    "nano-gpt\u0000azure-o3-mini": {
+      "cached_read": null,
+      "in": 1.088,
+      "out": 4.3996
+    },
+    "nano-gpt\u0000baichuan-m2": {
+      "cached_read": null,
+      "in": 15.73,
+      "out": 15.73
+    },
+    "nano-gpt\u0000baichuan4-air": {
+      "cached_read": null,
+      "in": 0.157,
+      "out": 0.157
+    },
+    "nano-gpt\u0000baichuan4-turbo": {
+      "cached_read": null,
+      "in": 2.42,
+      "out": 2.42
+    },
+    "nano-gpt\u0000baidu/ernie-4.5-vl-28b-a3b": {
+      "cached_read": null,
+      "in": 0.13999999999999999,
+      "out": 0.5599999999999999
+    },
+    "nano-gpt\u0000baseten/kimi-k2-instruct-fp4": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 2.0
+    },
+    "nano-gpt\u0000brave": {
+      "cached_read": null,
+      "in": 5.0,
+      "out": 5.0
+    },
+    "nano-gpt\u0000brave-pro": {
+      "cached_read": null,
+      "in": 5.0,
+      "out": 5.0
+    },
+    "nano-gpt\u0000brave-research": {
+      "cached_read": null,
+      "in": 5.0,
+      "out": 5.0
+    },
+    "nano-gpt\u0000bytedance-seed/seed-2.0-lite": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "nano-gpt\u0000chutesai/mistral-small-3.2-24b-instruct-2506": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.4
+    },
+    "nano-gpt\u0000claude-3-5-haiku-20241022": {
+      "cached_read": null,
+      "in": 0.8,
+      "out": 4.0
+    },
+    "nano-gpt\u0000claude-haiku-4-5-20251001": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "nano-gpt\u0000claude-haiku-4-5-20251001-thinking": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "nano-gpt\u0000claude-opus-4-1-20250805": {
+      "cached_read": null,
+      "in": 14.994,
+      "out": 75.004
+    },
+    "nano-gpt\u0000claude-opus-4-1-thinking": {
+      "cached_read": null,
+      "in": 14.994,
+      "out": 75.004
+    },
+    "nano-gpt\u0000claude-opus-4-1-thinking:1024": {
+      "cached_read": null,
+      "in": 14.994,
+      "out": 75.004
+    },
+    "nano-gpt\u0000claude-opus-4-1-thinking:32000": {
+      "cached_read": null,
+      "in": 14.994,
+      "out": 75.004
+    },
+    "nano-gpt\u0000claude-opus-4-1-thinking:32768": {
+      "cached_read": null,
+      "in": 14.994,
+      "out": 75.004
+    },
+    "nano-gpt\u0000claude-opus-4-1-thinking:8192": {
+      "cached_read": null,
+      "in": 14.994,
+      "out": 75.004
+    },
+    "nano-gpt\u0000claude-opus-4-20250514": {
+      "cached_read": null,
+      "in": 14.994,
+      "out": 75.004
+    },
+    "nano-gpt\u0000claude-opus-4-5-20251101": {
+      "cached_read": null,
+      "in": 4.998,
+      "out": 25.007
+    },
+    "nano-gpt\u0000claude-opus-4-5-20251101:thinking": {
+      "cached_read": null,
+      "in": 4.998,
+      "out": 25.007
+    },
+    "nano-gpt\u0000claude-opus-4-thinking": {
+      "cached_read": null,
+      "in": 14.994,
+      "out": 75.004
+    },
+    "nano-gpt\u0000claude-opus-4-thinking:1024": {
+      "cached_read": null,
+      "in": 14.994,
+      "out": 75.004
+    },
+    "nano-gpt\u0000claude-opus-4-thinking:32000": {
+      "cached_read": null,
+      "in": 14.994,
+      "out": 75.004
+    },
+    "nano-gpt\u0000claude-opus-4-thinking:32768": {
+      "cached_read": null,
+      "in": 14.994,
+      "out": 75.004
+    },
+    "nano-gpt\u0000claude-opus-4-thinking:8192": {
+      "cached_read": null,
+      "in": 14.994,
+      "out": 75.004
+    },
+    "nano-gpt\u0000claude-sonnet-4-20250514": {
+      "cached_read": null,
+      "in": 2.992,
+      "out": 14.994
+    },
+    "nano-gpt\u0000claude-sonnet-4-5-20250929": {
+      "cached_read": null,
+      "in": 2.992,
+      "out": 14.994
+    },
+    "nano-gpt\u0000claude-sonnet-4-5-20250929-thinking": {
+      "cached_read": null,
+      "in": 2.992,
+      "out": 14.994
+    },
+    "nano-gpt\u0000claude-sonnet-4-thinking": {
+      "cached_read": null,
+      "in": 2.992,
+      "out": 14.994
+    },
+    "nano-gpt\u0000claude-sonnet-4-thinking:1024": {
+      "cached_read": null,
+      "in": 2.992,
+      "out": 14.994
+    },
+    "nano-gpt\u0000claude-sonnet-4-thinking:32768": {
+      "cached_read": null,
+      "in": 2.992,
+      "out": 14.994
+    },
+    "nano-gpt\u0000claude-sonnet-4-thinking:64000": {
+      "cached_read": null,
+      "in": 2.992,
+      "out": 14.994
+    },
+    "nano-gpt\u0000claude-sonnet-4-thinking:8192": {
+      "cached_read": null,
+      "in": 2.992,
+      "out": 14.994
+    },
+    "nano-gpt\u0000claw-high": {
+      "cached_read": null,
+      "in": 4.998,
+      "out": 25.007
+    },
+    "nano-gpt\u0000claw-low": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 1.5
+    },
+    "nano-gpt\u0000claw-medium": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "nano-gpt\u0000cognitivecomputations/dolphin-2.9.2-qwen2-72b": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000cohere/command-r": {
+      "cached_read": null,
+      "in": 0.476,
+      "out": 1.428
+    },
+    "nano-gpt\u0000cohere/command-r-plus-08-2024": {
+      "cached_read": null,
+      "in": 2.856,
+      "out": 14.246
+    },
+    "nano-gpt\u0000command-a-plus-05-2026": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "nano-gpt\u0000command-a-reasoning-08-2025": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "nano-gpt\u0000deepclaude": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "nano-gpt\u0000deepcogito/cogito-v1-preview-qwen-32b": {
+      "cached_read": null,
+      "in": 1.7999999999999998,
+      "out": 1.7999999999999998
+    },
+    "nano-gpt\u0000deepseek-ai/deepseek-r1-0528": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 1.7
+    },
+    "nano-gpt\u0000deepseek-ai/deepseek-v3.1": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.7
+    },
+    "nano-gpt\u0000deepseek-ai/deepseek-v3.1-terminus": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 0.7
+    },
+    "nano-gpt\u0000deepseek-ai/deepseek-v3.1-terminus:thinking": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 0.7
+    },
+    "nano-gpt\u0000deepseek-ai/deepseek-v3.1:thinking": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.7
+    },
+    "nano-gpt\u0000deepseek-ai/deepseek-v3.2-exp": {
+      "cached_read": null,
+      "in": 0.27999999999999997,
+      "out": 0.42000000000000004
+    },
+    "nano-gpt\u0000deepseek-ai/deepseek-v3.2-exp-thinking": {
+      "cached_read": null,
+      "in": 0.27999999999999997,
+      "out": 0.42000000000000004
+    },
+    "nano-gpt\u0000deepseek-chat": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 0.7
+    },
+    "nano-gpt\u0000deepseek-chat-cheaper": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 0.7
+    },
+    "nano-gpt\u0000deepseek-math-v2": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "nano-gpt\u0000deepseek-r1": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 1.7
+    },
+    "nano-gpt\u0000deepseek-r1-sambanova": {
+      "cached_read": null,
+      "in": 4.998,
+      "out": 6.987
+    },
+    "nano-gpt\u0000deepseek-reasoner": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 1.7
+    },
+    "nano-gpt\u0000deepseek-reasoner-cheaper": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 1.7
+    },
+    "nano-gpt\u0000deepseek-v3-0324": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 0.7
+    },
+    "nano-gpt\u0000deepseek/deepseek-latest": {
+      "cached_read": 0.11,
+      "in": 1.1,
+      "out": 2.2
+    },
+    "nano-gpt\u0000deepseek/deepseek-prover-v2-671b": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 2.5
+    },
+    "nano-gpt\u0000deepseek/deepseek-v3.2": {
+      "cached_read": null,
+      "in": 0.27999999999999997,
+      "out": 0.42000000000000004
+    },
+    "nano-gpt\u0000deepseek/deepseek-v3.2-speciale": {
+      "cached_read": null,
+      "in": 0.27999999999999997,
+      "out": 0.42000000000000004
+    },
+    "nano-gpt\u0000deepseek/deepseek-v3.2:thinking": {
+      "cached_read": null,
+      "in": 0.27999999999999997,
+      "out": 0.42000000000000004
+    },
+    "nano-gpt\u0000deepseek/deepseek-v4-flash": {
+      "cached_read": 0.028,
+      "in": 0.14,
+      "out": 0.28
+    },
+    "nano-gpt\u0000deepseek/deepseek-v4-flash:thinking": {
+      "cached_read": 0.028,
+      "in": 0.14,
+      "out": 0.28
+    },
+    "nano-gpt\u0000deepseek/deepseek-v4-pro": {
+      "cached_read": 0.11,
+      "in": 1.1,
+      "out": 2.2
+    },
+    "nano-gpt\u0000deepseek/deepseek-v4-pro-cheaper": {
+      "cached_read": 0.003625,
+      "in": 0.435,
+      "out": 0.87
+    },
+    "nano-gpt\u0000deepseek/deepseek-v4-pro-cheaper:thinking": {
+      "cached_read": 0.003625,
+      "in": 0.435,
+      "out": 0.87
+    },
+    "nano-gpt\u0000deepseek/deepseek-v4-pro:thinking": {
+      "cached_read": 0.11,
+      "in": 1.1,
+      "out": 2.2
+    },
+    "nano-gpt\u0000dmind/dmind-1": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.6
+    },
+    "nano-gpt\u0000dmind/dmind-1-mini": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.4
+    },
+    "nano-gpt\u0000doctor-shotgun/ms3.2-24b-magnum-diamond": {
+      "cached_read": null,
+      "in": 0.49299999999999994,
+      "out": 0.49299999999999994
+    },
+    "nano-gpt\u0000doubao-1-5-thinking-pro-250415": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.4
+    },
+    "nano-gpt\u0000doubao-1-5-thinking-pro-vision-250415": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.4
+    },
+    "nano-gpt\u0000doubao-1-5-thinking-vision-pro-250428": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 1.43
+    },
+    "nano-gpt\u0000doubao-1.5-pro-256k": {
+      "cached_read": null,
+      "in": 0.799,
+      "out": 1.445
+    },
+    "nano-gpt\u0000doubao-1.5-pro-32k": {
+      "cached_read": null,
+      "in": 0.1343,
+      "out": 0.3349
+    },
+    "nano-gpt\u0000doubao-1.5-vision-pro-32k": {
+      "cached_read": null,
+      "in": 0.459,
+      "out": 1.377
+    },
+    "nano-gpt\u0000doubao-seed-1-6-250615": {
+      "cached_read": null,
+      "in": 0.204,
+      "out": 0.51
+    },
+    "nano-gpt\u0000doubao-seed-1-6-flash-250615": {
+      "cached_read": null,
+      "in": 0.0374,
+      "out": 0.374
+    },
+    "nano-gpt\u0000doubao-seed-1-6-thinking-250615": {
+      "cached_read": null,
+      "in": 0.204,
+      "out": 2.04
+    },
+    "nano-gpt\u0000doubao-seed-1-8-251215": {
+      "cached_read": null,
+      "in": 0.612,
+      "out": 6.12
+    },
+    "nano-gpt\u0000doubao-seed-2-0-code-preview-260215": {
+      "cached_read": null,
+      "in": 0.782,
+      "out": 3.893
+    },
+    "nano-gpt\u0000doubao-seed-2-0-lite-260215": {
+      "cached_read": null,
+      "in": 0.1462,
+      "out": 0.8738
+    },
+    "nano-gpt\u0000doubao-seed-2-0-mini-260215": {
+      "cached_read": null,
+      "in": 0.0493,
+      "out": 0.4845
+    },
+    "nano-gpt\u0000doubao-seed-2-0-pro-260215": {
+      "cached_read": null,
+      "in": 0.782,
+      "out": 3.876
+    },
+    "nano-gpt\u0000envoid/llama-3.05-nemotron-tenyxchat-storybreaker-70b": {
+      "cached_read": null,
+      "in": 0.49299999999999994,
+      "out": 0.49299999999999994
+    },
+    "nano-gpt\u0000envoid/llama-3.05-nt-storybreaker-ministral-70b": {
+      "cached_read": null,
+      "in": 0.49299999999999994,
+      "out": 0.49299999999999994
+    },
+    "nano-gpt\u0000ernie-4.5-8k-preview": {
+      "cached_read": null,
+      "in": 0.66,
+      "out": 2.6
+    },
+    "nano-gpt\u0000ernie-4.5-turbo-128k": {
+      "cached_read": null,
+      "in": 0.132,
+      "out": 0.55
+    },
+    "nano-gpt\u0000ernie-4.5-turbo-vl-32k": {
+      "cached_read": null,
+      "in": 0.495,
+      "out": 1.43
+    },
+    "nano-gpt\u0000ernie-5.0-thinking-preview": {
+      "cached_read": null,
+      "in": 1.1,
+      "out": 2.0
+    },
+    "nano-gpt\u0000ernie-5.1": {
+      "cached_read": 0.75,
+      "in": 0.75,
+      "out": 3.0
+    },
+    "nano-gpt\u0000ernie-5.1:thinking": {
+      "cached_read": 0.75,
+      "in": 0.75,
+      "out": 3.0
+    },
+    "nano-gpt\u0000ernie-x1-32k": {
+      "cached_read": null,
+      "in": 0.33,
+      "out": 1.32
+    },
+    "nano-gpt\u0000ernie-x1-32k-preview": {
+      "cached_read": null,
+      "in": 0.33,
+      "out": 1.32
+    },
+    "nano-gpt\u0000ernie-x1-turbo-32k": {
+      "cached_read": null,
+      "in": 0.165,
+      "out": 0.66
+    },
+    "nano-gpt\u0000ernie-x1.1-preview": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "nano-gpt\u0000essentialai/rnj-1-instruct": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.15
+    },
+    "nano-gpt\u0000eva-unit-01/eva-llama-3.33-70b-v0.0": {
+      "cached_read": null,
+      "in": 2.006,
+      "out": 2.006
+    },
+    "nano-gpt\u0000eva-unit-01/eva-llama-3.33-70b-v0.1": {
+      "cached_read": null,
+      "in": 2.006,
+      "out": 2.006
+    },
+    "nano-gpt\u0000eva-unit-01/eva-qwen2.5-32b-v0.2": {
+      "cached_read": null,
+      "in": 0.7989999999999999,
+      "out": 0.7989999999999999
+    },
+    "nano-gpt\u0000eva-unit-01/eva-qwen2.5-72b-v0.2": {
+      "cached_read": null,
+      "in": 0.7989999999999999,
+      "out": 0.7989999999999999
+    },
+    "nano-gpt\u0000exa-answer": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 2.5
+    },
+    "nano-gpt\u0000exa-research": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 2.5
+    },
+    "nano-gpt\u0000exa-research-pro": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 2.5
+    },
+    "nano-gpt\u0000failspy/meta-llama-3-70b-instruct-abliterated-v3.5": {
+      "cached_read": null,
+      "in": 0.7,
+      "out": 0.7
+    },
+    "nano-gpt\u0000fastgpt": {
+      "cached_read": null,
+      "in": 7.5,
+      "out": 7.5
+    },
+    "nano-gpt\u0000featherless-ai/qwerky-72b": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 0.5
+    },
+    "nano-gpt\u0000galrionsoftworks/mn-loosecannon-12b-v1": {
+      "cached_read": null,
+      "in": 0.49299999999999994,
+      "out": 0.49299999999999994
+    },
+    "nano-gpt\u0000gemini-2.0-flash-001": {
+      "cached_read": null,
+      "in": 0.1003,
+      "out": 0.408
+    },
+    "nano-gpt\u0000gemini-2.0-flash-exp-image-generation": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.8
+    },
+    "nano-gpt\u0000gemini-2.0-flash-thinking-exp-01-21": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 1.003
+    },
+    "nano-gpt\u0000gemini-2.0-flash-thinking-exp-1219": {
+      "cached_read": null,
+      "in": 0.1003,
+      "out": 0.408
+    },
+    "nano-gpt\u0000gemini-2.0-pro-exp-02-05": {
+      "cached_read": null,
+      "in": 1.989,
+      "out": 7.956
+    },
+    "nano-gpt\u0000gemini-2.0-pro-reasoner": {
+      "cached_read": null,
+      "in": 1.292,
+      "out": 4.998
+    },
+    "nano-gpt\u0000gemini-2.5-flash": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "nano-gpt\u0000gemini-2.5-flash-lite": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "nano-gpt\u0000gemini-2.5-flash-lite-preview-06-17": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "nano-gpt\u0000gemini-2.5-flash-lite-preview-09-2025": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "nano-gpt\u0000gemini-2.5-flash-lite-preview-09-2025-thinking": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "nano-gpt\u0000gemini-2.5-flash-nothinking": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "nano-gpt\u0000gemini-2.5-flash-preview-04-17": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "nano-gpt\u0000gemini-2.5-flash-preview-04-17:thinking": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 3.5
+    },
+    "nano-gpt\u0000gemini-2.5-flash-preview-05-20": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "nano-gpt\u0000gemini-2.5-flash-preview-05-20:thinking": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 3.5
+    },
+    "nano-gpt\u0000gemini-2.5-flash-preview-09-2025": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "nano-gpt\u0000gemini-2.5-flash-preview-09-2025-thinking": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "nano-gpt\u0000gemini-2.5-pro": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "nano-gpt\u0000gemini-2.5-pro-exp-03-25": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "nano-gpt\u0000gemini-2.5-pro-preview-03-25": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "nano-gpt\u0000gemini-2.5-pro-preview-05-06": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "nano-gpt\u0000gemini-2.5-pro-preview-06-05": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "nano-gpt\u0000gemini-3-pro-image-preview": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "nano-gpt\u0000gemini-exp-1206": {
+      "cached_read": null,
+      "in": 1.258,
+      "out": 4.998
+    },
+    "nano-gpt\u0000gemma-4-31b-claude-4.6-opus-reasoning-distilled": {
+      "cached_read": 0.0306,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000gemma-4-31b-cognitive-unshackled": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000gemma-4-31b-darkidol": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000gemma-4-31b-fabled": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000gemma-4-31b-garnet": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000gemma-4-31b-garnetv2": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000gemma-4-31b-gemopus": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000gemma-4-31b-it": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000gemma-4-31b-k1-v5": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000gemma-4-31b-larkspur-v0.5": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000gemma-4-31b-meromero": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000gemma-4-31b-musica-v1": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000gemma-4-31b-queen": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000glm-4": {
+      "cached_read": null,
+      "in": 14.994,
+      "out": 14.994
+    },
+    "nano-gpt\u0000glm-4-air": {
+      "cached_read": null,
+      "in": 0.2006,
+      "out": 0.2006
+    },
+    "nano-gpt\u0000glm-4-air-0111": {
+      "cached_read": null,
+      "in": 0.1394,
+      "out": 0.1394
+    },
+    "nano-gpt\u0000glm-4-airx": {
+      "cached_read": null,
+      "in": 2.006,
+      "out": 2.006
+    },
+    "nano-gpt\u0000glm-4-flash": {
+      "cached_read": null,
+      "in": 0.1003,
+      "out": 0.1003
+    },
+    "nano-gpt\u0000glm-4-long": {
+      "cached_read": null,
+      "in": 0.2006,
+      "out": 0.2006
+    },
+    "nano-gpt\u0000glm-4-plus": {
+      "cached_read": null,
+      "in": 7.497,
+      "out": 7.497
+    },
+    "nano-gpt\u0000glm-4-plus-0111": {
+      "cached_read": null,
+      "in": 9.996,
+      "out": 9.996
+    },
+    "nano-gpt\u0000glm-4.1v-thinking-flash": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.3
+    },
+    "nano-gpt\u0000glm-4.1v-thinking-flashx": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.3
+    },
+    "nano-gpt\u0000glm-4.6-derestricted-v5": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 1.5
+    },
+    "nano-gpt\u0000glm-z1-air": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.07
+    },
+    "nano-gpt\u0000glm-z1-airx": {
+      "cached_read": null,
+      "in": 0.7,
+      "out": 0.7
+    },
+    "nano-gpt\u0000glm-zero-preview": {
+      "cached_read": null,
+      "in": 1.802,
+      "out": 1.802
+    },
+    "nano-gpt\u0000google/gemini-3-flash-preview": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "nano-gpt\u0000google/gemini-3-flash-preview-thinking": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "nano-gpt\u0000google/gemini-3.1-flash-lite": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 1.5
+    },
+    "nano-gpt\u0000google/gemini-3.1-pro-preview": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "nano-gpt\u0000google/gemini-3.1-pro-preview-customtools": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "nano-gpt\u0000google/gemini-3.1-pro-preview-high": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "nano-gpt\u0000google/gemini-3.1-pro-preview-low": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "nano-gpt\u0000google/gemini-3.5-flash": {
+      "cached_read": 0.15,
+      "in": 1.5,
+      "out": 9.0
+    },
+    "nano-gpt\u0000google/gemini-3.5-flash-thinking": {
+      "cached_read": 0.15,
+      "in": 1.5,
+      "out": 9.0
+    },
+    "nano-gpt\u0000google/gemini-flash-1.5": {
+      "cached_read": null,
+      "in": 0.0748,
+      "out": 0.306
+    },
+    "nano-gpt\u0000google/gemini-flash-latest": {
+      "cached_read": 0.15,
+      "in": 1.5,
+      "out": 9.0
+    },
+    "nano-gpt\u0000google/gemini-flash-lite-latest": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 1.5
+    },
+    "nano-gpt\u0000google/gemini-pro-latest": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "nano-gpt\u0000google/gemma-4-26b-a4b-it": {
+      "cached_read": null,
+      "in": 0.13,
+      "out": 0.4
+    },
+    "nano-gpt\u0000google/gemma-4-26b-a4b-it:thinking": {
+      "cached_read": null,
+      "in": 0.13,
+      "out": 0.4
+    },
+    "nano-gpt\u0000google/gemma-4-31b-it": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.35
+    },
+    "nano-gpt\u0000google/gemma-4-31b-it:thinking": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.35
+    },
+    "nano-gpt\u0000gryphe/mythomax-l2-13b": {
+      "cached_read": null,
+      "in": 0.1003,
+      "out": 0.1003
+    },
+    "nano-gpt\u0000hermes-high": {
+      "cached_read": null,
+      "in": 4.998,
+      "out": 25.007
+    },
+    "nano-gpt\u0000hermes-low": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 1.5
+    },
+    "nano-gpt\u0000hermes-medium": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "nano-gpt\u0000holo3-35b-a3b": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 1.8
+    },
+    "nano-gpt\u0000holo3-35b-a3b:thinking": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 1.8
+    },
+    "nano-gpt\u0000huihui-ai/deepseek-r1-distill-llama-70b-abliterated": {
+      "cached_read": null,
+      "in": 0.7,
+      "out": 0.7
+    },
+    "nano-gpt\u0000huihui-ai/deepseek-r1-distill-qwen-32b-abliterated": {
+      "cached_read": null,
+      "in": 1.4,
+      "out": 1.4
+    },
+    "nano-gpt\u0000huihui-ai/llama-3.3-70b-instruct-abliterated": {
+      "cached_read": null,
+      "in": 0.7,
+      "out": 0.7
+    },
+    "nano-gpt\u0000huihui-ai/qwen2.5-32b-instruct-abliterated": {
+      "cached_read": null,
+      "in": 0.7,
+      "out": 0.7
+    },
+    "nano-gpt\u0000hunyuan-turbos-20250226": {
+      "cached_read": null,
+      "in": 0.187,
+      "out": 0.374
+    },
+    "nano-gpt\u0000ibm-granite/granite-4.1-8b": {
+      "cached_read": 0.05,
+      "in": 0.05,
+      "out": 0.1
+    },
+    "nano-gpt\u0000inclusionai/ling-2.6-1t": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "nano-gpt\u0000inclusionai/ling-2.6-flash": {
+      "cached_read": null,
+      "in": 0.08,
+      "out": 0.24
+    },
+    "nano-gpt\u0000inclusionai/ring-2.6-1t": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "nano-gpt\u0000infermatic/mn-12b-inferor-v0.0": {
+      "cached_read": null,
+      "in": 0.25499999999999995,
+      "out": 0.49299999999999994
+    },
+    "nano-gpt\u0000inflatebot/mn-12b-mag-mell-r1": {
+      "cached_read": null,
+      "in": 0.49299999999999994,
+      "out": 0.49299999999999994
+    },
+    "nano-gpt\u0000inflection/inflection-3-pi": {
+      "cached_read": null,
+      "in": 2.499,
+      "out": 9.996
+    },
+    "nano-gpt\u0000inflection/inflection-3-productivity": {
+      "cached_read": null,
+      "in": 2.499,
+      "out": 9.996
+    },
+    "nano-gpt\u0000jamba-large": {
+      "cached_read": null,
+      "in": 1.989,
+      "out": 7.99
+    },
+    "nano-gpt\u0000jamba-large-1.6": {
+      "cached_read": null,
+      "in": 1.989,
+      "out": 7.99
+    },
+    "nano-gpt\u0000jamba-large-1.7": {
+      "cached_read": null,
+      "in": 1.989,
+      "out": 7.99
+    },
+    "nano-gpt\u0000jamba-mini": {
+      "cached_read": null,
+      "in": 0.1989,
+      "out": 0.408
+    },
+    "nano-gpt\u0000jamba-mini-1.6": {
+      "cached_read": null,
+      "in": 0.1989,
+      "out": 0.408
+    },
+    "nano-gpt\u0000jamba-mini-1.7": {
+      "cached_read": null,
+      "in": 0.1989,
+      "out": 0.408
+    },
+    "nano-gpt\u0000kat-coder-air-v1": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.2
+    },
+    "nano-gpt\u0000kat-coder-exp-72b-1010": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.2
+    },
+    "nano-gpt\u0000kimi-k2-instruct-fast": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 2.0
+    },
+    "nano-gpt\u0000kimi-thinking-preview": {
+      "cached_read": null,
+      "in": 31.46,
+      "out": 31.46
+    },
+    "nano-gpt\u0000kwaipilot/kat-coder-pro-v2": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "nano-gpt\u0000latitudegames/wayfarer-large-70b-llama-3.3": {
+      "cached_read": null,
+      "in": 0.700000007,
+      "out": 0.700000007
+    },
+    "nano-gpt\u0000learnlm-1.5-pro-experimental": {
+      "cached_read": null,
+      "in": 3.502,
+      "out": 10.506
+    },
+    "nano-gpt\u0000liquid/lfm-2-24b-a2b": {
+      "cached_read": null,
+      "in": 0.03,
+      "out": 0.12
+    },
+    "nano-gpt\u0000llm360/k2-think": {
+      "cached_read": null,
+      "in": 0.17,
+      "out": 0.68
+    },
+    "nano-gpt\u0000magistral-small-2506": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 1.4
+    },
+    "nano-gpt\u0000marinaraspaghetti/nemomix-unleashed-12b": {
+      "cached_read": null,
+      "in": 0.49299999999999994,
+      "out": 0.49299999999999994
+    },
+    "nano-gpt\u0000meganova-ai/manta-flash-1.0": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.16
+    },
+    "nano-gpt\u0000meganova-ai/manta-mini-1.0": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.16
+    },
+    "nano-gpt\u0000meganova-ai/manta-pro-1.0": {
+      "cached_read": null,
+      "in": 0.060000000000000005,
+      "out": 0.5
+    },
+    "nano-gpt\u0000mercury-2": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 0.75
+    },
+    "nano-gpt\u0000meta-llama-3-1-8b-instruct-fp8": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.03
+    },
+    "nano-gpt\u0000meta-llama/llama-3.1-8b-instruct": {
+      "cached_read": null,
+      "in": 0.0544,
+      "out": 0.0544
+    },
+    "nano-gpt\u0000meta-llama/llama-3.2-3b-instruct": {
+      "cached_read": null,
+      "in": 0.0306,
+      "out": 0.0493
+    },
+    "nano-gpt\u0000meta-llama/llama-3.3-70b-instruct": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.23
+    },
+    "nano-gpt\u0000meta-llama/llama-4-maverick": {
+      "cached_read": null,
+      "in": 0.18000000000000002,
+      "out": 0.8
+    },
+    "nano-gpt\u0000meta-llama/llama-4-scout": {
+      "cached_read": null,
+      "in": 0.085,
+      "out": 0.46
+    },
+    "nano-gpt\u0000microsoft/wizardlm-2-8x22b": {
+      "cached_read": null,
+      "in": 0.49299999999999994,
+      "out": 0.49299999999999994
+    },
+    "nano-gpt\u0000minimax-m1": {
+      "cached_read": null,
+      "in": 0.1394,
+      "out": 1.3328
+    },
+    "nano-gpt\u0000minimax-m2": {
+      "cached_read": null,
+      "in": 0.17,
+      "out": 1.53
+    },
+    "nano-gpt\u0000minimax/minimax-01": {
+      "cached_read": null,
+      "in": 0.1394,
+      "out": 1.1219999999999999
+    },
+    "nano-gpt\u0000minimax/minimax-latest": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "nano-gpt\u0000minimax/minimax-m2-her": {
+      "cached_read": null,
+      "in": 0.30200000000000005,
+      "out": 1.2069999999999999
+    },
+    "nano-gpt\u0000minimax/minimax-m2.1": {
+      "cached_read": null,
+      "in": 0.33,
+      "out": 1.32
+    },
+    "nano-gpt\u0000minimax/minimax-m2.5": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "nano-gpt\u0000minimax/minimax-m2.7": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "nano-gpt\u0000minimax/minimax-m2.7-turbo": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.4
+    },
+    "nano-gpt\u0000minimax/minimax-m3": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "nano-gpt\u0000minimax/minimax-m3:thinking": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "nano-gpt\u0000minimaxai/minimax-m1-80k": {
+      "cached_read": null,
+      "in": 0.6052,
+      "out": 2.4225000000000003
+    },
+    "nano-gpt\u0000mirothinker-1-7-deepresearch": {
+      "cached_read": null,
+      "in": 4.0,
+      "out": 25.0
+    },
+    "nano-gpt\u0000mirothinker-1-7-deepresearch-mini": {
+      "cached_read": null,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "nano-gpt\u0000mistral-code-agent-latest": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "nano-gpt\u0000mistral-code-latest": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.9
+    },
+    "nano-gpt\u0000mistral-small-31-24b-instruct": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "nano-gpt\u0000mistral/mistral-medium-3.5": {
+      "cached_read": null,
+      "in": 1.5,
+      "out": 7.5
+    },
+    "nano-gpt\u0000mistral/mistral-medium-3.5:thinking": {
+      "cached_read": null,
+      "in": 1.5,
+      "out": 7.5
+    },
+    "nano-gpt\u0000mistralai/codestral-2508": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.8999999999999999
+    },
+    "nano-gpt\u0000mistralai/devstral-2-123b-instruct-2512": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 1.4
+    },
+    "nano-gpt\u0000mistralai/devstral-small-2505": {
+      "cached_read": null,
+      "in": 0.060000000000000005,
+      "out": 0.060000000000000005
+    },
+    "nano-gpt\u0000mistralai/ministral-14b-2512": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "nano-gpt\u0000mistralai/ministral-14b-instruct-2512": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "nano-gpt\u0000mistralai/ministral-3b-2512": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "nano-gpt\u0000mistralai/ministral-8b-2512": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.15
+    },
+    "nano-gpt\u0000mistralai/mistral-large": {
+      "cached_read": null,
+      "in": 2.006,
+      "out": 6.001
+    },
+    "nano-gpt\u0000mistralai/mistral-large-3-675b-instruct-2512": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "nano-gpt\u0000mistralai/mistral-medium-3": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "nano-gpt\u0000mistralai/mistral-medium-3.1": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "nano-gpt\u0000mistralai/mistral-nemo-instruct-2407": {
+      "cached_read": null,
+      "in": 0.1003,
+      "out": 0.1207
+    },
+    "nano-gpt\u0000mistralai/mistral-saba": {
+      "cached_read": null,
+      "in": 0.1989,
+      "out": 0.595
+    },
+    "nano-gpt\u0000mistralai/mistral-small-4-119b-2603": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 1.4
+    },
+    "nano-gpt\u0000mistralai/mistral-small-4-119b-2603:thinking": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 1.4
+    },
+    "nano-gpt\u0000mistralai/mixtral-8x22b-instruct-v0.1": {
+      "cached_read": null,
+      "in": 0.8999999999999999,
+      "out": 0.8999999999999999
+    },
+    "nano-gpt\u0000mistralai/mixtral-8x7b-instruct-v0.1": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 0.27
+    },
+    "nano-gpt\u0000mlabonne/neuraldaredevil-8b-abliterated": {
+      "cached_read": null,
+      "in": 0.44,
+      "out": 0.44
+    },
+    "nano-gpt\u0000moonshotai/kimi-k2-instruct": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 2.0
+    },
+    "nano-gpt\u0000moonshotai/kimi-k2-instruct-0711": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 2.0
+    },
+    "nano-gpt\u0000moonshotai/kimi-k2-instruct-0905": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "nano-gpt\u0000moonshotai/kimi-k2-thinking": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "nano-gpt\u0000moonshotai/kimi-k2-thinking-original": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.5
+    },
+    "nano-gpt\u0000moonshotai/kimi-k2-thinking-turbo-original": {
+      "cached_read": null,
+      "in": 1.15,
+      "out": 8.0
+    },
+    "nano-gpt\u0000moonshotai/kimi-k2.5": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.9
+    },
+    "nano-gpt\u0000moonshotai/kimi-k2.5:thinking": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.9
+    },
+    "nano-gpt\u0000moonshotai/kimi-k2.6": {
+      "cached_read": null,
+      "in": 0.53,
+      "out": 2.73
+    },
+    "nano-gpt\u0000moonshotai/kimi-k2.6:thinking": {
+      "cached_read": null,
+      "in": 0.53,
+      "out": 2.73
+    },
+    "nano-gpt\u0000moonshotai/kimi-latest": {
+      "cached_read": 0.125,
+      "in": 0.5,
+      "out": 2.6
+    },
+    "nano-gpt\u0000nanogpt/coding-router": {
+      "cached_read": 0.11,
+      "in": 1.1,
+      "out": 2.2
+    },
+    "nano-gpt\u0000nanogpt/coding-router:high": {
+      "cached_read": 0.11,
+      "in": 1.1,
+      "out": 2.2
+    },
+    "nano-gpt\u0000nanogpt/coding-router:low": {
+      "cached_read": 0.028,
+      "in": 0.14,
+      "out": 0.28
+    },
+    "nano-gpt\u0000nanogpt/coding-router:max": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 30.0
+    },
+    "nano-gpt\u0000nanogpt/coding-router:medium": {
+      "cached_read": 0.028,
+      "in": 0.14,
+      "out": 0.28
+    },
+    "nano-gpt\u0000neversleep/lumimaid-v0.2-70b": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 1.5
+    },
+    "nano-gpt\u0000nex-agi/deepseek-v3.1-nex-n1": {
+      "cached_read": null,
+      "in": 0.27999999999999997,
+      "out": 0.42000000000000004
+    },
+    "nano-gpt\u0000nothingiisreal/l3.1-70b-celeste-v0.1-bf16": {
+      "cached_read": null,
+      "in": 0.49299999999999994,
+      "out": 0.49299999999999994
+    },
+    "nano-gpt\u0000nousresearch/deephermes-3-mistral-24b-preview": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.3
+    },
+    "nano-gpt\u0000nousresearch/hermes-3-llama-3.1-70b": {
+      "cached_read": null,
+      "in": 0.408,
+      "out": 0.408
+    },
+    "nano-gpt\u0000nousresearch/hermes-4-405b": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "nano-gpt\u0000nousresearch/hermes-4-405b:thinking": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "nano-gpt\u0000nousresearch/hermes-4-70b": {
+      "cached_read": null,
+      "in": 0.2006,
+      "out": 0.3995
+    },
+    "nano-gpt\u0000nousresearch/hermes-4-70b:thinking": {
+      "cached_read": null,
+      "in": 0.2006,
+      "out": 0.3995
+    },
+    "nano-gpt\u0000nvidia/llama-3.1-nemotron-70b-instruct-hf": {
+      "cached_read": null,
+      "in": 0.357,
+      "out": 0.408
+    },
+    "nano-gpt\u0000nvidia/llama-3.3-nemotron-super-49b-v1": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.15
+    },
+    "nano-gpt\u0000nvidia/llama-3_3-nemotron-super-49b-v1_5": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.25
+    },
+    "nano-gpt\u0000nvidia/nemotron-3-nano-30b-a3b": {
+      "cached_read": null,
+      "in": 0.17,
+      "out": 0.68
+    },
+    "nano-gpt\u0000nvidia/nemotron-3-nano-omni-30b-a3b-reasoning": {
+      "cached_read": null,
+      "in": 0.105,
+      "out": 0.42
+    },
+    "nano-gpt\u0000nvidia/nemotron-3-super-120b-a12b": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.25
+    },
+    "nano-gpt\u0000nvidia/nemotron-3-super-120b-a12b:thinking": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.25
+    },
+    "nano-gpt\u0000nvidia/nvidia-nemotron-nano-9b-v2": {
+      "cached_read": null,
+      "in": 0.17,
+      "out": 0.68
+    },
+    "nano-gpt\u0000openai/gpt-3.5-turbo": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "nano-gpt\u0000openai/gpt-4-turbo": {
+      "cached_read": null,
+      "in": 10.0,
+      "out": 30.0
+    },
+    "nano-gpt\u0000openai/gpt-4-turbo-preview": {
+      "cached_read": null,
+      "in": 9.996,
+      "out": 30.004999999999995
+    },
+    "nano-gpt\u0000openai/gpt-4.1": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "nano-gpt\u0000openai/gpt-4.1-mini": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 1.6
+    },
+    "nano-gpt\u0000openai/gpt-4.1-nano": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "nano-gpt\u0000openai/gpt-4o": {
+      "cached_read": null,
+      "in": 2.499,
+      "out": 9.996
+    },
+    "nano-gpt\u0000openai/gpt-4o-2024-08-06": {
+      "cached_read": null,
+      "in": 2.499,
+      "out": 9.996
+    },
+    "nano-gpt\u0000openai/gpt-4o-2024-11-20": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "nano-gpt\u0000openai/gpt-4o-mini": {
+      "cached_read": null,
+      "in": 0.1496,
+      "out": 0.595
+    },
+    "nano-gpt\u0000openai/gpt-4o-mini-search-preview": {
+      "cached_read": null,
+      "in": 0.088,
+      "out": 0.35
+    },
+    "nano-gpt\u0000openai/gpt-4o-search-preview": {
+      "cached_read": null,
+      "in": 1.47,
+      "out": 5.88
+    },
+    "nano-gpt\u0000openai/gpt-5": {
+      "cached_read": null,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "nano-gpt\u0000openai/gpt-5-codex": {
+      "cached_read": null,
+      "in": 9.996,
+      "out": 19.992
+    },
+    "nano-gpt\u0000openai/gpt-5-mini": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "nano-gpt\u0000openai/gpt-5-nano": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.4
+    },
+    "nano-gpt\u0000openai/gpt-5-pro": {
+      "cached_read": null,
+      "in": 15.0,
+      "out": 120.0
+    },
+    "nano-gpt\u0000openai/gpt-5.1": {
+      "cached_read": null,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "nano-gpt\u0000openai/gpt-5.1-2025-11-13": {
+      "cached_read": null,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "nano-gpt\u0000openai/gpt-5.1-codex": {
+      "cached_read": null,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "nano-gpt\u0000openai/gpt-5.1-codex-max": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 20.0
+    },
+    "nano-gpt\u0000openai/gpt-5.1-codex-mini": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "nano-gpt\u0000openai/gpt-5.2": {
+      "cached_read": null,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "nano-gpt\u0000openai/gpt-5.2-codex": {
+      "cached_read": null,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "nano-gpt\u0000openai/gpt-5.2-pro": {
+      "cached_read": null,
+      "in": 21.0,
+      "out": 168.0
+    },
+    "nano-gpt\u0000openai/gpt-5.3-codex": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "nano-gpt\u0000openai/gpt-5.4": {
+      "cached_read": 0.25,
+      "in": 2.5,
+      "out": 15.0
+    },
+    "nano-gpt\u0000openai/gpt-5.4-mini": {
+      "cached_read": 0.075,
+      "in": 0.75,
+      "out": 4.5
+    },
+    "nano-gpt\u0000openai/gpt-5.4-nano": {
+      "cached_read": 0.02,
+      "in": 0.2,
+      "out": 1.25
+    },
+    "nano-gpt\u0000openai/gpt-5.4-pro": {
+      "cached_read": 3.0,
+      "in": 30.0,
+      "out": 180.0
+    },
+    "nano-gpt\u0000openai/gpt-5.5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 30.0
+    },
+    "nano-gpt\u0000openai/gpt-chat-latest": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 30.0
+    },
+    "nano-gpt\u0000openai/gpt-latest": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 30.0
+    },
+    "nano-gpt\u0000openai/gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.25
+    },
+    "nano-gpt\u0000openai/gpt-oss-20b": {
+      "cached_read": null,
+      "in": 0.04,
+      "out": 0.15
+    },
+    "nano-gpt\u0000openai/gpt-oss-safeguard-20b": {
+      "cached_read": null,
+      "in": 0.075,
+      "out": 0.3
+    },
+    "nano-gpt\u0000openai/o1": {
+      "cached_read": null,
+      "in": 14.993999999999998,
+      "out": 59.993
+    },
+    "nano-gpt\u0000openai/o1-preview": {
+      "cached_read": null,
+      "in": 14.993999999999998,
+      "out": 59.993
+    },
+    "nano-gpt\u0000openai/o1-pro": {
+      "cached_read": null,
+      "in": 150.0,
+      "out": 600.0
+    },
+    "nano-gpt\u0000openai/o3": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "nano-gpt\u0000openai/o3-deep-research": {
+      "cached_read": null,
+      "in": 9.996,
+      "out": 19.992
+    },
+    "nano-gpt\u0000openai/o3-mini": {
+      "cached_read": null,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "nano-gpt\u0000openai/o3-mini-high": {
+      "cached_read": null,
+      "in": 0.64,
+      "out": 2.588
+    },
+    "nano-gpt\u0000openai/o3-mini-low": {
+      "cached_read": null,
+      "in": 9.996,
+      "out": 19.992
+    },
+    "nano-gpt\u0000openai/o3-pro-2025-06-10": {
+      "cached_read": null,
+      "in": 9.996,
+      "out": 19.992
+    },
+    "nano-gpt\u0000openai/o4-mini": {
+      "cached_read": null,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "nano-gpt\u0000openai/o4-mini-deep-research": {
+      "cached_read": null,
+      "in": 9.996,
+      "out": 19.992
+    },
+    "nano-gpt\u0000openai/o4-mini-high": {
+      "cached_read": null,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "nano-gpt\u0000owl": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "nano-gpt\u0000pamanseau/openreasoning-nemotron-32b": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "nano-gpt\u0000perceptron/perceptron-mk1": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 1.5
+    },
+    "nano-gpt\u0000phi-4-mini-instruct": {
+      "cached_read": null,
+      "in": 0.17,
+      "out": 0.68
+    },
+    "nano-gpt\u0000phi-4-multimodal-instruct": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.11
+    },
+    "nano-gpt\u0000poolside/laguna-m.1": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "nano-gpt\u0000poolside/laguna-xs.2": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "nano-gpt\u0000qvq-max": {
+      "cached_read": null,
+      "in": 1.4,
+      "out": 5.3
+    },
+    "nano-gpt\u0000qwen-3.6-plus": {
+      "cached_read": null,
+      "in": 0.45,
+      "out": 2.7
+    },
+    "nano-gpt\u0000qwen-long": {
+      "cached_read": null,
+      "in": 0.1003,
+      "out": 0.408
+    },
+    "nano-gpt\u0000qwen-max": {
+      "cached_read": null,
+      "in": 1.5997,
+      "out": 6.392
+    },
+    "nano-gpt\u0000qwen-plus": {
+      "cached_read": null,
+      "in": 0.3995,
+      "out": 1.2002
+    },
+    "nano-gpt\u0000qwen-turbo": {
+      "cached_read": null,
+      "in": 0.04998,
+      "out": 0.2006
+    },
+    "nano-gpt\u0000qwen/qwen-2.5-72b-instruct": {
+      "cached_read": null,
+      "in": 0.357,
+      "out": 0.408
+    },
+    "nano-gpt\u0000qwen/qwen2.5-coder-32b-instruct": {
+      "cached_read": null,
+      "in": 0.2006,
+      "out": 0.2006
+    },
+    "nano-gpt\u0000qwen/qwen3-14b": {
+      "cached_read": null,
+      "in": 0.08,
+      "out": 0.24
+    },
+    "nano-gpt\u0000qwen/qwen3-235b-a22b": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.5
+    },
+    "nano-gpt\u0000qwen/qwen3-235b-a22b-instruct-2507": {
+      "cached_read": null,
+      "in": 0.13,
+      "out": 0.5
+    },
+    "nano-gpt\u0000qwen/qwen3-235b-a22b-instruct-2507-tee": {
+      "cached_read": null,
+      "in": 0.13,
+      "out": 0.5
+    },
+    "nano-gpt\u0000qwen/qwen3-235b-a22b-thinking-2507": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.5
+    },
+    "nano-gpt\u0000qwen/qwen3-30b-a3b": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "nano-gpt\u0000qwen/qwen3-32b": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "nano-gpt\u0000qwen/qwen3-8b": {
+      "cached_read": null,
+      "in": 0.47,
+      "out": 0.47
+    },
+    "nano-gpt\u0000qwen/qwen3-coder": {
+      "cached_read": null,
+      "in": 0.13,
+      "out": 0.5
+    },
+    "nano-gpt\u0000qwen/qwen3-coder-flash": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.5
+    },
+    "nano-gpt\u0000qwen/qwen3-coder-next": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 1.5
+    },
+    "nano-gpt\u0000qwen/qwen3-coder-plus": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "nano-gpt\u0000qwen/qwen3-max": {
+      "cached_read": null,
+      "in": 1.08018,
+      "out": 5.4009
+    },
+    "nano-gpt\u0000qwen/qwen3-next-80b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.65
+    },
+    "nano-gpt\u0000qwen/qwen3-next-80b-a3b-thinking": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.65
+    },
+    "nano-gpt\u0000qwen/qwen3-vl-235b-a22b-instruct": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "nano-gpt\u0000qwen/qwen3.5-397b-a17b": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 3.6
+    },
+    "nano-gpt\u0000qwen/qwen3.5-397b-a17b-thinking": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 3.6
+    },
+    "nano-gpt\u0000qwen/qwen3.5-9b": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.15
+    },
+    "nano-gpt\u0000qwen/qwen3.5-plus": {
+      "cached_read": 0.04,
+      "in": 0.4,
+      "out": 2.4
+    },
+    "nano-gpt\u0000qwen/qwen3.5-plus-thinking": {
+      "cached_read": 0.04,
+      "in": 0.4,
+      "out": 2.4
+    },
+    "nano-gpt\u0000qwen/qwen3.6-35b-a3b": {
+      "cached_read": null,
+      "in": 0.112,
+      "out": 0.8
+    },
+    "nano-gpt\u0000qwen/qwen3.6-35b-a3b:thinking": {
+      "cached_read": null,
+      "in": 0.112,
+      "out": 0.8
+    },
+    "nano-gpt\u0000qwen/qwq-32b-preview": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "nano-gpt\u0000qwen2.5-32b-eva-v0.2": {
+      "cached_read": null,
+      "in": 0.493,
+      "out": 0.493
+    },
+    "nano-gpt\u0000qwen25-vl-72b-instruct": {
+      "cached_read": null,
+      "in": 0.69989,
+      "out": 0.69989
+    },
+    "nano-gpt\u0000qwen3-30b-a3b-instruct-2507": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "nano-gpt\u0000qwen3-coder-30b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "nano-gpt\u0000qwen3-max-2026-01-23": {
+      "cached_read": null,
+      "in": 1.2002,
+      "out": 6.001
+    },
+    "nano-gpt\u0000qwen3-vl-235b-a22b-instruct-original": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.2
+    },
+    "nano-gpt\u0000qwen3-vl-235b-a22b-thinking": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 6.0
+    },
+    "nano-gpt\u0000qwen3.5-122b-a10b": {
+      "cached_read": null,
+      "in": 0.36,
+      "out": 2.88
+    },
+    "nano-gpt\u0000qwen3.5-122b-a10b:thinking": {
+      "cached_read": null,
+      "in": 0.36,
+      "out": 2.88
+    },
+    "nano-gpt\u0000qwen3.5-27b": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 2.16
+    },
+    "nano-gpt\u0000qwen3.5-27b-anko": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000qwen3.5-27b-bluestar-derestricted": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000qwen3.5-27b-bluestar-derestricted-lite": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000qwen3.5-27b-bluestar-v2-derestricted": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000qwen3.5-27b-bluestar-v2-derestricted-lite": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000qwen3.5-27b-bluestar-v3-derestricted": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000qwen3.5-27b-bluestar-v3-derestricted-lite": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000qwen3.5-27b-derestricted": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000qwen3.5-27b-earica-derestricted": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000qwen3.5-27b-earica-derestricted-lite": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000qwen3.5-27b-infracelestial": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000qwen3.5-27b-marvin-dpo-v2-derestricted": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000qwen3.5-27b-marvin-dpo-v2-derestricted-lite": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000qwen3.5-27b-marvin-v2-derestricted": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000qwen3.5-27b-marvin-v2-derestricted-lite": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000qwen3.5-27b-musica-v1": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000qwen3.5-27b-nanovel-derestricted": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000qwen3.5-27b-nanovel-derestricted-lite": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000qwen3.5-27b-omega-evolution-v2.0-derestricted": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000qwen3.5-27b-omega-evolution-v2.0-derestricted-lite": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000qwen3.5-27b-omega-evolution-v2.2-derestricted": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000qwen3.5-27b-omega-evolution-v2.2-derestricted-lite": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000qwen3.5-27b-queen-derestricted": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000qwen3.5-27b-queen-derestricted-lite": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000qwen3.5-27b-rprmax-v1": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000qwen3.5-27b-vivid-durian": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000qwen3.5-27b-writer-derestricted": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000qwen3.5-27b-writer-derestricted-lite": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000qwen3.5-27b-writer-v2-derestricted": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000qwen3.5-27b-writer-v2-derestricted-lite": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "nano-gpt\u0000qwen3.5-27b:thinking": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 2.16
+    },
+    "nano-gpt\u0000qwen3.5-35b-a3b": {
+      "cached_read": null,
+      "in": 0.225,
+      "out": 1.8
+    },
+    "nano-gpt\u0000qwen3.5-35b-a3b:thinking": {
+      "cached_read": null,
+      "in": 0.225,
+      "out": 1.8
+    },
+    "nano-gpt\u0000qwen3.5-flash": {
+      "cached_read": null,
+      "in": 0.09,
+      "out": 0.36
+    },
+    "nano-gpt\u0000qwen3.5-flash:thinking": {
+      "cached_read": null,
+      "in": 0.09,
+      "out": 0.36
+    },
+    "nano-gpt\u0000qwen3.5-omni-flash": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nano-gpt\u0000qwen3.5-omni-plus": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nano-gpt\u0000qwen3.6-max-preview": {
+      "cached_read": null,
+      "in": 1.3,
+      "out": 7.8
+    },
+    "nano-gpt\u0000qwen3.7-max": {
+      "cached_read": 0.25,
+      "in": 2.5,
+      "out": 7.5
+    },
+    "nano-gpt\u0000qwen3.7-max:thinking": {
+      "cached_read": 0.25,
+      "in": 2.5,
+      "out": 7.5
+    },
+    "nano-gpt\u0000qwen3.7-plus": {
+      "cached_read": 0.04,
+      "in": 0.4,
+      "out": 1.6
+    },
+    "nano-gpt\u0000qwen3.7-plus:thinking": {
+      "cached_read": 0.04,
+      "in": 0.4,
+      "out": 1.6
+    },
+    "nano-gpt\u0000qwq-32b": {
+      "cached_read": null,
+      "in": 0.25599999,
+      "out": 0.30499999
+    },
+    "nano-gpt\u0000readyart/ms3.2-the-omega-directive-24b-unslop-v2.0": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 0.5
+    },
+    "nano-gpt\u0000salesforce/llama-xlam-2-70b-fc-r": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 2.5
+    },
+    "nano-gpt\u0000sao10k/l3-8b-stheno-v3.2": {
+      "cached_read": null,
+      "in": 0.2006,
+      "out": 0.2006
+    },
+    "nano-gpt\u0000sao10k/l3.1-70b-euryale-v2.2": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.357
+    },
+    "nano-gpt\u0000sao10k/l3.1-70b-hanami-x1": {
+      "cached_read": null,
+      "in": 0.49299999999999994,
+      "out": 0.49299999999999994
+    },
+    "nano-gpt\u0000sao10k/l3.3-70b-euryale-v2.3": {
+      "cached_read": null,
+      "in": 0.49299999999999994,
+      "out": 0.49299999999999994
+    },
+    "nano-gpt\u0000sarvam-105b": {
+      "cached_read": 0.028,
+      "in": 0.045,
+      "out": 0.177
+    },
+    "nano-gpt\u0000sarvam-30b": {
+      "cached_read": 0.017,
+      "in": 0.028,
+      "out": 0.111
+    },
+    "nano-gpt\u0000shisa-ai/shisa-v2-llama3.3-70b": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 0.5
+    },
+    "nano-gpt\u0000shisa-ai/shisa-v2.1-llama3.3-70b": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 0.5
+    },
+    "nano-gpt\u0000sonar": {
+      "cached_read": null,
+      "in": 1.003,
+      "out": 1.003
+    },
+    "nano-gpt\u0000sonar-deep-research": {
+      "cached_read": null,
+      "in": 3.4,
+      "out": 13.6
+    },
+    "nano-gpt\u0000sonar-pro": {
+      "cached_read": null,
+      "in": 2.992,
+      "out": 14.994
+    },
+    "nano-gpt\u0000sonar-reasoning-pro": {
+      "cached_read": null,
+      "in": 2.006,
+      "out": 7.9985
+    },
+    "nano-gpt\u0000soob3123/amoral-gemma3-27b-v2": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.3
+    },
+    "nano-gpt\u0000soob3123/grayline-qwen3-8b": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.3
+    },
+    "nano-gpt\u0000soob3123/veiled-calla-12b": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.3
+    },
+    "nano-gpt\u0000steelskull/l3.3-cu-mai-r1-70b": {
+      "cached_read": null,
+      "in": 0.49299999999999994,
+      "out": 0.49299999999999994
+    },
+    "nano-gpt\u0000steelskull/l3.3-electra-r1-70b": {
+      "cached_read": null,
+      "in": 0.69989,
+      "out": 0.69989
+    },
+    "nano-gpt\u0000steelskull/l3.3-ms-evalebis-70b": {
+      "cached_read": null,
+      "in": 0.49299999999999994,
+      "out": 0.49299999999999994
+    },
+    "nano-gpt\u0000steelskull/l3.3-ms-evayale-70b": {
+      "cached_read": null,
+      "in": 0.49299999999999994,
+      "out": 0.49299999999999994
+    },
+    "nano-gpt\u0000steelskull/l3.3-ms-nevoria-70b": {
+      "cached_read": null,
+      "in": 0.49299999999999994,
+      "out": 0.49299999999999994
+    },
+    "nano-gpt\u0000steelskull/l3.3-nevoria-r1-70b": {
+      "cached_read": null,
+      "in": 0.49299999999999994,
+      "out": 0.49299999999999994
+    },
+    "nano-gpt\u0000step-2-16k-exp": {
+      "cached_read": null,
+      "in": 7.004,
+      "out": 19.992
+    },
+    "nano-gpt\u0000step-2-mini": {
+      "cached_read": null,
+      "in": 0.2006,
+      "out": 0.408
+    },
+    "nano-gpt\u0000step-3": {
+      "cached_read": null,
+      "in": 0.2499,
+      "out": 0.6494
+    },
+    "nano-gpt\u0000step-r1-v-mini": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 11.0
+    },
+    "nano-gpt\u0000stepfun-ai/step-3.5-flash": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "nano-gpt\u0000stepfun-ai/step-3.5-flash-2603": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "nano-gpt\u0000stepfun/step-3.7-flash:thinking": {
+      "cached_read": 0.04,
+      "in": 0.2,
+      "out": 1.15
+    },
+    "nano-gpt\u0000tee/deepseek-v3.1": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 2.5
+    },
+    "nano-gpt\u0000tee/deepseek-v3.2": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.0
+    },
+    "nano-gpt\u0000tee/deepseek-v4-pro": {
+      "cached_read": 0.15,
+      "in": 1.5,
+      "out": 5.25
+    },
+    "nano-gpt\u0000tee/deepseek-v4-pro:thinking": {
+      "cached_read": 0.15,
+      "in": 1.5,
+      "out": 5.25
+    },
+    "nano-gpt\u0000tee/gemma-3-27b-it": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.8
+    },
+    "nano-gpt\u0000tee/gemma-4-26b-a4b-uncensored": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.7
+    },
+    "nano-gpt\u0000tee/gemma-4-31b-it": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.46
+    },
+    "nano-gpt\u0000tee/gemma4-31b": {
+      "cached_read": null,
+      "in": 0.45,
+      "out": 1.0
+    },
+    "nano-gpt\u0000tee/gemma4-31b:thinking": {
+      "cached_read": null,
+      "in": 0.45,
+      "out": 1.0
+    },
+    "nano-gpt\u0000tee/glm-4.7": {
+      "cached_read": null,
+      "in": 0.85,
+      "out": 3.3
+    },
+    "nano-gpt\u0000tee/glm-4.7-flash": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.5
+    },
+    "nano-gpt\u0000tee/glm-5": {
+      "cached_read": null,
+      "in": 1.2,
+      "out": 3.5
+    },
+    "nano-gpt\u0000tee/glm-5.1": {
+      "cached_read": 0.3,
+      "in": 1.5,
+      "out": 5.25
+    },
+    "nano-gpt\u0000tee/glm-5.1-thinking": {
+      "cached_read": 0.3,
+      "in": 1.5,
+      "out": 5.25
+    },
+    "nano-gpt\u0000tee/gpt-oss-120b": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 2.0
+    },
+    "nano-gpt\u0000tee/gpt-oss-20b": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.8
+    },
+    "nano-gpt\u0000tee/kimi-k2.5": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.9
+    },
+    "nano-gpt\u0000tee/kimi-k2.5-thinking": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.9
+    },
+    "nano-gpt\u0000tee/kimi-k2.6": {
+      "cached_read": 0.375,
+      "in": 1.5,
+      "out": 5.25
+    },
+    "nano-gpt\u0000tee/llama3-3-70b": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 2.0
+    },
+    "nano-gpt\u0000tee/minimax-m2.5": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 1.38
+    },
+    "nano-gpt\u0000tee/qwen2.5-vl-72b-instruct": {
+      "cached_read": null,
+      "in": 0.7,
+      "out": 0.7
+    },
+    "nano-gpt\u0000tee/qwen3-30b-a3b-instruct-2507": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.44999999999999996
+    },
+    "nano-gpt\u0000tee/qwen3.5-122b-a10b": {
+      "cached_read": null,
+      "in": 0.46,
+      "out": 3.68
+    },
+    "nano-gpt\u0000tee/qwen3.5-27b": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 2.4
+    },
+    "nano-gpt\u0000tee/qwen3.5-397b-a17b": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 3.6
+    },
+    "nano-gpt\u0000tee/qwen3.6-35b-a3b-uncensored": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.5
+    },
+    "nano-gpt\u0000tencent/hunyuan-mt-7b": {
+      "cached_read": null,
+      "in": 10.0,
+      "out": 20.0
+    },
+    "nano-gpt\u0000tencent/hy3-preview": {
+      "cached_read": 0.029,
+      "in": 0.066,
+      "out": 0.26
+    },
+    "nano-gpt\u0000thedrummer/anubis-70b-v1": {
+      "cached_read": null,
+      "in": 0.31,
+      "out": 0.31
+    },
+    "nano-gpt\u0000thedrummer/anubis-70b-v1.1": {
+      "cached_read": null,
+      "in": 0.31,
+      "out": 0.31
+    },
+    "nano-gpt\u0000thedrummer/cydonia-24b-v2": {
+      "cached_read": null,
+      "in": 0.1003,
+      "out": 0.1207
+    },
+    "nano-gpt\u0000thedrummer/cydonia-24b-v4": {
+      "cached_read": null,
+      "in": 0.2006,
+      "out": 0.2414
+    },
+    "nano-gpt\u0000thedrummer/cydonia-24b-v4.1": {
+      "cached_read": null,
+      "in": 0.1003,
+      "out": 0.1207
+    },
+    "nano-gpt\u0000thedrummer/cydonia-24b-v4.3": {
+      "cached_read": null,
+      "in": 0.1003,
+      "out": 0.1207
+    },
+    "nano-gpt\u0000thedrummer/magidonia-24b-v4.3": {
+      "cached_read": null,
+      "in": 0.1003,
+      "out": 0.1207
+    },
+    "nano-gpt\u0000thedrummer/rocinante-12b-v1.1": {
+      "cached_read": null,
+      "in": 0.408,
+      "out": 0.595
+    },
+    "nano-gpt\u0000thedrummer/skyfall-31b-v4.2": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 0.8
+    },
+    "nano-gpt\u0000thedrummer/skyfall-36b-v2": {
+      "cached_read": null,
+      "in": 0.493,
+      "out": 0.493
+    },
+    "nano-gpt\u0000thedrummer/unslopnemo-12b-v4.1": {
+      "cached_read": null,
+      "in": 0.493,
+      "out": 0.493
+    },
+    "nano-gpt\u0000thudm/glm-4-32b-0414": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "nano-gpt\u0000thudm/glm-4-9b-0414": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "nano-gpt\u0000thudm/glm-z1-32b-0414": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "nano-gpt\u0000thudm/glm-z1-9b-0414": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "nano-gpt\u0000tongyi-zhiwen/qwenlong-l1-32b": {
+      "cached_read": null,
+      "in": 0.13999999999999999,
+      "out": 0.6
+    },
+    "nano-gpt\u0000unbabel/m-prometheus-14b": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "nano-gpt\u0000undi95/remm-slerp-l2-13b": {
+      "cached_read": null,
+      "in": 0.7989999999999999,
+      "out": 1.2069999999999999
+    },
+    "nano-gpt\u0000universal-summarizer": {
+      "cached_read": null,
+      "in": 30.0,
+      "out": 30.0
+    },
+    "nano-gpt\u0000unsloth/gemma-3-12b-it": {
+      "cached_read": null,
+      "in": 0.272,
+      "out": 0.272
+    },
+    "nano-gpt\u0000unsloth/gemma-3-27b-it": {
+      "cached_read": null,
+      "in": 0.2992,
+      "out": 0.2992
+    },
+    "nano-gpt\u0000unsloth/gemma-3-4b-it": {
+      "cached_read": null,
+      "in": 0.2006,
+      "out": 0.2006
+    },
+    "nano-gpt\u0000upstage/solar-pro-3": {
+      "cached_read": 0.015,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "nano-gpt\u0000v0-1.0-md": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "nano-gpt\u0000v0-1.5-lg": {
+      "cached_read": null,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "nano-gpt\u0000v0-1.5-md": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "nano-gpt\u0000venice-uncensored": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 0.4
+    },
+    "nano-gpt\u0000venice-uncensored:web": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 0.4
+    },
+    "nano-gpt\u0000vongolachouko/starcannon-unleashed-12b-v1.0": {
+      "cached_read": null,
+      "in": 0.49299999999999994,
+      "out": 0.49299999999999994
+    },
+    "nano-gpt\u0000x-ai/grok-4.20": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "nano-gpt\u0000x-ai/grok-4.20-multi-agent": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "nano-gpt\u0000x-ai/grok-4.3": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "nano-gpt\u0000x-ai/grok-build-0.1": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 2.0
+    },
+    "nano-gpt\u0000x-ai/grok-latest": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "nano-gpt\u0000xiaomi/mimo-v2-flash": {
+      "cached_read": null,
+      "in": 0.102,
+      "out": 0.306
+    },
+    "nano-gpt\u0000xiaomi/mimo-v2-flash-original": {
+      "cached_read": null,
+      "in": 0.102,
+      "out": 0.306
+    },
+    "nano-gpt\u0000xiaomi/mimo-v2-flash-thinking": {
+      "cached_read": null,
+      "in": 0.102,
+      "out": 0.306
+    },
+    "nano-gpt\u0000xiaomi/mimo-v2-flash-thinking-original": {
+      "cached_read": null,
+      "in": 0.102,
+      "out": 0.306
+    },
+    "nano-gpt\u0000xiaomi/mimo-v2-omni": {
+      "cached_read": 0.08,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "nano-gpt\u0000xiaomi/mimo-v2-pro": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "nano-gpt\u0000xiaomi/mimo-v2.5": {
+      "cached_read": 0.0028,
+      "in": 0.14,
+      "out": 0.28
+    },
+    "nano-gpt\u0000xiaomi/mimo-v2.5-pro": {
+      "cached_read": 0.0036,
+      "in": 0.435,
+      "out": 0.87
+    },
+    "nano-gpt\u0000yi-large": {
+      "cached_read": null,
+      "in": 3.196,
+      "out": 3.196
+    },
+    "nano-gpt\u0000yi-lightning": {
+      "cached_read": null,
+      "in": 0.2006,
+      "out": 0.2006
+    },
+    "nano-gpt\u0000yi-medium-200k": {
+      "cached_read": null,
+      "in": 2.499,
+      "out": 2.499
+    },
+    "nano-gpt\u0000z-ai/glm-4.5v": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 1.7999999999999998
+    },
+    "nano-gpt\u0000z-ai/glm-4.5v:thinking": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 1.7999999999999998
+    },
+    "nano-gpt\u0000z-ai/glm-4.6": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 1.5
+    },
+    "nano-gpt\u0000z-ai/glm-4.6:thinking": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 1.5
+    },
+    "nano-gpt\u0000z-ai/glm-5-turbo": {
+      "cached_read": 0.24,
+      "in": 1.2,
+      "out": 4.0
+    },
+    "nano-gpt\u0000z-ai/glm-5v-turbo": {
+      "cached_read": 0.24,
+      "in": 1.2,
+      "out": 4.0
+    },
+    "nano-gpt\u0000z-ai/glm-5v-turbo:thinking": {
+      "cached_read": 0.24,
+      "in": 1.2,
+      "out": 4.0
+    },
+    "nano-gpt\u0000zai-org/glm-4.5": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.3
+    },
+    "nano-gpt\u0000zai-org/glm-4.5-air": {
+      "cached_read": null,
+      "in": 0.12,
+      "out": 0.8
+    },
+    "nano-gpt\u0000zai-org/glm-4.5-air:thinking": {
+      "cached_read": null,
+      "in": 0.12,
+      "out": 0.8
+    },
+    "nano-gpt\u0000zai-org/glm-4.5:thinking": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.3
+    },
+    "nano-gpt\u0000zai-org/glm-4.6-original": {
+      "cached_read": null,
+      "in": 0.35,
+      "out": 1.4
+    },
+    "nano-gpt\u0000zai-org/glm-4.6-turbo": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "nano-gpt\u0000zai-org/glm-4.6-turbo:thinking": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "nano-gpt\u0000zai-org/glm-4.6v": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.9
+    },
+    "nano-gpt\u0000zai-org/glm-4.6v-flash-original": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "nano-gpt\u0000zai-org/glm-4.6v-original": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 0.9
+    },
+    "nano-gpt\u0000zai-org/glm-4.7": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.8
+    },
+    "nano-gpt\u0000zai-org/glm-4.7-flash": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.4
+    },
+    "nano-gpt\u0000zai-org/glm-4.7-flash-original": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.4
+    },
+    "nano-gpt\u0000zai-org/glm-4.7-flash-original:thinking": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.4
+    },
+    "nano-gpt\u0000zai-org/glm-4.7-flash:thinking": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.4
+    },
+    "nano-gpt\u0000zai-org/glm-4.7-original": {
+      "cached_read": 0.11,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "nano-gpt\u0000zai-org/glm-4.7-original:thinking": {
+      "cached_read": 0.11,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "nano-gpt\u0000zai-org/glm-4.7:thinking": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.8
+    },
+    "nano-gpt\u0000zai-org/glm-5": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 2.55
+    },
+    "nano-gpt\u0000zai-org/glm-5-original": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 3.2
+    },
+    "nano-gpt\u0000zai-org/glm-5-original:thinking": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 3.2
+    },
+    "nano-gpt\u0000zai-org/glm-5.1": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 2.55
+    },
+    "nano-gpt\u0000zai-org/glm-5.1:thinking": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 2.55
+    },
+    "nano-gpt\u0000zai-org/glm-5:thinking": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 2.55
+    },
+    "nano-gpt\u0000zai-org/glm-latest": {
+      "cached_read": 0.15,
+      "in": 0.75,
+      "out": 2.6
+    },
+    "nearai\u0000anthropic/claude-haiku-4-5": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "nearai\u0000anthropic/claude-opus-4-6": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "nearai\u0000anthropic/claude-opus-4-7": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "nearai\u0000anthropic/claude-sonnet-4-5": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.5
+    },
+    "nearai\u0000anthropic/claude-sonnet-4-6": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "nearai\u0000black-forest-labs/flux.2-klein-4b": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 1.0
+    },
+    "nearai\u0000google/gemini-2.5-flash": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "nearai\u0000google/gemini-2.5-flash-lite": {
+      "cached_read": 0.01,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "nearai\u0000google/gemini-2.5-pro": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "nearai\u0000google/gemini-3-pro": {
+      "cached_read": 0.0,
+      "in": 1.25,
+      "out": 15.0
+    },
+    "nearai\u0000google/gemini-3.1-flash-lite": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 1.5
+    },
+    "nearai\u0000google/gemini-3.5-flash": {
+      "cached_read": 0.15,
+      "in": 1.5,
+      "out": 9.0
+    },
+    "nearai\u0000google/gemma-4-31b-it": {
+      "cached_read": 0.026,
+      "in": 0.13,
+      "out": 0.4
+    },
+    "nearai\u0000openai/gpt-4.1": {
+      "cached_read": 0.5,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "nearai\u0000openai/gpt-4.1-mini": {
+      "cached_read": 0.1,
+      "in": 0.4,
+      "out": 1.6
+    },
+    "nearai\u0000openai/gpt-4.1-nano": {
+      "cached_read": 0.025,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "nearai\u0000openai/gpt-5": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "nearai\u0000openai/gpt-5-mini": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "nearai\u0000openai/gpt-5-nano": {
+      "cached_read": 0.005,
+      "in": 0.05,
+      "out": 0.4
+    },
+    "nearai\u0000openai/gpt-5.1": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "nearai\u0000openai/gpt-5.2": {
+      "cached_read": 0.18,
+      "in": 1.8,
+      "out": 15.5
+    },
+    "nearai\u0000openai/gpt-5.4": {
+      "cached_read": 0.25,
+      "in": 2.5,
+      "out": 15.0
+    },
+    "nearai\u0000openai/gpt-5.4-mini": {
+      "cached_read": 0.075,
+      "in": 0.75,
+      "out": 4.5
+    },
+    "nearai\u0000openai/gpt-5.4-nano": {
+      "cached_read": 0.02,
+      "in": 0.2,
+      "out": 1.25
+    },
+    "nearai\u0000openai/gpt-5.5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 30.0
+    },
+    "nearai\u0000openai/gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.55
+    },
+    "nearai\u0000openai/o3": {
+      "cached_read": 0.5,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "nearai\u0000openai/o3-mini": {
+      "cached_read": 0.55,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "nearai\u0000openai/o4-mini": {
+      "cached_read": 0.275,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "nearai\u0000openai/whisper-large-v3": {
+      "cached_read": null,
+      "in": 0.01,
+      "out": 0.0
+    },
+    "nearai\u0000qwen/qwen3-30b-a3b-instruct-2507": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.55
+    },
+    "nearai\u0000qwen/qwen3-embedding-0.6b": {
+      "cached_read": null,
+      "in": 0.01,
+      "out": 0.0
+    },
+    "nearai\u0000qwen/qwen3-reranker-0.6b": {
+      "cached_read": null,
+      "in": 0.01,
+      "out": 0.01
+    },
+    "nearai\u0000qwen/qwen3-vl-30b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.55
+    },
+    "nearai\u0000qwen/qwen3.5-122b-a10b": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 3.2
+    },
+    "nearai\u0000qwen/qwen3.6-35b-a3b-fp8": {
+      "cached_read": 0.056,
+      "in": 0.17,
+      "out": 1.1
+    },
+    "nearai\u0000zai-org/glm-5.1-fp8": {
+      "cached_read": null,
+      "in": 0.85,
+      "out": 3.3
+    },
+    "nebius\u0000deepseek-ai/deepseek-v3.2": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 0.45
+    },
+    "nebius\u0000deepseek-ai/deepseek-v3.2-fast": {
+      "cached_read": 0.04,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "nebius\u0000deepseek-ai/deepseek-v4-pro": {
+      "cached_read": 0.15,
+      "in": 1.75,
+      "out": 3.5
+    },
+    "nebius\u0000google/gemma-2-2b-it": {
+      "cached_read": 0.002,
+      "in": 0.02,
+      "out": 0.06
+    },
+    "nebius\u0000google/gemma-3-27b-it": {
+      "cached_read": 0.01,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "nebius\u0000meta-llama/llama-3.3-70b-instruct": {
+      "cached_read": 0.013,
+      "in": 0.13,
+      "out": 0.4
+    },
+    "nebius\u0000meta-llama/meta-llama-3.1-8b-instruct": {
+      "cached_read": 0.002,
+      "in": 0.02,
+      "out": 0.06
+    },
+    "nebius\u0000minimaxai/minimax-m2.5": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "nebius\u0000minimaxai/minimax-m2.5-fast": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "nebius\u0000moonshotai/kimi-k2.5": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 2.5
+    },
+    "nebius\u0000moonshotai/kimi-k2.5-fast": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 2.5
+    },
+    "nebius\u0000nousresearch/hermes-4-405b": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "nebius\u0000nousresearch/hermes-4-70b": {
+      "cached_read": 0.013,
+      "in": 0.13,
+      "out": 0.4
+    },
+    "nebius\u0000nvidia/llama-3_1-nemotron-ultra-253b-v1": {
+      "cached_read": 0.06,
+      "in": 0.6,
+      "out": 1.8
+    },
+    "nebius\u0000nvidia/nemotron-3-nano-omni": {
+      "cached_read": 0.006,
+      "in": 0.06,
+      "out": 0.24
+    },
+    "nebius\u0000nvidia/nemotron-3-super-120b-a12b": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.9
+    },
+    "nebius\u0000nvidia/nvidia-nemotron-3-nano-30b-a3b": {
+      "cached_read": 0.006,
+      "in": 0.06,
+      "out": 0.24
+    },
+    "nebius\u0000openai/gpt-oss-120b": {
+      "cached_read": 0.015,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "nebius\u0000openai/gpt-oss-120b-fast": {
+      "cached_read": 0.01,
+      "in": 0.1,
+      "out": 0.5
+    },
+    "nebius\u0000primeintellect/intellect-3": {
+      "cached_read": 0.02,
+      "in": 0.2,
+      "out": 1.1
+    },
+    "nebius\u0000qwen/qwen2.5-vl-72b-instruct": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 0.75
+    },
+    "nebius\u0000qwen/qwen3-235b-a22b-instruct-2507": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.6
+    },
+    "nebius\u0000qwen/qwen3-235b-a22b-thinking-2507-fast": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 2.0
+    },
+    "nebius\u0000qwen/qwen3-30b-a3b-instruct-2507": {
+      "cached_read": 0.01,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "nebius\u0000qwen/qwen3-32b": {
+      "cached_read": 0.01,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "nebius\u0000qwen/qwen3-embedding-8b": {
+      "cached_read": null,
+      "in": 0.01,
+      "out": 0.0
+    },
+    "nebius\u0000qwen/qwen3-next-80b-a3b-thinking": {
+      "cached_read": 0.015,
+      "in": 0.15,
+      "out": 1.2
+    },
+    "nebius\u0000qwen/qwen3-next-80b-a3b-thinking-fast": {
+      "cached_read": 0.015,
+      "in": 0.15,
+      "out": 1.2
+    },
+    "nebius\u0000qwen/qwen3.5-397b-a17b": {
+      "cached_read": 0.06,
+      "in": 0.6,
+      "out": 3.6
+    },
+    "nebius\u0000qwen/qwen3.5-397b-a17b-fast": {
+      "cached_read": 0.06,
+      "in": 0.6,
+      "out": 3.6
+    },
+    "nebius\u0000zai-org/glm-5": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 3.2
+    },
+    "neuralwatt\u0000glm-5-fast": {
+      "cached_read": null,
+      "in": 1.1,
+      "out": 3.6
+    },
+    "neuralwatt\u0000glm-5.1-fast": {
+      "cached_read": null,
+      "in": 1.1,
+      "out": 3.6
+    },
+    "neuralwatt\u0000kimi-k2.5-fast": {
+      "cached_read": null,
+      "in": 0.52,
+      "out": 2.59
+    },
+    "neuralwatt\u0000kimi-k2.6-fast": {
+      "cached_read": null,
+      "in": 0.69,
+      "out": 3.22
+    },
+    "neuralwatt\u0000minimaxai/minimax-m2.5": {
+      "cached_read": null,
+      "in": 0.35,
+      "out": 1.38
+    },
+    "neuralwatt\u0000mistralai/devstral-small-2-24b-instruct-2512": {
+      "cached_read": null,
+      "in": 0.12,
+      "out": 0.35
+    },
+    "neuralwatt\u0000moonshotai/kimi-k2.5": {
+      "cached_read": null,
+      "in": 0.52,
+      "out": 2.59
+    },
+    "neuralwatt\u0000moonshotai/kimi-k2.6": {
+      "cached_read": null,
+      "in": 0.69,
+      "out": 3.22
+    },
+    "neuralwatt\u0000openai/gpt-oss-20b": {
+      "cached_read": null,
+      "in": 0.03,
+      "out": 0.16
+    },
+    "neuralwatt\u0000qwen/qwen3.5-397b-a17b-fp8": {
+      "cached_read": null,
+      "in": 0.69,
+      "out": 4.14
+    },
+    "neuralwatt\u0000qwen/qwen3.6-35b-a3b": {
+      "cached_read": null,
+      "in": 0.29,
+      "out": 1.15
+    },
+    "neuralwatt\u0000qwen3.5-397b-fast": {
+      "cached_read": null,
+      "in": 0.69,
+      "out": 4.14
+    },
+    "neuralwatt\u0000qwen3.6-35b-fast": {
+      "cached_read": null,
+      "in": 0.29,
+      "out": 1.15
+    },
+    "neuralwatt\u0000zai-org/glm-5.1-fp8": {
+      "cached_read": null,
+      "in": 1.1,
+      "out": 3.6
+    },
+    "nova\u0000nova-2-lite-v1": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nova\u0000nova-2-pro-v1": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "novita-ai\u0000baichuan/baichuan-m2-32b": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.07
+    },
+    "novita-ai\u0000baidu/ernie-4.5-21b-a3b": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.28
+    },
+    "novita-ai\u0000baidu/ernie-4.5-21b-a3b-thinking": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.28
+    },
+    "novita-ai\u0000baidu/ernie-4.5-300b-a47b-paddle": {
+      "cached_read": null,
+      "in": 0.28,
+      "out": 1.1
+    },
+    "novita-ai\u0000baidu/ernie-4.5-vl-28b-a3b": {
+      "cached_read": null,
+      "in": 1.4,
+      "out": 5.6
+    },
+    "novita-ai\u0000baidu/ernie-4.5-vl-28b-a3b-thinking": {
+      "cached_read": null,
+      "in": 0.39,
+      "out": 0.39
+    },
+    "novita-ai\u0000baidu/ernie-4.5-vl-424b-a47b": {
+      "cached_read": null,
+      "in": 0.42,
+      "out": 1.25
+    },
+    "novita-ai\u0000deepseek/deepseek-ocr": {
+      "cached_read": null,
+      "in": 0.03,
+      "out": 0.03
+    },
+    "novita-ai\u0000deepseek/deepseek-ocr-2": {
+      "cached_read": null,
+      "in": 0.03,
+      "out": 0.03
+    },
+    "novita-ai\u0000deepseek/deepseek-prover-v2-671b": {
+      "cached_read": null,
+      "in": 0.7,
+      "out": 2.5
+    },
+    "novita-ai\u0000deepseek/deepseek-r1-0528": {
+      "cached_read": 0.35,
+      "in": 0.7,
+      "out": 2.5
+    },
+    "novita-ai\u0000deepseek/deepseek-r1-0528-qwen3-8b": {
+      "cached_read": null,
+      "in": 0.06,
+      "out": 0.09
+    },
+    "novita-ai\u0000deepseek/deepseek-r1-distill-llama-70b": {
+      "cached_read": null,
+      "in": 0.8,
+      "out": 0.8
+    },
+    "novita-ai\u0000deepseek/deepseek-r1-distill-qwen-14b": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.15
+    },
+    "novita-ai\u0000deepseek/deepseek-r1-distill-qwen-32b": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.3
+    },
+    "novita-ai\u0000deepseek/deepseek-r1-turbo": {
+      "cached_read": null,
+      "in": 0.7,
+      "out": 2.5
+    },
+    "novita-ai\u0000deepseek/deepseek-v3-0324": {
+      "cached_read": 0.135,
+      "in": 0.27,
+      "out": 1.12
+    },
+    "novita-ai\u0000deepseek/deepseek-v3-turbo": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 1.3
+    },
+    "novita-ai\u0000deepseek/deepseek-v3.1": {
+      "cached_read": 0.135,
+      "in": 0.27,
+      "out": 1.0
+    },
+    "novita-ai\u0000deepseek/deepseek-v3.1-terminus": {
+      "cached_read": 0.135,
+      "in": 0.27,
+      "out": 1.0
+    },
+    "novita-ai\u0000deepseek/deepseek-v3.2": {
+      "cached_read": 0.1345,
+      "in": 0.269,
+      "out": 0.4
+    },
+    "novita-ai\u0000deepseek/deepseek-v3.2-exp": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 0.41
+    },
+    "novita-ai\u0000deepseek/deepseek-v4-flash": {
+      "cached_read": 0.028,
+      "in": 0.14,
+      "out": 0.28
+    },
+    "novita-ai\u0000deepseek/deepseek-v4-pro": {
+      "cached_read": 0.13,
+      "in": 1.69,
+      "out": 3.38
+    },
+    "novita-ai\u0000google/gemma-3-12b-it": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.1
+    },
+    "novita-ai\u0000google/gemma-3-27b-it": {
+      "cached_read": null,
+      "in": 0.119,
+      "out": 0.2
+    },
+    "novita-ai\u0000google/gemma-4-26b-a4b-it": {
+      "cached_read": null,
+      "in": 0.13,
+      "out": 0.4
+    },
+    "novita-ai\u0000google/gemma-4-31b-it": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.4
+    },
+    "novita-ai\u0000gryphe/mythomax-l2-13b": {
+      "cached_read": null,
+      "in": 0.09,
+      "out": 0.09
+    },
+    "novita-ai\u0000inclusionai/ling-2.6-1t": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "novita-ai\u0000inclusionai/ling-2.6-flash": {
+      "cached_read": 0.02,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "novita-ai\u0000inclusionai/ring-2.6-1t": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "novita-ai\u0000kwaipilot/kat-coder-pro": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "novita-ai\u0000meta-llama/llama-3-70b-instruct": {
+      "cached_read": null,
+      "in": 0.51,
+      "out": 0.74
+    },
+    "novita-ai\u0000meta-llama/llama-3-8b-instruct": {
+      "cached_read": null,
+      "in": 0.04,
+      "out": 0.04
+    },
+    "novita-ai\u0000meta-llama/llama-3.1-8b-instruct": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.05
+    },
+    "novita-ai\u0000meta-llama/llama-3.2-3b-instruct": {
+      "cached_read": null,
+      "in": 0.03,
+      "out": 0.05
+    },
+    "novita-ai\u0000meta-llama/llama-3.3-70b-instruct": {
+      "cached_read": null,
+      "in": 0.135,
+      "out": 0.4
+    },
+    "novita-ai\u0000meta-llama/llama-4-maverick-17b-128e-instruct-fp8": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 0.85
+    },
+    "novita-ai\u0000meta-llama/llama-4-scout-17b-16e-instruct": {
+      "cached_read": null,
+      "in": 0.18,
+      "out": 0.59
+    },
+    "novita-ai\u0000microsoft/wizardlm-2-8x22b": {
+      "cached_read": null,
+      "in": 0.62,
+      "out": 0.62
+    },
+    "novita-ai\u0000minimax/minimax-m2": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "novita-ai\u0000minimax/minimax-m2.1": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "novita-ai\u0000minimax/minimax-m2.5": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "novita-ai\u0000minimax/minimax-m2.5-highspeed": {
+      "cached_read": 0.03,
+      "in": 0.6,
+      "out": 2.4
+    },
+    "novita-ai\u0000minimax/minimax-m2.7": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "novita-ai\u0000minimax/minimax-m2.7-highspeed": {
+      "cached_read": 0.06,
+      "in": 0.6,
+      "out": 2.4
+    },
+    "novita-ai\u0000minimaxai/minimax-m1-80k": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 2.2
+    },
+    "novita-ai\u0000mistralai/mistral-nemo": {
+      "cached_read": null,
+      "in": 0.04,
+      "out": 0.17
+    },
+    "novita-ai\u0000moonshotai/kimi-k2-0905": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.5
+    },
+    "novita-ai\u0000moonshotai/kimi-k2-instruct": {
+      "cached_read": null,
+      "in": 0.57,
+      "out": 2.3
+    },
+    "novita-ai\u0000moonshotai/kimi-k2-thinking": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.5
+    },
+    "novita-ai\u0000moonshotai/kimi-k2.5": {
+      "cached_read": 0.1,
+      "in": 0.6,
+      "out": 3.0
+    },
+    "novita-ai\u0000moonshotai/kimi-k2.6": {
+      "cached_read": 0.16,
+      "in": 0.95,
+      "out": 4.0
+    },
+    "novita-ai\u0000nousresearch/hermes-2-pro-llama-3-8b": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.14
+    },
+    "novita-ai\u0000openai/gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.25
+    },
+    "novita-ai\u0000openai/gpt-oss-20b": {
+      "cached_read": null,
+      "in": 0.04,
+      "out": 0.15
+    },
+    "novita-ai\u0000paddlepaddle/paddleocr-vl": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.02
+    },
+    "novita-ai\u0000qwen/qwen-2.5-72b-instruct": {
+      "cached_read": null,
+      "in": 0.38,
+      "out": 0.4
+    },
+    "novita-ai\u0000qwen/qwen-mt-plus": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 0.75
+    },
+    "novita-ai\u0000qwen/qwen2.5-7b-instruct": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.07
+    },
+    "novita-ai\u0000qwen/qwen2.5-vl-72b-instruct": {
+      "cached_read": null,
+      "in": 0.8,
+      "out": 0.8
+    },
+    "novita-ai\u0000qwen/qwen3-235b-a22b-fp8": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.8
+    },
+    "novita-ai\u0000qwen/qwen3-235b-a22b-instruct-2507": {
+      "cached_read": null,
+      "in": 0.09,
+      "out": 0.58
+    },
+    "novita-ai\u0000qwen/qwen3-235b-a22b-thinking-2507": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 3.0
+    },
+    "novita-ai\u0000qwen/qwen3-30b-a3b-fp8": {
+      "cached_read": null,
+      "in": 0.09,
+      "out": 0.45
+    },
+    "novita-ai\u0000qwen/qwen3-32b-fp8": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.45
+    },
+    "novita-ai\u0000qwen/qwen3-4b-fp8": {
+      "cached_read": null,
+      "in": 0.03,
+      "out": 0.03
+    },
+    "novita-ai\u0000qwen/qwen3-8b-fp8": {
+      "cached_read": null,
+      "in": 0.035,
+      "out": 0.138
+    },
+    "novita-ai\u0000qwen/qwen3-coder-30b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.27
+    },
+    "novita-ai\u0000qwen/qwen3-coder-480b-a35b-instruct": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.3
+    },
+    "novita-ai\u0000qwen/qwen3-coder-next": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 1.5
+    },
+    "novita-ai\u0000qwen/qwen3-max": {
+      "cached_read": null,
+      "in": 2.11,
+      "out": 8.45
+    },
+    "novita-ai\u0000qwen/qwen3-next-80b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 1.5
+    },
+    "novita-ai\u0000qwen/qwen3-next-80b-a3b-thinking": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 1.5
+    },
+    "novita-ai\u0000qwen/qwen3-omni-30b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 0.97
+    },
+    "novita-ai\u0000qwen/qwen3-omni-30b-a3b-thinking": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 0.97
+    },
+    "novita-ai\u0000qwen/qwen3-vl-235b-a22b-instruct": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.5
+    },
+    "novita-ai\u0000qwen/qwen3-vl-235b-a22b-thinking": {
+      "cached_read": null,
+      "in": 0.98,
+      "out": 3.95
+    },
+    "novita-ai\u0000qwen/qwen3-vl-30b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.7
+    },
+    "novita-ai\u0000qwen/qwen3-vl-30b-a3b-thinking": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 1.0
+    },
+    "novita-ai\u0000qwen/qwen3-vl-8b-instruct": {
+      "cached_read": null,
+      "in": 0.08,
+      "out": 0.5
+    },
+    "novita-ai\u0000qwen/qwen3.5-122b-a10b": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 3.2
+    },
+    "novita-ai\u0000qwen/qwen3.5-27b": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 2.4
+    },
+    "novita-ai\u0000qwen/qwen3.5-35b-a3b": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "novita-ai\u0000qwen/qwen3.5-397b-a17b": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 3.6
+    },
+    "novita-ai\u0000qwen/qwen3.7-max": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 3.75
+    },
+    "novita-ai\u0000sao10k/l3-70b-euryale-v2.1": {
+      "cached_read": null,
+      "in": 1.48,
+      "out": 1.48
+    },
+    "novita-ai\u0000sao10k/l3-8b-lunaris": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.05
+    },
+    "novita-ai\u0000sao10k/l3-8b-stheno-v3.2": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.05
+    },
+    "novita-ai\u0000sao10k/l31-70b-euryale-v2.2": {
+      "cached_read": null,
+      "in": 1.48,
+      "out": 1.48
+    },
+    "novita-ai\u0000xiaomimimo/mimo-v2-flash": {
+      "cached_read": 0.3,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "novita-ai\u0000xiaomimimo/mimo-v2-pro": {
+      "cached_read": 0.4,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "novita-ai\u0000xiaomimimo/mimo-v2.5-pro": {
+      "cached_read": 0.4,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "novita-ai\u0000zai-org/autoglm-phone-9b-multilingual": {
+      "cached_read": null,
+      "in": 0.035,
+      "out": 0.138
+    },
+    "novita-ai\u0000zai-org/glm-4.5": {
+      "cached_read": 0.11,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "novita-ai\u0000zai-org/glm-4.5-air": {
+      "cached_read": null,
+      "in": 0.13,
+      "out": 0.85
+    },
+    "novita-ai\u0000zai-org/glm-4.5v": {
+      "cached_read": 0.11,
+      "in": 0.6,
+      "out": 1.8
+    },
+    "novita-ai\u0000zai-org/glm-4.6": {
+      "cached_read": 0.11,
+      "in": 0.55,
+      "out": 2.2
+    },
+    "novita-ai\u0000zai-org/glm-4.6v": {
+      "cached_read": 0.055,
+      "in": 0.3,
+      "out": 0.9
+    },
+    "novita-ai\u0000zai-org/glm-4.7": {
+      "cached_read": 0.11,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "novita-ai\u0000zai-org/glm-4.7-flash": {
+      "cached_read": 0.01,
+      "in": 0.07,
+      "out": 0.4
+    },
+    "novita-ai\u0000zai-org/glm-5": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 3.2
+    },
+    "novita-ai\u0000zai-org/glm-5.1": {
+      "cached_read": 0.26,
+      "in": 1.4,
+      "out": 4.4
+    },
+    "nvidia\u0000abacusai/dracarys-llama-3_1-70b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000baai/bge-m3": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000black-forest-labs/flux.1-dev": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000black-forest-labs/flux_1-kontext-dev": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000black-forest-labs/flux_1-schnell": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000black-forest-labs/flux_2-klein-4b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000bytedance/seed-oss-36b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000deepseek-ai/deepseek-v3.1-terminus": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000deepseek-ai/deepseek-v3.2": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000deepseek-ai/deepseek-v4-flash": {
+      "cached_read": 0.0028,
+      "in": 0.14,
+      "out": 0.28
+    },
+    "nvidia\u0000deepseek-ai/deepseek-v4-pro": {
+      "cached_read": 0.003625,
+      "in": 0.435,
+      "out": 0.87
+    },
+    "nvidia\u0000google/gemma-2-2b-it": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000google/gemma-3-27b-it": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000google/gemma-3n-e2b-it": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000google/gemma-3n-e4b-it": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000google/gemma-4-31b-it": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000google/google-paligemma": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000meta/esm2-650m": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000meta/esmfold": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000meta/llama-3.1-70b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000meta/llama-3.1-8b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000meta/llama-3.2-11b-vision-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000meta/llama-3.2-1b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000meta/llama-3.2-3b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000meta/llama-3.2-90b-vision-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000meta/llama-3.3-70b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000meta/llama-4-maverick-17b-128e-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000meta/llama-guard-4-12b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000microsoft/phi-4-mini-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000microsoft/phi-4-multimodal-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000minimaxai/minimax-m2.5": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000minimaxai/minimax-m2.7": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000mistralai/devstral-2-123b-instruct-2512": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000mistralai/magistral-small-2506": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000mistralai/mistral-7b-instruct-v03": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000mistralai/mistral-large-3-675b-instruct-2512": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000mistralai/mistral-medium-3-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000mistralai/mistral-nemotron": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000mistralai/mistral-small-4-119b-2603": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000mistralai/mixtral-8x22b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000mistralai/mixtral-8x7b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000moonshotai/kimi-k2-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000moonshotai/kimi-k2-instruct-0905": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000moonshotai/kimi-k2-thinking": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000moonshotai/kimi-k2.6": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000nvidia/active-speaker-detection": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000nvidia/bevformer": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000nvidia/cosmos-predict1-5b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000nvidia/cosmos-transfer1-7b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000nvidia/cosmos-transfer2_5-2b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000nvidia/gliner-pii": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000nvidia/llama-3_1-nemotron-safety-guard-8b-v3": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000nvidia/llama-3_2-nemoretriever-300m-embed-v1": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000nvidia/llama-3_3-nemotron-super-49b-v1": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000nvidia/llama-3_3-nemotron-super-49b-v1_5": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000nvidia/llama-nemotron-embed-vl-1b-v2": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000nvidia/llama-nemotron-rerank-vl-1b-v2": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000nvidia/magpie-tts-zeroshot": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000nvidia/nemotron-3-content-safety": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000nvidia/nemotron-3-nano-30b-a3b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000nvidia/nemotron-3-nano-omni-30b-a3b-reasoning": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000nvidia/nemotron-3-super-120b-a12b": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.8
+    },
+    "nvidia\u0000nvidia/nemotron-content-safety-reasoning-4b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000nvidia/nemotron-mini-4b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000nvidia/nemotron-voicechat": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000nvidia/nv-embed-v1": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000nvidia/nv-embedcode-7b-v1": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000nvidia/nvidia-nemotron-nano-9b-v2": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000nvidia/rerank-qa-mistral-4b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000nvidia/riva-translate-4b-instruct-v1_1": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000nvidia/sparsedrive": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000nvidia/streampetr": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000nvidia/studiovoice": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000nvidia/synthetic-video-detector": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000nvidia/usdcode": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000nvidia/usdvalidate": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000openai/gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000openai/gpt-oss-20b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000openai/whisper-large-v3": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000qwen/qwen-image": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000qwen/qwen-image-edit": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000qwen/qwen2.5-coder-32b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000qwen/qwen3-coder-480b-a35b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000qwen/qwen3-next-80b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000qwen/qwen3-next-80b-a3b-thinking": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000qwen/qwen3.5-122b-a10b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000qwen/qwen3.5-397b-a17b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000sarvamai/sarvam-m": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000stepfun-ai/step-3.5-flash": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000stepfun-ai/step-3.7-flash": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000upstage/solar-10_7b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000z-ai/glm-5.1": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia\u0000z-ai/glm4.7": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "openai\u0000gpt-3.5-turbo": {
+      "cached_read": 0.0,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "openai\u0000gpt-4": {
+      "cached_read": null,
+      "in": 30.0,
+      "out": 60.0
+    },
+    "openai\u0000gpt-4-turbo": {
+      "cached_read": null,
+      "in": 10.0,
+      "out": 30.0
+    },
+    "openai\u0000gpt-4.1": {
+      "cached_read": 0.5,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "openai\u0000gpt-4.1-mini": {
+      "cached_read": 0.1,
+      "in": 0.4,
+      "out": 1.6
+    },
+    "openai\u0000gpt-4.1-nano": {
+      "cached_read": 0.025,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "openai\u0000gpt-4o": {
+      "cached_read": 1.25,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "openai\u0000gpt-4o-2024-05-13": {
+      "cached_read": null,
+      "in": 5.0,
+      "out": 15.0
+    },
+    "openai\u0000gpt-4o-2024-08-06": {
+      "cached_read": 1.25,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "openai\u0000gpt-4o-2024-11-20": {
+      "cached_read": 1.25,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "openai\u0000gpt-4o-mini": {
+      "cached_read": 0.075,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "openai\u0000gpt-5": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "openai\u0000gpt-5-chat-latest": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "openai\u0000gpt-5-codex": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "openai\u0000gpt-5-mini": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "openai\u0000gpt-5-nano": {
+      "cached_read": 0.005,
+      "in": 0.05,
+      "out": 0.4
+    },
+    "openai\u0000gpt-5-pro": {
+      "cached_read": null,
+      "in": 15.0,
+      "out": 120.0
+    },
+    "openai\u0000gpt-5.1": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "openai\u0000gpt-5.1-chat-latest": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "openai\u0000gpt-5.1-codex": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "openai\u0000gpt-5.1-codex-max": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "openai\u0000gpt-5.1-codex-mini": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "openai\u0000gpt-5.2": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "openai\u0000gpt-5.2-chat-latest": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "openai\u0000gpt-5.2-codex": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "openai\u0000gpt-5.2-pro": {
+      "cached_read": null,
+      "in": 21.0,
+      "out": 168.0
+    },
+    "openai\u0000gpt-5.3-chat-latest": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "openai\u0000gpt-5.3-codex": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "openai\u0000gpt-5.3-codex-spark": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "openai\u0000gpt-5.4": {
+      "cached_read": 0.25,
+      "in": 2.5,
+      "out": 15.0
+    },
+    "openai\u0000gpt-5.4-mini": {
+      "cached_read": 0.075,
+      "in": 0.75,
+      "out": 4.5
+    },
+    "openai\u0000gpt-5.4-nano": {
+      "cached_read": 0.02,
+      "in": 0.2,
+      "out": 1.25
+    },
+    "openai\u0000gpt-5.4-pro": {
+      "cached_read": null,
+      "in": 30.0,
+      "out": 180.0
+    },
+    "openai\u0000gpt-5.5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 30.0
+    },
+    "openai\u0000gpt-5.5-pro": {
+      "cached_read": null,
+      "in": 30.0,
+      "out": 180.0
+    },
+    "openai\u0000o1": {
+      "cached_read": 7.5,
+      "in": 15.0,
+      "out": 60.0
+    },
+    "openai\u0000o1-mini": {
+      "cached_read": 0.55,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "openai\u0000o1-preview": {
+      "cached_read": 7.5,
+      "in": 15.0,
+      "out": 60.0
+    },
+    "openai\u0000o1-pro": {
+      "cached_read": null,
+      "in": 150.0,
+      "out": 600.0
+    },
+    "openai\u0000o3": {
+      "cached_read": 0.5,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "openai\u0000o3-deep-research": {
+      "cached_read": 2.5,
+      "in": 10.0,
+      "out": 40.0
+    },
+    "openai\u0000o3-mini": {
+      "cached_read": 0.55,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "openai\u0000o3-pro": {
+      "cached_read": null,
+      "in": 20.0,
+      "out": 80.0
+    },
+    "openai\u0000o4-mini": {
+      "cached_read": 0.275,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "openai\u0000o4-mini-deep-research": {
+      "cached_read": 0.5,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "openai\u0000text-embedding-3-large": {
+      "cached_read": null,
+      "in": 0.13,
+      "out": 0.0
+    },
+    "openai\u0000text-embedding-3-small": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.0
+    },
+    "openai\u0000text-embedding-ada-002": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.0
+    },
+    "opencode\u0000big-pickle": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "opencode\u0000claude-3-5-haiku": {
+      "cached_read": 0.08,
+      "in": 0.8,
+      "out": 4.0
+    },
+    "opencode\u0000claude-haiku-4-5": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "opencode\u0000claude-opus-4-1": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "opencode\u0000claude-opus-4-5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "opencode\u0000claude-opus-4-6": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "opencode\u0000claude-opus-4-7": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "opencode\u0000claude-opus-4-8": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "opencode\u0000claude-sonnet-4": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "opencode\u0000claude-sonnet-4-5": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "opencode\u0000claude-sonnet-4-6": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "opencode\u0000deepseek-v4-flash": {
+      "cached_read": 0.03,
+      "in": 0.14,
+      "out": 0.28
+    },
+    "opencode\u0000deepseek-v4-flash-free": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "opencode\u0000gemini-3-flash": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "opencode\u0000gemini-3-pro": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "opencode\u0000gemini-3.1-pro": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "opencode\u0000gemini-3.5-flash": {
+      "cached_read": 0.15,
+      "in": 1.5,
+      "out": 9.0
+    },
+    "opencode\u0000glm-4.6": {
+      "cached_read": 0.1,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "opencode\u0000glm-4.7": {
+      "cached_read": 0.1,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "opencode\u0000glm-4.7-free": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "opencode\u0000glm-5": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 3.2
+    },
+    "opencode\u0000glm-5-free": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "opencode\u0000glm-5.1": {
+      "cached_read": 0.26,
+      "in": 1.4,
+      "out": 4.4
+    },
+    "opencode\u0000gpt-5": {
+      "cached_read": 0.107,
+      "in": 1.07,
+      "out": 8.5
+    },
+    "opencode\u0000gpt-5-codex": {
+      "cached_read": 0.107,
+      "in": 1.07,
+      "out": 8.5
+    },
+    "opencode\u0000gpt-5-nano": {
+      "cached_read": 0.005,
+      "in": 0.05,
+      "out": 0.4
+    },
+    "opencode\u0000gpt-5.1": {
+      "cached_read": 0.107,
+      "in": 1.07,
+      "out": 8.5
+    },
+    "opencode\u0000gpt-5.1-codex": {
+      "cached_read": 0.107,
+      "in": 1.07,
+      "out": 8.5
+    },
+    "opencode\u0000gpt-5.1-codex-max": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "opencode\u0000gpt-5.1-codex-mini": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "opencode\u0000gpt-5.2": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "opencode\u0000gpt-5.2-codex": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "opencode\u0000gpt-5.3-codex": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "opencode\u0000gpt-5.3-codex-spark": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "opencode\u0000gpt-5.4": {
+      "cached_read": 0.25,
+      "in": 2.5,
+      "out": 15.0
+    },
+    "opencode\u0000gpt-5.4-mini": {
+      "cached_read": 0.075,
+      "in": 0.75,
+      "out": 4.5
+    },
+    "opencode\u0000gpt-5.4-nano": {
+      "cached_read": 0.02,
+      "in": 0.2,
+      "out": 1.25
+    },
+    "opencode\u0000gpt-5.4-pro": {
+      "cached_read": 30.0,
+      "in": 30.0,
+      "out": 180.0
+    },
+    "opencode\u0000gpt-5.5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 30.0
+    },
+    "opencode\u0000gpt-5.5-pro": {
+      "cached_read": 30.0,
+      "in": 30.0,
+      "out": 180.0
+    },
+    "opencode\u0000grok-build-0.1": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 2.0
+    },
+    "opencode\u0000grok-code": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "opencode\u0000hy3-preview-free": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "opencode\u0000kimi-k2": {
+      "cached_read": 0.4,
+      "in": 0.4,
+      "out": 2.5
+    },
+    "opencode\u0000kimi-k2-thinking": {
+      "cached_read": 0.4,
+      "in": 0.4,
+      "out": 2.5
+    },
+    "opencode\u0000kimi-k2.5": {
+      "cached_read": 0.08,
+      "in": 0.6,
+      "out": 3.0
+    },
+    "opencode\u0000kimi-k2.5-free": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "opencode\u0000kimi-k2.6": {
+      "cached_read": 0.16,
+      "in": 0.95,
+      "out": 4.0
+    },
+    "opencode\u0000ling-2.6-flash-free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "opencode\u0000mimo-v2-flash-free": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "opencode\u0000mimo-v2-omni-free": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "opencode\u0000mimo-v2-pro-free": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "opencode\u0000mimo-v2.5-free": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "opencode\u0000minimax-m2.1": {
+      "cached_read": 0.1,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "opencode\u0000minimax-m2.1-free": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "opencode\u0000minimax-m2.5": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "opencode\u0000minimax-m2.5-free": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "opencode\u0000minimax-m2.7": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "opencode\u0000minimax-m3-free": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "opencode\u0000nemotron-3-super-free": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "opencode\u0000nemotron-3-ultra-free": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "opencode\u0000qwen3-coder": {
+      "cached_read": null,
+      "in": 0.45,
+      "out": 1.8
+    },
+    "opencode\u0000qwen3.5-plus": {
+      "cached_read": 0.02,
+      "in": 0.2,
+      "out": 1.2
+    },
+    "opencode\u0000qwen3.6-plus": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "opencode\u0000qwen3.6-plus-free": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "opencode\u0000ring-2.6-1t-free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "opencode\u0000trinity-large-preview-free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "opencode-go\u0000deepseek-v4-flash": {
+      "cached_read": 0.0028,
+      "in": 0.14,
+      "out": 0.28
+    },
+    "opencode-go\u0000deepseek-v4-pro": {
+      "cached_read": 0.0145,
+      "in": 1.74,
+      "out": 3.48
+    },
+    "opencode-go\u0000glm-5": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 3.2
+    },
+    "opencode-go\u0000glm-5.1": {
+      "cached_read": 0.26,
+      "in": 1.4,
+      "out": 4.4
+    },
+    "opencode-go\u0000kimi-k2.5": {
+      "cached_read": 0.1,
+      "in": 0.6,
+      "out": 3.0
+    },
+    "opencode-go\u0000kimi-k2.6": {
+      "cached_read": 0.16,
+      "in": 0.95,
+      "out": 4.0
+    },
+    "opencode-go\u0000mimo-v2-omni": {
+      "cached_read": 0.08,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "opencode-go\u0000mimo-v2-pro": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "opencode-go\u0000mimo-v2.5": {
+      "cached_read": 0.0028,
+      "in": 0.14,
+      "out": 0.28
+    },
+    "opencode-go\u0000mimo-v2.5-pro": {
+      "cached_read": 0.0145,
+      "in": 1.74,
+      "out": 3.48
+    },
+    "opencode-go\u0000minimax-m2.5": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "opencode-go\u0000minimax-m2.7": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "opencode-go\u0000minimax-m3": {
+      "cached_read": 0.12,
+      "in": 0.6,
+      "out": 2.4
+    },
+    "opencode-go\u0000qwen3.5-plus": {
+      "cached_read": 0.02,
+      "in": 0.2,
+      "out": 1.2
+    },
+    "opencode-go\u0000qwen3.6-plus": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "opencode-go\u0000qwen3.7-max": {
+      "cached_read": 0.5,
+      "in": 2.5,
+      "out": 7.5
+    },
+    "opencode-go\u0000qwen3.7-plus": {
+      "cached_read": 0.04,
+      "in": 0.4,
+      "out": 1.6
+    },
+    "openrouter\u0000ai21/jamba-large-1.7": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "openrouter\u0000aion-labs/aion-1.0": {
+      "cached_read": null,
+      "in": 4.0,
+      "out": 8.0
+    },
+    "openrouter\u0000aion-labs/aion-1.0-mini": {
+      "cached_read": null,
+      "in": 0.7,
+      "out": 1.4
+    },
+    "openrouter\u0000aion-labs/aion-2.0": {
+      "cached_read": 0.2,
+      "in": 0.8,
+      "out": 1.6
+    },
+    "openrouter\u0000aion-labs/aion-rp-llama-3.1-8b": {
+      "cached_read": null,
+      "in": 0.8,
+      "out": 1.6
+    },
+    "openrouter\u0000allenai/olmo-3-32b-think": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.5
+    },
+    "openrouter\u0000amazon/nova-2-lite-v1": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "openrouter\u0000amazon/nova-lite-v1": {
+      "cached_read": null,
+      "in": 0.06,
+      "out": 0.24
+    },
+    "openrouter\u0000amazon/nova-micro-v1": {
+      "cached_read": null,
+      "in": 0.035,
+      "out": 0.14
+    },
+    "openrouter\u0000amazon/nova-premier-v1": {
+      "cached_read": 0.625,
+      "in": 2.5,
+      "out": 12.5
+    },
+    "openrouter\u0000amazon/nova-pro-v1": {
+      "cached_read": null,
+      "in": 0.8,
+      "out": 3.2
+    },
+    "openrouter\u0000anthracite-org/magnum-v4-72b": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 5.0
+    },
+    "openrouter\u0000anthropic/claude-3-haiku": {
+      "cached_read": 0.03,
+      "in": 0.25,
+      "out": 1.25
+    },
+    "openrouter\u0000anthropic/claude-3.5-haiku": {
+      "cached_read": 0.08,
+      "in": 0.8,
+      "out": 4.0
+    },
+    "openrouter\u0000anthropic/claude-haiku-4.5": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "openrouter\u0000anthropic/claude-opus-4": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "openrouter\u0000anthropic/claude-opus-4.1": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "openrouter\u0000anthropic/claude-opus-4.5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "openrouter\u0000anthropic/claude-opus-4.6": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "openrouter\u0000anthropic/claude-opus-4.6-fast": {
+      "cached_read": 3.0,
+      "in": 30.0,
+      "out": 150.0
+    },
+    "openrouter\u0000anthropic/claude-opus-4.7": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "openrouter\u0000anthropic/claude-opus-4.7-fast": {
+      "cached_read": 3.0,
+      "in": 30.0,
+      "out": 150.0
+    },
+    "openrouter\u0000anthropic/claude-opus-4.8": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "openrouter\u0000anthropic/claude-opus-4.8-fast": {
+      "cached_read": 1.0,
+      "in": 10.0,
+      "out": 50.0
+    },
+    "openrouter\u0000anthropic/claude-sonnet-4": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "openrouter\u0000anthropic/claude-sonnet-4.5": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "openrouter\u0000anthropic/claude-sonnet-4.6": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "openrouter\u0000arcee-ai/coder-large": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 0.8
+    },
+    "openrouter\u0000arcee-ai/maestro-reasoning": {
+      "cached_read": null,
+      "in": 0.9,
+      "out": 3.3
+    },
+    "openrouter\u0000arcee-ai/trinity-large-thinking": {
+      "cached_read": 0.06,
+      "in": 0.22,
+      "out": 0.85
+    },
+    "openrouter\u0000arcee-ai/trinity-mini": {
+      "cached_read": null,
+      "in": 0.045,
+      "out": 0.15
+    },
+    "openrouter\u0000arcee-ai/virtuoso-large": {
+      "cached_read": null,
+      "in": 0.75,
+      "out": 1.2
+    },
+    "openrouter\u0000baidu/ernie-4.5-vl-424b-a47b": {
+      "cached_read": null,
+      "in": 0.42,
+      "out": 1.25
+    },
+    "openrouter\u0000bytedance-seed/seed-1.6": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "openrouter\u0000bytedance-seed/seed-1.6-flash": {
+      "cached_read": null,
+      "in": 0.075,
+      "out": 0.3
+    },
+    "openrouter\u0000bytedance-seed/seed-2.0-lite": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "openrouter\u0000bytedance-seed/seed-2.0-mini": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "openrouter\u0000bytedance/ui-tars-1.5-7b": {
+      "cached_read": 0.1,
+      "in": 0.1,
+      "out": 0.2
+    },
+    "openrouter\u0000cognitivecomputations/dolphin-mistral-24b-venice-edition:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "openrouter\u0000cohere/command-a": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "openrouter\u0000cohere/command-r-08-2024": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "openrouter\u0000cohere/command-r-plus-08-2024": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "openrouter\u0000cohere/command-r7b-12-2024": {
+      "cached_read": null,
+      "in": 0.0375,
+      "out": 0.15
+    },
+    "openrouter\u0000deepcogito/cogito-v2.1-671b": {
+      "cached_read": null,
+      "in": 1.25,
+      "out": 1.25
+    },
+    "openrouter\u0000deepseek/deepseek-chat": {
+      "cached_read": null,
+      "in": 0.2002,
+      "out": 0.8001
+    },
+    "openrouter\u0000deepseek/deepseek-chat-v3-0324": {
+      "cached_read": 0.135,
+      "in": 0.2,
+      "out": 0.77
+    },
+    "openrouter\u0000deepseek/deepseek-chat-v3.1": {
+      "cached_read": 0.13,
+      "in": 0.21,
+      "out": 0.79
+    },
+    "openrouter\u0000deepseek/deepseek-r1": {
+      "cached_read": null,
+      "in": 0.7,
+      "out": 2.5
+    },
+    "openrouter\u0000deepseek/deepseek-r1-0528": {
+      "cached_read": 0.35,
+      "in": 0.5,
+      "out": 2.15
+    },
+    "openrouter\u0000deepseek/deepseek-r1-distill-llama-70b": {
+      "cached_read": null,
+      "in": 0.7,
+      "out": 0.8
+    },
+    "openrouter\u0000deepseek/deepseek-r1-distill-qwen-32b": {
+      "cached_read": null,
+      "in": 0.29,
+      "out": 0.29
+    },
+    "openrouter\u0000deepseek/deepseek-v3.1-terminus": {
+      "cached_read": 0.13,
+      "in": 0.27,
+      "out": 0.95
+    },
+    "openrouter\u0000deepseek/deepseek-v3.2": {
+      "cached_read": null,
+      "in": 0.2288,
+      "out": 0.3432
+    },
+    "openrouter\u0000deepseek/deepseek-v3.2-exp": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 0.41
+    },
+    "openrouter\u0000deepseek/deepseek-v4-flash": {
+      "cached_read": 0.0197,
+      "in": 0.0983,
+      "out": 0.1966
+    },
+    "openrouter\u0000deepseek/deepseek-v4-pro": {
+      "cached_read": 0.003625,
+      "in": 0.435,
+      "out": 0.87
+    },
+    "openrouter\u0000essentialai/rnj-1-instruct": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.15
+    },
+    "openrouter\u0000google/gemini-2.5-flash": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "openrouter\u0000google/gemini-2.5-flash-image": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "openrouter\u0000google/gemini-2.5-flash-lite": {
+      "cached_read": 0.01,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "openrouter\u0000google/gemini-2.5-flash-lite-preview-09-2025": {
+      "cached_read": 0.01,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "openrouter\u0000google/gemini-2.5-pro": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "openrouter\u0000google/gemini-2.5-pro-preview": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "openrouter\u0000google/gemini-2.5-pro-preview-05-06": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "openrouter\u0000google/gemini-3-flash-preview": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "openrouter\u0000google/gemini-3-pro-image-preview": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "openrouter\u0000google/gemini-3.1-flash-image-preview": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "openrouter\u0000google/gemini-3.1-flash-lite": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 1.5
+    },
+    "openrouter\u0000google/gemini-3.1-flash-lite-preview": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 1.5
+    },
+    "openrouter\u0000google/gemini-3.1-pro-preview": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "openrouter\u0000google/gemini-3.1-pro-preview-customtools": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "openrouter\u0000google/gemini-3.5-flash": {
+      "cached_read": 0.15,
+      "in": 1.5,
+      "out": 9.0
+    },
+    "openrouter\u0000google/gemma-2-27b-it": {
+      "cached_read": null,
+      "in": 0.65,
+      "out": 0.65
+    },
+    "openrouter\u0000google/gemma-3-12b-it": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.15
+    },
+    "openrouter\u0000google/gemma-3-27b-it": {
+      "cached_read": null,
+      "in": 0.08,
+      "out": 0.16
+    },
+    "openrouter\u0000google/gemma-3-4b-it": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.1
+    },
+    "openrouter\u0000google/gemma-3n-e4b-it": {
+      "cached_read": null,
+      "in": 0.06,
+      "out": 0.12
+    },
+    "openrouter\u0000google/gemma-4-26b-a4b-it": {
+      "cached_read": null,
+      "in": 0.06,
+      "out": 0.33
+    },
+    "openrouter\u0000google/gemma-4-26b-a4b-it:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "openrouter\u0000google/gemma-4-31b-it": {
+      "cached_read": 0.09,
+      "in": 0.12,
+      "out": 0.36
+    },
+    "openrouter\u0000google/gemma-4-31b-it:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "openrouter\u0000google/lyria-3-clip-preview": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "openrouter\u0000google/lyria-3-pro-preview": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "openrouter\u0000gryphe/mythomax-l2-13b": {
+      "cached_read": null,
+      "in": 0.06,
+      "out": 0.06
+    },
+    "openrouter\u0000ibm-granite/granite-4.0-h-micro": {
+      "cached_read": null,
+      "in": 0.017,
+      "out": 0.112
+    },
+    "openrouter\u0000ibm-granite/granite-4.1-8b": {
+      "cached_read": 0.05,
+      "in": 0.05,
+      "out": 0.1
+    },
+    "openrouter\u0000inception/mercury-2": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 0.75
+    },
+    "openrouter\u0000inclusionai/ling-2.6-1t": {
+      "cached_read": 0.015,
+      "in": 0.075,
+      "out": 0.625
+    },
+    "openrouter\u0000inclusionai/ling-2.6-flash": {
+      "cached_read": 0.002,
+      "in": 0.01,
+      "out": 0.03
+    },
+    "openrouter\u0000inclusionai/ring-2.6-1t": {
+      "cached_read": 0.015,
+      "in": 0.075,
+      "out": 0.625
+    },
+    "openrouter\u0000inflection/inflection-3-pi": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "openrouter\u0000inflection/inflection-3-productivity": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "openrouter\u0000kwaipilot/kat-coder-pro-v2": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "openrouter\u0000liquid/lfm-2-24b-a2b": {
+      "cached_read": null,
+      "in": 0.03,
+      "out": 0.12
+    },
+    "openrouter\u0000liquid/lfm-2.5-1.2b-instruct:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "openrouter\u0000liquid/lfm-2.5-1.2b-thinking:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "openrouter\u0000mancer/weaver": {
+      "cached_read": null,
+      "in": 0.75,
+      "out": 1.0
+    },
+    "openrouter\u0000meta-llama/llama-3-70b-instruct": {
+      "cached_read": null,
+      "in": 0.51,
+      "out": 0.74
+    },
+    "openrouter\u0000meta-llama/llama-3-8b-instruct": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.14
+    },
+    "openrouter\u0000meta-llama/llama-3.1-70b-instruct": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 0.4
+    },
+    "openrouter\u0000meta-llama/llama-3.1-8b-instruct": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.03
+    },
+    "openrouter\u0000meta-llama/llama-3.2-11b-vision-instruct": {
+      "cached_read": null,
+      "in": 0.345,
+      "out": 0.345
+    },
+    "openrouter\u0000meta-llama/llama-3.2-1b-instruct": {
+      "cached_read": null,
+      "in": 0.027,
+      "out": 0.201
+    },
+    "openrouter\u0000meta-llama/llama-3.2-3b-instruct": {
+      "cached_read": null,
+      "in": 0.0509,
+      "out": 0.335
+    },
+    "openrouter\u0000meta-llama/llama-3.2-3b-instruct:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "openrouter\u0000meta-llama/llama-3.3-70b-instruct": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.32
+    },
+    "openrouter\u0000meta-llama/llama-3.3-70b-instruct:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "openrouter\u0000meta-llama/llama-4-maverick": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "openrouter\u0000meta-llama/llama-4-scout": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "openrouter\u0000meta-llama/llama-guard-3-8b": {
+      "cached_read": null,
+      "in": 0.484,
+      "out": 0.03
+    },
+    "openrouter\u0000meta-llama/llama-guard-4-12b": {
+      "cached_read": null,
+      "in": 0.18,
+      "out": 0.18
+    },
+    "openrouter\u0000microsoft/phi-4": {
+      "cached_read": null,
+      "in": 0.065,
+      "out": 0.14
+    },
+    "openrouter\u0000microsoft/phi-4-mini-instruct": {
+      "cached_read": 0.08,
+      "in": 0.08,
+      "out": 0.35
+    },
+    "openrouter\u0000microsoft/wizardlm-2-8x22b": {
+      "cached_read": null,
+      "in": 0.62,
+      "out": 0.62
+    },
+    "openrouter\u0000minimax/minimax-01": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 1.1
+    },
+    "openrouter\u0000minimax/minimax-m1": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.2
+    },
+    "openrouter\u0000minimax/minimax-m2": {
+      "cached_read": 0.03,
+      "in": 0.255,
+      "out": 1.0
+    },
+    "openrouter\u0000minimax/minimax-m2-her": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "openrouter\u0000minimax/minimax-m2.1": {
+      "cached_read": 0.03,
+      "in": 0.29,
+      "out": 0.95
+    },
+    "openrouter\u0000minimax/minimax-m2.5": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 1.15
+    },
+    "openrouter\u0000minimax/minimax-m2.7": {
+      "cached_read": null,
+      "in": 0.279,
+      "out": 1.2
+    },
+    "openrouter\u0000minimax/minimax-m3": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "openrouter\u0000mistralai/codestral-2508": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 0.9
+    },
+    "openrouter\u0000mistralai/devstral-2512": {
+      "cached_read": 0.04,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "openrouter\u0000mistralai/ministral-14b-2512": {
+      "cached_read": 0.02,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "openrouter\u0000mistralai/ministral-3b-2512": {
+      "cached_read": 0.01,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "openrouter\u0000mistralai/ministral-8b-2512": {
+      "cached_read": 0.015,
+      "in": 0.15,
+      "out": 0.15
+    },
+    "openrouter\u0000mistralai/mistral-large": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "openrouter\u0000mistralai/mistral-large-2407": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "openrouter\u0000mistralai/mistral-large-2512": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "openrouter\u0000mistralai/mistral-medium-3": {
+      "cached_read": 0.04,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "openrouter\u0000mistralai/mistral-medium-3-5": {
+      "cached_read": null,
+      "in": 1.5,
+      "out": 7.5
+    },
+    "openrouter\u0000mistralai/mistral-medium-3.1": {
+      "cached_read": 0.04,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "openrouter\u0000mistralai/mistral-nemo": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.03
+    },
+    "openrouter\u0000mistralai/mistral-saba": {
+      "cached_read": 0.02,
+      "in": 0.2,
+      "out": 0.6
+    },
+    "openrouter\u0000mistralai/mistral-small-24b-instruct-2501": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.08
+    },
+    "openrouter\u0000mistralai/mistral-small-2603": {
+      "cached_read": 0.015,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "openrouter\u0000mistralai/mistral-small-3.1-24b-instruct": {
+      "cached_read": null,
+      "in": 0.351,
+      "out": 0.555
+    },
+    "openrouter\u0000mistralai/mistral-small-3.2-24b-instruct": {
+      "cached_read": null,
+      "in": 0.075,
+      "out": 0.2
+    },
+    "openrouter\u0000mistralai/mixtral-8x22b-instruct": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "openrouter\u0000mistralai/voxtral-small-24b-2507": {
+      "cached_read": 0.01,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "openrouter\u0000moonshotai/kimi-k2": {
+      "cached_read": null,
+      "in": 0.57,
+      "out": 2.3
+    },
+    "openrouter\u0000moonshotai/kimi-k2-0905": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.5
+    },
+    "openrouter\u0000moonshotai/kimi-k2-thinking": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.5
+    },
+    "openrouter\u0000moonshotai/kimi-k2.5": {
+      "cached_read": 0.09,
+      "in": 0.4,
+      "out": 1.9
+    },
+    "openrouter\u0000moonshotai/kimi-k2.6": {
+      "cached_read": 0.144,
+      "in": 0.684,
+      "out": 3.42
+    },
+    "openrouter\u0000moonshotai/kimi-k2.6:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "openrouter\u0000morph/morph-v3-fast": {
+      "cached_read": null,
+      "in": 0.8,
+      "out": 1.2
+    },
+    "openrouter\u0000morph/morph-v3-large": {
+      "cached_read": null,
+      "in": 0.9,
+      "out": 1.9
+    },
+    "openrouter\u0000nex-agi/deepseek-v3.1-nex-n1": {
+      "cached_read": null,
+      "in": 0.135,
+      "out": 0.5
+    },
+    "openrouter\u0000nousresearch/hermes-3-llama-3.1-405b": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 1.0
+    },
+    "openrouter\u0000nousresearch/hermes-3-llama-3.1-405b:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "openrouter\u0000nousresearch/hermes-3-llama-3.1-70b": {
+      "cached_read": null,
+      "in": 0.7,
+      "out": 0.7
+    },
+    "openrouter\u0000nousresearch/hermes-4-405b": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "openrouter\u0000nousresearch/hermes-4-70b": {
+      "cached_read": null,
+      "in": 0.13,
+      "out": 0.4
+    },
+    "openrouter\u0000nvidia/llama-3.3-nemotron-super-49b-v1.5": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 0.4
+    },
+    "openrouter\u0000nvidia/nemotron-3-nano-30b-a3b": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.2
+    },
+    "openrouter\u0000nvidia/nemotron-3-nano-30b-a3b:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "openrouter\u0000nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "openrouter\u0000nvidia/nemotron-3-super-120b-a12b": {
+      "cached_read": null,
+      "in": 0.09,
+      "out": 0.45
+    },
+    "openrouter\u0000nvidia/nemotron-3-super-120b-a12b:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "openrouter\u0000nvidia/nemotron-3-ultra-550b-a55b": {
+      "cached_read": 0.15,
+      "in": 0.5,
+      "out": 2.5
+    },
+    "openrouter\u0000nvidia/nemotron-3-ultra-550b-a55b:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "openrouter\u0000nvidia/nemotron-3.5-content-safety:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "openrouter\u0000nvidia/nemotron-nano-12b-v2-vl:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "openrouter\u0000nvidia/nemotron-nano-9b-v2": {
+      "cached_read": null,
+      "in": 0.04,
+      "out": 0.16
+    },
+    "openrouter\u0000nvidia/nemotron-nano-9b-v2:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "openrouter\u0000openai/gpt-3.5-turbo": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "openrouter\u0000openai/gpt-3.5-turbo-0613": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 2.0
+    },
+    "openrouter\u0000openai/gpt-3.5-turbo-16k": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 4.0
+    },
+    "openrouter\u0000openai/gpt-3.5-turbo-instruct": {
+      "cached_read": null,
+      "in": 1.5,
+      "out": 2.0
+    },
+    "openrouter\u0000openai/gpt-4": {
+      "cached_read": null,
+      "in": 30.0,
+      "out": 60.0
+    },
+    "openrouter\u0000openai/gpt-4-turbo": {
+      "cached_read": null,
+      "in": 10.0,
+      "out": 30.0
+    },
+    "openrouter\u0000openai/gpt-4-turbo-preview": {
+      "cached_read": null,
+      "in": 10.0,
+      "out": 30.0
+    },
+    "openrouter\u0000openai/gpt-4.1": {
+      "cached_read": 0.5,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "openrouter\u0000openai/gpt-4.1-mini": {
+      "cached_read": 0.1,
+      "in": 0.4,
+      "out": 1.6
+    },
+    "openrouter\u0000openai/gpt-4.1-nano": {
+      "cached_read": 0.025,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "openrouter\u0000openai/gpt-4o": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "openrouter\u0000openai/gpt-4o-2024-05-13": {
+      "cached_read": null,
+      "in": 5.0,
+      "out": 15.0
+    },
+    "openrouter\u0000openai/gpt-4o-2024-08-06": {
+      "cached_read": 1.25,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "openrouter\u0000openai/gpt-4o-2024-11-20": {
+      "cached_read": 1.25,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "openrouter\u0000openai/gpt-4o-mini": {
+      "cached_read": 0.075,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "openrouter\u0000openai/gpt-4o-mini-2024-07-18": {
+      "cached_read": 0.075,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "openrouter\u0000openai/gpt-4o-mini-search-preview": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "openrouter\u0000openai/gpt-4o-search-preview": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "openrouter\u0000openai/gpt-5": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "openrouter\u0000openai/gpt-5-chat": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "openrouter\u0000openai/gpt-5-codex": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "openrouter\u0000openai/gpt-5-image": {
+      "cached_read": 1.25,
+      "in": 10.0,
+      "out": 10.0
+    },
+    "openrouter\u0000openai/gpt-5-image-mini": {
+      "cached_read": 0.25,
+      "in": 2.5,
+      "out": 2.0
+    },
+    "openrouter\u0000openai/gpt-5-mini": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "openrouter\u0000openai/gpt-5-nano": {
+      "cached_read": 0.01,
+      "in": 0.05,
+      "out": 0.4
+    },
+    "openrouter\u0000openai/gpt-5-pro": {
+      "cached_read": null,
+      "in": 15.0,
+      "out": 120.0
+    },
+    "openrouter\u0000openai/gpt-5.1": {
+      "cached_read": 0.13,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "openrouter\u0000openai/gpt-5.1-chat": {
+      "cached_read": 0.13,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "openrouter\u0000openai/gpt-5.1-codex": {
+      "cached_read": 0.13,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "openrouter\u0000openai/gpt-5.1-codex-max": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "openrouter\u0000openai/gpt-5.1-codex-mini": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "openrouter\u0000openai/gpt-5.2": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "openrouter\u0000openai/gpt-5.2-chat": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "openrouter\u0000openai/gpt-5.2-codex": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "openrouter\u0000openai/gpt-5.2-pro": {
+      "cached_read": null,
+      "in": 21.0,
+      "out": 168.0
+    },
+    "openrouter\u0000openai/gpt-5.3-chat": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "openrouter\u0000openai/gpt-5.3-codex": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "openrouter\u0000openai/gpt-5.4": {
+      "cached_read": 0.25,
+      "in": 2.5,
+      "out": 15.0
+    },
+    "openrouter\u0000openai/gpt-5.4-image-2": {
+      "cached_read": 2.0,
+      "in": 8.0,
+      "out": 15.0
+    },
+    "openrouter\u0000openai/gpt-5.4-mini": {
+      "cached_read": 0.075,
+      "in": 0.75,
+      "out": 4.5
+    },
+    "openrouter\u0000openai/gpt-5.4-nano": {
+      "cached_read": 0.02,
+      "in": 0.2,
+      "out": 1.25
+    },
+    "openrouter\u0000openai/gpt-5.4-pro": {
+      "cached_read": null,
+      "in": 30.0,
+      "out": 180.0
+    },
+    "openrouter\u0000openai/gpt-5.5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 30.0
+    },
+    "openrouter\u0000openai/gpt-5.5-pro": {
+      "cached_read": null,
+      "in": 30.0,
+      "out": 180.0
+    },
+    "openrouter\u0000openai/gpt-audio": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "openrouter\u0000openai/gpt-audio-mini": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.4
+    },
+    "openrouter\u0000openai/gpt-chat-latest": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 30.0
+    },
+    "openrouter\u0000openai/gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.039,
+      "out": 0.18
+    },
+    "openrouter\u0000openai/gpt-oss-120b:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "openrouter\u0000openai/gpt-oss-20b": {
+      "cached_read": null,
+      "in": 0.029,
+      "out": 0.14
+    },
+    "openrouter\u0000openai/gpt-oss-20b:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "openrouter\u0000openai/gpt-oss-safeguard-20b": {
+      "cached_read": 0.037,
+      "in": 0.075,
+      "out": 0.3
+    },
+    "openrouter\u0000openai/o1": {
+      "cached_read": 7.5,
+      "in": 15.0,
+      "out": 60.0
+    },
+    "openrouter\u0000openai/o1-pro": {
+      "cached_read": null,
+      "in": 150.0,
+      "out": 600.0
+    },
+    "openrouter\u0000openai/o3": {
+      "cached_read": 0.5,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "openrouter\u0000openai/o3-deep-research": {
+      "cached_read": 2.5,
+      "in": 10.0,
+      "out": 40.0
+    },
+    "openrouter\u0000openai/o3-mini": {
+      "cached_read": 0.55,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "openrouter\u0000openai/o3-mini-high": {
+      "cached_read": 0.55,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "openrouter\u0000openai/o3-pro": {
+      "cached_read": null,
+      "in": 20.0,
+      "out": 80.0
+    },
+    "openrouter\u0000openai/o4-mini": {
+      "cached_read": 0.275,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "openrouter\u0000openai/o4-mini-deep-research": {
+      "cached_read": 0.5,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "openrouter\u0000openai/o4-mini-high": {
+      "cached_read": 0.275,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "openrouter\u0000openrouter/free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "openrouter\u0000openrouter/owl-alpha": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "openrouter\u0000perceptron/perceptron-mk1": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 1.5
+    },
+    "openrouter\u0000perplexity/sonar": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 1.0
+    },
+    "openrouter\u0000perplexity/sonar-deep-research": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "openrouter\u0000perplexity/sonar-pro": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "openrouter\u0000perplexity/sonar-pro-search": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "openrouter\u0000perplexity/sonar-reasoning-pro": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "openrouter\u0000poolside/laguna-m.1:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "openrouter\u0000poolside/laguna-xs.2:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "openrouter\u0000prime-intellect/intellect-3": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 1.1
+    },
+    "openrouter\u0000qwen/qwen-2.5-72b-instruct": {
+      "cached_read": null,
+      "in": 0.36,
+      "out": 0.4
+    },
+    "openrouter\u0000qwen/qwen-2.5-7b-instruct": {
+      "cached_read": null,
+      "in": 0.04,
+      "out": 0.1
+    },
+    "openrouter\u0000qwen/qwen-2.5-coder-32b-instruct": {
+      "cached_read": null,
+      "in": 0.66,
+      "out": 1.0
+    },
+    "openrouter\u0000qwen/qwen-plus": {
+      "cached_read": 0.052,
+      "in": 0.26,
+      "out": 0.78
+    },
+    "openrouter\u0000qwen/qwen-plus-2025-07-28": {
+      "cached_read": null,
+      "in": 0.26,
+      "out": 0.78
+    },
+    "openrouter\u0000qwen/qwen-plus-2025-07-28:thinking": {
+      "cached_read": null,
+      "in": 0.26,
+      "out": 0.78
+    },
+    "openrouter\u0000qwen/qwen2.5-vl-72b-instruct": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 0.75
+    },
+    "openrouter\u0000qwen/qwen3-14b": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.24
+    },
+    "openrouter\u0000qwen/qwen3-235b-a22b": {
+      "cached_read": null,
+      "in": 0.455,
+      "out": 1.82
+    },
+    "openrouter\u0000qwen/qwen3-235b-a22b-2507": {
+      "cached_read": null,
+      "in": 0.09,
+      "out": 0.1
+    },
+    "openrouter\u0000qwen/qwen3-235b-a22b-thinking-2507": {
+      "cached_read": 0.1,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "openrouter\u0000qwen/qwen3-30b-a3b": {
+      "cached_read": null,
+      "in": 0.12,
+      "out": 0.5
+    },
+    "openrouter\u0000qwen/qwen3-30b-a3b-instruct-2507": {
+      "cached_read": null,
+      "in": 0.04815,
+      "out": 0.19305
+    },
+    "openrouter\u0000qwen/qwen3-30b-a3b-thinking-2507": {
+      "cached_read": 0.08,
+      "in": 0.08,
+      "out": 0.4
+    },
+    "openrouter\u0000qwen/qwen3-32b": {
+      "cached_read": null,
+      "in": 0.08,
+      "out": 0.28
+    },
+    "openrouter\u0000qwen/qwen3-8b": {
+      "cached_read": 0.05,
+      "in": 0.05,
+      "out": 0.4
+    },
+    "openrouter\u0000qwen/qwen3-coder": {
+      "cached_read": null,
+      "in": 0.22,
+      "out": 1.8
+    },
+    "openrouter\u0000qwen/qwen3-coder-30b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.27
+    },
+    "openrouter\u0000qwen/qwen3-coder-flash": {
+      "cached_read": 0.039,
+      "in": 0.195,
+      "out": 0.975
+    },
+    "openrouter\u0000qwen/qwen3-coder-next": {
+      "cached_read": 0.07,
+      "in": 0.11,
+      "out": 0.8
+    },
+    "openrouter\u0000qwen/qwen3-coder-plus": {
+      "cached_read": 0.13,
+      "in": 0.65,
+      "out": 3.25
+    },
+    "openrouter\u0000qwen/qwen3-coder:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "openrouter\u0000qwen/qwen3-max": {
+      "cached_read": 0.156,
+      "in": 0.78,
+      "out": 3.9
+    },
+    "openrouter\u0000qwen/qwen3-max-thinking": {
+      "cached_read": null,
+      "in": 0.78,
+      "out": 3.9
+    },
+    "openrouter\u0000qwen/qwen3-next-80b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.09,
+      "out": 1.1
+    },
+    "openrouter\u0000qwen/qwen3-next-80b-a3b-instruct:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "openrouter\u0000qwen/qwen3-next-80b-a3b-thinking": {
+      "cached_read": null,
+      "in": 0.0975,
+      "out": 0.78
+    },
+    "openrouter\u0000qwen/qwen3-vl-235b-a22b-instruct": {
+      "cached_read": 0.11,
+      "in": 0.2,
+      "out": 0.88
+    },
+    "openrouter\u0000qwen/qwen3-vl-235b-a22b-thinking": {
+      "cached_read": null,
+      "in": 0.26,
+      "out": 2.6
+    },
+    "openrouter\u0000qwen/qwen3-vl-30b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.13,
+      "out": 0.52
+    },
+    "openrouter\u0000qwen/qwen3-vl-30b-a3b-thinking": {
+      "cached_read": null,
+      "in": 0.13,
+      "out": 1.56
+    },
+    "openrouter\u0000qwen/qwen3-vl-32b-instruct": {
+      "cached_read": null,
+      "in": 0.104,
+      "out": 0.416
+    },
+    "openrouter\u0000qwen/qwen3-vl-8b-instruct": {
+      "cached_read": null,
+      "in": 0.08,
+      "out": 0.5
+    },
+    "openrouter\u0000qwen/qwen3-vl-8b-thinking": {
+      "cached_read": null,
+      "in": 0.117,
+      "out": 1.365
+    },
+    "openrouter\u0000qwen/qwen3.5-122b-a10b": {
+      "cached_read": null,
+      "in": 0.26,
+      "out": 2.08
+    },
+    "openrouter\u0000qwen/qwen3.5-27b": {
+      "cached_read": null,
+      "in": 0.195,
+      "out": 1.56
+    },
+    "openrouter\u0000qwen/qwen3.5-35b-a3b": {
+      "cached_read": 0.05,
+      "in": 0.14,
+      "out": 1.0
+    },
+    "openrouter\u0000qwen/qwen3.5-397b-a17b": {
+      "cached_read": null,
+      "in": 0.39,
+      "out": 2.34
+    },
+    "openrouter\u0000qwen/qwen3.5-9b": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.15
+    },
+    "openrouter\u0000qwen/qwen3.5-flash-02-23": {
+      "cached_read": null,
+      "in": 0.065,
+      "out": 0.26
+    },
+    "openrouter\u0000qwen/qwen3.5-plus-02-15": {
+      "cached_read": null,
+      "in": 0.26,
+      "out": 1.56
+    },
+    "openrouter\u0000qwen/qwen3.5-plus-20260420": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.8
+    },
+    "openrouter\u0000qwen/qwen3.6-27b": {
+      "cached_read": null,
+      "in": 0.289,
+      "out": 2.4
+    },
+    "openrouter\u0000qwen/qwen3.6-35b-a3b": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 1.0
+    },
+    "openrouter\u0000qwen/qwen3.6-flash": {
+      "cached_read": null,
+      "in": 0.1875,
+      "out": 1.125
+    },
+    "openrouter\u0000qwen/qwen3.6-max-preview": {
+      "cached_read": null,
+      "in": 1.04,
+      "out": 6.24
+    },
+    "openrouter\u0000qwen/qwen3.6-plus": {
+      "cached_read": null,
+      "in": 0.325,
+      "out": 1.95
+    },
+    "openrouter\u0000qwen/qwen3.7-max": {
+      "cached_read": 0.25,
+      "in": 1.25,
+      "out": 3.75
+    },
+    "openrouter\u0000qwen/qwen3.7-plus": {
+      "cached_read": 0.08,
+      "in": 0.4,
+      "out": 1.6
+    },
+    "openrouter\u0000rekaai/reka-edge": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "openrouter\u0000rekaai/reka-flash-3": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.2
+    },
+    "openrouter\u0000relace/relace-apply-3": {
+      "cached_read": null,
+      "in": 0.85,
+      "out": 1.25
+    },
+    "openrouter\u0000relace/relace-search": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "openrouter\u0000sao10k/l3-lunaris-8b": {
+      "cached_read": null,
+      "in": 0.04,
+      "out": 0.05
+    },
+    "openrouter\u0000sao10k/l3.1-70b-hanami-x1": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 3.0
+    },
+    "openrouter\u0000sao10k/l3.1-euryale-70b": {
+      "cached_read": null,
+      "in": 0.85,
+      "out": 0.85
+    },
+    "openrouter\u0000sao10k/l3.3-euryale-70b": {
+      "cached_read": null,
+      "in": 0.65,
+      "out": 0.75
+    },
+    "openrouter\u0000stepfun/step-3.5-flash": {
+      "cached_read": 0.02,
+      "in": 0.09,
+      "out": 0.3
+    },
+    "openrouter\u0000stepfun/step-3.7-flash": {
+      "cached_read": 0.04,
+      "in": 0.2,
+      "out": 1.15
+    },
+    "openrouter\u0000switchpoint/router": {
+      "cached_read": null,
+      "in": 0.85,
+      "out": 3.4
+    },
+    "openrouter\u0000tencent/hunyuan-a13b-instruct": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.57
+    },
+    "openrouter\u0000tencent/hy3-preview": {
+      "cached_read": 0.021,
+      "in": 0.063,
+      "out": 0.21
+    },
+    "openrouter\u0000thedrummer/cydonia-24b-v4.1": {
+      "cached_read": 0.15,
+      "in": 0.3,
+      "out": 0.5
+    },
+    "openrouter\u0000thedrummer/rocinante-12b": {
+      "cached_read": null,
+      "in": 0.17,
+      "out": 0.43
+    },
+    "openrouter\u0000thedrummer/skyfall-36b-v2": {
+      "cached_read": 0.25,
+      "in": 0.55,
+      "out": 0.8
+    },
+    "openrouter\u0000thedrummer/unslopnemo-12b": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 0.4
+    },
+    "openrouter\u0000undi95/remm-slerp-l2-13b": {
+      "cached_read": null,
+      "in": 0.45,
+      "out": 0.65
+    },
+    "openrouter\u0000upstage/solar-pro-3": {
+      "cached_read": 0.015,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "openrouter\u0000writer/palmyra-x5": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 6.0
+    },
+    "openrouter\u0000x-ai/grok-4.20": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "openrouter\u0000x-ai/grok-4.20-multi-agent": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "openrouter\u0000x-ai/grok-4.3": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "openrouter\u0000x-ai/grok-build-0.1": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 2.0
+    },
+    "openrouter\u0000xiaomi/mimo-v2-flash": {
+      "cached_read": 0.01,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "openrouter\u0000xiaomi/mimo-v2.5": {
+      "cached_read": 0.0028,
+      "in": 0.14,
+      "out": 0.28
+    },
+    "openrouter\u0000xiaomi/mimo-v2.5-pro": {
+      "cached_read": 0.0036,
+      "in": 0.435,
+      "out": 0.87
+    },
+    "openrouter\u0000z-ai/glm-4-32b": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "openrouter\u0000z-ai/glm-4.5": {
+      "cached_read": 0.11,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "openrouter\u0000z-ai/glm-4.5-air": {
+      "cached_read": 0.06,
+      "in": 0.125,
+      "out": 0.85
+    },
+    "openrouter\u0000z-ai/glm-4.5-air:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "openrouter\u0000z-ai/glm-4.5v": {
+      "cached_read": 0.11,
+      "in": 0.6,
+      "out": 1.8
+    },
+    "openrouter\u0000z-ai/glm-4.6": {
+      "cached_read": 0.08,
+      "in": 0.43,
+      "out": 1.74
+    },
+    "openrouter\u0000z-ai/glm-4.6v": {
+      "cached_read": 0.05,
+      "in": 0.3,
+      "out": 0.9
+    },
+    "openrouter\u0000z-ai/glm-4.7": {
+      "cached_read": 0.08,
+      "in": 0.4,
+      "out": 1.75
+    },
+    "openrouter\u0000z-ai/glm-4.7-flash": {
+      "cached_read": 0.01,
+      "in": 0.06,
+      "out": 0.4
+    },
+    "openrouter\u0000z-ai/glm-5": {
+      "cached_read": 0.12,
+      "in": 0.6,
+      "out": 1.92
+    },
+    "openrouter\u0000z-ai/glm-5-turbo": {
+      "cached_read": 0.24,
+      "in": 1.2,
+      "out": 4.0
+    },
+    "openrouter\u0000z-ai/glm-5.1": {
+      "cached_read": 0.182,
+      "in": 0.98,
+      "out": 3.08
+    },
+    "openrouter\u0000z-ai/glm-5v-turbo": {
+      "cached_read": 0.24,
+      "in": 1.2,
+      "out": 4.0
+    },
+    "openrouter\u0000~anthropic/claude-haiku-latest": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "openrouter\u0000~anthropic/claude-opus-latest": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "openrouter\u0000~anthropic/claude-sonnet-latest": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "openrouter\u0000~google/gemini-flash-latest": {
+      "cached_read": 0.15,
+      "in": 1.5,
+      "out": 9.0
+    },
+    "openrouter\u0000~google/gemini-pro-latest": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "openrouter\u0000~moonshotai/kimi-latest": {
+      "cached_read": 0.144,
+      "in": 0.684,
+      "out": 3.42
+    },
+    "openrouter\u0000~openai/gpt-latest": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 30.0
+    },
+    "openrouter\u0000~openai/gpt-mini-latest": {
+      "cached_read": 0.075,
+      "in": 0.75,
+      "out": 4.5
+    },
+    "orcarouter\u0000anthropic/claude-haiku-4.5": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "orcarouter\u0000anthropic/claude-opus-4": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "orcarouter\u0000anthropic/claude-opus-4.1": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "orcarouter\u0000anthropic/claude-opus-4.5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "orcarouter\u0000anthropic/claude-opus-4.6": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "orcarouter\u0000anthropic/claude-opus-4.7": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "orcarouter\u0000anthropic/claude-sonnet-4": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "orcarouter\u0000anthropic/claude-sonnet-4.5": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "orcarouter\u0000anthropic/claude-sonnet-4.6": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "orcarouter\u0000deepseek/deepseek-chat": {
+      "cached_read": 0.028,
+      "in": 0.14,
+      "out": 0.28
+    },
+    "orcarouter\u0000deepseek/deepseek-reasoner": {
+      "cached_read": 0.028,
+      "in": 0.435,
+      "out": 0.87
+    },
+    "orcarouter\u0000deepseek/deepseek-v4-flash": {
+      "cached_read": 0.0028,
+      "in": 0.19,
+      "out": 0.37
+    },
+    "orcarouter\u0000deepseek/deepseek-v4-pro": {
+      "cached_read": 0.003625,
+      "in": 0.56,
+      "out": 1.12
+    },
+    "orcarouter\u0000google/gemini-2.5-flash": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "orcarouter\u0000google/gemini-2.5-flash-lite": {
+      "cached_read": 0.01,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "orcarouter\u0000google/gemini-2.5-pro": {
+      "cached_read": 0.125,
+      "in": 2.5,
+      "out": 15.0
+    },
+    "orcarouter\u0000google/gemini-3-flash-preview": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "orcarouter\u0000google/gemini-3-pro-preview": {
+      "cached_read": 0.2,
+      "in": 4.0,
+      "out": 18.0
+    },
+    "orcarouter\u0000google/gemini-3.1-flash-lite-preview": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 1.5
+    },
+    "orcarouter\u0000google/gemini-3.1-pro-preview": {
+      "cached_read": 0.2,
+      "in": 4.0,
+      "out": 18.0
+    },
+    "orcarouter\u0000google/gemini-3.1-pro-preview-customtools": {
+      "cached_read": 0.2,
+      "in": 4.0,
+      "out": 18.0
+    },
+    "orcarouter\u0000google/gemini-flash-latest": {
+      "cached_read": 0.075,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "orcarouter\u0000google/gemini-flash-lite-latest": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 1.5
+    },
+    "orcarouter\u0000google/gemma-4-26b-a4b-it": {
+      "cached_read": null,
+      "in": 0.06,
+      "out": 0.33
+    },
+    "orcarouter\u0000google/gemma-4-31b-it": {
+      "cached_read": null,
+      "in": 0.13,
+      "out": 0.38
+    },
+    "orcarouter\u0000grok/grok-4.3": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "orcarouter\u0000kimi/kimi-k2.5": {
+      "cached_read": 0.1,
+      "in": 0.6,
+      "out": 3.0
+    },
+    "orcarouter\u0000kimi/kimi-k2.6": {
+      "cached_read": 0.16,
+      "in": 0.95,
+      "out": 4.0
+    },
+    "orcarouter\u0000minimax/minimax-m2.5": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "orcarouter\u0000minimax/minimax-m2.5-highspeed": {
+      "cached_read": 0.06,
+      "in": 0.6,
+      "out": 2.4
+    },
+    "orcarouter\u0000minimax/minimax-m2.7": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "orcarouter\u0000minimax/minimax-m2.7-highspeed": {
+      "cached_read": 0.06,
+      "in": 0.6,
+      "out": 2.4
+    },
+    "orcarouter\u0000openai/gpt-3.5-turbo": {
+      "cached_read": 0.0,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "orcarouter\u0000openai/gpt-4": {
+      "cached_read": null,
+      "in": 30.0,
+      "out": 60.0
+    },
+    "orcarouter\u0000openai/gpt-4-turbo": {
+      "cached_read": null,
+      "in": 10.0,
+      "out": 30.0
+    },
+    "orcarouter\u0000openai/gpt-4.1": {
+      "cached_read": 0.5,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "orcarouter\u0000openai/gpt-4.1-mini": {
+      "cached_read": 0.1,
+      "in": 0.4,
+      "out": 1.6
+    },
+    "orcarouter\u0000openai/gpt-4.1-nano": {
+      "cached_read": 0.025,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "orcarouter\u0000openai/gpt-4o": {
+      "cached_read": 1.25,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "orcarouter\u0000openai/gpt-4o-2024-05-13": {
+      "cached_read": null,
+      "in": 5.0,
+      "out": 15.0
+    },
+    "orcarouter\u0000openai/gpt-4o-2024-08-06": {
+      "cached_read": 1.25,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "orcarouter\u0000openai/gpt-4o-2024-11-20": {
+      "cached_read": 1.25,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "orcarouter\u0000openai/gpt-4o-mini": {
+      "cached_read": 0.075,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "orcarouter\u0000openai/gpt-5": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "orcarouter\u0000openai/gpt-5-chat-latest": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "orcarouter\u0000openai/gpt-5-codex": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "orcarouter\u0000openai/gpt-5-mini": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "orcarouter\u0000openai/gpt-5-nano": {
+      "cached_read": 0.005,
+      "in": 0.05,
+      "out": 0.4
+    },
+    "orcarouter\u0000openai/gpt-5-pro": {
+      "cached_read": null,
+      "in": 15.0,
+      "out": 120.0
+    },
+    "orcarouter\u0000openai/gpt-5.1": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "orcarouter\u0000openai/gpt-5.1-chat-latest": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "orcarouter\u0000openai/gpt-5.1-codex": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "orcarouter\u0000openai/gpt-5.1-codex-max": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "orcarouter\u0000openai/gpt-5.1-codex-mini": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "orcarouter\u0000openai/gpt-5.2": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "orcarouter\u0000openai/gpt-5.2-chat-latest": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "orcarouter\u0000openai/gpt-5.2-codex": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "orcarouter\u0000openai/gpt-5.2-pro": {
+      "cached_read": null,
+      "in": 21.0,
+      "out": 168.0
+    },
+    "orcarouter\u0000openai/gpt-5.3-chat-latest": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "orcarouter\u0000openai/gpt-5.3-codex": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "orcarouter\u0000openai/gpt-5.4": {
+      "cached_read": 0.25,
+      "in": 5.0,
+      "out": 22.5
+    },
+    "orcarouter\u0000openai/gpt-5.4-mini": {
+      "cached_read": 0.075,
+      "in": 0.75,
+      "out": 4.5
+    },
+    "orcarouter\u0000openai/gpt-5.4-nano": {
+      "cached_read": 0.02,
+      "in": 0.2,
+      "out": 1.25
+    },
+    "orcarouter\u0000openai/gpt-5.4-pro": {
+      "cached_read": null,
+      "in": 60.0,
+      "out": 270.0
+    },
+    "orcarouter\u0000openai/gpt-5.5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 30.0
+    },
+    "orcarouter\u0000openai/gpt-5.5-pro": {
+      "cached_read": null,
+      "in": 30.0,
+      "out": 180.0
+    },
+    "orcarouter\u0000orcarouter/auto": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "orcarouter\u0000qwen/qwen3-max": {
+      "cached_read": null,
+      "in": 0.359,
+      "out": 1.434
+    },
+    "orcarouter\u0000qwen/qwen3.5-122b-a10b": {
+      "cached_read": null,
+      "in": 0.115,
+      "out": 0.917
+    },
+    "orcarouter\u0000qwen/qwen3.5-27b": {
+      "cached_read": null,
+      "in": 0.086,
+      "out": 0.688
+    },
+    "orcarouter\u0000qwen/qwen3.5-35b-a3b": {
+      "cached_read": null,
+      "in": 0.057,
+      "out": 0.459
+    },
+    "orcarouter\u0000qwen/qwen3.5-397b-a17b": {
+      "cached_read": null,
+      "in": 0.172,
+      "out": 1.032
+    },
+    "orcarouter\u0000qwen/qwen3.5-plus": {
+      "cached_read": null,
+      "in": 0.115,
+      "out": 0.688
+    },
+    "orcarouter\u0000qwen/qwen3.6-35b-a3b": {
+      "cached_read": null,
+      "in": 0.248,
+      "out": 1.485
+    },
+    "orcarouter\u0000qwen/qwen3.6-plus": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "orcarouter\u0000z-ai/glm-4.5": {
+      "cached_read": 0.11,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "orcarouter\u0000z-ai/glm-4.5-air": {
+      "cached_read": 0.03,
+      "in": 0.2,
+      "out": 1.1
+    },
+    "orcarouter\u0000z-ai/glm-4.6": {
+      "cached_read": 0.11,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "orcarouter\u0000z-ai/glm-4.7": {
+      "cached_read": 0.11,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "orcarouter\u0000z-ai/glm-5": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 3.2
+    },
+    "orcarouter\u0000z-ai/glm-5.1": {
+      "cached_read": 0.26,
+      "in": 1.4,
+      "out": 4.4
+    },
+    "ovhcloud\u0000gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.09,
+      "out": 0.47
+    },
+    "ovhcloud\u0000gpt-oss-20b": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.18
+    },
+    "ovhcloud\u0000llama-3.1-8b-instruct": {
+      "cached_read": null,
+      "in": 0.11,
+      "out": 0.11
+    },
+    "ovhcloud\u0000meta-llama-3_3-70b-instruct": {
+      "cached_read": null,
+      "in": 0.74,
+      "out": 0.74
+    },
+    "ovhcloud\u0000mistral-7b-instruct-v0.3": {
+      "cached_read": null,
+      "in": 0.11,
+      "out": 0.11
+    },
+    "ovhcloud\u0000mistral-nemo-instruct-2407": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.14
+    },
+    "ovhcloud\u0000mistral-small-3.2-24b-instruct-2506": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.31
+    },
+    "ovhcloud\u0000qwen2.5-vl-72b-instruct": {
+      "cached_read": null,
+      "in": 1.01,
+      "out": 1.01
+    },
+    "ovhcloud\u0000qwen3-32b": {
+      "cached_read": null,
+      "in": 0.09,
+      "out": 0.25
+    },
+    "ovhcloud\u0000qwen3-coder-30b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.26
+    },
+    "ovhcloud\u0000qwen3.5-397b-a17b": {
+      "cached_read": null,
+      "in": 0.71,
+      "out": 4.25
+    },
+    "ovhcloud\u0000qwen3.5-9b": {
+      "cached_read": null,
+      "in": 0.12,
+      "out": 0.18
+    },
+    "ovhcloud\u0000qwen3.6-27b": {
+      "cached_read": null,
+      "in": 0.47,
+      "out": 3.19
+    },
+    "perplexity\u0000sonar": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 1.0
+    },
+    "perplexity\u0000sonar-deep-research": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "perplexity\u0000sonar-pro": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "perplexity\u0000sonar-reasoning-pro": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "perplexity-agent\u0000anthropic/claude-haiku-4-5": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "perplexity-agent\u0000anthropic/claude-opus-4-5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "perplexity-agent\u0000anthropic/claude-opus-4-6": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "perplexity-agent\u0000anthropic/claude-opus-4-7": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "perplexity-agent\u0000anthropic/claude-sonnet-4-5": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "perplexity-agent\u0000anthropic/claude-sonnet-4-6": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "perplexity-agent\u0000google/gemini-2.5-flash": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "perplexity-agent\u0000google/gemini-2.5-pro": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "perplexity-agent\u0000google/gemini-3-flash-preview": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "perplexity-agent\u0000google/gemini-3.1-pro-preview": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "perplexity-agent\u0000nvidia/nemotron-3-super-120b-a12b": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 2.5
+    },
+    "perplexity-agent\u0000openai/gpt-5-mini": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "perplexity-agent\u0000openai/gpt-5.1": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "perplexity-agent\u0000openai/gpt-5.2": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "perplexity-agent\u0000openai/gpt-5.4": {
+      "cached_read": 0.25,
+      "in": 2.5,
+      "out": 15.0
+    },
+    "perplexity-agent\u0000openai/gpt-5.5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 30.0
+    },
+    "perplexity-agent\u0000perplexity/sonar": {
+      "cached_read": 0.0625,
+      "in": 0.25,
+      "out": 2.5
+    },
+    "perplexity-agent\u0000xai/grok-4-1-fast-non-reasoning": {
+      "cached_read": 0.05,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "poe\u0000anthropic/claude-haiku-3": {
+      "cached_read": 0.021,
+      "in": 0.21,
+      "out": 1.1
+    },
+    "poe\u0000anthropic/claude-haiku-3.5": {
+      "cached_read": 0.068,
+      "in": 0.68,
+      "out": 3.4
+    },
+    "poe\u0000anthropic/claude-haiku-4.5": {
+      "cached_read": 0.085,
+      "in": 0.85,
+      "out": 4.3
+    },
+    "poe\u0000anthropic/claude-opus-4": {
+      "cached_read": 1.3,
+      "in": 13.0,
+      "out": 64.0
+    },
+    "poe\u0000anthropic/claude-opus-4.1": {
+      "cached_read": 1.3,
+      "in": 13.0,
+      "out": 64.0
+    },
+    "poe\u0000anthropic/claude-opus-4.5": {
+      "cached_read": 0.43,
+      "in": 4.3,
+      "out": 21.0
+    },
+    "poe\u0000anthropic/claude-opus-4.6": {
+      "cached_read": 0.43,
+      "in": 4.3,
+      "out": 21.0
+    },
+    "poe\u0000anthropic/claude-opus-4.7": {
+      "cached_read": 0.43,
+      "in": 4.3,
+      "out": 21.0
+    },
+    "poe\u0000anthropic/claude-opus-4.8": {
+      "cached_read": null,
+      "in": 4.2929,
+      "out": 21.4646
+    },
+    "poe\u0000anthropic/claude-sonnet-3.5": {
+      "cached_read": 0.26,
+      "in": 2.6,
+      "out": 13.0
+    },
+    "poe\u0000anthropic/claude-sonnet-3.5-june": {
+      "cached_read": 0.26,
+      "in": 2.6,
+      "out": 13.0
+    },
+    "poe\u0000anthropic/claude-sonnet-3.7": {
+      "cached_read": 0.26,
+      "in": 2.6,
+      "out": 13.0
+    },
+    "poe\u0000anthropic/claude-sonnet-4": {
+      "cached_read": 0.26,
+      "in": 2.6,
+      "out": 13.0
+    },
+    "poe\u0000anthropic/claude-sonnet-4.5": {
+      "cached_read": 0.26,
+      "in": 2.6,
+      "out": 13.0
+    },
+    "poe\u0000anthropic/claude-sonnet-4.6": {
+      "cached_read": 0.26,
+      "in": 2.6,
+      "out": 13.0
+    },
+    "poe\u0000cerebras/gpt-oss-120b-cs": {
+      "cached_read": null,
+      "in": 0.35,
+      "out": 0.75
+    },
+    "poe\u0000cerebras/llama-3.1-8b-cs": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "poe\u0000empiriolabs/deepseek-v4-flash-el": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.28
+    },
+    "poe\u0000empiriolabs/deepseek-v4-pro-el": {
+      "cached_read": null,
+      "in": 1.67,
+      "out": 3.33
+    },
+    "poe\u0000fireworks-ai/kimi-k2.5-fw": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "poe\u0000google/gemini-2.0-flash": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.42
+    },
+    "poe\u0000google/gemini-2.0-flash-lite": {
+      "cached_read": null,
+      "in": 0.052,
+      "out": 0.21
+    },
+    "poe\u0000google/gemini-2.5-flash": {
+      "cached_read": 0.021,
+      "in": 0.21,
+      "out": 1.8
+    },
+    "poe\u0000google/gemini-2.5-flash-lite": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.28
+    },
+    "poe\u0000google/gemini-2.5-pro": {
+      "cached_read": 0.087,
+      "in": 0.87,
+      "out": 7.0
+    },
+    "poe\u0000google/gemini-3-flash": {
+      "cached_read": 0.04,
+      "in": 0.4,
+      "out": 2.4
+    },
+    "poe\u0000google/gemini-3-pro": {
+      "cached_read": 0.16,
+      "in": 1.6,
+      "out": 9.6
+    },
+    "poe\u0000google/gemini-3.1-flash-lite": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 1.5
+    },
+    "poe\u0000google/gemini-3.1-pro": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "poe\u0000google/gemini-3.5-flash": {
+      "cached_read": 0.1515,
+      "in": 1.5152,
+      "out": 9.0909
+    },
+    "poe\u0000google/gemini-deep-research": {
+      "cached_read": null,
+      "in": 1.6,
+      "out": 9.6
+    },
+    "poe\u0000google/gemma-4-31b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "poe\u0000google/nano-banana": {
+      "cached_read": 0.021,
+      "in": 0.21,
+      "out": 1.8
+    },
+    "poe\u0000google/nano-banana-pro": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "poe\u0000novita/deepseek-v3.2": {
+      "cached_read": 0.13,
+      "in": 0.27,
+      "out": 0.4
+    },
+    "poe\u0000novita/glm-5": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 3.2
+    },
+    "poe\u0000novita/kimi-k2.5": {
+      "cached_read": 0.1,
+      "in": 0.6,
+      "out": 3.0
+    },
+    "poe\u0000novita/kimi-k2.6": {
+      "cached_read": 0.16,
+      "in": 0.96,
+      "out": 4.04
+    },
+    "poe\u0000openai/chatgpt-4o-latest": {
+      "cached_read": null,
+      "in": 4.5,
+      "out": 14.0
+    },
+    "poe\u0000openai/gpt-3.5-turbo": {
+      "cached_read": null,
+      "in": 0.45,
+      "out": 1.4
+    },
+    "poe\u0000openai/gpt-3.5-turbo-instruct": {
+      "cached_read": null,
+      "in": 1.4,
+      "out": 1.8
+    },
+    "poe\u0000openai/gpt-3.5-turbo-raw": {
+      "cached_read": null,
+      "in": 0.45,
+      "out": 1.4
+    },
+    "poe\u0000openai/gpt-4-classic": {
+      "cached_read": null,
+      "in": 27.0,
+      "out": 54.0
+    },
+    "poe\u0000openai/gpt-4-classic-0314": {
+      "cached_read": null,
+      "in": 27.0,
+      "out": 54.0
+    },
+    "poe\u0000openai/gpt-4-turbo": {
+      "cached_read": null,
+      "in": 9.0,
+      "out": 27.0
+    },
+    "poe\u0000openai/gpt-4.1": {
+      "cached_read": 0.45,
+      "in": 1.8,
+      "out": 7.2
+    },
+    "poe\u0000openai/gpt-4.1-mini": {
+      "cached_read": 0.09,
+      "in": 0.36,
+      "out": 1.4
+    },
+    "poe\u0000openai/gpt-4.1-nano": {
+      "cached_read": 0.022,
+      "in": 0.09,
+      "out": 0.36
+    },
+    "poe\u0000openai/gpt-4o-aug": {
+      "cached_read": 1.1,
+      "in": 2.2,
+      "out": 9.0
+    },
+    "poe\u0000openai/gpt-4o-mini": {
+      "cached_read": 0.068,
+      "in": 0.14,
+      "out": 0.54
+    },
+    "poe\u0000openai/gpt-4o-mini-search": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.54
+    },
+    "poe\u0000openai/gpt-4o-search": {
+      "cached_read": null,
+      "in": 2.2,
+      "out": 9.0
+    },
+    "poe\u0000openai/gpt-5": {
+      "cached_read": 0.11,
+      "in": 1.1,
+      "out": 9.0
+    },
+    "poe\u0000openai/gpt-5-chat": {
+      "cached_read": 0.11,
+      "in": 1.1,
+      "out": 9.0
+    },
+    "poe\u0000openai/gpt-5-codex": {
+      "cached_read": null,
+      "in": 1.1,
+      "out": 9.0
+    },
+    "poe\u0000openai/gpt-5-mini": {
+      "cached_read": 0.022,
+      "in": 0.22,
+      "out": 1.8
+    },
+    "poe\u0000openai/gpt-5-nano": {
+      "cached_read": 0.0045,
+      "in": 0.045,
+      "out": 0.36
+    },
+    "poe\u0000openai/gpt-5-pro": {
+      "cached_read": null,
+      "in": 14.0,
+      "out": 110.0
+    },
+    "poe\u0000openai/gpt-5.1": {
+      "cached_read": 0.11,
+      "in": 1.1,
+      "out": 9.0
+    },
+    "poe\u0000openai/gpt-5.1-codex": {
+      "cached_read": 0.11,
+      "in": 1.1,
+      "out": 9.0
+    },
+    "poe\u0000openai/gpt-5.1-codex-max": {
+      "cached_read": 0.11,
+      "in": 1.1,
+      "out": 9.0
+    },
+    "poe\u0000openai/gpt-5.1-codex-mini": {
+      "cached_read": 0.022,
+      "in": 0.22,
+      "out": 1.8
+    },
+    "poe\u0000openai/gpt-5.1-instant": {
+      "cached_read": 0.11,
+      "in": 1.1,
+      "out": 9.0
+    },
+    "poe\u0000openai/gpt-5.2": {
+      "cached_read": 0.16,
+      "in": 1.6,
+      "out": 13.0
+    },
+    "poe\u0000openai/gpt-5.2-codex": {
+      "cached_read": 0.16,
+      "in": 1.6,
+      "out": 13.0
+    },
+    "poe\u0000openai/gpt-5.2-instant": {
+      "cached_read": 0.16,
+      "in": 1.6,
+      "out": 13.0
+    },
+    "poe\u0000openai/gpt-5.2-pro": {
+      "cached_read": null,
+      "in": 19.0,
+      "out": 150.0
+    },
+    "poe\u0000openai/gpt-5.3-codex": {
+      "cached_read": 0.16,
+      "in": 1.6,
+      "out": 13.0
+    },
+    "poe\u0000openai/gpt-5.3-codex-spark": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "poe\u0000openai/gpt-5.3-instant": {
+      "cached_read": 0.16,
+      "in": 1.6,
+      "out": 13.0
+    },
+    "poe\u0000openai/gpt-5.4": {
+      "cached_read": 0.22,
+      "in": 2.2,
+      "out": 14.0
+    },
+    "poe\u0000openai/gpt-5.4-mini": {
+      "cached_read": 0.068,
+      "in": 0.68,
+      "out": 4.0
+    },
+    "poe\u0000openai/gpt-5.4-nano": {
+      "cached_read": 0.018,
+      "in": 0.18,
+      "out": 1.1
+    },
+    "poe\u0000openai/gpt-5.4-pro": {
+      "cached_read": null,
+      "in": 27.0,
+      "out": 160.0
+    },
+    "poe\u0000openai/gpt-5.5": {
+      "cached_read": 0.4545,
+      "in": 4.5455,
+      "out": 27.2727
+    },
+    "poe\u0000openai/gpt-5.5-pro": {
+      "cached_read": null,
+      "in": 27.2727,
+      "out": 163.6364
+    },
+    "poe\u0000openai/gpt-image-2": {
+      "cached_read": 1.2626,
+      "in": 5.0505,
+      "out": 32.3232
+    },
+    "poe\u0000openai/o1": {
+      "cached_read": null,
+      "in": 14.0,
+      "out": 54.0
+    },
+    "poe\u0000openai/o1-pro": {
+      "cached_read": null,
+      "in": 140.0,
+      "out": 540.0
+    },
+    "poe\u0000openai/o3": {
+      "cached_read": 0.45,
+      "in": 1.8,
+      "out": 7.2
+    },
+    "poe\u0000openai/o3-deep-research": {
+      "cached_read": 2.2,
+      "in": 9.0,
+      "out": 36.0
+    },
+    "poe\u0000openai/o3-mini": {
+      "cached_read": null,
+      "in": 0.99,
+      "out": 4.0
+    },
+    "poe\u0000openai/o3-mini-high": {
+      "cached_read": null,
+      "in": 0.99,
+      "out": 4.0
+    },
+    "poe\u0000openai/o3-pro": {
+      "cached_read": null,
+      "in": 18.0,
+      "out": 72.0
+    },
+    "poe\u0000openai/o4-mini": {
+      "cached_read": 0.25,
+      "in": 0.99,
+      "out": 4.0
+    },
+    "poe\u0000openai/o4-mini-deep-research": {
+      "cached_read": 0.45,
+      "in": 1.8,
+      "out": 7.2
+    },
+    "poe\u0000xai/grok-3": {
+      "cached_read": 0.75,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "poe\u0000xai/grok-3-mini": {
+      "cached_read": 0.075,
+      "in": 0.3,
+      "out": 0.5
+    },
+    "poe\u0000xai/grok-4": {
+      "cached_read": 0.75,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "poe\u0000xai/grok-4-fast-non-reasoning": {
+      "cached_read": 0.05,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "poe\u0000xai/grok-4-fast-reasoning": {
+      "cached_read": 0.05,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "poe\u0000xai/grok-4.20-multi-agent": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "poe\u0000xai/grok-code-fast-1": {
+      "cached_read": 0.02,
+      "in": 0.2,
+      "out": 1.5
+    },
+    "poolside\u0000poolside/laguna-m.1": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "poolside\u0000poolside/laguna-xs.2": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "privatemode-ai\u0000gemma-3-27b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "privatemode-ai\u0000gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "privatemode-ai\u0000qwen3-coder-30b-a3b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "privatemode-ai\u0000qwen3-embedding-4b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "privatemode-ai\u0000whisper-large-v3": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "qihang-ai\u0000claude-haiku-4-5-20251001": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.71
+    },
+    "qihang-ai\u0000claude-opus-4-5-20251101": {
+      "cached_read": null,
+      "in": 0.71,
+      "out": 3.57
+    },
+    "qihang-ai\u0000claude-sonnet-4-5-20250929": {
+      "cached_read": null,
+      "in": 0.43,
+      "out": 2.14
+    },
+    "qihang-ai\u0000gemini-2.5-flash": {
+      "cached_read": null,
+      "in": 0.09,
+      "out": 0.71
+    },
+    "qihang-ai\u0000gemini-3-flash-preview": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.43
+    },
+    "qihang-ai\u0000gemini-3-pro-preview": {
+      "cached_read": null,
+      "in": 0.57,
+      "out": 3.43
+    },
+    "qihang-ai\u0000gpt-5-mini": {
+      "cached_read": null,
+      "in": 0.04,
+      "out": 0.29
+    },
+    "qihang-ai\u0000gpt-5.2": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "qihang-ai\u0000gpt-5.2-codex": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 1.14
+    },
+    "qiniu-ai\u0000mimo-v2-flash": {
+      "cached_read": 0.01,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "qiniu-ai\u0000xiaomi/mimo-v2-flash": {
+      "cached_read": 0.01,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "regolo-ai\u0000gpt-oss-120b": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 4.2
+    },
+    "regolo-ai\u0000gpt-oss-20b": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 1.8
+    },
+    "regolo-ai\u0000llama-3.1-8b-instruct": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.25
+    },
+    "regolo-ai\u0000llama-3.3-70b-instruct": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.7
+    },
+    "regolo-ai\u0000minimax-m2.5": {
+      "cached_read": null,
+      "in": 0.8,
+      "out": 3.5
+    },
+    "regolo-ai\u0000mistral-small-4-119b": {
+      "cached_read": null,
+      "in": 0.75,
+      "out": 3.0
+    },
+    "regolo-ai\u0000mistral-small3.2": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 2.2
+    },
+    "regolo-ai\u0000qwen-image": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 2.0
+    },
+    "regolo-ai\u0000qwen3-coder-next": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "regolo-ai\u0000qwen3-embedding-8b": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "regolo-ai\u0000qwen3-reranker-4b": {
+      "cached_read": null,
+      "in": 0.12,
+      "out": 0.12
+    },
+    "regolo-ai\u0000qwen3.5-122b": {
+      "cached_read": null,
+      "in": 0.9,
+      "out": 3.6
+    },
+    "regolo-ai\u0000qwen3.5-9b": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "requesty\u0000anthropic/claude-3-7-sonnet": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "requesty\u0000anthropic/claude-haiku-4-5": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "requesty\u0000anthropic/claude-opus-4": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "requesty\u0000anthropic/claude-opus-4-1": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "requesty\u0000anthropic/claude-opus-4-5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "requesty\u0000anthropic/claude-opus-4-6": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "requesty\u0000anthropic/claude-sonnet-4": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "requesty\u0000anthropic/claude-sonnet-4-5": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "requesty\u0000anthropic/claude-sonnet-4-6": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "requesty\u0000google/gemini-2.5-flash": {
+      "cached_read": 0.075,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "requesty\u0000google/gemini-2.5-pro": {
+      "cached_read": 0.31,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "requesty\u0000google/gemini-3-flash-preview": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "requesty\u0000google/gemini-3-pro-preview": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "requesty\u0000openai/gpt-4.1": {
+      "cached_read": 0.5,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "requesty\u0000openai/gpt-4.1-mini": {
+      "cached_read": 0.1,
+      "in": 0.4,
+      "out": 1.6
+    },
+    "requesty\u0000openai/gpt-4o-mini": {
+      "cached_read": 0.08,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "requesty\u0000openai/gpt-5": {
+      "cached_read": 0.13,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "requesty\u0000openai/gpt-5-chat": {
+      "cached_read": null,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "requesty\u0000openai/gpt-5-codex": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "requesty\u0000openai/gpt-5-image": {
+      "cached_read": 1.25,
+      "in": 5.0,
+      "out": 10.0
+    },
+    "requesty\u0000openai/gpt-5-mini": {
+      "cached_read": 0.03,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "requesty\u0000openai/gpt-5-nano": {
+      "cached_read": 0.01,
+      "in": 0.05,
+      "out": 0.4
+    },
+    "requesty\u0000openai/gpt-5-pro": {
+      "cached_read": null,
+      "in": 15.0,
+      "out": 120.0
+    },
+    "requesty\u0000openai/gpt-5.1": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "requesty\u0000openai/gpt-5.1-chat": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "requesty\u0000openai/gpt-5.1-codex": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "requesty\u0000openai/gpt-5.1-codex-max": {
+      "cached_read": 0.11,
+      "in": 1.1,
+      "out": 9.0
+    },
+    "requesty\u0000openai/gpt-5.1-codex-mini": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "requesty\u0000openai/gpt-5.2": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "requesty\u0000openai/gpt-5.2-chat": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "requesty\u0000openai/gpt-5.2-codex": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "requesty\u0000openai/gpt-5.2-pro": {
+      "cached_read": null,
+      "in": 21.0,
+      "out": 168.0
+    },
+    "requesty\u0000openai/gpt-5.3-codex": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "requesty\u0000openai/gpt-5.4": {
+      "cached_read": 0.25,
+      "in": 2.5,
+      "out": 15.0
+    },
+    "requesty\u0000openai/gpt-5.4-pro": {
+      "cached_read": 30.0,
+      "in": 30.0,
+      "out": 180.0
+    },
+    "requesty\u0000openai/o4-mini": {
+      "cached_read": 0.28,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "requesty\u0000xai/grok-4": {
+      "cached_read": 0.75,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "requesty\u0000xai/grok-4-fast": {
+      "cached_read": 0.05,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "routing-run\u0000route/deepseek-v3.2": {
+      "cached_read": null,
+      "in": 0.4928,
+      "out": 0.7392
+    },
+    "routing-run\u0000route/deepseek-v4-flash": {
+      "cached_read": 0.0028,
+      "in": 0.4928,
+      "out": 0.7392
+    },
+    "routing-run\u0000route/deepseek-v4-flash-6bit": {
+      "cached_read": 0.0028,
+      "in": 0.4928,
+      "out": 0.7392
+    },
+    "routing-run\u0000route/deepseek-v4-pro": {
+      "cached_read": 0.003625,
+      "in": 0.4928,
+      "out": 0.7392
+    },
+    "routing-run\u0000route/deepseek-v4-pro-6bit": {
+      "cached_read": 0.003625,
+      "in": 0.4928,
+      "out": 0.7392
+    },
+    "routing-run\u0000route/gemma-4-31b-it": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "routing-run\u0000route/glm-5.1": {
+      "cached_read": 0.26,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "routing-run\u0000route/glm-5.1-6bit": {
+      "cached_read": 0.26,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "routing-run\u0000route/kimi-k2.5": {
+      "cached_read": 0.1,
+      "in": 0.462,
+      "out": 2.42
+    },
+    "routing-run\u0000route/kimi-k2.6": {
+      "cached_read": 0.16,
+      "in": 0.462,
+      "out": 2.42
+    },
+    "routing-run\u0000route/kimi-k2.6-6bit": {
+      "cached_read": 0.16,
+      "in": 0.462,
+      "out": 2.42
+    },
+    "routing-run\u0000route/mimo-v2.5": {
+      "cached_read": 0.2,
+      "in": 0.45,
+      "out": 1.35
+    },
+    "routing-run\u0000route/mimo-v2.5-pro": {
+      "cached_read": 0.2,
+      "in": 0.45,
+      "out": 1.35
+    },
+    "routing-run\u0000route/mimo-v2.5-pro-6bit": {
+      "cached_read": 0.2,
+      "in": 0.45,
+      "out": 1.35
+    },
+    "routing-run\u0000route/minimax-m2.5": {
+      "cached_read": 0.03,
+      "in": 0.193,
+      "out": 1.238
+    },
+    "routing-run\u0000route/minimax-m2.5-highspeed": {
+      "cached_read": 0.06,
+      "in": 0.193,
+      "out": 1.238
+    },
+    "routing-run\u0000route/minimax-m2.7": {
+      "cached_read": 0.06,
+      "in": 0.33,
+      "out": 1.32
+    },
+    "routing-run\u0000route/minimax-m2.7-highspeed": {
+      "cached_read": 0.06,
+      "in": 0.33,
+      "out": 1.32
+    },
+    "routing-run\u0000route/mistral-large-3": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "routing-run\u0000route/mistral-medium-2505": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "routing-run\u0000route/mistral-small-2503": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "routing-run\u0000route/qwen3.6-27b": {
+      "cached_read": null,
+      "in": 1.1,
+      "out": 3.3
+    },
+    "routing-run\u0000route/qwen3.6-27b-202k": {
+      "cached_read": null,
+      "in": 1.1,
+      "out": 3.3
+    },
+    "routing-run\u0000route/step-3.5-flash": {
+      "cached_read": 0.019,
+      "in": 0.096,
+      "out": 0.288
+    },
+    "routing-run\u0000route/step-3.5-flash-2603": {
+      "cached_read": 0.02,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "routing-run\u0000route/stepfun-3.5-flash": {
+      "cached_read": 0.019,
+      "in": 0.096,
+      "out": 0.288
+    },
+    "sap-ai-core\u0000anthropic--claude-3-haiku": {
+      "cached_read": 0.03,
+      "in": 0.25,
+      "out": 1.25
+    },
+    "sap-ai-core\u0000anthropic--claude-3-opus": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "sap-ai-core\u0000anthropic--claude-3-sonnet": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "sap-ai-core\u0000anthropic--claude-3.5-sonnet": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "sap-ai-core\u0000anthropic--claude-3.7-sonnet": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "sap-ai-core\u0000anthropic--claude-4-opus": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "sap-ai-core\u0000anthropic--claude-4-sonnet": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "sap-ai-core\u0000anthropic--claude-4.5-haiku": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "sap-ai-core\u0000anthropic--claude-4.5-opus": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "sap-ai-core\u0000anthropic--claude-4.5-sonnet": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "sap-ai-core\u0000anthropic--claude-4.6-opus": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "sap-ai-core\u0000anthropic--claude-4.6-sonnet": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "sap-ai-core\u0000anthropic--claude-4.7-opus": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "sap-ai-core\u0000gemini-2.5-flash": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "sap-ai-core\u0000gemini-2.5-flash-lite": {
+      "cached_read": 0.01,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "sap-ai-core\u0000gemini-2.5-pro": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "sap-ai-core\u0000gpt-4.1": {
+      "cached_read": 0.5,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "sap-ai-core\u0000gpt-4.1-mini": {
+      "cached_read": 0.1,
+      "in": 0.4,
+      "out": 1.6
+    },
+    "sap-ai-core\u0000gpt-5": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "sap-ai-core\u0000gpt-5-mini": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "sap-ai-core\u0000gpt-5-nano": {
+      "cached_read": 0.005,
+      "in": 0.05,
+      "out": 0.4
+    },
+    "sap-ai-core\u0000gpt-5.4": {
+      "cached_read": 0.25,
+      "in": 2.5,
+      "out": 15.0
+    },
+    "sap-ai-core\u0000gpt-5.5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 30.0
+    },
+    "sap-ai-core\u0000sonar": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 1.0
+    },
+    "sap-ai-core\u0000sonar-deep-research": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "sap-ai-core\u0000sonar-pro": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "scaleway\u0000bge-multilingual-gemma2": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.0
+    },
+    "scaleway\u0000devstral-2-123b-instruct-2512": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "scaleway\u0000gemma-3-27b-it": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 0.5
+    },
+    "scaleway\u0000gemma-4-26b-a4b-it": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 0.5
+    },
+    "scaleway\u0000gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "scaleway\u0000llama-3.3-70b-instruct": {
+      "cached_read": null,
+      "in": 0.9,
+      "out": 0.9
+    },
+    "scaleway\u0000mistral-medium-3.5-128b": {
+      "cached_read": null,
+      "in": 1.5,
+      "out": 7.5
+    },
+    "scaleway\u0000mistral-small-3.2-24b-instruct-2506": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.35
+    },
+    "scaleway\u0000pixtral-12b-2409": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "scaleway\u0000qwen3-235b-a22b-instruct-2507": {
+      "cached_read": null,
+      "in": 0.75,
+      "out": 2.25
+    },
+    "scaleway\u0000qwen3-coder-30b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.8
+    },
+    "scaleway\u0000qwen3-embedding-8b": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.0
+    },
+    "scaleway\u0000qwen3.5-397b-a17b": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 3.6
+    },
+    "scaleway\u0000qwen3.6-35b-a3b": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 1.5
+    },
+    "scaleway\u0000voxtral-small-24b-2507": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.35
+    },
+    "scaleway\u0000whisper-large-v3": {
+      "cached_read": null,
+      "in": 0.003,
+      "out": 0.0
+    },
+    "siliconflow\u0000baidu/ernie-4.5-300b-a47b": {
+      "cached_read": null,
+      "in": 0.28,
+      "out": 1.1
+    },
+    "siliconflow\u0000bytedance-seed/seed-oss-36b-instruct": {
+      "cached_read": null,
+      "in": 0.21,
+      "out": 0.57
+    },
+    "siliconflow\u0000deepseek-ai/deepseek-r1": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 2.18
+    },
+    "siliconflow\u0000deepseek-ai/deepseek-r1-distill-qwen-14b": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "siliconflow\u0000deepseek-ai/deepseek-r1-distill-qwen-32b": {
+      "cached_read": null,
+      "in": 0.18,
+      "out": 0.18
+    },
+    "siliconflow\u0000deepseek-ai/deepseek-v3": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 1.0
+    },
+    "siliconflow\u0000deepseek-ai/deepseek-v3.1": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 1.0
+    },
+    "siliconflow\u0000deepseek-ai/deepseek-v3.1-terminus": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 1.0
+    },
+    "siliconflow\u0000deepseek-ai/deepseek-v3.2": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 0.42
+    },
+    "siliconflow\u0000deepseek-ai/deepseek-v3.2-exp": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 0.41
+    },
+    "siliconflow\u0000deepseek-ai/deepseek-v4-flash": {
+      "cached_read": 0.028,
+      "in": 0.14,
+      "out": 0.28
+    },
+    "siliconflow\u0000deepseek-ai/deepseek-v4-pro": {
+      "cached_read": 0.145,
+      "in": 1.74,
+      "out": 3.48
+    },
+    "siliconflow\u0000deepseek-ai/deepseek-vl2": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.15
+    },
+    "siliconflow\u0000inclusionai/ling-flash-2.0": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.57
+    },
+    "siliconflow\u0000inclusionai/ling-mini-2.0": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.28
+    },
+    "siliconflow\u0000inclusionai/ring-flash-2.0": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.57
+    },
+    "siliconflow\u0000meta-llama/meta-llama-3.1-8b-instruct": {
+      "cached_read": null,
+      "in": 0.06,
+      "out": 0.06
+    },
+    "siliconflow\u0000minimaxai/minimax-m2.1": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "siliconflow\u0000minimaxai/minimax-m2.5": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "siliconflow\u0000moonshotai/kimi-k2-instruct": {
+      "cached_read": null,
+      "in": 0.58,
+      "out": 2.29
+    },
+    "siliconflow\u0000moonshotai/kimi-k2-instruct-0905": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "siliconflow\u0000moonshotai/kimi-k2-thinking": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 2.5
+    },
+    "siliconflow\u0000moonshotai/kimi-k2.5": {
+      "cached_read": null,
+      "in": 0.45,
+      "out": 2.25
+    },
+    "siliconflow\u0000moonshotai/kimi-k2.6": {
+      "cached_read": 0.16,
+      "in": 0.95,
+      "out": 4.0
+    },
+    "siliconflow\u0000nex-agi/deepseek-v3.1-nex-n1": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 2.0
+    },
+    "siliconflow\u0000openai/gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.45
+    },
+    "siliconflow\u0000openai/gpt-oss-20b": {
+      "cached_read": null,
+      "in": 0.04,
+      "out": 0.18
+    },
+    "siliconflow\u0000qwen/qwen2.5-14b-instruct": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "siliconflow\u0000qwen/qwen2.5-32b-instruct": {
+      "cached_read": null,
+      "in": 0.18,
+      "out": 0.18
+    },
+    "siliconflow\u0000qwen/qwen2.5-72b-instruct": {
+      "cached_read": null,
+      "in": 0.59,
+      "out": 0.59
+    },
+    "siliconflow\u0000qwen/qwen2.5-72b-instruct-128k": {
+      "cached_read": null,
+      "in": 0.59,
+      "out": 0.59
+    },
+    "siliconflow\u0000qwen/qwen2.5-7b-instruct": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.05
+    },
+    "siliconflow\u0000qwen/qwen2.5-coder-32b-instruct": {
+      "cached_read": null,
+      "in": 0.18,
+      "out": 0.18
+    },
+    "siliconflow\u0000qwen/qwen2.5-vl-32b-instruct": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 0.27
+    },
+    "siliconflow\u0000qwen/qwen2.5-vl-72b-instruct": {
+      "cached_read": null,
+      "in": 0.59,
+      "out": 0.59
+    },
+    "siliconflow\u0000qwen/qwen2.5-vl-7b-instruct": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.05
+    },
+    "siliconflow\u0000qwen/qwen3-14b": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.28
+    },
+    "siliconflow\u0000qwen/qwen3-235b-a22b": {
+      "cached_read": null,
+      "in": 0.35,
+      "out": 1.42
+    },
+    "siliconflow\u0000qwen/qwen3-235b-a22b-instruct-2507": {
+      "cached_read": null,
+      "in": 0.09,
+      "out": 0.6
+    },
+    "siliconflow\u0000qwen/qwen3-235b-a22b-thinking-2507": {
+      "cached_read": null,
+      "in": 0.13,
+      "out": 0.6
+    },
+    "siliconflow\u0000qwen/qwen3-30b-a3b-instruct-2507": {
+      "cached_read": null,
+      "in": 0.09,
+      "out": 0.3
+    },
+    "siliconflow\u0000qwen/qwen3-30b-a3b-thinking-2507": {
+      "cached_read": null,
+      "in": 0.09,
+      "out": 0.3
+    },
+    "siliconflow\u0000qwen/qwen3-32b": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.57
+    },
+    "siliconflow\u0000qwen/qwen3-8b": {
+      "cached_read": null,
+      "in": 0.06,
+      "out": 0.06
+    },
+    "siliconflow\u0000qwen/qwen3-coder-30b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.28
+    },
+    "siliconflow\u0000qwen/qwen3-coder-480b-a35b-instruct": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 1.0
+    },
+    "siliconflow\u0000qwen/qwen3-next-80b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 1.4
+    },
+    "siliconflow\u0000qwen/qwen3-next-80b-a3b-thinking": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.57
+    },
+    "siliconflow\u0000qwen/qwen3-omni-30b-a3b-captioner": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "siliconflow\u0000qwen/qwen3-omni-30b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "siliconflow\u0000qwen/qwen3-omni-30b-a3b-thinking": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "siliconflow\u0000qwen/qwen3-vl-235b-a22b-instruct": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.5
+    },
+    "siliconflow\u0000qwen/qwen3-vl-235b-a22b-thinking": {
+      "cached_read": null,
+      "in": 0.45,
+      "out": 3.5
+    },
+    "siliconflow\u0000qwen/qwen3-vl-30b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.29,
+      "out": 1.0
+    },
+    "siliconflow\u0000qwen/qwen3-vl-30b-a3b-thinking": {
+      "cached_read": null,
+      "in": 0.29,
+      "out": 1.0
+    },
+    "siliconflow\u0000qwen/qwen3-vl-32b-instruct": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.6
+    },
+    "siliconflow\u0000qwen/qwen3-vl-32b-thinking": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 1.5
+    },
+    "siliconflow\u0000qwen/qwen3-vl-8b-instruct": {
+      "cached_read": null,
+      "in": 0.18,
+      "out": 0.68
+    },
+    "siliconflow\u0000qwen/qwen3-vl-8b-thinking": {
+      "cached_read": null,
+      "in": 0.18,
+      "out": 2.0
+    },
+    "siliconflow\u0000qwen/qwq-32b": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.58
+    },
+    "siliconflow\u0000stepfun-ai/step-3.5-flash": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "siliconflow\u0000tencent/hunyuan-a13b-instruct": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.57
+    },
+    "siliconflow\u0000tencent/hunyuan-mt-7b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "siliconflow\u0000thudm/glm-4-32b-0414": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 0.27
+    },
+    "siliconflow\u0000thudm/glm-4-9b-0414": {
+      "cached_read": null,
+      "in": 0.086,
+      "out": 0.086
+    },
+    "siliconflow\u0000thudm/glm-z1-32b-0414": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.57
+    },
+    "siliconflow\u0000thudm/glm-z1-9b-0414": {
+      "cached_read": null,
+      "in": 0.086,
+      "out": 0.086
+    },
+    "siliconflow\u0000zai-org/glm-4.5": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "siliconflow\u0000zai-org/glm-4.5-air": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.86
+    },
+    "siliconflow\u0000zai-org/glm-4.5v": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.86
+    },
+    "siliconflow\u0000zai-org/glm-4.6": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.9
+    },
+    "siliconflow\u0000zai-org/glm-4.6v": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.9
+    },
+    "siliconflow\u0000zai-org/glm-4.7": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "siliconflow\u0000zai-org/glm-5": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 3.2
+    },
+    "siliconflow\u0000zai-org/glm-5.1": {
+      "cached_read": null,
+      "in": 1.4,
+      "out": 4.4
+    },
+    "siliconflow\u0000zai-org/glm-5v-turbo": {
+      "cached_read": null,
+      "in": 1.2,
+      "out": 4.0
+    },
+    "siliconflow-cn\u0000ascend-tribe/pangu-pro-moe": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.6
+    },
+    "siliconflow-cn\u0000baidu/ernie-4.5-300b-a47b": {
+      "cached_read": null,
+      "in": 0.28,
+      "out": 1.1
+    },
+    "siliconflow-cn\u0000bytedance-seed/seed-oss-36b-instruct": {
+      "cached_read": null,
+      "in": 0.21,
+      "out": 0.57
+    },
+    "siliconflow-cn\u0000deepseek-ai/deepseek-ocr": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "siliconflow-cn\u0000deepseek-ai/deepseek-r1": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 2.18
+    },
+    "siliconflow-cn\u0000deepseek-ai/deepseek-r1-distill-qwen-14b": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "siliconflow-cn\u0000deepseek-ai/deepseek-r1-distill-qwen-32b": {
+      "cached_read": null,
+      "in": 0.18,
+      "out": 0.18
+    },
+    "siliconflow-cn\u0000deepseek-ai/deepseek-v3": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 1.0
+    },
+    "siliconflow-cn\u0000deepseek-ai/deepseek-v3.1-terminus": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 1.0
+    },
+    "siliconflow-cn\u0000deepseek-ai/deepseek-v3.2": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 0.42
+    },
+    "siliconflow-cn\u0000deepseek-ai/deepseek-v4-pro": {
+      "cached_read": 0.145,
+      "in": 1.74,
+      "out": 3.48
+    },
+    "siliconflow-cn\u0000deepseek-ai/deepseek-vl2": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.15
+    },
+    "siliconflow-cn\u0000inclusionai/ling-flash-2.0": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.57
+    },
+    "siliconflow-cn\u0000inclusionai/ling-mini-2.0": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.28
+    },
+    "siliconflow-cn\u0000inclusionai/ring-flash-2.0": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.57
+    },
+    "siliconflow-cn\u0000kwaipilot/kat-dev": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.6
+    },
+    "siliconflow-cn\u0000moonshotai/kimi-k2-instruct-0905": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "siliconflow-cn\u0000moonshotai/kimi-k2-thinking": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 2.5
+    },
+    "siliconflow-cn\u0000paddlepaddle/paddleocr-vl": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "siliconflow-cn\u0000paddlepaddle/paddleocr-vl-1.5": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "siliconflow-cn\u0000pro/deepseek-ai/deepseek-r1": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 2.18
+    },
+    "siliconflow-cn\u0000pro/deepseek-ai/deepseek-v3": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 1.0
+    },
+    "siliconflow-cn\u0000pro/deepseek-ai/deepseek-v3.1-terminus": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 1.0
+    },
+    "siliconflow-cn\u0000pro/deepseek-ai/deepseek-v3.2": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 0.42
+    },
+    "siliconflow-cn\u0000pro/minimaxai/minimax-m2.1": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "siliconflow-cn\u0000pro/minimaxai/minimax-m2.5": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.22
+    },
+    "siliconflow-cn\u0000pro/moonshotai/kimi-k2-instruct-0905": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "siliconflow-cn\u0000pro/moonshotai/kimi-k2-thinking": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 2.5
+    },
+    "siliconflow-cn\u0000pro/moonshotai/kimi-k2.5": {
+      "cached_read": null,
+      "in": 0.45,
+      "out": 2.25
+    },
+    "siliconflow-cn\u0000pro/moonshotai/kimi-k2.6": {
+      "cached_read": 0.16,
+      "in": 0.95,
+      "out": 4.0
+    },
+    "siliconflow-cn\u0000pro/zai-org/glm-4.7": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "siliconflow-cn\u0000pro/zai-org/glm-5": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 3.2
+    },
+    "siliconflow-cn\u0000pro/zai-org/glm-5.1": {
+      "cached_read": null,
+      "in": 1.4,
+      "out": 4.4
+    },
+    "siliconflow-cn\u0000qwen/qwen2.5-14b-instruct": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "siliconflow-cn\u0000qwen/qwen2.5-32b-instruct": {
+      "cached_read": null,
+      "in": 0.18,
+      "out": 0.18
+    },
+    "siliconflow-cn\u0000qwen/qwen2.5-72b-instruct": {
+      "cached_read": null,
+      "in": 0.59,
+      "out": 0.59
+    },
+    "siliconflow-cn\u0000qwen/qwen2.5-72b-instruct-128k": {
+      "cached_read": null,
+      "in": 0.59,
+      "out": 0.59
+    },
+    "siliconflow-cn\u0000qwen/qwen2.5-7b-instruct": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.05
+    },
+    "siliconflow-cn\u0000qwen/qwen2.5-coder-32b-instruct": {
+      "cached_read": null,
+      "in": 0.18,
+      "out": 0.18
+    },
+    "siliconflow-cn\u0000qwen/qwen2.5-vl-32b-instruct": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 0.27
+    },
+    "siliconflow-cn\u0000qwen/qwen2.5-vl-72b-instruct": {
+      "cached_read": null,
+      "in": 0.59,
+      "out": 0.59
+    },
+    "siliconflow-cn\u0000qwen/qwen3-14b": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.28
+    },
+    "siliconflow-cn\u0000qwen/qwen3-235b-a22b-instruct-2507": {
+      "cached_read": null,
+      "in": 0.09,
+      "out": 0.6
+    },
+    "siliconflow-cn\u0000qwen/qwen3-235b-a22b-thinking-2507": {
+      "cached_read": null,
+      "in": 0.13,
+      "out": 0.6
+    },
+    "siliconflow-cn\u0000qwen/qwen3-30b-a3b-instruct-2507": {
+      "cached_read": null,
+      "in": 0.09,
+      "out": 0.3
+    },
+    "siliconflow-cn\u0000qwen/qwen3-30b-a3b-thinking-2507": {
+      "cached_read": null,
+      "in": 0.09,
+      "out": 0.3
+    },
+    "siliconflow-cn\u0000qwen/qwen3-32b": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.57
+    },
+    "siliconflow-cn\u0000qwen/qwen3-8b": {
+      "cached_read": null,
+      "in": 0.06,
+      "out": 0.06
+    },
+    "siliconflow-cn\u0000qwen/qwen3-coder-30b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.28
+    },
+    "siliconflow-cn\u0000qwen/qwen3-coder-480b-a35b-instruct": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 1.0
+    },
+    "siliconflow-cn\u0000qwen/qwen3-next-80b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 1.4
+    },
+    "siliconflow-cn\u0000qwen/qwen3-next-80b-a3b-thinking": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.57
+    },
+    "siliconflow-cn\u0000qwen/qwen3-omni-30b-a3b-captioner": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "siliconflow-cn\u0000qwen/qwen3-omni-30b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "siliconflow-cn\u0000qwen/qwen3-omni-30b-a3b-thinking": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "siliconflow-cn\u0000qwen/qwen3-vl-235b-a22b-instruct": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.5
+    },
+    "siliconflow-cn\u0000qwen/qwen3-vl-235b-a22b-thinking": {
+      "cached_read": null,
+      "in": 0.45,
+      "out": 3.5
+    },
+    "siliconflow-cn\u0000qwen/qwen3-vl-30b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.29,
+      "out": 1.0
+    },
+    "siliconflow-cn\u0000qwen/qwen3-vl-30b-a3b-thinking": {
+      "cached_read": null,
+      "in": 0.29,
+      "out": 1.0
+    },
+    "siliconflow-cn\u0000qwen/qwen3-vl-32b-instruct": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.6
+    },
+    "siliconflow-cn\u0000qwen/qwen3-vl-32b-thinking": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 1.5
+    },
+    "siliconflow-cn\u0000qwen/qwen3-vl-8b-instruct": {
+      "cached_read": null,
+      "in": 0.18,
+      "out": 0.68
+    },
+    "siliconflow-cn\u0000qwen/qwen3-vl-8b-thinking": {
+      "cached_read": null,
+      "in": 0.18,
+      "out": 2.0
+    },
+    "siliconflow-cn\u0000qwen/qwen3.5-122b-a10b": {
+      "cached_read": null,
+      "in": 0.29,
+      "out": 2.32
+    },
+    "siliconflow-cn\u0000qwen/qwen3.5-27b": {
+      "cached_read": null,
+      "in": 0.26,
+      "out": 2.09
+    },
+    "siliconflow-cn\u0000qwen/qwen3.5-35b-a3b": {
+      "cached_read": null,
+      "in": 0.23,
+      "out": 1.86
+    },
+    "siliconflow-cn\u0000qwen/qwen3.5-397b-a17b": {
+      "cached_read": null,
+      "in": 0.29,
+      "out": 1.74
+    },
+    "siliconflow-cn\u0000qwen/qwen3.5-4b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "siliconflow-cn\u0000qwen/qwen3.5-9b": {
+      "cached_read": null,
+      "in": 0.22,
+      "out": 1.74
+    },
+    "siliconflow-cn\u0000qwen/qwen3.6-35b-a3b": {
+      "cached_read": null,
+      "in": 0.23,
+      "out": 1.86
+    },
+    "siliconflow-cn\u0000qwen/qwq-32b": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.58
+    },
+    "siliconflow-cn\u0000stepfun-ai/step-3.5-flash": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "siliconflow-cn\u0000tencent/hunyuan-a13b-instruct": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.57
+    },
+    "siliconflow-cn\u0000tencent/hunyuan-mt-7b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "siliconflow-cn\u0000thudm/glm-4-32b-0414": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 0.27
+    },
+    "siliconflow-cn\u0000thudm/glm-4-9b-0414": {
+      "cached_read": null,
+      "in": 0.086,
+      "out": 0.086
+    },
+    "siliconflow-cn\u0000thudm/glm-z1-32b-0414": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.57
+    },
+    "siliconflow-cn\u0000thudm/glm-z1-9b-0414": {
+      "cached_read": null,
+      "in": 0.086,
+      "out": 0.086
+    },
+    "siliconflow-cn\u0000zai-org/glm-4.5-air": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.86
+    },
+    "siliconflow-cn\u0000zai-org/glm-4.5v": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.86
+    },
+    "siliconflow-cn\u0000zai-org/glm-4.6": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.9
+    },
+    "siliconflow-cn\u0000zai-org/glm-4.6v": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.9
+    },
+    "stackit\u0000cortecs/llama-3.3-70b-instruct-fp8-dynamic": {
+      "cached_read": null,
+      "in": 0.49,
+      "out": 0.71
+    },
+    "stackit\u0000google/gemma-3-27b-it": {
+      "cached_read": null,
+      "in": 0.49,
+      "out": 0.71
+    },
+    "stackit\u0000intfloat/e5-mistral-7b-instruct": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.02
+    },
+    "stackit\u0000neuralmagic/meta-llama-3.1-8b-instruct-fp8": {
+      "cached_read": null,
+      "in": 0.16,
+      "out": 0.27
+    },
+    "stackit\u0000neuralmagic/mistral-nemo-instruct-2407-fp8": {
+      "cached_read": null,
+      "in": 0.49,
+      "out": 0.71
+    },
+    "stackit\u0000openai/gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.49,
+      "out": 0.71
+    },
+    "stackit\u0000qwen/qwen3-vl-235b-a22b-instruct-fp8": {
+      "cached_read": null,
+      "in": 1.64,
+      "out": 1.91
+    },
+    "stackit\u0000qwen/qwen3-vl-embedding-8b": {
+      "cached_read": null,
+      "in": 0.09,
+      "out": 0.09
+    },
+    "stepfun\u0000step-1-32k": {
+      "cached_read": 0.41,
+      "in": 2.05,
+      "out": 9.59
+    },
+    "stepfun\u0000step-2-16k": {
+      "cached_read": 1.04,
+      "in": 5.21,
+      "out": 16.44
+    },
+    "stepfun\u0000step-3.5-flash": {
+      "cached_read": 0.019,
+      "in": 0.096,
+      "out": 0.288
+    },
+    "stepfun\u0000step-3.5-flash-2603": {
+      "cached_read": 0.02,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "stepfun-ai\u0000step-3.5-flash": {
+      "cached_read": 0.019,
+      "in": 0.096,
+      "out": 0.288
+    },
+    "stepfun-ai\u0000step-3.5-flash-2603": {
+      "cached_read": 0.02,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "submodel\u0000deepseek-ai/deepseek-r1-0528": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 2.15
+    },
+    "submodel\u0000deepseek-ai/deepseek-v3-0324": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.8
+    },
+    "submodel\u0000deepseek-ai/deepseek-v3.1": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.8
+    },
+    "submodel\u0000openai/gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.5
+    },
+    "submodel\u0000qwen/qwen3-235b-a22b-instruct-2507": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.3
+    },
+    "submodel\u0000qwen/qwen3-235b-a22b-thinking-2507": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.6
+    },
+    "submodel\u0000qwen/qwen3-coder-480b-a35b-instruct-fp8": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.8
+    },
+    "submodel\u0000zai-org/glm-4.5-air": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.5
+    },
+    "submodel\u0000zai-org/glm-4.5-fp8": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.8
+    },
+    "synthetic\u0000hf:deepseek-ai/deepseek-r1": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 2.19
+    },
+    "synthetic\u0000hf:deepseek-ai/deepseek-r1-0528": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 8.0
+    },
+    "synthetic\u0000hf:deepseek-ai/deepseek-v3": {
+      "cached_read": null,
+      "in": 1.25,
+      "out": 1.25
+    },
+    "synthetic\u0000hf:deepseek-ai/deepseek-v3-0324": {
+      "cached_read": null,
+      "in": 1.2,
+      "out": 1.2
+    },
+    "synthetic\u0000hf:deepseek-ai/deepseek-v3.1": {
+      "cached_read": null,
+      "in": 0.56,
+      "out": 1.68
+    },
+    "synthetic\u0000hf:deepseek-ai/deepseek-v3.1-terminus": {
+      "cached_read": null,
+      "in": 1.2,
+      "out": 1.2
+    },
+    "synthetic\u0000hf:deepseek-ai/deepseek-v3.2": {
+      "cached_read": 0.27,
+      "in": 0.27,
+      "out": 0.4
+    },
+    "synthetic\u0000hf:meta-llama/llama-3.1-405b-instruct": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 3.0
+    },
+    "synthetic\u0000hf:meta-llama/llama-3.1-70b-instruct": {
+      "cached_read": null,
+      "in": 0.9,
+      "out": 0.9
+    },
+    "synthetic\u0000hf:meta-llama/llama-3.1-8b-instruct": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "synthetic\u0000hf:meta-llama/llama-3.3-70b-instruct": {
+      "cached_read": null,
+      "in": 0.9,
+      "out": 0.9
+    },
+    "synthetic\u0000hf:meta-llama/llama-4-maverick-17b-128e-instruct-fp8": {
+      "cached_read": null,
+      "in": 0.22,
+      "out": 0.88
+    },
+    "synthetic\u0000hf:meta-llama/llama-4-scout-17b-16e-instruct": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "synthetic\u0000hf:minimaxai/minimax-m2": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 2.19
+    },
+    "synthetic\u0000hf:minimaxai/minimax-m2.1": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 2.19
+    },
+    "synthetic\u0000hf:minimaxai/minimax-m2.5": {
+      "cached_read": 0.6,
+      "in": 0.6,
+      "out": 3.0
+    },
+    "synthetic\u0000hf:moonshotai/kimi-k2-instruct-0905": {
+      "cached_read": null,
+      "in": 1.2,
+      "out": 1.2
+    },
+    "synthetic\u0000hf:moonshotai/kimi-k2-thinking": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 2.19
+    },
+    "synthetic\u0000hf:moonshotai/kimi-k2.5": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 2.19
+    },
+    "synthetic\u0000hf:moonshotai/kimi-k2.6": {
+      "cached_read": 0.95,
+      "in": 0.95,
+      "out": 4.0
+    },
+    "synthetic\u0000hf:nvidia/kimi-k2.5-nvfp4": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 2.19
+    },
+    "synthetic\u0000hf:nvidia/nvidia-nemotron-3-super-120b-a12b-nvfp4": {
+      "cached_read": 0.3,
+      "in": 0.3,
+      "out": 1.0
+    },
+    "synthetic\u0000hf:openai/gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "synthetic\u0000hf:qwen/qwen2.5-coder-32b-instruct": {
+      "cached_read": null,
+      "in": 0.8,
+      "out": 0.8
+    },
+    "synthetic\u0000hf:qwen/qwen3-235b-a22b-instruct-2507": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.6
+    },
+    "synthetic\u0000hf:qwen/qwen3-235b-a22b-thinking-2507": {
+      "cached_read": null,
+      "in": 0.65,
+      "out": 3.0
+    },
+    "synthetic\u0000hf:qwen/qwen3-coder-480b-a35b-instruct": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 2.0
+    },
+    "synthetic\u0000hf:qwen/qwen3.5-397b-a17b": {
+      "cached_read": 0.6,
+      "in": 0.6,
+      "out": 3.0
+    },
+    "synthetic\u0000hf:zai-org/glm-4.6": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 2.19
+    },
+    "synthetic\u0000hf:zai-org/glm-4.7": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 2.19
+    },
+    "synthetic\u0000hf:zai-org/glm-4.7-flash": {
+      "cached_read": 0.06,
+      "in": 0.06,
+      "out": 0.4
+    },
+    "synthetic\u0000hf:zai-org/glm-5": {
+      "cached_read": 1.0,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "synthetic\u0000hf:zai-org/glm-5.1": {
+      "cached_read": 1.0,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "tencent-coding-plan\u0000glm-5": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "tencent-coding-plan\u0000hunyuan-2.0-instruct": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "tencent-coding-plan\u0000hunyuan-2.0-thinking": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "tencent-coding-plan\u0000hunyuan-t1": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "tencent-coding-plan\u0000hunyuan-turbos": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "tencent-coding-plan\u0000kimi-k2.5": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "tencent-coding-plan\u0000minimax-m2.5": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "tencent-coding-plan\u0000tc-code-latest": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "tencent-tokenhub\u0000hy3-preview": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "together\u0000deepseek-ai/deepseek-r1": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 7.0
+    },
+    "together\u0000deepseek-ai/deepseek-v3": {
+      "cached_read": null,
+      "in": 1.25,
+      "out": 1.25
+    },
+    "together\u0000deepseek-ai/deepseek-v3-1": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 1.7
+    },
+    "together\u0000deepseek-ai/deepseek-v4-pro": {
+      "cached_read": 0.2,
+      "in": 2.1,
+      "out": 4.4
+    },
+    "together\u0000essentialai/rnj-1-instruct": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.15
+    },
+    "together\u0000google/gemma-4-31b-it": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "together\u0000meta-llama/llama-3.3-70b-instruct-turbo": {
+      "cached_read": null,
+      "in": 0.88,
+      "out": 0.88
+    },
+    "together\u0000minimaxai/minimax-m2.5": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "together\u0000minimaxai/minimax-m2.7": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "together\u0000moonshotai/kimi-k2.5": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 2.8
+    },
+    "together\u0000moonshotai/kimi-k2.6": {
+      "cached_read": 0.2,
+      "in": 1.2,
+      "out": 4.5
+    },
+    "together\u0000nvidia/nemotron-3-ultra-550b-a55b": {
+      "cached_read": 0.2,
+      "in": 0.6,
+      "out": 3.6
+    },
+    "together\u0000openai/gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "together\u0000qwen/qwen3-235b-a22b-instruct-2507-tput": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.6
+    },
+    "together\u0000qwen/qwen3-coder-480b-a35b-instruct-fp8": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 2.0
+    },
+    "together\u0000qwen/qwen3-coder-next-fp8": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.2
+    },
+    "together\u0000qwen/qwen3.5-397b-a17b": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 3.6
+    },
+    "together\u0000qwen/qwen3.6-plus": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "together\u0000qwen/qwen3.7-max": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 7.5
+    },
+    "together\u0000zai-org/glm-5.1": {
+      "cached_read": null,
+      "in": 1.4,
+      "out": 4.4
+    },
+    "umans-ai-coding-plan\u0000umans-coder": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "umans-ai-coding-plan\u0000umans-flash": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "umans-ai-coding-plan\u0000umans-glm-5.1": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "umans-ai-coding-plan\u0000umans-kimi-k2.6": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "umans-ai-coding-plan\u0000umans-qwen3.6-35b-a3b": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "upstage\u0000solar-mini": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.15
+    },
+    "upstage\u0000solar-pro2": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 0.25
+    },
+    "upstage\u0000solar-pro3": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 0.25
+    },
+    "v0\u0000v0-1.0-md": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "v0\u0000v0-1.5-lg": {
+      "cached_read": null,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "v0\u0000v0-1.5-md": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "venice\u0000aion-labs-aion-2-0": {
+      "cached_read": 0.25,
+      "in": 1.0,
+      "out": 2.0
+    },
+    "venice\u0000arcee-trinity-large-thinking": {
+      "cached_read": 0.075,
+      "in": 0.3125,
+      "out": 1.125
+    },
+    "venice\u0000claude-opus-4-5": {
+      "cached_read": 0.6,
+      "in": 6.0,
+      "out": 30.0
+    },
+    "venice\u0000claude-opus-4-6": {
+      "cached_read": 0.6,
+      "in": 6.0,
+      "out": 30.0
+    },
+    "venice\u0000claude-opus-4-6-fast": {
+      "cached_read": 3.6,
+      "in": 36.0,
+      "out": 180.0
+    },
+    "venice\u0000claude-opus-4-7": {
+      "cached_read": 0.6,
+      "in": 6.0,
+      "out": 30.0
+    },
+    "venice\u0000claude-opus-4-7-fast": {
+      "cached_read": 3.6,
+      "in": 36.0,
+      "out": 180.0
+    },
+    "venice\u0000claude-opus-4-8": {
+      "cached_read": 0.6,
+      "in": 6.0,
+      "out": 30.0
+    },
+    "venice\u0000claude-opus-4-8-fast": {
+      "cached_read": 1.2,
+      "in": 12.0,
+      "out": 60.0
+    },
+    "venice\u0000claude-sonnet-4-5": {
+      "cached_read": 0.375,
+      "in": 3.75,
+      "out": 18.75
+    },
+    "venice\u0000claude-sonnet-4-6": {
+      "cached_read": 0.36,
+      "in": 3.6,
+      "out": 18.0
+    },
+    "venice\u0000deepseek-v3.2": {
+      "cached_read": 0.16,
+      "in": 0.33,
+      "out": 0.48
+    },
+    "venice\u0000deepseek-v4-flash": {
+      "cached_read": 0.028,
+      "in": 0.17,
+      "out": 0.35
+    },
+    "venice\u0000deepseek-v4-pro": {
+      "cached_read": 0.33,
+      "in": 1.73,
+      "out": 3.796
+    },
+    "venice\u0000gemini-3-1-pro-preview": {
+      "cached_read": 0.5,
+      "in": 2.5,
+      "out": 15.0
+    },
+    "venice\u0000gemini-3-5-flash": {
+      "cached_read": 0.155,
+      "in": 1.55,
+      "out": 9.45
+    },
+    "venice\u0000gemini-3-flash-preview": {
+      "cached_read": 0.07,
+      "in": 0.7,
+      "out": 3.75
+    },
+    "venice\u0000gemma-4-uncensored": {
+      "cached_read": null,
+      "in": 0.1625,
+      "out": 0.5
+    },
+    "venice\u0000google-gemma-3-27b-it": {
+      "cached_read": null,
+      "in": 0.12,
+      "out": 0.2
+    },
+    "venice\u0000google-gemma-4-26b-a4b-it": {
+      "cached_read": null,
+      "in": 0.1625,
+      "out": 0.5
+    },
+    "venice\u0000google-gemma-4-31b-it": {
+      "cached_read": 0.12,
+      "in": 0.155,
+      "out": 0.44
+    },
+    "venice\u0000grok-4-20": {
+      "cached_read": 0.23,
+      "in": 1.42,
+      "out": 2.83
+    },
+    "venice\u0000grok-4-20-multi-agent": {
+      "cached_read": 0.23,
+      "in": 1.42,
+      "out": 2.83
+    },
+    "venice\u0000grok-4-3": {
+      "cached_read": 0.23,
+      "in": 1.42,
+      "out": 2.83
+    },
+    "venice\u0000grok-build-0-1": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 2.0
+    },
+    "venice\u0000hermes-3-llama-3.1-405b": {
+      "cached_read": null,
+      "in": 1.1,
+      "out": 3.0
+    },
+    "venice\u0000kimi-k2-5": {
+      "cached_read": 0.22,
+      "in": 0.56,
+      "out": 3.5
+    },
+    "venice\u0000kimi-k2-6": {
+      "cached_read": 0.22,
+      "in": 0.85,
+      "out": 4.655
+    },
+    "venice\u0000llama-3.2-3b": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "venice\u0000llama-3.3-70b": {
+      "cached_read": null,
+      "in": 0.7,
+      "out": 2.8
+    },
+    "venice\u0000mercury-2": {
+      "cached_read": 0.03125,
+      "in": 0.3125,
+      "out": 0.9375
+    },
+    "venice\u0000minimax-m25": {
+      "cached_read": 0.04,
+      "in": 0.34,
+      "out": 1.19
+    },
+    "venice\u0000minimax-m27": {
+      "cached_read": 0.075,
+      "in": 0.375,
+      "out": 1.5
+    },
+    "venice\u0000minimax-m3": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "venice\u0000mistral-small-2603": {
+      "cached_read": null,
+      "in": 0.1875,
+      "out": 0.75
+    },
+    "venice\u0000mistral-small-3-2-24b-instruct": {
+      "cached_read": null,
+      "in": 0.09375,
+      "out": 0.25
+    },
+    "venice\u0000nvidia-nemotron-3-nano-30b-a3b": {
+      "cached_read": null,
+      "in": 0.075,
+      "out": 0.3
+    },
+    "venice\u0000nvidia-nemotron-cascade-2-30b-a3b": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.8
+    },
+    "venice\u0000olafangensan-glm-4.7-flash-heretic": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.8
+    },
+    "venice\u0000openai-gpt-4o-2024-11-20": {
+      "cached_read": null,
+      "in": 3.125,
+      "out": 12.5
+    },
+    "venice\u0000openai-gpt-4o-mini-2024-07-18": {
+      "cached_read": 0.09375,
+      "in": 0.1875,
+      "out": 0.75
+    },
+    "venice\u0000openai-gpt-52": {
+      "cached_read": 0.219,
+      "in": 2.19,
+      "out": 17.5
+    },
+    "venice\u0000openai-gpt-52-codex": {
+      "cached_read": 0.219,
+      "in": 2.19,
+      "out": 17.5
+    },
+    "venice\u0000openai-gpt-53-codex": {
+      "cached_read": 0.219,
+      "in": 2.19,
+      "out": 17.5
+    },
+    "venice\u0000openai-gpt-54": {
+      "cached_read": 0.313,
+      "in": 3.13,
+      "out": 18.8
+    },
+    "venice\u0000openai-gpt-54-mini": {
+      "cached_read": 0.09375,
+      "in": 0.9375,
+      "out": 5.625
+    },
+    "venice\u0000openai-gpt-54-pro": {
+      "cached_read": null,
+      "in": 37.5,
+      "out": 225.0
+    },
+    "venice\u0000openai-gpt-55": {
+      "cached_read": 0.625,
+      "in": 6.25,
+      "out": 37.5
+    },
+    "venice\u0000openai-gpt-55-pro": {
+      "cached_read": null,
+      "in": 37.5,
+      "out": 225.0
+    },
+    "venice\u0000openai-gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.3
+    },
+    "venice\u0000qwen-3-6-plus": {
+      "cached_read": 0.0625,
+      "in": 0.625,
+      "out": 3.75
+    },
+    "venice\u0000qwen-3-7-max": {
+      "cached_read": 0.27,
+      "in": 2.7,
+      "out": 8.05
+    },
+    "venice\u0000qwen-3-7-plus": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 2.0
+    },
+    "venice\u0000qwen3-235b-a22b-instruct-2507": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.75
+    },
+    "venice\u0000qwen3-235b-a22b-thinking-2507": {
+      "cached_read": null,
+      "in": 0.45,
+      "out": 3.5
+    },
+    "venice\u0000qwen3-5-35b-a3b": {
+      "cached_read": 0.15625,
+      "in": 0.3125,
+      "out": 1.25
+    },
+    "venice\u0000qwen3-5-397b-a17b": {
+      "cached_read": null,
+      "in": 0.75,
+      "out": 4.5
+    },
+    "venice\u0000qwen3-5-9b": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.15
+    },
+    "venice\u0000qwen3-6-27b": {
+      "cached_read": null,
+      "in": 0.325,
+      "out": 3.25
+    },
+    "venice\u0000qwen3-coder-480b-a35b-instruct-turbo": {
+      "cached_read": 0.04,
+      "in": 0.35,
+      "out": 1.5
+    },
+    "venice\u0000qwen3-next-80b": {
+      "cached_read": null,
+      "in": 0.35,
+      "out": 1.9
+    },
+    "venice\u0000qwen3-vl-235b-a22b": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 1.5
+    },
+    "venice\u0000venice-uncensored-1-2": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.9
+    },
+    "venice\u0000venice-uncensored-role-play": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 2.0
+    },
+    "venice\u0000z-ai-glm-5-turbo": {
+      "cached_read": 0.24,
+      "in": 1.2,
+      "out": 4.0
+    },
+    "venice\u0000z-ai-glm-5v-turbo": {
+      "cached_read": 0.3,
+      "in": 1.5,
+      "out": 5.0
+    },
+    "venice\u0000zai-org-glm-4.6": {
+      "cached_read": 0.3,
+      "in": 0.85,
+      "out": 2.75
+    },
+    "venice\u0000zai-org-glm-4.7": {
+      "cached_read": 0.11,
+      "in": 0.55,
+      "out": 2.65
+    },
+    "venice\u0000zai-org-glm-4.7-flash": {
+      "cached_read": null,
+      "in": 0.125,
+      "out": 0.5
+    },
+    "venice\u0000zai-org-glm-5": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 3.2
+    },
+    "venice\u0000zai-org-glm-5-1": {
+      "cached_read": 0.325,
+      "in": 1.75,
+      "out": 5.5
+    },
+    "vercel\u0000alibaba/qwen-3-14b": {
+      "cached_read": null,
+      "in": 0.12,
+      "out": 0.24
+    },
+    "vercel\u0000alibaba/qwen-3-235b": {
+      "cached_read": null,
+      "in": 0.22,
+      "out": 0.88
+    },
+    "vercel\u0000alibaba/qwen-3-30b": {
+      "cached_read": null,
+      "in": 0.08,
+      "out": 0.29
+    },
+    "vercel\u0000alibaba/qwen-3-32b": {
+      "cached_read": null,
+      "in": 0.16,
+      "out": 0.64
+    },
+    "vercel\u0000alibaba/qwen-3.6-max-preview": {
+      "cached_read": 0.26,
+      "in": 1.3,
+      "out": 7.8
+    },
+    "vercel\u0000alibaba/qwen3-235b-a22b-thinking": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 4.0
+    },
+    "vercel\u0000alibaba/qwen3-coder": {
+      "cached_read": 0.3,
+      "in": 1.5,
+      "out": 7.5
+    },
+    "vercel\u0000alibaba/qwen3-coder-30b-a3b": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "vercel\u0000alibaba/qwen3-coder-next": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.2
+    },
+    "vercel\u0000alibaba/qwen3-coder-plus": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "vercel\u0000alibaba/qwen3-max": {
+      "cached_read": 0.24,
+      "in": 1.2,
+      "out": 6.0
+    },
+    "vercel\u0000alibaba/qwen3-max-preview": {
+      "cached_read": 0.24,
+      "in": 1.2,
+      "out": 6.0
+    },
+    "vercel\u0000alibaba/qwen3-max-thinking": {
+      "cached_read": 0.24,
+      "in": 1.2,
+      "out": 6.0
+    },
+    "vercel\u0000alibaba/qwen3-next-80b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 1.2
+    },
+    "vercel\u0000alibaba/qwen3-next-80b-a3b-thinking": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 1.2
+    },
+    "vercel\u0000alibaba/qwen3-vl-235b-a22b-instruct": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 1.6
+    },
+    "vercel\u0000alibaba/qwen3-vl-instruct": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 1.6
+    },
+    "vercel\u0000alibaba/qwen3-vl-thinking": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 4.0
+    },
+    "vercel\u0000alibaba/qwen3.5-flash": {
+      "cached_read": 0.001,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "vercel\u0000alibaba/qwen3.5-plus": {
+      "cached_read": 0.04,
+      "in": 0.4,
+      "out": 2.4
+    },
+    "vercel\u0000alibaba/qwen3.6-27b": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 3.6
+    },
+    "vercel\u0000alibaba/qwen3.6-plus": {
+      "cached_read": 0.1,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "vercel\u0000alibaba/qwen3.7-max": {
+      "cached_read": 0.25,
+      "in": 1.25,
+      "out": 3.75
+    },
+    "vercel\u0000alibaba/qwen3.7-plus": {
+      "cached_read": 0.08,
+      "in": 0.4,
+      "out": 1.6
+    },
+    "vercel\u0000amazon/nova-2-lite": {
+      "cached_read": 0.075,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "vercel\u0000amazon/nova-lite": {
+      "cached_read": 0.015,
+      "in": 0.06,
+      "out": 0.24
+    },
+    "vercel\u0000amazon/nova-micro": {
+      "cached_read": 0.00875,
+      "in": 0.035,
+      "out": 0.14
+    },
+    "vercel\u0000amazon/nova-pro": {
+      "cached_read": 0.2,
+      "in": 0.8,
+      "out": 3.2
+    },
+    "vercel\u0000anthropic/claude-3-haiku": {
+      "cached_read": 0.03,
+      "in": 0.25,
+      "out": 1.25
+    },
+    "vercel\u0000anthropic/claude-3-opus": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "vercel\u0000anthropic/claude-3.5-haiku": {
+      "cached_read": 0.08,
+      "in": 0.8,
+      "out": 4.0
+    },
+    "vercel\u0000anthropic/claude-3.5-sonnet": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "vercel\u0000anthropic/claude-3.5-sonnet-20240620": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "vercel\u0000anthropic/claude-3.7-sonnet": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "vercel\u0000anthropic/claude-haiku-4.5": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "vercel\u0000anthropic/claude-opus-4": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "vercel\u0000anthropic/claude-opus-4.1": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "vercel\u0000anthropic/claude-opus-4.5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "vercel\u0000anthropic/claude-opus-4.6": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "vercel\u0000anthropic/claude-opus-4.7": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "vercel\u0000anthropic/claude-opus-4.8": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "vercel\u0000anthropic/claude-sonnet-4": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "vercel\u0000anthropic/claude-sonnet-4.5": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "vercel\u0000anthropic/claude-sonnet-4.6": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "vercel\u0000arcee-ai/trinity-large-preview": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 1.0
+    },
+    "vercel\u0000arcee-ai/trinity-large-thinking": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 0.8999999999999999
+    },
+    "vercel\u0000arcee-ai/trinity-mini": {
+      "cached_read": null,
+      "in": 0.045,
+      "out": 0.15
+    },
+    "vercel\u0000bytedance/seed-1.6": {
+      "cached_read": 0.05,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "vercel\u0000bytedance/seed-1.8": {
+      "cached_read": 0.05,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "vercel\u0000cohere/command-a": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "vercel\u0000deepseek/deepseek-r1": {
+      "cached_read": null,
+      "in": 1.35,
+      "out": 5.4
+    },
+    "vercel\u0000deepseek/deepseek-v3": {
+      "cached_read": 0.135,
+      "in": 0.27,
+      "out": 1.12
+    },
+    "vercel\u0000deepseek/deepseek-v3.1": {
+      "cached_read": 0.28,
+      "in": 0.56,
+      "out": 1.68
+    },
+    "vercel\u0000deepseek/deepseek-v3.1-terminus": {
+      "cached_read": 0.135,
+      "in": 0.27,
+      "out": 1.0
+    },
+    "vercel\u0000deepseek/deepseek-v3.2": {
+      "cached_read": 0.028,
+      "in": 0.28,
+      "out": 0.42
+    },
+    "vercel\u0000deepseek/deepseek-v3.2-exp": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 0.4
+    },
+    "vercel\u0000deepseek/deepseek-v3.2-thinking": {
+      "cached_read": null,
+      "in": 0.62,
+      "out": 1.85
+    },
+    "vercel\u0000deepseek/deepseek-v4-flash": {
+      "cached_read": 0.0028,
+      "in": 0.14,
+      "out": 0.28
+    },
+    "vercel\u0000deepseek/deepseek-v4-pro": {
+      "cached_read": 0.0036,
+      "in": 0.435,
+      "out": 0.87
+    },
+    "vercel\u0000google/gemini-2.0-flash": {
+      "cached_read": 0.025,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "vercel\u0000google/gemini-2.0-flash-lite": {
+      "cached_read": null,
+      "in": 0.075,
+      "out": 0.3
+    },
+    "vercel\u0000google/gemini-2.5-flash": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "vercel\u0000google/gemini-2.5-flash-image": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "vercel\u0000google/gemini-2.5-flash-image-preview": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "vercel\u0000google/gemini-2.5-flash-lite": {
+      "cached_read": 0.01,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "vercel\u0000google/gemini-2.5-flash-lite-preview-09-2025": {
+      "cached_read": 0.01,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "vercel\u0000google/gemini-2.5-flash-preview-09-2025": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "vercel\u0000google/gemini-2.5-pro": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "vercel\u0000google/gemini-3-flash": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "vercel\u0000google/gemini-3-pro-image": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "vercel\u0000google/gemini-3-pro-preview": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "vercel\u0000google/gemini-3.1-flash-image": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "vercel\u0000google/gemini-3.1-flash-image-preview": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "vercel\u0000google/gemini-3.1-flash-lite": {
+      "cached_read": 0.03,
+      "in": 0.25,
+      "out": 1.5
+    },
+    "vercel\u0000google/gemini-3.1-flash-lite-preview": {
+      "cached_read": 0.03,
+      "in": 0.25,
+      "out": 1.5
+    },
+    "vercel\u0000google/gemini-3.1-pro-preview": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "vercel\u0000google/gemini-3.5-flash": {
+      "cached_read": 0.15,
+      "in": 1.5,
+      "out": 9.0
+    },
+    "vercel\u0000google/gemma-4-26b-a4b-it": {
+      "cached_read": 0.015,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "vercel\u0000google/gemma-4-31b-it": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.4
+    },
+    "vercel\u0000inception/mercury-2": {
+      "cached_read": 0.024999999999999998,
+      "in": 0.25,
+      "out": 0.75
+    },
+    "vercel\u0000inception/mercury-coder-small": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 1.0
+    },
+    "vercel\u0000inception/mercury-edit-2": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 0.75
+    },
+    "vercel\u0000interfaze/interfaze-beta": {
+      "cached_read": null,
+      "in": 1.5,
+      "out": 3.5
+    },
+    "vercel\u0000kwaipilot/kat-coder-pro-v1": {
+      "cached_read": 0.06,
+      "in": 0.03,
+      "out": 1.2
+    },
+    "vercel\u0000kwaipilot/kat-coder-pro-v2": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "vercel\u0000meituan/longcat-flash-thinking": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 1.5
+    },
+    "vercel\u0000meta/llama-3.1-70b": {
+      "cached_read": null,
+      "in": 0.72,
+      "out": 0.72
+    },
+    "vercel\u0000meta/llama-3.1-8b": {
+      "cached_read": null,
+      "in": 0.22,
+      "out": 0.22
+    },
+    "vercel\u0000meta/llama-3.2-11b": {
+      "cached_read": null,
+      "in": 0.16,
+      "out": 0.16
+    },
+    "vercel\u0000meta/llama-3.2-1b": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "vercel\u0000meta/llama-3.2-3b": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.15
+    },
+    "vercel\u0000meta/llama-3.2-90b": {
+      "cached_read": null,
+      "in": 0.72,
+      "out": 0.72
+    },
+    "vercel\u0000meta/llama-3.3-70b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "vercel\u0000meta/llama-4-maverick": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "vercel\u0000meta/llama-4-scout": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "vercel\u0000minimax/minimax-m2": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "vercel\u0000minimax/minimax-m2.1": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "vercel\u0000minimax/minimax-m2.1-lightning": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 2.4
+    },
+    "vercel\u0000minimax/minimax-m2.5": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "vercel\u0000minimax/minimax-m2.5-highspeed": {
+      "cached_read": 0.03,
+      "in": 0.6,
+      "out": 2.4
+    },
+    "vercel\u0000minimax/minimax-m2.7": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "vercel\u0000minimax/minimax-m2.7-highspeed": {
+      "cached_read": 0.06,
+      "in": 0.6,
+      "out": 2.4
+    },
+    "vercel\u0000minimax/minimax-m3": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "vercel\u0000mistral/codestral": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.9
+    },
+    "vercel\u0000mistral/devstral-2": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "vercel\u0000mistral/devstral-small": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "vercel\u0000mistral/devstral-small-2": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "vercel\u0000mistral/magistral-medium": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 5.0
+    },
+    "vercel\u0000mistral/magistral-small": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "vercel\u0000mistral/ministral-14b": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "vercel\u0000mistral/ministral-3b": {
+      "cached_read": null,
+      "in": 0.04,
+      "out": 0.04
+    },
+    "vercel\u0000mistral/ministral-8b": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "vercel\u0000mistral/mistral-large-3": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "vercel\u0000mistral/mistral-medium": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "vercel\u0000mistral/mistral-medium-3.5": {
+      "cached_read": null,
+      "in": 1.5,
+      "out": 7.5
+    },
+    "vercel\u0000mistral/mistral-nemo": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.04
+    },
+    "vercel\u0000mistral/mistral-small": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "vercel\u0000mistral/mixtral-8x22b-instruct": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "vercel\u0000mistral/pixtral-12b": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.15
+    },
+    "vercel\u0000mistral/pixtral-large": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "vercel\u0000moonshotai/kimi-k2": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "vercel\u0000moonshotai/kimi-k2-0905": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.5
+    },
+    "vercel\u0000moonshotai/kimi-k2-thinking": {
+      "cached_read": 0.15,
+      "in": 0.6,
+      "out": 2.5
+    },
+    "vercel\u0000moonshotai/kimi-k2-thinking-turbo": {
+      "cached_read": 0.15,
+      "in": 1.15,
+      "out": 8.0
+    },
+    "vercel\u0000moonshotai/kimi-k2-turbo": {
+      "cached_read": 0.15,
+      "in": 1.15,
+      "out": 8.0
+    },
+    "vercel\u0000moonshotai/kimi-k2.5": {
+      "cached_read": 0.1,
+      "in": 0.6,
+      "out": 3.0
+    },
+    "vercel\u0000moonshotai/kimi-k2.6": {
+      "cached_read": 0.16,
+      "in": 0.95,
+      "out": 4.0
+    },
+    "vercel\u0000morph/morph-v3-fast": {
+      "cached_read": null,
+      "in": 0.8,
+      "out": 1.2
+    },
+    "vercel\u0000morph/morph-v3-large": {
+      "cached_read": null,
+      "in": 0.9,
+      "out": 1.9
+    },
+    "vercel\u0000nvidia/nemotron-3-nano-30b-a3b": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.24
+    },
+    "vercel\u0000nvidia/nemotron-3-super-120b-a12b": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.65
+    },
+    "vercel\u0000nvidia/nemotron-3-ultra-550b-a55b": {
+      "cached_read": 0.12,
+      "in": 0.6,
+      "out": 2.4
+    },
+    "vercel\u0000nvidia/nemotron-nano-12b-v2-vl": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.6
+    },
+    "vercel\u0000nvidia/nemotron-nano-9b-v2": {
+      "cached_read": null,
+      "in": 0.06,
+      "out": 0.23
+    },
+    "vercel\u0000openai/codex-mini": {
+      "cached_read": 0.38,
+      "in": 1.5,
+      "out": 6.0
+    },
+    "vercel\u0000openai/gpt-3.5-turbo": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "vercel\u0000openai/gpt-3.5-turbo-instruct": {
+      "cached_read": null,
+      "in": 1.5,
+      "out": 2.0
+    },
+    "vercel\u0000openai/gpt-4-turbo": {
+      "cached_read": null,
+      "in": 10.0,
+      "out": 30.0
+    },
+    "vercel\u0000openai/gpt-4.1": {
+      "cached_read": 0.5,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "vercel\u0000openai/gpt-4.1-mini": {
+      "cached_read": 0.1,
+      "in": 0.4,
+      "out": 1.6
+    },
+    "vercel\u0000openai/gpt-4.1-nano": {
+      "cached_read": 0.025,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "vercel\u0000openai/gpt-4o": {
+      "cached_read": 1.25,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "vercel\u0000openai/gpt-4o-mini": {
+      "cached_read": 0.075,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "vercel\u0000openai/gpt-4o-mini-search-preview": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "vercel\u0000openai/gpt-5": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "vercel\u0000openai/gpt-5-chat": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "vercel\u0000openai/gpt-5-codex": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "vercel\u0000openai/gpt-5-mini": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "vercel\u0000openai/gpt-5-nano": {
+      "cached_read": 0.005,
+      "in": 0.05,
+      "out": 0.4
+    },
+    "vercel\u0000openai/gpt-5-pro": {
+      "cached_read": null,
+      "in": 15.0,
+      "out": 120.0
+    },
+    "vercel\u0000openai/gpt-5.1-codex": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "vercel\u0000openai/gpt-5.1-codex-max": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "vercel\u0000openai/gpt-5.1-codex-mini": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "vercel\u0000openai/gpt-5.1-instant": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "vercel\u0000openai/gpt-5.1-thinking": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "vercel\u0000openai/gpt-5.2": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "vercel\u0000openai/gpt-5.2-chat": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "vercel\u0000openai/gpt-5.2-codex": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "vercel\u0000openai/gpt-5.2-pro": {
+      "cached_read": null,
+      "in": 21.0,
+      "out": 168.0
+    },
+    "vercel\u0000openai/gpt-5.3-chat": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "vercel\u0000openai/gpt-5.3-codex": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "vercel\u0000openai/gpt-5.4": {
+      "cached_read": 0.25,
+      "in": 2.5,
+      "out": 15.0
+    },
+    "vercel\u0000openai/gpt-5.4-mini": {
+      "cached_read": 0.075,
+      "in": 0.75,
+      "out": 4.5
+    },
+    "vercel\u0000openai/gpt-5.4-nano": {
+      "cached_read": 0.02,
+      "in": 0.2,
+      "out": 1.25
+    },
+    "vercel\u0000openai/gpt-5.4-pro": {
+      "cached_read": null,
+      "in": 30.0,
+      "out": 180.0
+    },
+    "vercel\u0000openai/gpt-5.5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 30.0
+    },
+    "vercel\u0000openai/gpt-5.5-pro": {
+      "cached_read": null,
+      "in": 30.0,
+      "out": 180.0
+    },
+    "vercel\u0000openai/gpt-oss-120b": {
+      "cached_read": 0.25,
+      "in": 0.35,
+      "out": 0.75
+    },
+    "vercel\u0000openai/gpt-oss-20b": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.2
+    },
+    "vercel\u0000openai/gpt-oss-safeguard-20b": {
+      "cached_read": 0.037,
+      "in": 0.075,
+      "out": 0.3
+    },
+    "vercel\u0000openai/o1": {
+      "cached_read": 7.5,
+      "in": 15.0,
+      "out": 60.0
+    },
+    "vercel\u0000openai/o3": {
+      "cached_read": 0.5,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "vercel\u0000openai/o3-deep-research": {
+      "cached_read": 2.5,
+      "in": 10.0,
+      "out": 40.0
+    },
+    "vercel\u0000openai/o3-mini": {
+      "cached_read": 0.55,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "vercel\u0000openai/o3-pro": {
+      "cached_read": null,
+      "in": 20.0,
+      "out": 80.0
+    },
+    "vercel\u0000openai/o4-mini": {
+      "cached_read": 0.275,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "vercel\u0000perplexity/sonar-reasoning": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "vercel\u0000prime-intellect/intellect-3": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 1.1
+    },
+    "vercel\u0000stepfun/step-3.5-flash": {
+      "cached_read": null,
+      "in": 0.09,
+      "out": 0.3
+    },
+    "vercel\u0000stepfun/step-3.7-flash": {
+      "cached_read": 0.04,
+      "in": 0.2,
+      "out": 1.15
+    },
+    "vercel\u0000vercel/v0-1.0-md": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "vercel\u0000vercel/v0-1.5-md": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "vercel\u0000xai/grok-4-fast-reasoning": {
+      "cached_read": 0.05,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "vercel\u0000xai/grok-4.1-fast-non-reasoning": {
+      "cached_read": 0.05,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "vercel\u0000xai/grok-4.1-fast-reasoning": {
+      "cached_read": 0.05,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "vercel\u0000xai/grok-4.20-multi-agent": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "vercel\u0000xai/grok-4.20-multi-agent-beta": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "vercel\u0000xai/grok-4.20-non-reasoning": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "vercel\u0000xai/grok-4.20-non-reasoning-beta": {
+      "cached_read": 0.4,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "vercel\u0000xai/grok-4.20-reasoning": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "vercel\u0000xai/grok-4.20-reasoning-beta": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "vercel\u0000xai/grok-4.3": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "vercel\u0000xai/grok-build-0.1": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 2.0
+    },
+    "vercel\u0000xiaomi/mimo-v2-flash": {
+      "cached_read": 0.01,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "vercel\u0000xiaomi/mimo-v2-pro": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "vercel\u0000xiaomi/mimo-v2.5": {
+      "cached_read": 0.0028,
+      "in": 0.14,
+      "out": 0.28
+    },
+    "vercel\u0000xiaomi/mimo-v2.5-pro": {
+      "cached_read": 0.0036,
+      "in": 0.435,
+      "out": 0.87
+    },
+    "vercel\u0000zai/glm-4.5": {
+      "cached_read": 0.11,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "vercel\u0000zai/glm-4.5-air": {
+      "cached_read": 0.03,
+      "in": 0.2,
+      "out": 1.1
+    },
+    "vercel\u0000zai/glm-4.5v": {
+      "cached_read": 0.11,
+      "in": 0.6,
+      "out": 1.8
+    },
+    "vercel\u0000zai/glm-4.6": {
+      "cached_read": 0.11,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "vercel\u0000zai/glm-4.6v": {
+      "cached_read": 0.05,
+      "in": 0.3,
+      "out": 0.9
+    },
+    "vercel\u0000zai/glm-4.7": {
+      "cached_read": 2.25,
+      "in": 2.25,
+      "out": 2.75
+    },
+    "vercel\u0000zai/glm-4.7-flash": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.4
+    },
+    "vercel\u0000zai/glm-4.7-flashx": {
+      "cached_read": 0.01,
+      "in": 0.06,
+      "out": 0.4
+    },
+    "vercel\u0000zai/glm-5": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 3.2
+    },
+    "vercel\u0000zai/glm-5-turbo": {
+      "cached_read": 0.24,
+      "in": 1.2,
+      "out": 4.0
+    },
+    "vercel\u0000zai/glm-5.1": {
+      "cached_read": 0.26,
+      "in": 1.4,
+      "out": 4.4
+    },
+    "vercel\u0000zai/glm-5v-turbo": {
+      "cached_read": 0.24,
+      "in": 1.2,
+      "out": 4.0
+    },
+    "vivgrid\u0000deepseek-v3.2": {
+      "cached_read": null,
+      "in": 0.28,
+      "out": 0.42
+    },
+    "vivgrid\u0000deepseek-v4-pro": {
+      "cached_read": 0.003625,
+      "in": 0.435,
+      "out": 0.87
+    },
+    "vivgrid\u0000gemini-3.1-flash-lite-preview": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 1.5
+    },
+    "vivgrid\u0000gemini-3.1-pro-preview": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "vivgrid\u0000gpt-5-mini": {
+      "cached_read": 0.03,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "vivgrid\u0000gpt-5.1-codex": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "vivgrid\u0000gpt-5.1-codex-max": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "vivgrid\u0000gpt-5.2-codex": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "vivgrid\u0000gpt-5.3-codex": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "vivgrid\u0000gpt-5.4": {
+      "cached_read": 0.25,
+      "in": 2.5,
+      "out": 15.0
+    },
+    "vivgrid\u0000gpt-5.4-mini": {
+      "cached_read": 0.075,
+      "in": 0.75,
+      "out": 4.5
+    },
+    "vivgrid\u0000gpt-5.4-nano": {
+      "cached_read": 0.02,
+      "in": 0.2,
+      "out": 1.25
+    },
+    "vivgrid\u0000gpt-5.5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 30.0
+    },
+    "vultr\u0000minimaxai/minimax-m2.7": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "vultr\u0000moonshotai/kimi-k2.6": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "vultr\u0000nvidia/deepseek-v3.2-nvfp4": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 1.65
+    },
+    "vultr\u0000nvidia/llama-3.1-nemotron-safety-guard-8b-v3": {
+      "cached_read": null,
+      "in": 0.01,
+      "out": 0.01
+    },
+    "vultr\u0000nvidia/nemotron-3-nano-omni-30b-a3b-reasoning-bf16": {
+      "cached_read": null,
+      "in": 0.13,
+      "out": 0.38
+    },
+    "vultr\u0000nvidia/nemotron-cascade-2-30b-a3b": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "vultr\u0000zai-org/glm-5.1-fp8": {
+      "cached_read": null,
+      "in": 0.85,
+      "out": 3.1
+    },
+    "wafer.ai\u0000deepseek-v4-flash": {
+      "cached_read": 0.01,
+      "in": 0.14,
+      "out": 0.28
+    },
+    "wafer.ai\u0000deepseek-v4-pro": {
+      "cached_read": 0.02,
+      "in": 1.74,
+      "out": 3.48
+    },
+    "wafer.ai\u0000glm-5.1": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 3.2
+    },
+    "wafer.ai\u0000kimi-k2.6": {
+      "cached_read": 0.07,
+      "in": 0.68,
+      "out": 3.15
+    },
+    "wafer.ai\u0000qwen3.5-397b-a17b": {
+      "cached_read": 0.04,
+      "in": 0.43,
+      "out": 2.6
+    },
+    "wafer.ai\u0000qwen3.6-35b-a3b": {
+      "cached_read": 0.02,
+      "in": 0.15,
+      "out": 1.0
+    },
+    "wafer.ai\u0000qwen3.7-max": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 15.0
+    },
+    "wandb\u0000deepseek-ai/deepseek-v3.1": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 1.65
+    },
+    "wandb\u0000meta-llama/llama-3.1-70b-instruct": {
+      "cached_read": null,
+      "in": 0.8,
+      "out": 0.8
+    },
+    "wandb\u0000meta-llama/llama-3.1-8b-instruct": {
+      "cached_read": null,
+      "in": 0.22,
+      "out": 0.22
+    },
+    "wandb\u0000meta-llama/llama-3.3-70b-instruct": {
+      "cached_read": null,
+      "in": 0.71,
+      "out": 0.71
+    },
+    "wandb\u0000meta-llama/llama-4-scout-17b-16e-instruct": {
+      "cached_read": null,
+      "in": 0.17,
+      "out": 0.66
+    },
+    "wandb\u0000microsoft/phi-4-mini-instruct": {
+      "cached_read": null,
+      "in": 0.08,
+      "out": 0.35
+    },
+    "wandb\u0000minimaxai/minimax-m2.5": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "wandb\u0000moonshotai/kimi-k2.5": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 2.85
+    },
+    "wandb\u0000nvidia/nvidia-nemotron-3-super-120b-a12b-fp8": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.8
+    },
+    "wandb\u0000openai/gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "wandb\u0000openai/gpt-oss-20b": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.2
+    },
+    "wandb\u0000openpipe/qwen3-14b-instruct": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.22
+    },
+    "wandb\u0000qwen/qwen3-235b-a22b-instruct-2507": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "wandb\u0000qwen/qwen3-235b-a22b-thinking-2507": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "wandb\u0000qwen/qwen3-30b-a3b-instruct-2507": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "wandb\u0000qwen/qwen3-coder-480b-a35b-instruct": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 1.5
+    },
+    "wandb\u0000zai-org/glm-5-fp8": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 3.2
+    },
+    "wandb\u0000zai-org/glm-5.1": {
+      "cached_read": 0.26,
+      "in": 1.4,
+      "out": 4.4
+    },
+    "xai\u0000grok-4.20-0309-non-reasoning": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "xai\u0000grok-4.20-0309-reasoning": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "xai\u0000grok-4.20-multi-agent-0309": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "xai\u0000grok-4.3": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "xai\u0000grok-build-0.1": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 2.0
+    },
+    "xiaomi\u0000mimo-v2-flash": {
+      "cached_read": 0.01,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "xiaomi\u0000mimo-v2-omni": {
+      "cached_read": 0.08,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "xiaomi\u0000mimo-v2-pro": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "xiaomi\u0000mimo-v2.5": {
+      "cached_read": 0.08,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "xiaomi\u0000mimo-v2.5-pro": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "xiaomi-token-plan-ams\u0000mimo-v2-omni": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "xiaomi-token-plan-ams\u0000mimo-v2-pro": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "xiaomi-token-plan-ams\u0000mimo-v2-tts": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "xiaomi-token-plan-ams\u0000mimo-v2.5": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "xiaomi-token-plan-ams\u0000mimo-v2.5-pro": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "xiaomi-token-plan-ams\u0000mimo-v2.5-tts": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "xiaomi-token-plan-ams\u0000mimo-v2.5-tts-voiceclone": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "xiaomi-token-plan-ams\u0000mimo-v2.5-tts-voicedesign": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "xiaomi-token-plan-cn\u0000mimo-v2-omni": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "xiaomi-token-plan-cn\u0000mimo-v2-pro": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "xiaomi-token-plan-cn\u0000mimo-v2-tts": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "xiaomi-token-plan-cn\u0000mimo-v2.5": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "xiaomi-token-plan-cn\u0000mimo-v2.5-pro": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "xiaomi-token-plan-cn\u0000mimo-v2.5-tts": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "xiaomi-token-plan-cn\u0000mimo-v2.5-tts-voiceclone": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "xiaomi-token-plan-cn\u0000mimo-v2.5-tts-voicedesign": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "xiaomi-token-plan-sgp\u0000mimo-v2-omni": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "xiaomi-token-plan-sgp\u0000mimo-v2-pro": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "xiaomi-token-plan-sgp\u0000mimo-v2-tts": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "xiaomi-token-plan-sgp\u0000mimo-v2.5": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "xiaomi-token-plan-sgp\u0000mimo-v2.5-pro": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "xiaomi-token-plan-sgp\u0000mimo-v2.5-tts": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "xiaomi-token-plan-sgp\u0000mimo-v2.5-tts-voiceclone": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "xiaomi-token-plan-sgp\u0000mimo-v2.5-tts-voicedesign": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "xpersona\u0000xpersona-frieren-coder": {
+      "cached_read": 0.15,
+      "in": 1.5,
+      "out": 6.0
+    },
+    "xpersona\u0000xpersona-gpt-5.5": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 18.0
+    },
+    "zai\u0000glm-4.5": {
+      "cached_read": 0.11,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "zai\u0000glm-4.5-air": {
+      "cached_read": 0.03,
+      "in": 0.2,
+      "out": 1.1
+    },
+    "zai\u0000glm-4.5-flash": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "zai\u0000glm-4.5v": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 1.8
+    },
+    "zai\u0000glm-4.6": {
+      "cached_read": 0.11,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "zai\u0000glm-4.6v": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.9
+    },
+    "zai\u0000glm-4.7": {
+      "cached_read": 0.11,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "zai\u0000glm-4.7-flash": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "zai\u0000glm-4.7-flashx": {
+      "cached_read": 0.01,
+      "in": 0.07,
+      "out": 0.4
+    },
+    "zai\u0000glm-5": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 3.2
+    },
+    "zai\u0000glm-5-turbo": {
+      "cached_read": 0.24,
+      "in": 1.2,
+      "out": 4.0
+    },
+    "zai\u0000glm-5.1": {
+      "cached_read": 0.26,
+      "in": 1.4,
+      "out": 4.4
+    },
+    "zai\u0000glm-5v-turbo": {
+      "cached_read": 0.24,
+      "in": 1.2,
+      "out": 4.0
+    },
+    "zai-coding-plan\u0000glm-4.5-air": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "zai-coding-plan\u0000glm-4.7": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "zai-coding-plan\u0000glm-5-turbo": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "zai-coding-plan\u0000glm-5.1": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "zai-coding-plan\u0000glm-5v-turbo": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "zenmux\u0000anthropic/claude-3.5-haiku": {
+      "cached_read": 0.08,
+      "in": 0.8,
+      "out": 4.0
+    },
+    "zenmux\u0000anthropic/claude-3.7-sonnet": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "zenmux\u0000anthropic/claude-haiku-4.5": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "zenmux\u0000anthropic/claude-opus-4": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "zenmux\u0000anthropic/claude-opus-4.1": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "zenmux\u0000anthropic/claude-opus-4.5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "zenmux\u0000anthropic/claude-opus-4.6": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "zenmux\u0000anthropic/claude-opus-4.7": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "zenmux\u0000anthropic/claude-sonnet-4": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "zenmux\u0000anthropic/claude-sonnet-4.5": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "zenmux\u0000anthropic/claude-sonnet-4.6": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "zenmux\u0000baidu/ernie-5.0-thinking-preview": {
+      "cached_read": null,
+      "in": 0.84,
+      "out": 3.37
+    },
+    "zenmux\u0000deepseek/deepseek-chat": {
+      "cached_read": 0.03,
+      "in": 0.28,
+      "out": 0.42
+    },
+    "zenmux\u0000deepseek/deepseek-v3.2": {
+      "cached_read": null,
+      "in": 0.28,
+      "out": 0.43
+    },
+    "zenmux\u0000deepseek/deepseek-v3.2-exp": {
+      "cached_read": null,
+      "in": 0.22,
+      "out": 0.33
+    },
+    "zenmux\u0000deepseek/deepseek-v4-flash": {
+      "cached_read": 0.0028,
+      "in": 0.14,
+      "out": 0.28
+    },
+    "zenmux\u0000deepseek/deepseek-v4-pro": {
+      "cached_read": 0.003625,
+      "in": 0.435,
+      "out": 0.87
+    },
+    "zenmux\u0000google/gemini-2.5-flash": {
+      "cached_read": 0.07,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "zenmux\u0000google/gemini-2.5-flash-lite": {
+      "cached_read": 0.03,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "zenmux\u0000google/gemini-2.5-pro": {
+      "cached_read": 0.31,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "zenmux\u0000google/gemini-3-flash-preview": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "zenmux\u0000google/gemini-3.1-flash-lite-preview": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 1.5
+    },
+    "zenmux\u0000google/gemini-3.1-pro-preview": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "zenmux\u0000inclusionai/ling-1t": {
+      "cached_read": 0.11,
+      "in": 0.56,
+      "out": 2.24
+    },
+    "zenmux\u0000inclusionai/ring-1t": {
+      "cached_read": 0.11,
+      "in": 0.56,
+      "out": 2.24
+    },
+    "zenmux\u0000kuaishou/kat-coder-pro-v2": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "zenmux\u0000minimax/minimax-m2": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "zenmux\u0000minimax/minimax-m2.1": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "zenmux\u0000minimax/minimax-m2.5": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "zenmux\u0000minimax/minimax-m2.5-lightning": {
+      "cached_read": 0.06,
+      "in": 0.6,
+      "out": 4.8
+    },
+    "zenmux\u0000minimax/minimax-m2.7": {
+      "cached_read": null,
+      "in": 0.3055,
+      "out": 1.2219
+    },
+    "zenmux\u0000minimax/minimax-m2.7-highspeed": {
+      "cached_read": null,
+      "in": 0.611,
+      "out": 2.4439
+    },
+    "zenmux\u0000moonshotai/kimi-k2-0905": {
+      "cached_read": 0.15,
+      "in": 0.6,
+      "out": 2.5
+    },
+    "zenmux\u0000moonshotai/kimi-k2-thinking": {
+      "cached_read": 0.15,
+      "in": 0.6,
+      "out": 2.5
+    },
+    "zenmux\u0000moonshotai/kimi-k2-thinking-turbo": {
+      "cached_read": 0.15,
+      "in": 1.15,
+      "out": 8.0
+    },
+    "zenmux\u0000moonshotai/kimi-k2.5": {
+      "cached_read": 0.1,
+      "in": 0.58,
+      "out": 3.02
+    },
+    "zenmux\u0000moonshotai/kimi-k2.6": {
+      "cached_read": 0.16,
+      "in": 0.95,
+      "out": 4.0
+    },
+    "zenmux\u0000openai/gpt-5": {
+      "cached_read": 0.12,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "zenmux\u0000openai/gpt-5-codex": {
+      "cached_read": 0.12,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "zenmux\u0000openai/gpt-5.1": {
+      "cached_read": 0.12,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "zenmux\u0000openai/gpt-5.1-chat": {
+      "cached_read": 0.12,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "zenmux\u0000openai/gpt-5.1-codex": {
+      "cached_read": 0.12,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "zenmux\u0000openai/gpt-5.1-codex-mini": {
+      "cached_read": 0.03,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "zenmux\u0000openai/gpt-5.2": {
+      "cached_read": 0.17,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "zenmux\u0000openai/gpt-5.2-codex": {
+      "cached_read": 0.17,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "zenmux\u0000openai/gpt-5.2-pro": {
+      "cached_read": null,
+      "in": 21.0,
+      "out": 168.0
+    },
+    "zenmux\u0000openai/gpt-5.3-chat": {
+      "cached_read": null,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "zenmux\u0000openai/gpt-5.3-codex": {
+      "cached_read": null,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "zenmux\u0000openai/gpt-5.4": {
+      "cached_read": null,
+      "in": 3.75,
+      "out": 18.75
+    },
+    "zenmux\u0000openai/gpt-5.4-mini": {
+      "cached_read": null,
+      "in": 0.75,
+      "out": 4.5
+    },
+    "zenmux\u0000openai/gpt-5.4-nano": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 1.25
+    },
+    "zenmux\u0000openai/gpt-5.4-pro": {
+      "cached_read": null,
+      "in": 45.0,
+      "out": 225.0
+    },
+    "zenmux\u0000openai/gpt-5.5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 30.0
+    },
+    "zenmux\u0000openai/gpt-5.5-pro": {
+      "cached_read": null,
+      "in": 30.0,
+      "out": 180.0
+    },
+    "zenmux\u0000qwen/qwen3-coder-plus": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "zenmux\u0000qwen/qwen3-max": {
+      "cached_read": null,
+      "in": 1.2,
+      "out": 6.0
+    },
+    "zenmux\u0000qwen/qwen3.5-flash": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "zenmux\u0000qwen/qwen3.5-plus": {
+      "cached_read": null,
+      "in": 0.8,
+      "out": 4.8
+    },
+    "zenmux\u0000qwen/qwen3.6-plus": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "zenmux\u0000sapiens-ai/agnes-1.5-lite": {
+      "cached_read": null,
+      "in": 0.12,
+      "out": 0.6
+    },
+    "zenmux\u0000sapiens-ai/agnes-1.5-pro": {
+      "cached_read": null,
+      "in": 0.16,
+      "out": 0.8
+    },
+    "zenmux\u0000stepfun/step-3": {
+      "cached_read": null,
+      "in": 0.21,
+      "out": 0.57
+    },
+    "zenmux\u0000stepfun/step-3.5-flash": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "zenmux\u0000stepfun/step-3.5-flash-free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "zenmux\u0000tencent/hy3-preview": {
+      "cached_read": 0.058,
+      "in": 0.172,
+      "out": 0.572
+    },
+    "zenmux\u0000volcengine/doubao-seed-1.8": {
+      "cached_read": 0.02,
+      "in": 0.11,
+      "out": 0.28
+    },
+    "zenmux\u0000volcengine/doubao-seed-2.0-code": {
+      "cached_read": null,
+      "in": 0.9,
+      "out": 4.48
+    },
+    "zenmux\u0000volcengine/doubao-seed-2.0-lite": {
+      "cached_read": 0.02,
+      "in": 0.09,
+      "out": 0.51
+    },
+    "zenmux\u0000volcengine/doubao-seed-2.0-mini": {
+      "cached_read": 0.01,
+      "in": 0.03,
+      "out": 0.28
+    },
+    "zenmux\u0000volcengine/doubao-seed-2.0-pro": {
+      "cached_read": 0.09,
+      "in": 0.45,
+      "out": 2.24
+    },
+    "zenmux\u0000volcengine/doubao-seed-code": {
+      "cached_read": 0.03,
+      "in": 0.17,
+      "out": 1.12
+    },
+    "zenmux\u0000x-ai/grok-4": {
+      "cached_read": 0.75,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "zenmux\u0000x-ai/grok-4-fast": {
+      "cached_read": 0.05,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "zenmux\u0000x-ai/grok-4.1-fast": {
+      "cached_read": 0.05,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "zenmux\u0000x-ai/grok-4.1-fast-non-reasoning": {
+      "cached_read": 0.05,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "zenmux\u0000x-ai/grok-4.2-fast": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 9.0
+    },
+    "zenmux\u0000x-ai/grok-4.2-fast-non-reasoning": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 9.0
+    },
+    "zenmux\u0000x-ai/grok-code-fast-1": {
+      "cached_read": 0.02,
+      "in": 0.2,
+      "out": 1.5
+    },
+    "zenmux\u0000xiaomi/mimo-v2-flash": {
+      "cached_read": 0.01,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "zenmux\u0000xiaomi/mimo-v2-omni": {
+      "cached_read": 0.08,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "zenmux\u0000xiaomi/mimo-v2-pro": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "zenmux\u0000xiaomi/mimo-v2.5": {
+      "cached_read": 0.08,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "zenmux\u0000xiaomi/mimo-v2.5-pro": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "zenmux\u0000z-ai/glm-4.5": {
+      "cached_read": 0.07,
+      "in": 0.35,
+      "out": 1.54
+    },
+    "zenmux\u0000z-ai/glm-4.5-air": {
+      "cached_read": 0.02,
+      "in": 0.11,
+      "out": 0.56
+    },
+    "zenmux\u0000z-ai/glm-4.6": {
+      "cached_read": 0.07,
+      "in": 0.35,
+      "out": 1.54
+    },
+    "zenmux\u0000z-ai/glm-4.6v": {
+      "cached_read": 0.03,
+      "in": 0.14,
+      "out": 0.42
+    },
+    "zenmux\u0000z-ai/glm-4.6v-flash": {
+      "cached_read": 0.0043,
+      "in": 0.02,
+      "out": 0.21
+    },
+    "zenmux\u0000z-ai/glm-4.6v-flash-free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "zenmux\u0000z-ai/glm-4.7": {
+      "cached_read": 0.06,
+      "in": 0.28,
+      "out": 1.14
+    },
+    "zenmux\u0000z-ai/glm-4.7-flash-free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "zenmux\u0000z-ai/glm-4.7-flashx": {
+      "cached_read": 0.01,
+      "in": 0.07,
+      "out": 0.42
+    },
+    "zenmux\u0000z-ai/glm-5": {
+      "cached_read": 0.14,
+      "in": 0.58,
+      "out": 2.6
+    },
+    "zenmux\u0000z-ai/glm-5-turbo": {
+      "cached_read": null,
+      "in": 0.88,
+      "out": 3.48
+    },
+    "zenmux\u0000z-ai/glm-5.1": {
+      "cached_read": 0.1903,
+      "in": 0.8781,
+      "out": 3.5126
+    },
+    "zenmux\u0000z-ai/glm-5v-turbo": {
+      "cached_read": 0.1743,
+      "in": 0.726,
+      "out": 3.1946
+    },
+    "zhipuai\u0000glm-4.5": {
+      "cached_read": 0.11,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "zhipuai\u0000glm-4.5-air": {
+      "cached_read": 0.03,
+      "in": 0.2,
+      "out": 1.1
+    },
+    "zhipuai\u0000glm-4.5-flash": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "zhipuai\u0000glm-4.5v": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 1.8
+    },
+    "zhipuai\u0000glm-4.6": {
+      "cached_read": 0.11,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "zhipuai\u0000glm-4.6v": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.9
+    },
+    "zhipuai\u0000glm-4.7": {
+      "cached_read": 0.11,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "zhipuai\u0000glm-4.7-flash": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "zhipuai\u0000glm-4.7-flashx": {
+      "cached_read": 0.01,
+      "in": 0.07,
+      "out": 0.4
+    },
+    "zhipuai\u0000glm-5": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 3.2
+    },
+    "zhipuai\u0000glm-5.1": {
+      "cached_read": 1.3,
+      "in": 6.0,
+      "out": 24.0
+    },
+    "zhipuai\u0000glm-5v-turbo": {
+      "cached_read": 1.2,
+      "in": 5.0,
+      "out": 22.0
+    },
+    "zhipuai-coding-plan\u0000glm-4.5-air": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "zhipuai-coding-plan\u0000glm-4.6v": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.9
+    },
+    "zhipuai-coding-plan\u0000glm-4.7": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "zhipuai-coding-plan\u0000glm-5-turbo": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "zhipuai-coding-plan\u0000glm-5.1": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "zhipuai-coding-plan\u0000glm-5v-turbo": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    }
+  },
+  "pricing": {
+    "@cf/aisingapore/gemma-sea-lion-v4-27b-it": {
+      "cached_read": null,
+      "in": 0.351,
+      "out": 0.555
+    },
+    "@cf/deepseek-ai/deepseek-r1-distill-qwen-32b": {
+      "cached_read": null,
+      "in": 0.497,
+      "out": 4.881
+    },
+    "@cf/google/gemma-4-26b-a4b-it": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "@cf/ibm-granite/granite-4.0-h-micro": {
+      "cached_read": null,
+      "in": 0.017,
+      "out": 0.112
+    },
+    "@cf/meta/llama-3.1-8b-instruct-fp8": {
+      "cached_read": null,
+      "in": 0.152,
+      "out": 0.287
+    },
+    "@cf/meta/llama-3.2-11b-vision-instruct": {
+      "cached_read": null,
+      "in": 0.0485,
+      "out": 0.676
+    },
+    "@cf/meta/llama-3.2-1b-instruct": {
+      "cached_read": null,
+      "in": 0.027,
+      "out": 0.201
+    },
+    "@cf/meta/llama-3.2-3b-instruct": {
+      "cached_read": null,
+      "in": 0.0509,
+      "out": 0.335
+    },
+    "@cf/meta/llama-3.3-70b-instruct-fp8-fast": {
+      "cached_read": null,
+      "in": 0.293,
+      "out": 2.253
+    },
+    "@cf/meta/llama-4-scout-17b-16e-instruct": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 0.85
+    },
+    "@cf/meta/llama-guard-3-8b": {
+      "cached_read": null,
+      "in": 0.484,
+      "out": 0.03
+    },
+    "@cf/mistralai/mistral-small-3.1-24b-instruct": {
+      "cached_read": null,
+      "in": 0.351,
+      "out": 0.555
+    },
+    "@cf/moonshotai/kimi-k2.6": {
+      "cached_read": 0.16,
+      "in": 0.95,
+      "out": 4.0
+    },
+    "@cf/nvidia/nemotron-3-120b-a12b": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "@cf/openai/gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.35,
+      "out": 0.75
+    },
+    "@cf/openai/gpt-oss-20b": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.3
+    },
+    "@cf/qwen/qwen2.5-coder-32b-instruct": {
+      "cached_read": null,
+      "in": 0.66,
+      "out": 1.0
+    },
+    "@cf/qwen/qwen3-30b-a3b-fp8": {
+      "cached_read": null,
+      "in": 0.0509,
+      "out": 0.335
+    },
+    "@cf/qwen/qwq-32b": {
+      "cached_read": null,
+      "in": 0.66,
+      "out": 1.0
+    },
+    "@cf/zai-org/glm-4.7-flash": {
+      "cached_read": null,
+      "in": 0.0605,
+      "out": 0.4
+    },
+    "abacusai/dracarys-72b-instruct": {
+      "cached_read": null,
+      "in": 0.49299999999999994,
+      "out": 0.49299999999999994
+    },
+    "abacusai/dracarys-llama-3_1-70b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "abliterated-model": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 3.0
+    },
+    "accounts/fireworks/models/deepseek-v4-flash": {
+      "cached_read": 0.03,
+      "in": 0.14,
+      "out": 0.28
+    },
+    "accounts/fireworks/models/deepseek-v4-pro": {
+      "cached_read": 0.145,
+      "in": 1.74,
+      "out": 3.48
+    },
+    "accounts/fireworks/models/glm-5p1": {
+      "cached_read": 0.26,
+      "in": 1.4,
+      "out": 4.4
+    },
+    "accounts/fireworks/models/gpt-oss-120b": {
+      "cached_read": 0.015,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "accounts/fireworks/models/gpt-oss-20b": {
+      "cached_read": 0.035,
+      "in": 0.07,
+      "out": 0.3
+    },
+    "accounts/fireworks/models/kimi-k2p5": {
+      "cached_read": 0.1,
+      "in": 0.6,
+      "out": 3.0
+    },
+    "accounts/fireworks/models/kimi-k2p6": {
+      "cached_read": 0.16,
+      "in": 0.95,
+      "out": 4.0
+    },
+    "accounts/fireworks/models/minimax-m2p5": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "accounts/fireworks/models/minimax-m2p7": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "accounts/fireworks/models/qwen3p6-plus": {
+      "cached_read": 0.1,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "accounts/fireworks/routers/glm-5p1-fast": {
+      "cached_read": 0.52,
+      "in": 2.8,
+      "out": 8.8
+    },
+    "accounts/fireworks/routers/kimi-k2p6-fast": {
+      "cached_read": 0.3,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "accounts/fireworks/routers/kimi-k2p6-turbo": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "ai21-labs/ai21-jamba-1.5-large": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "ai21-labs/ai21-jamba-1.5-mini": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "ai21/jamba-large-1.7": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "aion-labs-aion-2-0": {
+      "cached_read": 0.25,
+      "in": 1.0,
+      "out": 2.0
+    },
+    "aion-labs/aion-1.0": {
+      "cached_read": null,
+      "in": 4.0,
+      "out": 8.0
+    },
+    "aion-labs/aion-1.0-mini": {
+      "cached_read": null,
+      "in": 0.7,
+      "out": 1.4
+    },
+    "aion-labs/aion-2.0": {
+      "cached_read": null,
+      "in": 0.8,
+      "out": 1.6
+    },
+    "aion-labs/aion-2.5": {
+      "cached_read": 0.35,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "aion-labs/aion-rp-llama-3.1-8b": {
+      "cached_read": null,
+      "in": 0.8,
+      "out": 1.6
+    },
+    "alfredpros/codellama-7b-instruct-solidity": {
+      "cached_read": null,
+      "in": 0.8,
+      "out": 1.2
+    },
+    "alibaba-nlp/tongyi-deepresearch-30b-a3b": {
+      "cached_read": null,
+      "in": 0.08,
+      "out": 0.24000000000000002
+    },
+    "alibaba-qwen3-32b": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 0.55
+    },
+    "alibaba/qwen-3-14b": {
+      "cached_read": null,
+      "in": 0.12,
+      "out": 0.24
+    },
+    "alibaba/qwen-3-235b": {
+      "cached_read": null,
+      "in": 0.22,
+      "out": 0.88
+    },
+    "alibaba/qwen-3-30b": {
+      "cached_read": null,
+      "in": 0.08,
+      "out": 0.29
+    },
+    "alibaba/qwen-3-32b": {
+      "cached_read": null,
+      "in": 0.16,
+      "out": 0.64
+    },
+    "alibaba/qwen-3.6-max-preview": {
+      "cached_read": 0.26,
+      "in": 1.3,
+      "out": 7.8
+    },
+    "alibaba/qwen3-235b-a22b-thinking": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 4.0
+    },
+    "alibaba/qwen3-coder": {
+      "cached_read": 0.3,
+      "in": 1.5,
+      "out": 7.5
+    },
+    "alibaba/qwen3-coder-30b-a3b": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "alibaba/qwen3-coder-next": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.2
+    },
+    "alibaba/qwen3-coder-plus": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "alibaba/qwen3-max": {
+      "cached_read": 0.24,
+      "in": 1.2,
+      "out": 6.0
+    },
+    "alibaba/qwen3-max-preview": {
+      "cached_read": 0.24,
+      "in": 1.2,
+      "out": 6.0
+    },
+    "alibaba/qwen3-max-thinking": {
+      "cached_read": 0.24,
+      "in": 1.2,
+      "out": 6.0
+    },
+    "alibaba/qwen3-next-80b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 1.2
+    },
+    "alibaba/qwen3-next-80b-a3b-thinking": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 1.2
+    },
+    "alibaba/qwen3-vl-235b-a22b-instruct": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 1.6
+    },
+    "alibaba/qwen3-vl-instruct": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 1.6
+    },
+    "alibaba/qwen3-vl-thinking": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 4.0
+    },
+    "alibaba/qwen3.5-flash": {
+      "cached_read": 0.001,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "alibaba/qwen3.5-plus": {
+      "cached_read": 0.04,
+      "in": 0.4,
+      "out": 2.4
+    },
+    "alibaba/qwen3.6-27b": {
+      "cached_read": null,
+      "in": 0.203,
+      "out": 2.24
+    },
+    "alibaba/qwen3.6-27b:thinking": {
+      "cached_read": null,
+      "in": 0.203,
+      "out": 2.24
+    },
+    "alibaba/qwen3.6-flash": {
+      "cached_read": null,
+      "in": 0.19,
+      "out": 1.16
+    },
+    "alibaba/qwen3.6-plus": {
+      "cached_read": 0.1,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "alibaba/qwen3.7-max": {
+      "cached_read": 0.25,
+      "in": 1.25,
+      "out": 3.75
+    },
+    "alibaba/qwen3.7-plus": {
+      "cached_read": 0.08,
+      "in": 0.4,
+      "out": 1.6
+    },
+    "alicloud-deepseek-v4-flash": {
+      "cached_read": 0.028,
+      "in": 0.14,
+      "out": 0.28
+    },
+    "alicloud-deepseek-v4-pro": {
+      "cached_read": 0.13,
+      "in": 1.69,
+      "out": 3.38
+    },
+    "alicloud-glm-5.1": {
+      "cached_read": 0.169,
+      "in": 0.84,
+      "out": 3.38
+    },
+    "all-mini-lm-l6-v2": {
+      "cached_read": null,
+      "in": 0.009,
+      "out": 0.0
+    },
+    "allam-2-7b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "allenai/olmo-3-32b-think": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.5
+    },
+    "amazon.nova-2-lite-v1:0": {
+      "cached_read": null,
+      "in": 0.33,
+      "out": 2.75
+    },
+    "amazon.nova-lite-v1:0": {
+      "cached_read": 0.015,
+      "in": 0.06,
+      "out": 0.24
+    },
+    "amazon.nova-micro-v1:0": {
+      "cached_read": 0.00875,
+      "in": 0.035,
+      "out": 0.14
+    },
+    "amazon.nova-pro-v1:0": {
+      "cached_read": 0.2,
+      "in": 0.8,
+      "out": 3.2
+    },
+    "amazon/nova-2-lite": {
+      "cached_read": 0.075,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "amazon/nova-2-lite-v1": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "amazon/nova-lite": {
+      "cached_read": 0.015,
+      "in": 0.06,
+      "out": 0.24
+    },
+    "amazon/nova-lite-v1": {
+      "cached_read": null,
+      "in": 0.06,
+      "out": 0.24
+    },
+    "amazon/nova-micro": {
+      "cached_read": 0.00875,
+      "in": 0.035,
+      "out": 0.14
+    },
+    "amazon/nova-micro-v1": {
+      "cached_read": null,
+      "in": 0.035,
+      "out": 0.14
+    },
+    "amazon/nova-premier-v1": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 12.5
+    },
+    "amazon/nova-pro": {
+      "cached_read": 0.2,
+      "in": 0.8,
+      "out": 3.2
+    },
+    "amazon/nova-pro-v1": {
+      "cached_read": null,
+      "in": 0.8,
+      "out": 3.2
+    },
+    "anthracite-org/magnum-v2-72b": {
+      "cached_read": null,
+      "in": 2.006,
+      "out": 2.992
+    },
+    "anthracite-org/magnum-v4-72b": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 5.0
+    },
+    "anthropic--claude-3-haiku": {
+      "cached_read": 0.03,
+      "in": 0.25,
+      "out": 1.25
+    },
+    "anthropic--claude-3-opus": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "anthropic--claude-3-sonnet": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "anthropic--claude-3.5-sonnet": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "anthropic--claude-3.7-sonnet": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "anthropic--claude-4-opus": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "anthropic--claude-4-sonnet": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "anthropic--claude-4.5-haiku": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "anthropic--claude-4.5-opus": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "anthropic--claude-4.5-sonnet": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "anthropic--claude-4.6-opus": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "anthropic--claude-4.6-sonnet": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "anthropic--claude-4.7-opus": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "anthropic-claude-3-opus": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "anthropic-claude-3.5-haiku": {
+      "cached_read": 0.08,
+      "in": 0.8,
+      "out": 4.0
+    },
+    "anthropic-claude-3.5-sonnet": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "anthropic-claude-3.7-sonnet": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "anthropic-claude-4.1-opus": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "anthropic-claude-4.5-haiku": {
+      "cached_read": 1.0,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "anthropic-claude-4.5-sonnet": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "anthropic-claude-4.6-sonnet": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "anthropic-claude-haiku-4.5": {
+      "cached_read": 1.0,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "anthropic-claude-opus-4": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "anthropic-claude-opus-4.5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "anthropic-claude-opus-4.6": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "anthropic-claude-opus-4.7": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "anthropic-claude-opus-4.8": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "anthropic-claude-sonnet-4": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "anthropic.claude-haiku-4-5-20251001-v1:0": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "anthropic.claude-opus-4-1-20250805-v1:0": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "anthropic.claude-opus-4-5-20251101-v1:0": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "anthropic.claude-opus-4-6-v1": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "anthropic.claude-opus-4-7": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "anthropic.claude-opus-4-8": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "anthropic.claude-sonnet-4-5-20250929-v1:0": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "anthropic.claude-sonnet-4-6": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "anthropic/claude-3-5-haiku": {
+      "cached_read": 0.08,
+      "in": 0.8,
+      "out": 4.0
+    },
+    "anthropic/claude-3-7-sonnet": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "anthropic/claude-3-7-sonnet-latest": {
+      "cached_read": 0.33,
+      "in": 3.3,
+      "out": 16.5
+    },
+    "anthropic/claude-3-haiku": {
+      "cached_read": 0.03,
+      "in": 0.25,
+      "out": 1.25
+    },
+    "anthropic/claude-3-opus": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "anthropic/claude-3-sonnet": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "anthropic/claude-3.5-haiku": {
+      "cached_read": 0.08,
+      "in": 0.8,
+      "out": 4.0
+    },
+    "anthropic/claude-3.5-sonnet": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "anthropic/claude-3.5-sonnet-20240620": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "anthropic/claude-3.7-sonnet": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "anthropic/claude-4-opus": {
+      "cached_read": null,
+      "in": 16.5,
+      "out": 82.5
+    },
+    "anthropic/claude-haiku-3": {
+      "cached_read": 0.021,
+      "in": 0.21,
+      "out": 1.1
+    },
+    "anthropic/claude-haiku-3.5": {
+      "cached_read": 0.068,
+      "in": 0.68,
+      "out": 3.4
+    },
+    "anthropic/claude-haiku-4-5": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "anthropic/claude-haiku-4-5-20251001": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "anthropic/claude-haiku-4.5": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "anthropic/claude-haiku-latest": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "anthropic/claude-opus-4": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "anthropic/claude-opus-4-1": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "anthropic/claude-opus-4-1-20250805": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "anthropic/claude-opus-4-20250514": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "anthropic/claude-opus-4-5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "anthropic/claude-opus-4-5-20251101": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "anthropic/claude-opus-4-6": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "anthropic/claude-opus-4-7": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "anthropic/claude-opus-4-8": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "anthropic/claude-opus-4.1": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "anthropic/claude-opus-4.5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "anthropic/claude-opus-4.6": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "anthropic/claude-opus-4.6-fast": {
+      "cached_read": 3.0,
+      "in": 30.0,
+      "out": 150.0
+    },
+    "anthropic/claude-opus-4.6:thinking": {
+      "cached_read": null,
+      "in": 4.998,
+      "out": 25.007
+    },
+    "anthropic/claude-opus-4.6:thinking:low": {
+      "cached_read": null,
+      "in": 4.998,
+      "out": 25.007
+    },
+    "anthropic/claude-opus-4.6:thinking:max": {
+      "cached_read": null,
+      "in": 4.998,
+      "out": 25.007
+    },
+    "anthropic/claude-opus-4.6:thinking:medium": {
+      "cached_read": null,
+      "in": 4.998,
+      "out": 25.007
+    },
+    "anthropic/claude-opus-4.7": {
+      "cached_read": 0.45,
+      "in": 4.5,
+      "out": 22.5
+    },
+    "anthropic/claude-opus-4.7-fast": {
+      "cached_read": 3.0,
+      "in": 30.0,
+      "out": 150.0
+    },
+    "anthropic/claude-opus-4.7:thinking": {
+      "cached_read": 0.4998,
+      "in": 4.998,
+      "out": 25.007
+    },
+    "anthropic/claude-opus-4.8": {
+      "cached_read": 0.4998,
+      "in": 4.998,
+      "out": 25.007
+    },
+    "anthropic/claude-opus-4.8-fast": {
+      "cached_read": 1.0,
+      "in": 10.0,
+      "out": 50.0
+    },
+    "anthropic/claude-opus-4.8:thinking": {
+      "cached_read": 0.4998,
+      "in": 4.998,
+      "out": 25.007
+    },
+    "anthropic/claude-opus-latest": {
+      "cached_read": 0.4998,
+      "in": 4.998,
+      "out": 25.007
+    },
+    "anthropic/claude-sonnet-3.5": {
+      "cached_read": 0.26,
+      "in": 2.6,
+      "out": 13.0
+    },
+    "anthropic/claude-sonnet-3.5-june": {
+      "cached_read": 0.26,
+      "in": 2.6,
+      "out": 13.0
+    },
+    "anthropic/claude-sonnet-3.7": {
+      "cached_read": 0.26,
+      "in": 2.6,
+      "out": 13.0
+    },
+    "anthropic/claude-sonnet-4": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "anthropic/claude-sonnet-4-20250514": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "anthropic/claude-sonnet-4-5": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "anthropic/claude-sonnet-4-5-20250929": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "anthropic/claude-sonnet-4-6": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "anthropic/claude-sonnet-4.5": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "anthropic/claude-sonnet-4.6": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "anthropic/claude-sonnet-4.6:thinking": {
+      "cached_read": null,
+      "in": 2.992,
+      "out": 14.993999999999998
+    },
+    "anthropic/claude-sonnet-latest": {
+      "cached_read": 0.2992,
+      "in": 2.992,
+      "out": 14.994
+    },
+    "arcee-ai/coder-large": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 0.8
+    },
+    "arcee-ai/maestro-reasoning": {
+      "cached_read": null,
+      "in": 0.9,
+      "out": 3.3
+    },
+    "arcee-ai/spotlight": {
+      "cached_read": null,
+      "in": 0.18,
+      "out": 0.18
+    },
+    "arcee-ai/trinity-large-preview": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 1.0
+    },
+    "arcee-ai/trinity-large-thinking": {
+      "cached_read": null,
+      "in": 0.22,
+      "out": 0.85
+    },
+    "arcee-ai/trinity-mini": {
+      "cached_read": null,
+      "in": 0.045,
+      "out": 0.15
+    },
+    "arcee-ai/virtuoso-large": {
+      "cached_read": null,
+      "in": 0.75,
+      "out": 1.2
+    },
+    "arcee-trinity-large-thinking": {
+      "cached_read": 0.06,
+      "in": 0.25,
+      "out": 0.9
+    },
+    "arcee_ai/afm/models/trinity-mini": {
+      "cached_read": null,
+      "in": 0.045,
+      "out": 0.15
+    },
+    "ascend-tribe/pangu-pro-moe": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.6
+    },
+    "asi1-mini": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 1.0
+    },
+    "au.anthropic.claude-haiku-4-5-20251001-v1:0": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "au.anthropic.claude-opus-4-6-v1": {
+      "cached_read": 1.65,
+      "in": 16.5,
+      "out": 82.5
+    },
+    "au.anthropic.claude-opus-4-8": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "au.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "au.anthropic.claude-sonnet-4-6": {
+      "cached_read": 0.33,
+      "in": 3.3,
+      "out": 16.5
+    },
+    "auto": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "auto-model": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "auto-model-basic": {
+      "cached_read": null,
+      "in": 9.996,
+      "out": 19.992
+    },
+    "auto-model-premium": {
+      "cached_read": null,
+      "in": 9.996,
+      "out": 19.992
+    },
+    "auto-model-standard": {
+      "cached_read": null,
+      "in": 9.996,
+      "out": 19.992
+    },
+    "azure-gpt-4-turbo": {
+      "cached_read": null,
+      "in": 9.996,
+      "out": 30.005
+    },
+    "azure-gpt-4o": {
+      "cached_read": null,
+      "in": 2.499,
+      "out": 9.996
+    },
+    "azure-gpt-4o-mini": {
+      "cached_read": null,
+      "in": 0.1496,
+      "out": 0.595
+    },
+    "azure-o1": {
+      "cached_read": null,
+      "in": 14.994,
+      "out": 59.993
+    },
+    "azure-o3-mini": {
+      "cached_read": null,
+      "in": 1.088,
+      "out": 4.3996
+    },
+    "baai/bge-m3": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "baichuan-m2": {
+      "cached_read": null,
+      "in": 15.73,
+      "out": 15.73
+    },
+    "baichuan/baichuan-m2-32b": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.07
+    },
+    "baichuan4-air": {
+      "cached_read": null,
+      "in": 0.157,
+      "out": 0.157
+    },
+    "baichuan4-turbo": {
+      "cached_read": null,
+      "in": 2.42,
+      "out": 2.42
+    },
+    "baidu/cobuddy:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "baidu/ernie-4.5-21b-a3b": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.28
+    },
+    "baidu/ernie-4.5-21b-a3b-thinking": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.28
+    },
+    "baidu/ernie-4.5-300b-a47b": {
+      "cached_read": null,
+      "in": 0.28,
+      "out": 1.1
+    },
+    "baidu/ernie-4.5-300b-a47b-paddle": {
+      "cached_read": null,
+      "in": 0.28,
+      "out": 1.1
+    },
+    "baidu/ernie-4.5-vl-28b-a3b": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.56
+    },
+    "baidu/ernie-4.5-vl-28b-a3b-thinking": {
+      "cached_read": null,
+      "in": 0.39,
+      "out": 0.39
+    },
+    "baidu/ernie-4.5-vl-424b-a47b": {
+      "cached_read": null,
+      "in": 0.42,
+      "out": 1.25
+    },
+    "baidu/ernie-5.0-thinking-preview": {
+      "cached_read": null,
+      "in": 0.84,
+      "out": 3.37
+    },
+    "baidu/qianfan-ocr-fast": {
+      "cached_read": null,
+      "in": 0.68,
+      "out": 2.81
+    },
+    "baseten/kimi-k2-instruct-fp4": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 2.0
+    },
+    "bge-m3": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.0
+    },
+    "bge-multilingual-gemma2": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.0
+    },
+    "bge-reranker-v2-m3": {
+      "cached_read": null,
+      "in": 0.01,
+      "out": 0.0
+    },
+    "big-pickle": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "black-forest-labs/flux.1-dev": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "black-forest-labs/flux.2-klein-4b": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 1.0
+    },
+    "black-forest-labs/flux_1-kontext-dev": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "black-forest-labs/flux_1-schnell": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "black-forest-labs/flux_2-klein-4b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "brave": {
+      "cached_read": null,
+      "in": 5.0,
+      "out": 5.0
+    },
+    "brave-pro": {
+      "cached_read": null,
+      "in": 5.0,
+      "out": 5.0
+    },
+    "brave-research": {
+      "cached_read": null,
+      "in": 5.0,
+      "out": 5.0
+    },
+    "bytedance-seed/seed-1.6": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "bytedance-seed/seed-1.6-flash": {
+      "cached_read": null,
+      "in": 0.075,
+      "out": 0.3
+    },
+    "bytedance-seed/seed-2.0-lite": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "bytedance-seed/seed-2.0-mini": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "bytedance-seed/seed-oss-36b-instruct": {
+      "cached_read": null,
+      "in": 0.21,
+      "out": 0.57
+    },
+    "bytedance/seed-1.6": {
+      "cached_read": 0.05,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "bytedance/seed-1.8": {
+      "cached_read": 0.05,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "bytedance/seed-oss-36b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "bytedance/ui-tars-1.5-7b": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.2
+    },
+    "canopylabs/orpheus-arabic-saudi": {
+      "cached_read": null,
+      "in": 40.0,
+      "out": 0.0
+    },
+    "canopylabs/orpheus-v1-english": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "cerebras-llama-4-maverick-17b-128e-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "cerebras-llama-4-scout-17b-16e-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "cerebras/gpt-oss-120b-cs": {
+      "cached_read": null,
+      "in": 0.35,
+      "out": 0.75
+    },
+    "cerebras/llama-3.1-8b-cs": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "chatgpt-4o-latest": {
+      "cached_read": null,
+      "in": 5.0,
+      "out": 15.0
+    },
+    "chutesai/mistral-small-3.2-24b-instruct-2506": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.4
+    },
+    "clarifai/main/models/mm-poly-8b": {
+      "cached_read": null,
+      "in": 0.658,
+      "out": 1.11
+    },
+    "claude-3-5-haiku": {
+      "cached_read": 0.08,
+      "in": 0.8,
+      "out": 4.0
+    },
+    "claude-3-5-haiku-20241022": {
+      "cached_read": null,
+      "in": 0.8,
+      "out": 4.0
+    },
+    "claude-3-5-haiku-latest": {
+      "cached_read": null,
+      "in": 0.8,
+      "out": 4.0
+    },
+    "claude-3-5-haiku@20241022": {
+      "cached_read": 0.08,
+      "in": 0.8,
+      "out": 4.0
+    },
+    "claude-3-5-sonnet-20240620": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "claude-3-5-sonnet-20241022": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "claude-3-5-sonnet@20241022": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "claude-3-7-sonnet": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "claude-3-7-sonnet-20250219": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "claude-3-7-sonnet@20250219": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "claude-3-haiku-20240307": {
+      "cached_read": 0.03,
+      "in": 0.25,
+      "out": 1.25
+    },
+    "claude-3-opus": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "claude-3-opus-20240229": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "claude-3-sonnet-20240229": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "claude-3.5-haiku": {
+      "cached_read": 0.08,
+      "in": 0.7999999999999999,
+      "out": 4.0
+    },
+    "claude-3.5-sonnet-v2": {
+      "cached_read": 0.30000000000000004,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "claude-3.7-sonnet": {
+      "cached_read": 0.30000000000000004,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "claude-4-5-sonnet": {
+      "cached_read": null,
+      "in": 3.259,
+      "out": 16.296
+    },
+    "claude-4-6-sonnet": {
+      "cached_read": null,
+      "in": 3.59,
+      "out": 17.92
+    },
+    "claude-4.5-haiku": {
+      "cached_read": 0.09999999999999999,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "claude-4.5-opus": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "claude-4.5-sonnet": {
+      "cached_read": 0.30000000000000004,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "claude-haiku-4-5": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "claude-haiku-4-5-20251001": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "claude-haiku-4-5-20251001-thinking": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "claude-haiku-4-5@20251001": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "claude-haiku-4.5": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "claude-opus-4": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "claude-opus-4-0": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "claude-opus-4-1": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "claude-opus-4-1-20250805": {
+      "cached_read": null,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "claude-opus-4-1-20250805-thinking": {
+      "cached_read": null,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "claude-opus-4-1-thinking": {
+      "cached_read": null,
+      "in": 14.994,
+      "out": 75.004
+    },
+    "claude-opus-4-1-thinking:1024": {
+      "cached_read": null,
+      "in": 14.994,
+      "out": 75.004
+    },
+    "claude-opus-4-1-thinking:32000": {
+      "cached_read": null,
+      "in": 14.994,
+      "out": 75.004
+    },
+    "claude-opus-4-1-thinking:32768": {
+      "cached_read": null,
+      "in": 14.994,
+      "out": 75.004
+    },
+    "claude-opus-4-1-thinking:8192": {
+      "cached_read": null,
+      "in": 14.994,
+      "out": 75.004
+    },
+    "claude-opus-4-1@20250805": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "claude-opus-4-20250514": {
+      "cached_read": null,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "claude-opus-4-5": {
+      "cached_read": null,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "claude-opus-4-5-20251101": {
+      "cached_read": null,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "claude-opus-4-5-20251101-thinking": {
+      "cached_read": null,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "claude-opus-4-5-20251101:thinking": {
+      "cached_read": null,
+      "in": 4.998,
+      "out": 25.007
+    },
+    "claude-opus-4-5@20251101": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "claude-opus-4-6": {
+      "cached_read": null,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "claude-opus-4-6-fast": {
+      "cached_read": 3.6,
+      "in": 36.0,
+      "out": 180.0
+    },
+    "claude-opus-4-6-think": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "claude-opus-4-6-thinking": {
+      "cached_read": null,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "claude-opus-4-6@default": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "claude-opus-4-7": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "claude-opus-4-7-fast": {
+      "cached_read": 3.6,
+      "in": 36.0,
+      "out": 180.0
+    },
+    "claude-opus-4-7-think": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "claude-opus-4-7@default": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "claude-opus-4-8": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "claude-opus-4-8-fast": {
+      "cached_read": 1.2,
+      "in": 12.0,
+      "out": 60.0
+    },
+    "claude-opus-4-8@default": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "claude-opus-4-thinking": {
+      "cached_read": null,
+      "in": 14.994,
+      "out": 75.004
+    },
+    "claude-opus-4-thinking:1024": {
+      "cached_read": null,
+      "in": 14.994,
+      "out": 75.004
+    },
+    "claude-opus-4-thinking:32000": {
+      "cached_read": null,
+      "in": 14.994,
+      "out": 75.004
+    },
+    "claude-opus-4-thinking:32768": {
+      "cached_read": null,
+      "in": 14.994,
+      "out": 75.004
+    },
+    "claude-opus-4-thinking:8192": {
+      "cached_read": null,
+      "in": 14.994,
+      "out": 75.004
+    },
+    "claude-opus-4.5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "claude-opus-4.6": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "claude-opus-4.7": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "claude-opus-4.8": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "claude-opus-4@20250514": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "claude-opus4-5": {
+      "cached_read": null,
+      "in": 5.98,
+      "out": 29.89
+    },
+    "claude-opus4-6": {
+      "cached_read": null,
+      "in": 5.98,
+      "out": 29.89
+    },
+    "claude-opus4-7": {
+      "cached_read": 0.56,
+      "in": 5.6,
+      "out": 27.99
+    },
+    "claude-sonnet-4": {
+      "cached_read": null,
+      "in": 3.307,
+      "out": 16.536
+    },
+    "claude-sonnet-4-0": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "claude-sonnet-4-20250514": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "claude-sonnet-4-5": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "claude-sonnet-4-5-20250929": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "claude-sonnet-4-5-20250929-thinking": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "claude-sonnet-4-5@20250929": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "claude-sonnet-4-6": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "claude-sonnet-4-6-think": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "claude-sonnet-4-6-thinking": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "claude-sonnet-4-6@default": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "claude-sonnet-4-thinking": {
+      "cached_read": null,
+      "in": 2.992,
+      "out": 14.994
+    },
+    "claude-sonnet-4-thinking:1024": {
+      "cached_read": null,
+      "in": 2.992,
+      "out": 14.994
+    },
+    "claude-sonnet-4-thinking:32768": {
+      "cached_read": null,
+      "in": 2.992,
+      "out": 14.994
+    },
+    "claude-sonnet-4-thinking:64000": {
+      "cached_read": null,
+      "in": 2.992,
+      "out": 14.994
+    },
+    "claude-sonnet-4-thinking:8192": {
+      "cached_read": null,
+      "in": 2.992,
+      "out": 14.994
+    },
+    "claude-sonnet-4.5": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "claude-sonnet-4.6": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "claude-sonnet-4@20250514": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "claudinio": {
+      "cached_read": 0.15,
+      "in": 0.5,
+      "out": 2.0
+    },
+    "claw-high": {
+      "cached_read": null,
+      "in": 4.998,
+      "out": 25.007
+    },
+    "claw-low": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 1.5
+    },
+    "claw-medium": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "codestral-2501": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.9
+    },
+    "codestral-2508": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 0.9
+    },
+    "codestral-latest": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.9
+    },
+    "codex-mini": {
+      "cached_read": 0.375,
+      "in": 1.5,
+      "out": 6.0
+    },
+    "coding-glm-5.1": {
+      "cached_read": 0.013,
+      "in": 0.06,
+      "out": 0.22
+    },
+    "coding-glm-5.1-free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "coding-minimax-m2.7": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "coding-minimax-m2.7-free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "coding-minimax-m2.7-highspeed": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "coding-xiaomi-mimo-v2.5": {
+      "cached_read": 0.016,
+      "in": 0.08,
+      "out": 0.4
+    },
+    "coding-xiaomi-mimo-v2.5-pro": {
+      "cached_read": 0.04,
+      "in": 0.2,
+      "out": 0.6
+    },
+    "cognitivecomputations/dolphin-2.9.2-qwen2-72b": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "cognitivecomputations/dolphin-mistral-24b-venice-edition:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "cohere-command-a": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "cohere-command-r-08-2024": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "cohere-command-r-plus-08-2024": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "cohere-embed-v-4-0": {
+      "cached_read": null,
+      "in": 0.12,
+      "out": 0.0
+    },
+    "cohere-embed-v3-english": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.0
+    },
+    "cohere-embed-v3-multilingual": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.0
+    },
+    "cohere/cohere-command-a": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "cohere/cohere-command-r": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "cohere/cohere-command-r-08-2024": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "cohere/cohere-command-r-plus": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "cohere/cohere-command-r-plus-08-2024": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "cohere/command-a": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "cohere/command-a-03-2025": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "cohere/command-r": {
+      "cached_read": null,
+      "in": 0.476,
+      "out": 1.428
+    },
+    "cohere/command-r-08-2024": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "cohere/command-r-plus-08-2024": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "cohere/command-r7b-12-2024": {
+      "cached_read": null,
+      "in": 0.0375,
+      "out": 0.15
+    },
+    "command-a-03-2025": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "command-a-plus-05-2026": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "command-a-reasoning-08-2025": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "command-a-translate-08-2025": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "command-a-vision-07-2025": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "command-r-08-2024": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "command-r-plus-08-2024": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "command-r7b-12-2024": {
+      "cached_read": null,
+      "in": 0.0375,
+      "out": 0.15
+    },
+    "command-r7b-arabic-02-2025": {
+      "cached_read": null,
+      "in": 0.0375,
+      "out": 0.15
+    },
+    "core42/jais-30b-chat": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "cortecs/llama-3.3-70b-instruct-fp8-dynamic": {
+      "cached_read": null,
+      "in": 0.49,
+      "out": 0.71
+    },
+    "custom": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "databricks-claude-haiku-4-5": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "databricks-claude-opus-4-1": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "databricks-claude-opus-4-5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "databricks-claude-opus-4-6": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "databricks-claude-opus-4-7": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "databricks-claude-sonnet-4": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "databricks-claude-sonnet-4-5": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "databricks-claude-sonnet-4-6": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "databricks-gemini-2-5-flash": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "databricks-gemini-2-5-pro": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "databricks-gemini-3-1-flash-lite": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 1.5
+    },
+    "databricks-gemini-3-1-pro": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "databricks-gemini-3-flash": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "databricks-gemini-3-pro": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "databricks-gpt-5": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "databricks-gpt-5-1": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "databricks-gpt-5-2": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "databricks-gpt-5-4": {
+      "cached_read": 0.25,
+      "in": 2.5,
+      "out": 15.0
+    },
+    "databricks-gpt-5-4-mini": {
+      "cached_read": 0.075,
+      "in": 0.75,
+      "out": 4.5
+    },
+    "databricks-gpt-5-4-nano": {
+      "cached_read": 0.02,
+      "in": 0.2,
+      "out": 1.25
+    },
+    "databricks-gpt-5-5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 30.0
+    },
+    "databricks-gpt-5-mini": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "databricks-gpt-5-nano": {
+      "cached_read": 0.005,
+      "in": 0.05,
+      "out": 0.4
+    },
+    "databricks-gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.072,
+      "out": 0.28
+    },
+    "databricks-gpt-oss-20b": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.2
+    },
+    "deep-deepseek-v4-flash": {
+      "cached_read": 0.0308,
+      "in": 0.154,
+      "out": 0.308
+    },
+    "deep-deepseek-v4-pro": {
+      "cached_read": 0.004302,
+      "in": 0.478,
+      "out": 0.956
+    },
+    "deepclaude": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "deepcogito/cogito-v1-preview-qwen-32b": {
+      "cached_read": null,
+      "in": 1.7999999999999998,
+      "out": 1.7999999999999998
+    },
+    "deepcogito/cogito-v2.1-671b": {
+      "cached_read": null,
+      "in": 1.25,
+      "out": 1.25
+    },
+    "deepseek-3.2": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.6
+    },
+    "deepseek-ai/deepseek-ocr": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "deepseek-ai/deepseek-ocr/models/deepseek-ocr": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.7
+    },
+    "deepseek-ai/deepseek-r1": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 7.0
+    },
+    "deepseek-ai/deepseek-r1-0528": {
+      "cached_read": 0.35,
+      "in": 0.5,
+      "out": 2.15
+    },
+    "deepseek-ai/deepseek-r1-0528-tee": {
+      "cached_read": 0.225,
+      "in": 0.45,
+      "out": 2.15
+    },
+    "deepseek-ai/deepseek-r1-distill-llama-70b": {
+      "cached_read": 0.0136,
+      "in": 0.0272,
+      "out": 0.1087
+    },
+    "deepseek-ai/deepseek-r1-distill-qwen-14b": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "deepseek-ai/deepseek-r1-distill-qwen-32b": {
+      "cached_read": null,
+      "in": 0.18,
+      "out": 0.18
+    },
+    "deepseek-ai/deepseek-v3": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 1.0
+    },
+    "deepseek-ai/deepseek-v3-0324": {
+      "cached_read": null,
+      "in": 0.77,
+      "out": 0.77
+    },
+    "deepseek-ai/deepseek-v3-0324-tee": {
+      "cached_read": 0.125,
+      "in": 0.25,
+      "out": 1.0
+    },
+    "deepseek-ai/deepseek-v3-1": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 1.7
+    },
+    "deepseek-ai/deepseek-v3.1": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "deepseek-ai/deepseek-v3.1-maas": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 1.7
+    },
+    "deepseek-ai/deepseek-v3.1-tee": {
+      "cached_read": 0.135,
+      "in": 0.27,
+      "out": 1.0
+    },
+    "deepseek-ai/deepseek-v3.1-terminus": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 1.0
+    },
+    "deepseek-ai/deepseek-v3.1-terminus:thinking": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 0.7
+    },
+    "deepseek-ai/deepseek-v3.1:thinking": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.7
+    },
+    "deepseek-ai/deepseek-v3.2": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 0.4
+    },
+    "deepseek-ai/deepseek-v3.2-exp": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 0.4
+    },
+    "deepseek-ai/deepseek-v3.2-exp-thinking": {
+      "cached_read": null,
+      "in": 0.27999999999999997,
+      "out": 0.42000000000000004
+    },
+    "deepseek-ai/deepseek-v3.2-fast": {
+      "cached_read": 0.04,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "deepseek-ai/deepseek-v3.2-maas": {
+      "cached_read": 0.056,
+      "in": 0.56,
+      "out": 1.68
+    },
+    "deepseek-ai/deepseek-v3.2-tee": {
+      "cached_read": 0.14,
+      "in": 0.28,
+      "out": 0.42
+    },
+    "deepseek-ai/deepseek-v4-flash": {
+      "cached_read": 0.02,
+      "in": 0.1,
+      "out": 0.2
+    },
+    "deepseek-ai/deepseek-v4-pro": {
+      "cached_read": 0.15,
+      "in": 1.74,
+      "out": 3.48
+    },
+    "deepseek-ai/deepseek-vl2": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.15
+    },
+    "deepseek-chat": {
+      "cached_read": null,
+      "in": 0.29,
+      "out": 0.43
+    },
+    "deepseek-chat-cheaper": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 0.7
+    },
+    "deepseek-math-v2": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "deepseek-r1": {
+      "cached_read": null,
+      "in": 0.574,
+      "out": 2.294
+    },
+    "deepseek-r1-0528": {
+      "cached_read": null,
+      "in": 0.574,
+      "out": 2.294
+    },
+    "deepseek-r1-distill-llama-70b": {
+      "cached_read": null,
+      "in": 0.287,
+      "out": 0.861
+    },
+    "deepseek-r1-distill-llama-8b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "deepseek-r1-distill-qwen-1-5b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "deepseek-r1-distill-qwen-14b": {
+      "cached_read": null,
+      "in": 0.144,
+      "out": 0.431
+    },
+    "deepseek-r1-distill-qwen-32b": {
+      "cached_read": null,
+      "in": 0.287,
+      "out": 0.861
+    },
+    "deepseek-r1-distill-qwen-7b": {
+      "cached_read": null,
+      "in": 0.072,
+      "out": 0.144
+    },
+    "deepseek-r1-sambanova": {
+      "cached_read": null,
+      "in": 4.998,
+      "out": 6.987
+    },
+    "deepseek-reasoner": {
+      "cached_read": null,
+      "in": 0.29,
+      "out": 0.43
+    },
+    "deepseek-reasoner-cheaper": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 1.7
+    },
+    "deepseek-tng-r1t2-chimera": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "deepseek-v3": {
+      "cached_read": null,
+      "in": 0.287,
+      "out": 1.147
+    },
+    "deepseek-v3-0324": {
+      "cached_read": null,
+      "in": 1.14,
+      "out": 4.56
+    },
+    "deepseek-v3-1": {
+      "cached_read": null,
+      "in": 0.574,
+      "out": 1.721
+    },
+    "deepseek-v3-2-exp": {
+      "cached_read": null,
+      "in": 0.287,
+      "out": 0.431
+    },
+    "deepseek-v3.1": {
+      "cached_read": null,
+      "in": 0.56,
+      "out": 1.68
+    },
+    "deepseek-v3.1-terminus": {
+      "cached_read": 0.21600000000000003,
+      "in": 0.27,
+      "out": 1.0
+    },
+    "deepseek-v3.2": {
+      "cached_read": null,
+      "in": 0.29,
+      "out": 0.43
+    },
+    "deepseek-v3.2-speciale": {
+      "cached_read": null,
+      "in": 0.58,
+      "out": 1.68
+    },
+    "deepseek-v3.2-thinking": {
+      "cached_read": null,
+      "in": 0.29,
+      "out": 0.43
+    },
+    "deepseek-v4-flash": {
+      "cached_read": 0.0028,
+      "in": 0.14,
+      "out": 0.28
+    },
+    "deepseek-v4-flash-free": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "deepseek-v4-pro": {
+      "cached_read": 0.003625,
+      "in": 0.435,
+      "out": 0.87
+    },
+    "deepseek-v4-pro-lightning": {
+      "cached_read": 0.02,
+      "in": 0.8,
+      "out": 1.6
+    },
+    "deepseek.r1-v1:0": {
+      "cached_read": null,
+      "in": 1.35,
+      "out": 5.4
+    },
+    "deepseek.v3-v1:0": {
+      "cached_read": null,
+      "in": 0.58,
+      "out": 1.68
+    },
+    "deepseek.v3.2": {
+      "cached_read": null,
+      "in": 0.62,
+      "out": 1.85
+    },
+    "deepseek/deepseek-chat": {
+      "cached_read": 0.15,
+      "in": 0.32,
+      "out": 0.89
+    },
+    "deepseek/deepseek-chat-v3-0324": {
+      "cached_read": 0.095,
+      "in": 0.2,
+      "out": 0.77
+    },
+    "deepseek/deepseek-chat-v3.1": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.75
+    },
+    "deepseek/deepseek-latest": {
+      "cached_read": 0.11,
+      "in": 1.1,
+      "out": 2.2
+    },
+    "deepseek/deepseek-ocr": {
+      "cached_read": null,
+      "in": 0.03,
+      "out": 0.03
+    },
+    "deepseek/deepseek-ocr-2": {
+      "cached_read": null,
+      "in": 0.03,
+      "out": 0.03
+    },
+    "deepseek/deepseek-prover-v2-671b": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 2.5
+    },
+    "deepseek/deepseek-r1": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "deepseek/deepseek-r1-0528": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "deepseek/deepseek-r1-0528-qwen3-8b": {
+      "cached_read": null,
+      "in": 0.06,
+      "out": 0.09
+    },
+    "deepseek/deepseek-r1-distill-llama-70b": {
+      "cached_read": 0.015,
+      "in": 0.7,
+      "out": 0.8
+    },
+    "deepseek/deepseek-r1-distill-qwen-14b": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.15
+    },
+    "deepseek/deepseek-r1-distill-qwen-32b": {
+      "cached_read": null,
+      "in": 0.29,
+      "out": 0.29
+    },
+    "deepseek/deepseek-r1-turbo": {
+      "cached_read": null,
+      "in": 0.7,
+      "out": 2.5
+    },
+    "deepseek/deepseek-reasoner": {
+      "cached_read": 0.028,
+      "in": 0.435,
+      "out": 0.87
+    },
+    "deepseek/deepseek-v3": {
+      "cached_read": 0.135,
+      "in": 0.27,
+      "out": 1.12
+    },
+    "deepseek/deepseek-v3-0324": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "deepseek/deepseek-v3-turbo": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 1.3
+    },
+    "deepseek/deepseek-v3.1": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 1.66
+    },
+    "deepseek/deepseek-v3.1-terminus": {
+      "cached_read": 0.13,
+      "in": 0.21,
+      "out": 0.79
+    },
+    "deepseek/deepseek-v3.2": {
+      "cached_read": 0.125,
+      "in": 0.26,
+      "out": 0.38
+    },
+    "deepseek/deepseek-v3.2-exp": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 0.41
+    },
+    "deepseek/deepseek-v3.2-speciale": {
+      "cached_read": 0.135,
+      "in": 0.4,
+      "out": 1.2
+    },
+    "deepseek/deepseek-v3.2-thinking": {
+      "cached_read": null,
+      "in": 0.62,
+      "out": 1.85
+    },
+    "deepseek/deepseek-v3.2:thinking": {
+      "cached_read": null,
+      "in": 0.27999999999999997,
+      "out": 0.42000000000000004
+    },
+    "deepseek/deepseek-v4-flash": {
+      "cached_read": 0.0028,
+      "in": 0.14,
+      "out": 0.28
+    },
+    "deepseek/deepseek-v4-flash:thinking": {
+      "cached_read": 0.028,
+      "in": 0.14,
+      "out": 0.28
+    },
+    "deepseek/deepseek-v4-pro": {
+      "cached_read": 0.003625,
+      "in": 0.435,
+      "out": 0.87
+    },
+    "deepseek/deepseek-v4-pro-cheaper": {
+      "cached_read": 0.003625,
+      "in": 0.435,
+      "out": 0.87
+    },
+    "deepseek/deepseek-v4-pro-cheaper:thinking": {
+      "cached_read": 0.003625,
+      "in": 0.435,
+      "out": 0.87
+    },
+    "deepseek/deepseek-v4-pro:thinking": {
+      "cached_read": 0.11,
+      "in": 1.1,
+      "out": 2.2
+    },
+    "devstral-2-123b-instruct-2512": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "devstral-2512": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "devstral-latest": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "devstral-medium-2507": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "devstral-medium-latest": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "devstral-small-2505": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "devstral-small-2507": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "devstral-small-2512": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "dmind/dmind-1": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.6
+    },
+    "dmind/dmind-1-mini": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.4
+    },
+    "doctor-shotgun/ms3.2-24b-magnum-diamond": {
+      "cached_read": null,
+      "in": 0.49299999999999994,
+      "out": 0.49299999999999994
+    },
+    "doubao-1-5-thinking-pro-250415": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.4
+    },
+    "doubao-1-5-thinking-pro-vision-250415": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.4
+    },
+    "doubao-1-5-thinking-vision-pro-250428": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 1.43
+    },
+    "doubao-1.5-pro-256k": {
+      "cached_read": null,
+      "in": 0.799,
+      "out": 1.445
+    },
+    "doubao-1.5-pro-32k": {
+      "cached_read": null,
+      "in": 0.1343,
+      "out": 0.3349
+    },
+    "doubao-1.5-vision-pro-32k": {
+      "cached_read": null,
+      "in": 0.459,
+      "out": 1.377
+    },
+    "doubao-seed-1-6-250615": {
+      "cached_read": null,
+      "in": 0.204,
+      "out": 0.51
+    },
+    "doubao-seed-1-6-flash-250615": {
+      "cached_read": null,
+      "in": 0.0374,
+      "out": 0.374
+    },
+    "doubao-seed-1-6-thinking-250615": {
+      "cached_read": null,
+      "in": 0.204,
+      "out": 2.04
+    },
+    "doubao-seed-1-6-thinking-250715": {
+      "cached_read": null,
+      "in": 0.121,
+      "out": 1.21
+    },
+    "doubao-seed-1-6-vision-250815": {
+      "cached_read": null,
+      "in": 0.114,
+      "out": 1.143
+    },
+    "doubao-seed-1-8-251215": {
+      "cached_read": null,
+      "in": 0.114,
+      "out": 0.286
+    },
+    "doubao-seed-2-0-code-preview": {
+      "cached_read": 0.09644,
+      "in": 0.48,
+      "out": 2.41
+    },
+    "doubao-seed-2-0-code-preview-260215": {
+      "cached_read": null,
+      "in": 0.782,
+      "out": 3.893
+    },
+    "doubao-seed-2-0-lite-260215": {
+      "cached_read": null,
+      "in": 0.1462,
+      "out": 0.8738
+    },
+    "doubao-seed-2-0-lite-260428": {
+      "cached_read": 0.01692,
+      "in": 0.08,
+      "out": 0.51
+    },
+    "doubao-seed-2-0-mini-260215": {
+      "cached_read": null,
+      "in": 0.0493,
+      "out": 0.4845
+    },
+    "doubao-seed-2-0-mini-260428": {
+      "cached_read": 0.00564,
+      "in": 0.03,
+      "out": 0.28
+    },
+    "doubao-seed-2-0-pro": {
+      "cached_read": 0.09644,
+      "in": 0.48,
+      "out": 2.41
+    },
+    "doubao-seed-2-0-pro-260215": {
+      "cached_read": null,
+      "in": 0.782,
+      "out": 3.876
+    },
+    "doubao-seed-code-preview-251028": {
+      "cached_read": null,
+      "in": 0.17,
+      "out": 1.14
+    },
+    "duo-chat-gpt-5-1": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "duo-chat-gpt-5-2": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "duo-chat-gpt-5-2-codex": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "duo-chat-gpt-5-3-codex": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "duo-chat-gpt-5-4": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "duo-chat-gpt-5-4-mini": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "duo-chat-gpt-5-4-nano": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "duo-chat-gpt-5-5": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "duo-chat-gpt-5-codex": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "duo-chat-gpt-5-mini": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "duo-chat-haiku-4-5": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "duo-chat-opus-4-5": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "duo-chat-opus-4-6": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "duo-chat-opus-4-7": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "duo-chat-opus-4-8": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "duo-chat-sonnet-4-5": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "duo-chat-sonnet-4-6": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "e5-large-v2": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.0
+    },
+    "empiriolabs/deepseek-v4-flash-el": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.28
+    },
+    "empiriolabs/deepseek-v4-pro-el": {
+      "cached_read": null,
+      "in": 1.67,
+      "out": 3.33
+    },
+    "envoid/llama-3.05-nemotron-tenyxchat-storybreaker-70b": {
+      "cached_read": null,
+      "in": 0.49299999999999994,
+      "out": 0.49299999999999994
+    },
+    "envoid/llama-3.05-nt-storybreaker-ministral-70b": {
+      "cached_read": null,
+      "in": 0.49299999999999994,
+      "out": 0.49299999999999994
+    },
+    "ernie-4.5-21b-a3b-thinking": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.28
+    },
+    "ernie-4.5-8k-preview": {
+      "cached_read": null,
+      "in": 0.66,
+      "out": 2.6
+    },
+    "ernie-4.5-turbo-128k": {
+      "cached_read": null,
+      "in": 0.132,
+      "out": 0.55
+    },
+    "ernie-4.5-turbo-vl-32k": {
+      "cached_read": null,
+      "in": 0.495,
+      "out": 1.43
+    },
+    "ernie-5.0-thinking-preview": {
+      "cached_read": null,
+      "in": 1.1,
+      "out": 2.0
+    },
+    "ernie-5.1": {
+      "cached_read": 0.75,
+      "in": 0.75,
+      "out": 3.0
+    },
+    "ernie-5.1:thinking": {
+      "cached_read": 0.75,
+      "in": 0.75,
+      "out": 3.0
+    },
+    "ernie-x1-32k": {
+      "cached_read": null,
+      "in": 0.33,
+      "out": 1.32
+    },
+    "ernie-x1-32k-preview": {
+      "cached_read": null,
+      "in": 0.33,
+      "out": 1.32
+    },
+    "ernie-x1-turbo-32k": {
+      "cached_read": null,
+      "in": 0.165,
+      "out": 0.66
+    },
+    "ernie-x1.1-preview": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "essentialai/rnj-1-instruct": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.15
+    },
+    "eu.anthropic.claude-haiku-4-5-20251001-v1:0": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "eu.anthropic.claude-opus-4-5-20251101-v1:0": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "eu.anthropic.claude-opus-4-6-v1": {
+      "cached_read": 0.55,
+      "in": 5.5,
+      "out": 27.5
+    },
+    "eu.anthropic.claude-opus-4-7": {
+      "cached_read": 0.55,
+      "in": 5.5,
+      "out": 27.5
+    },
+    "eu.anthropic.claude-opus-4-8": {
+      "cached_read": 0.55,
+      "in": 5.5,
+      "out": 27.5
+    },
+    "eu.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+      "cached_read": 0.33,
+      "in": 3.3,
+      "out": 16.5
+    },
+    "eu.anthropic.claude-sonnet-4-6": {
+      "cached_read": 0.33,
+      "in": 3.3,
+      "out": 16.5
+    },
+    "eva-unit-01/eva-llama-3.33-70b-v0.0": {
+      "cached_read": null,
+      "in": 2.006,
+      "out": 2.006
+    },
+    "eva-unit-01/eva-llama-3.33-70b-v0.1": {
+      "cached_read": null,
+      "in": 2.006,
+      "out": 2.006
+    },
+    "eva-unit-01/eva-qwen2.5-32b-v0.2": {
+      "cached_read": null,
+      "in": 0.7989999999999999,
+      "out": 0.7989999999999999
+    },
+    "eva-unit-01/eva-qwen2.5-72b-v0.2": {
+      "cached_read": null,
+      "in": 0.7989999999999999,
+      "out": 0.7989999999999999
+    },
+    "exa-answer": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 2.5
+    },
+    "exa-research": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 2.5
+    },
+    "exa-research-pro": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 2.5
+    },
+    "failspy/meta-llama-3-70b-instruct-abliterated-v3.5": {
+      "cached_read": null,
+      "in": 0.7,
+      "out": 0.7
+    },
+    "fastgpt": {
+      "cached_read": null,
+      "in": 7.5,
+      "out": 7.5
+    },
+    "featherless-ai/qwerky-72b": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 0.5
+    },
+    "fireworks-ai/kimi-k2.5-fw": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "galrionsoftworks/mn-loosecannon-12b-v1": {
+      "cached_read": null,
+      "in": 0.49299999999999994,
+      "out": 0.49299999999999994
+    },
+    "gemini-2.0-flash": {
+      "cached_read": 0.025,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "gemini-2.0-flash-001": {
+      "cached_read": null,
+      "in": 0.1003,
+      "out": 0.408
+    },
+    "gemini-2.0-flash-exp-image-generation": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.8
+    },
+    "gemini-2.0-flash-lite": {
+      "cached_read": null,
+      "in": 0.075,
+      "out": 0.3
+    },
+    "gemini-2.0-flash-thinking-exp-01-21": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 1.003
+    },
+    "gemini-2.0-flash-thinking-exp-1219": {
+      "cached_read": null,
+      "in": 0.1003,
+      "out": 0.408
+    },
+    "gemini-2.0-pro-exp-02-05": {
+      "cached_read": null,
+      "in": 1.989,
+      "out": 7.956
+    },
+    "gemini-2.0-pro-reasoner": {
+      "cached_read": null,
+      "in": 1.292,
+      "out": 4.998
+    },
+    "gemini-2.5-flash": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "gemini-2.5-flash-image": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 30.0
+    },
+    "gemini-2.5-flash-lite": {
+      "cached_read": 0.01,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "gemini-2.5-flash-lite-preview-06-17": {
+      "cached_read": 0.025,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "gemini-2.5-flash-lite-preview-09-2025": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "gemini-2.5-flash-lite-preview-09-2025-thinking": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "gemini-2.5-flash-nothink": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "gemini-2.5-flash-nothinking": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "gemini-2.5-flash-preview-04-17": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "gemini-2.5-flash-preview-04-17:thinking": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 3.5
+    },
+    "gemini-2.5-flash-preview-05-20": {
+      "cached_read": null,
+      "in": 0.135,
+      "out": 3.15
+    },
+    "gemini-2.5-flash-preview-05-20:thinking": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 3.5
+    },
+    "gemini-2.5-flash-preview-09-2025": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "gemini-2.5-flash-preview-09-2025-thinking": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "gemini-2.5-flash-preview-tts": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 10.0
+    },
+    "gemini-2.5-flash-tts": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 10.0
+    },
+    "gemini-2.5-pro": {
+      "cached_read": null,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "gemini-2.5-pro-exp-03-25": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "gemini-2.5-pro-preview-03-25": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "gemini-2.5-pro-preview-05-06": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "gemini-2.5-pro-preview-06-05": {
+      "cached_read": null,
+      "in": 1.125,
+      "out": 9.0
+    },
+    "gemini-2.5-pro-preview-tts": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 20.0
+    },
+    "gemini-2.5-pro-tts": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 20.0
+    },
+    "gemini-3-1-pro-preview": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "gemini-3-5-flash": {
+      "cached_read": 0.155,
+      "in": 1.55,
+      "out": 9.45
+    },
+    "gemini-3-flash": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "gemini-3-flash-preview": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "gemini-3-pro": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "gemini-3-pro-image-preview": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 120.0
+    },
+    "gemini-3-pro-preview": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "gemini-3.1-flash-image-preview": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 60.0
+    },
+    "gemini-3.1-flash-lite": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 1.5
+    },
+    "gemini-3.1-flash-lite-preview": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 1.5
+    },
+    "gemini-3.1-pro": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "gemini-3.1-pro-preview": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "gemini-3.1-pro-preview-customtools": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "gemini-3.5-flash": {
+      "cached_read": 0.15,
+      "in": 1.5,
+      "out": 9.0
+    },
+    "gemini-embedding-001": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.0
+    },
+    "gemini-exp-1206": {
+      "cached_read": null,
+      "in": 1.258,
+      "out": 4.998
+    },
+    "gemini-flash-latest": {
+      "cached_read": 0.075,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "gemini-flash-lite-latest": {
+      "cached_read": 0.025,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "gemini-pro-latest": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "gemma-2-27b-it-together": {
+      "cached_read": null,
+      "in": 0.08,
+      "out": 0.08
+    },
+    "gemma-3-12b-it": {
+      "cached_read": null,
+      "in": 0.049999999999999996,
+      "out": 0.09999999999999999
+    },
+    "gemma-3-1b-it": {
+      "cached_read": null,
+      "in": 0.08,
+      "out": 0.3
+    },
+    "gemma-3-27b": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 0.27
+    },
+    "gemma-3-27b-it": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 0.5
+    },
+    "gemma-4-26b-a4b-it": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 0.5
+    },
+    "gemma-4-31b-claude-4.6-opus-reasoning-distilled": {
+      "cached_read": 0.0306,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "gemma-4-31b-cognitive-unshackled": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "gemma-4-31b-darkidol": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "gemma-4-31b-fabled": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "gemma-4-31b-garnet": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "gemma-4-31b-garnetv2": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "gemma-4-31b-gemopus": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "gemma-4-31b-it": {
+      "cached_read": 0.02,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "gemma-4-31b-k1-v5": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "gemma-4-31b-larkspur-v0.5": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "gemma-4-31b-meromero": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "gemma-4-31b-musica-v1": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "gemma-4-31b-queen": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "gemma-4-e4b-it-iq4_xs": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "gemma-4-e4b-it-mlx-4bit": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "gemma-4-uncensored": {
+      "cached_read": null,
+      "in": 0.1625,
+      "out": 0.5
+    },
+    "gemma2-9b-it": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "glm-4": {
+      "cached_read": null,
+      "in": 14.994,
+      "out": 14.994
+    },
+    "glm-4-32b-0414-128k": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "glm-4-air": {
+      "cached_read": null,
+      "in": 0.2006,
+      "out": 0.2006
+    },
+    "glm-4-air-0111": {
+      "cached_read": null,
+      "in": 0.1394,
+      "out": 0.1394
+    },
+    "glm-4-airx": {
+      "cached_read": null,
+      "in": 2.006,
+      "out": 2.006
+    },
+    "glm-4-flash": {
+      "cached_read": null,
+      "in": 0.1003,
+      "out": 0.1003
+    },
+    "glm-4-long": {
+      "cached_read": null,
+      "in": 0.2006,
+      "out": 0.2006
+    },
+    "glm-4-plus": {
+      "cached_read": null,
+      "in": 7.497,
+      "out": 7.497
+    },
+    "glm-4-plus-0111": {
+      "cached_read": null,
+      "in": 9.996,
+      "out": 9.996
+    },
+    "glm-4.1v-thinking-flash": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.3
+    },
+    "glm-4.1v-thinking-flashx": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.3
+    },
+    "glm-4.5": {
+      "cached_read": null,
+      "in": 0.286,
+      "out": 1.142
+    },
+    "glm-4.5-air": {
+      "cached_read": null,
+      "in": 0.1143,
+      "out": 0.286
+    },
+    "glm-4.5-airx": {
+      "cached_read": null,
+      "in": 0.572,
+      "out": 1.714
+    },
+    "glm-4.5-flash": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "glm-4.5-x": {
+      "cached_read": null,
+      "in": 1.143,
+      "out": 2.29
+    },
+    "glm-4.5v": {
+      "cached_read": null,
+      "in": 0.29,
+      "out": 0.86
+    },
+    "glm-4.6": {
+      "cached_read": null,
+      "in": 0.286,
+      "out": 1.142
+    },
+    "glm-4.6-derestricted-v5": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 1.5
+    },
+    "glm-4.6v": {
+      "cached_read": null,
+      "in": 0.145,
+      "out": 0.43
+    },
+    "glm-4.6v-flash": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "glm-4.6v-flashx": {
+      "cached_read": 0.004,
+      "in": 0.04,
+      "out": 0.4
+    },
+    "glm-4.7": {
+      "cached_read": null,
+      "in": 0.286,
+      "out": 1.142
+    },
+    "glm-4.7-flash": {
+      "cached_read": null,
+      "in": 0.09,
+      "out": 0.53
+    },
+    "glm-4.7-flashx": {
+      "cached_read": null,
+      "in": 0.0715,
+      "out": 0.429
+    },
+    "glm-4.7-free": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "glm-5": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.6
+    },
+    "glm-5-fast": {
+      "cached_read": null,
+      "in": 1.1,
+      "out": 3.6
+    },
+    "glm-5-free": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "glm-5-turbo": {
+      "cached_read": null,
+      "in": 0.72,
+      "out": 3.2
+    },
+    "glm-5.1": {
+      "cached_read": null,
+      "in": 0.86,
+      "out": 3.5
+    },
+    "glm-5.1-fast": {
+      "cached_read": null,
+      "in": 1.1,
+      "out": 3.6
+    },
+    "glm-5v-turbo": {
+      "cached_read": null,
+      "in": 0.72,
+      "out": 3.2
+    },
+    "glm-for-coding": {
+      "cached_read": null,
+      "in": 0.086,
+      "out": 0.343
+    },
+    "glm-z1-air": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.07
+    },
+    "glm-z1-airx": {
+      "cached_read": null,
+      "in": 0.7,
+      "out": 0.7
+    },
+    "glm-zero-preview": {
+      "cached_read": null,
+      "in": 1.802,
+      "out": 1.802
+    },
+    "global.anthropic.claude-haiku-4-5-20251001-v1:0": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "global.anthropic.claude-opus-4-5-20251101-v1:0": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "global.anthropic.claude-opus-4-6-v1": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "global.anthropic.claude-opus-4-7": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "global.anthropic.claude-opus-4-8": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "global.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "global.anthropic.claude-sonnet-4-6": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "google-gemma-3-27b-it": {
+      "cached_read": null,
+      "in": 0.12,
+      "out": 0.2
+    },
+    "google-gemma-4-26b-a4b-it": {
+      "cached_read": null,
+      "in": 0.1625,
+      "out": 0.5
+    },
+    "google-gemma-4-31b-it": {
+      "cached_read": 0.12,
+      "in": 0.155,
+      "out": 0.44
+    },
+    "google.gemma-3-12b-it": {
+      "cached_read": null,
+      "in": 0.049999999999999996,
+      "out": 0.09999999999999999
+    },
+    "google.gemma-3-27b-it": {
+      "cached_read": null,
+      "in": 0.12,
+      "out": 0.2
+    },
+    "google.gemma-3-4b-it": {
+      "cached_read": null,
+      "in": 0.04,
+      "out": 0.08
+    },
+    "google/gemini-2.0-flash": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.42
+    },
+    "google/gemini-2.0-flash-001": {
+      "cached_read": 0.025,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "google/gemini-2.0-flash-lite": {
+      "cached_read": null,
+      "in": 0.052,
+      "out": 0.21
+    },
+    "google/gemini-2.0-flash-lite-001": {
+      "cached_read": null,
+      "in": 0.075,
+      "out": 0.3
+    },
+    "google/gemini-2.5-flash": {
+      "cached_read": 0.0375,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "google/gemini-2.5-flash-image": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "google/gemini-2.5-flash-image-preview": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "google/gemini-2.5-flash-lite": {
+      "cached_read": 0.01,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "google/gemini-2.5-flash-lite-preview-09-2025": {
+      "cached_read": 0.01,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "google/gemini-2.5-flash-preview-09-2025": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "google/gemini-2.5-pro": {
+      "cached_read": 0.31,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "google/gemini-2.5-pro-preview": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "google/gemini-2.5-pro-preview-05-06": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "google/gemini-3-flash": {
+      "cached_read": 0.04,
+      "in": 0.4,
+      "out": 2.4
+    },
+    "google/gemini-3-flash-preview": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "google/gemini-3-flash-preview-thinking": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "google/gemini-3-pro": {
+      "cached_read": 0.0,
+      "in": 1.25,
+      "out": 15.0
+    },
+    "google/gemini-3-pro-image": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "google/gemini-3-pro-image-preview": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "google/gemini-3-pro-preview": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "google/gemini-3.1-flash-image": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "google/gemini-3.1-flash-image-preview": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "google/gemini-3.1-flash-lite": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 1.5
+    },
+    "google/gemini-3.1-flash-lite-preview": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 1.5
+    },
+    "google/gemini-3.1-pro": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "google/gemini-3.1-pro-preview": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "google/gemini-3.1-pro-preview-customtools": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "google/gemini-3.1-pro-preview-high": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "google/gemini-3.1-pro-preview-low": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "google/gemini-3.5-flash": {
+      "cached_read": 0.15,
+      "in": 1.5,
+      "out": 9.0
+    },
+    "google/gemini-3.5-flash-thinking": {
+      "cached_read": 0.15,
+      "in": 1.5,
+      "out": 9.0
+    },
+    "google/gemini-deep-research": {
+      "cached_read": null,
+      "in": 1.6,
+      "out": 9.6
+    },
+    "google/gemini-flash-1.5": {
+      "cached_read": null,
+      "in": 0.0748,
+      "out": 0.306
+    },
+    "google/gemini-flash-latest": {
+      "cached_read": 0.075,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "google/gemini-flash-lite-latest": {
+      "cached_read": 0.025,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "google/gemini-pro-latest": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "google/gemma-2-27b-it": {
+      "cached_read": null,
+      "in": 0.65,
+      "out": 0.65
+    },
+    "google/gemma-2-2b-it": {
+      "cached_read": 0.002,
+      "in": 0.02,
+      "out": 0.06
+    },
+    "google/gemma-3": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.3
+    },
+    "google/gemma-3-12b-it": {
+      "cached_read": 0.015,
+      "in": 0.04,
+      "out": 0.13
+    },
+    "google/gemma-3-27b-it": {
+      "cached_read": 0.02,
+      "in": 0.03,
+      "out": 0.11
+    },
+    "google/gemma-3-4b-it": {
+      "cached_read": null,
+      "in": 0.04,
+      "out": 0.08
+    },
+    "google/gemma-3n-e2b-it": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "google/gemma-3n-e4b-it": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.04
+    },
+    "google/gemma-4-26b-a4b-it": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.34
+    },
+    "google/gemma-4-26b-a4b-it:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "google/gemma-4-26b-a4b-it:thinking": {
+      "cached_read": null,
+      "in": 0.13,
+      "out": 0.4
+    },
+    "google/gemma-4-31b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "google/gemma-4-31b-it": {
+      "cached_read": null,
+      "in": 0.275,
+      "out": 0.55
+    },
+    "google/gemma-4-31b-it:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "google/gemma-4-31b-it:thinking": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.35
+    },
+    "google/gemma-4-31b-turbo-tee": {
+      "cached_read": 0.065,
+      "in": 0.13,
+      "out": 0.38
+    },
+    "google/google-paligemma": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "google/lyria-3-clip-preview": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "google/lyria-3-pro-preview": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "google/nano-banana": {
+      "cached_read": 0.021,
+      "in": 0.21,
+      "out": 1.8
+    },
+    "google/nano-banana-pro": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "gpt-3.5-turbo": {
+      "cached_read": 0.0,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "gpt-3.5-turbo-0125": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "gpt-3.5-turbo-0301": {
+      "cached_read": null,
+      "in": 1.5,
+      "out": 2.0
+    },
+    "gpt-3.5-turbo-0613": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 4.0
+    },
+    "gpt-3.5-turbo-1106": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 2.0
+    },
+    "gpt-3.5-turbo-instruct": {
+      "cached_read": null,
+      "in": 1.5,
+      "out": 2.0
+    },
+    "gpt-4": {
+      "cached_read": null,
+      "in": 60.0,
+      "out": 120.0
+    },
+    "gpt-4-32k": {
+      "cached_read": null,
+      "in": 60.0,
+      "out": 120.0
+    },
+    "gpt-4-turbo": {
+      "cached_read": null,
+      "in": 10.0,
+      "out": 30.0
+    },
+    "gpt-4-turbo-vision": {
+      "cached_read": null,
+      "in": 10.0,
+      "out": 30.0
+    },
+    "gpt-4.1": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "gpt-4.1-mini": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 1.6
+    },
+    "gpt-4.1-mini-2025-04-14": {
+      "cached_read": 0.09999999999999999,
+      "in": 0.39999999999999997,
+      "out": 1.5999999999999999
+    },
+    "gpt-4.1-nano": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "gpt-4o": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "gpt-4o-2024-05-13": {
+      "cached_read": null,
+      "in": 5.0,
+      "out": 15.0
+    },
+    "gpt-4o-2024-08-06": {
+      "cached_read": 1.25,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "gpt-4o-2024-11-20": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "gpt-4o-mini": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "gpt-4o-mini-search-preview": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "gpt-4o-search-preview": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "gpt-5": {
+      "cached_read": null,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "gpt-5-3-codex": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "gpt-5-4-mini": {
+      "cached_read": 0.075,
+      "in": 0.75,
+      "out": 4.5
+    },
+    "gpt-5-4-nano": {
+      "cached_read": 0.02,
+      "in": 0.2,
+      "out": 1.25
+    },
+    "gpt-5-5": {
+      "cached_read": 0.25,
+      "in": 2.5,
+      "out": 15.0
+    },
+    "gpt-5-chat": {
+      "cached_read": 0.13,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "gpt-5-chat-latest": {
+      "cached_read": 0.12500000000000003,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "gpt-5-codex": {
+      "cached_read": null,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "gpt-5-mini": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "gpt-5-nano": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.4
+    },
+    "gpt-5-pro": {
+      "cached_read": null,
+      "in": 15.0,
+      "out": 120.0
+    },
+    "gpt-5-thinking": {
+      "cached_read": null,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "gpt-5.1": {
+      "cached_read": null,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "gpt-5.1-chat": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "gpt-5.1-chat-latest": {
+      "cached_read": null,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "gpt-5.1-codex": {
+      "cached_read": null,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "gpt-5.1-codex-max": {
+      "cached_read": null,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "gpt-5.1-codex-mini": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "gpt-5.2": {
+      "cached_read": null,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "gpt-5.2-chat": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "gpt-5.2-chat-latest": {
+      "cached_read": null,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "gpt-5.2-codex": {
+      "cached_read": null,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "gpt-5.2-pro": {
+      "cached_read": null,
+      "in": 18.9,
+      "out": 151.2
+    },
+    "gpt-5.3-chat": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "gpt-5.3-chat-latest": {
+      "cached_read": null,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "gpt-5.3-codex": {
+      "cached_read": null,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "gpt-5.3-codex-spark": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "gpt-5.3-codex-xhigh": {
+      "cached_read": null,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "gpt-5.4": {
+      "cached_read": 0.25,
+      "in": 2.5,
+      "out": 15.0
+    },
+    "gpt-5.4-mini": {
+      "cached_read": null,
+      "in": 0.75,
+      "out": 4.5
+    },
+    "gpt-5.4-mini-2026-03-17": {
+      "cached_read": null,
+      "in": 0.75,
+      "out": 4.5
+    },
+    "gpt-5.4-nano": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 1.25
+    },
+    "gpt-5.4-nano-2026-03-17": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 1.25
+    },
+    "gpt-5.4-pro": {
+      "cached_read": 0.0,
+      "in": 30.0,
+      "out": 180.0
+    },
+    "gpt-5.5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 30.0
+    },
+    "gpt-5.5-pro": {
+      "cached_read": null,
+      "in": 30.0,
+      "out": 180.0
+    },
+    "gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 0.69
+    },
+    "gpt-oss-20b": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.2
+    },
+    "greg-1": {
+      "cached_read": 0.02,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "greg-1-mini": {
+      "cached_read": 0.01,
+      "in": 0.07,
+      "out": 0.15
+    },
+    "greg-1-super": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "greg-rp": {
+      "cached_read": 0.02,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "grok-3": {
+      "cached_read": 0.75,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "grok-3-mini": {
+      "cached_read": 0.075,
+      "in": 0.3,
+      "out": 0.5
+    },
+    "grok-4": {
+      "cached_read": 0.75,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "grok-4-0709": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "grok-4-1-fast-non-reasoning": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "grok-4-1-fast-reasoning": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "grok-4-20": {
+      "cached_read": 0.23,
+      "in": 1.42,
+      "out": 2.83
+    },
+    "grok-4-20-beta-0309-non-reasoning": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "grok-4-20-beta-0309-reasoning": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "grok-4-20-multi-agent": {
+      "cached_read": 0.23,
+      "in": 1.42,
+      "out": 2.83
+    },
+    "grok-4-20-non-reasoning": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "grok-4-20-reasoning": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "grok-4-3": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "grok-4-fast-non-reasoning": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "grok-4-fast-reasoning": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "grok-4.1": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 10.0
+    },
+    "grok-4.20-0309-non-reasoning": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "grok-4.20-0309-reasoning": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "grok-4.20-beta-0309-non-reasoning": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "grok-4.20-beta-0309-reasoning": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "grok-4.20-multi-agent-0309": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "grok-4.20-multi-agent-beta-0309": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "grok-4.3": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "grok-build-0-1": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 2.0
+    },
+    "grok-build-0.1": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 2.0
+    },
+    "grok-code": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "grok-code-fast-1": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 1.5
+    },
+    "grok/grok-4.3": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "groq-llama-4-maverick-17b-128e-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "groq/compound": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "groq/compound-mini": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "gryphe/mythomax-l2-13b": {
+      "cached_read": null,
+      "in": 0.06,
+      "out": 0.06
+    },
+    "gte-large-en-v1.5": {
+      "cached_read": null,
+      "in": 0.09,
+      "out": 0.0
+    },
+    "hermes-2-pro-llama-3-8b": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.14
+    },
+    "hermes-3-llama-3.1-405b": {
+      "cached_read": null,
+      "in": 1.1,
+      "out": 3.0
+    },
+    "hermes-4-70b": {
+      "cached_read": null,
+      "in": 0.116,
+      "out": 0.358
+    },
+    "hermes-high": {
+      "cached_read": null,
+      "in": 4.998,
+      "out": 25.007
+    },
+    "hermes-low": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 1.5
+    },
+    "hermes-medium": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "hf:deepseek-ai/deepseek-r1": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 2.19
+    },
+    "hf:deepseek-ai/deepseek-r1-0528": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 8.0
+    },
+    "hf:deepseek-ai/deepseek-v3": {
+      "cached_read": null,
+      "in": 1.25,
+      "out": 1.25
+    },
+    "hf:deepseek-ai/deepseek-v3-0324": {
+      "cached_read": null,
+      "in": 1.2,
+      "out": 1.2
+    },
+    "hf:deepseek-ai/deepseek-v3.1": {
+      "cached_read": null,
+      "in": 0.56,
+      "out": 1.68
+    },
+    "hf:deepseek-ai/deepseek-v3.1-terminus": {
+      "cached_read": null,
+      "in": 1.2,
+      "out": 1.2
+    },
+    "hf:deepseek-ai/deepseek-v3.2": {
+      "cached_read": 0.27,
+      "in": 0.27,
+      "out": 0.4
+    },
+    "hf:meta-llama/llama-3.1-405b-instruct": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 3.0
+    },
+    "hf:meta-llama/llama-3.1-70b-instruct": {
+      "cached_read": null,
+      "in": 0.9,
+      "out": 0.9
+    },
+    "hf:meta-llama/llama-3.1-8b-instruct": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "hf:meta-llama/llama-3.3-70b-instruct": {
+      "cached_read": null,
+      "in": 0.9,
+      "out": 0.9
+    },
+    "hf:meta-llama/llama-4-maverick-17b-128e-instruct-fp8": {
+      "cached_read": null,
+      "in": 0.22,
+      "out": 0.88
+    },
+    "hf:meta-llama/llama-4-scout-17b-16e-instruct": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "hf:minimaxai/minimax-m2": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 2.19
+    },
+    "hf:minimaxai/minimax-m2.1": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 2.19
+    },
+    "hf:minimaxai/minimax-m2.5": {
+      "cached_read": 0.6,
+      "in": 0.6,
+      "out": 3.0
+    },
+    "hf:moonshotai/kimi-k2-instruct-0905": {
+      "cached_read": null,
+      "in": 1.2,
+      "out": 1.2
+    },
+    "hf:moonshotai/kimi-k2-thinking": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 2.19
+    },
+    "hf:moonshotai/kimi-k2.5": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 2.19
+    },
+    "hf:moonshotai/kimi-k2.6": {
+      "cached_read": 0.95,
+      "in": 0.95,
+      "out": 4.0
+    },
+    "hf:nvidia/kimi-k2.5-nvfp4": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 2.19
+    },
+    "hf:nvidia/nvidia-nemotron-3-super-120b-a12b-nvfp4": {
+      "cached_read": 0.3,
+      "in": 0.3,
+      "out": 1.0
+    },
+    "hf:openai/gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "hf:qwen/qwen2.5-coder-32b-instruct": {
+      "cached_read": null,
+      "in": 0.8,
+      "out": 0.8
+    },
+    "hf:qwen/qwen3-235b-a22b-instruct-2507": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.6
+    },
+    "hf:qwen/qwen3-235b-a22b-thinking-2507": {
+      "cached_read": null,
+      "in": 0.65,
+      "out": 3.0
+    },
+    "hf:qwen/qwen3-coder-480b-a35b-instruct": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 2.0
+    },
+    "hf:qwen/qwen3.5-397b-a17b": {
+      "cached_read": 0.6,
+      "in": 0.6,
+      "out": 3.0
+    },
+    "hf:zai-org/glm-4.6": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 2.19
+    },
+    "hf:zai-org/glm-4.7": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 2.19
+    },
+    "hf:zai-org/glm-4.7-flash": {
+      "cached_read": 0.06,
+      "in": 0.06,
+      "out": 0.4
+    },
+    "hf:zai-org/glm-5": {
+      "cached_read": 1.0,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "hf:zai-org/glm-5.1": {
+      "cached_read": 1.0,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "holo3-35b-a3b": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 1.8
+    },
+    "holo3-35b-a3b:thinking": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 1.8
+    },
+    "huihui-ai/deepseek-r1-distill-llama-70b-abliterated": {
+      "cached_read": null,
+      "in": 0.7,
+      "out": 0.7
+    },
+    "huihui-ai/deepseek-r1-distill-qwen-32b-abliterated": {
+      "cached_read": null,
+      "in": 1.4,
+      "out": 1.4
+    },
+    "huihui-ai/llama-3.3-70b-instruct-abliterated": {
+      "cached_read": null,
+      "in": 0.7,
+      "out": 0.7
+    },
+    "huihui-ai/qwen2.5-32b-instruct-abliterated": {
+      "cached_read": null,
+      "in": 0.7,
+      "out": 0.7
+    },
+    "hunyuan-2.0-instruct": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "hunyuan-2.0-thinking": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "hunyuan-t1": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "hunyuan-turbos": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "hunyuan-turbos-20250226": {
+      "cached_read": null,
+      "in": 0.187,
+      "out": 0.374
+    },
+    "hy3-preview": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "hy3-preview-free": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "ibm-granite/granite-4.0-h-micro": {
+      "cached_read": null,
+      "in": 0.017,
+      "out": 0.11
+    },
+    "ibm-granite/granite-4.1-8b": {
+      "cached_read": 0.05,
+      "in": 0.05,
+      "out": 0.1
+    },
+    "inception/mercury-2": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 0.75
+    },
+    "inception/mercury-coder-small": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 1.0
+    },
+    "inception/mercury-edit-2": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 0.75
+    },
+    "inclusionai/ling-1t": {
+      "cached_read": 0.11,
+      "in": 0.56,
+      "out": 2.24
+    },
+    "inclusionai/ling-2.6-1t": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 2.5
+    },
+    "inclusionai/ling-2.6-flash": {
+      "cached_read": 0.016,
+      "in": 0.08,
+      "out": 0.24
+    },
+    "inclusionai/ling-flash-2.0": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.57
+    },
+    "inclusionai/ling-mini-2.0": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.28
+    },
+    "inclusionai/ring-1t": {
+      "cached_read": 0.11,
+      "in": 0.56,
+      "out": 2.24
+    },
+    "inclusionai/ring-2.6-1t": {
+      "cached_read": 0.015,
+      "in": 0.075,
+      "out": 0.625
+    },
+    "inclusionai/ring-flash-2.0": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.57
+    },
+    "infermatic/mn-12b-inferor-v0.0": {
+      "cached_read": null,
+      "in": 0.25499999999999995,
+      "out": 0.49299999999999994
+    },
+    "inflatebot/mn-12b-mag-mell-r1": {
+      "cached_read": null,
+      "in": 0.49299999999999994,
+      "out": 0.49299999999999994
+    },
+    "inflection/inflection-3-pi": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "inflection/inflection-3-productivity": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "intel/qwen3-coder-480b-a35b-instruct-int4-mixed-ar": {
+      "cached_read": 0.11,
+      "in": 0.22,
+      "out": 0.95
+    },
+    "intellect-3": {
+      "cached_read": null,
+      "in": 0.219,
+      "out": 1.202
+    },
+    "interfaze/interfaze-beta": {
+      "cached_read": null,
+      "in": 1.5,
+      "out": 3.5
+    },
+    "intfloat/e5-mistral-7b-instruct": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.02
+    },
+    "intfloat/multilingual-e5-large-instruct": {
+      "cached_read": null,
+      "in": 0.12,
+      "out": 0.12
+    },
+    "jamba-large": {
+      "cached_read": null,
+      "in": 1.989,
+      "out": 7.99
+    },
+    "jamba-large-1.6": {
+      "cached_read": null,
+      "in": 1.989,
+      "out": 7.99
+    },
+    "jamba-large-1.7": {
+      "cached_read": null,
+      "in": 1.989,
+      "out": 7.99
+    },
+    "jamba-mini": {
+      "cached_read": null,
+      "in": 0.1989,
+      "out": 0.408
+    },
+    "jamba-mini-1.6": {
+      "cached_read": null,
+      "in": 0.1989,
+      "out": 0.408
+    },
+    "jamba-mini-1.7": {
+      "cached_read": null,
+      "in": 0.1989,
+      "out": 0.408
+    },
+    "jp.anthropic.claude-opus-4-7": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "jp.anthropic.claude-opus-4-8": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "jp.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "jp.anthropic.claude-sonnet-4-6": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "k2p5": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "k2p6": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "kat-coder-air-v1": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.2
+    },
+    "kat-coder-exp-72b-1010": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.2
+    },
+    "kblab/kb-whisper-large": {
+      "cached_read": null,
+      "in": 0.00236,
+      "out": 0.00236
+    },
+    "kilo-auto/balanced": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 3.0
+    },
+    "kilo-auto/free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "kilo-auto/frontier": {
+      "cached_read": null,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "kilo-auto/small": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.4
+    },
+    "kimi-k2": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "kimi-k2-0711": {
+      "cached_read": null,
+      "in": 0.5700000000000001,
+      "out": 2.3
+    },
+    "kimi-k2-0711-preview": {
+      "cached_read": 0.15,
+      "in": 0.6,
+      "out": 2.5
+    },
+    "kimi-k2-0905": {
+      "cached_read": 0.39999999999999997,
+      "in": 0.5,
+      "out": 2.0
+    },
+    "kimi-k2-0905-preview": {
+      "cached_read": null,
+      "in": 0.632,
+      "out": 2.53
+    },
+    "kimi-k2-5": {
+      "cached_read": 0.22,
+      "in": 0.56,
+      "out": 3.5
+    },
+    "kimi-k2-6": {
+      "cached_read": 0.16,
+      "in": 0.95,
+      "out": 4.0
+    },
+    "kimi-k2-instruct": {
+      "cached_read": null,
+      "in": 0.551,
+      "out": 2.646
+    },
+    "kimi-k2-instruct-fast": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 2.0
+    },
+    "kimi-k2-thinking": {
+      "cached_read": null,
+      "in": 0.575,
+      "out": 2.3
+    },
+    "kimi-k2-thinking-turbo": {
+      "cached_read": null,
+      "in": 1.265,
+      "out": 9.119
+    },
+    "kimi-k2-turbo-preview": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 8.0
+    },
+    "kimi-k2.5": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 3.0
+    },
+    "kimi-k2.5-fast": {
+      "cached_read": null,
+      "in": 0.52,
+      "out": 2.59
+    },
+    "kimi-k2.5-free": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "kimi-k2.5-lightning": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "kimi-k2.6": {
+      "cached_read": 0.16,
+      "in": 0.95,
+      "out": 4.0
+    },
+    "kimi-k2.6-fast": {
+      "cached_read": null,
+      "in": 0.69,
+      "out": 3.22
+    },
+    "kimi-thinking-preview": {
+      "cached_read": null,
+      "in": 31.46,
+      "out": 31.46
+    },
+    "kimi/kimi-k2.5": {
+      "cached_read": 0.1,
+      "in": 0.6,
+      "out": 3.0
+    },
+    "kimi/kimi-k2.6": {
+      "cached_read": 0.16,
+      "in": 0.95,
+      "out": 4.0
+    },
+    "kuaishou/kat-coder-pro-v2": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "kwaipilot/kat-coder-pro": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "kwaipilot/kat-coder-pro-v1": {
+      "cached_read": 0.06,
+      "in": 0.03,
+      "out": 1.2
+    },
+    "kwaipilot/kat-coder-pro-v2": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "kwaipilot/kat-dev": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.6
+    },
+    "labs-devstral-small-2512": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "latitudegames/wayfarer-large-70b-llama-3.3": {
+      "cached_read": null,
+      "in": 0.700000007,
+      "out": 0.700000007
+    },
+    "learnlm-1.5-pro-experimental": {
+      "cached_read": null,
+      "in": 3.502,
+      "out": 10.506
+    },
+    "ling-1t": {
+      "cached_read": null,
+      "in": 0.57,
+      "out": 2.29
+    },
+    "ling-2.6-flash-free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "liquid/lfm-2-24b-a2b": {
+      "cached_read": null,
+      "in": 0.03,
+      "out": 0.12
+    },
+    "liquid/lfm-2.5-1.2b-instruct:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "liquid/lfm-2.5-1.2b-thinking:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "llama-3-70b-instruct": {
+      "cached_read": null,
+      "in": 0.51,
+      "out": 0.74
+    },
+    "llama-3-8b-instruct": {
+      "cached_read": null,
+      "in": 0.04,
+      "out": 0.04
+    },
+    "llama-3.1-405b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "llama-3.1-70b-instruct": {
+      "cached_read": null,
+      "in": 0.72,
+      "out": 0.72
+    },
+    "llama-3.1-8b-instant": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.08
+    },
+    "llama-3.1-8b-instruct": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.049999999999999996
+    },
+    "llama-3.1-8b-instruct-turbo": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.03
+    },
+    "llama-3.1-nemotron-ultra-253b": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 1.8
+    },
+    "llama-3.2-11b-instruct": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.33
+    },
+    "llama-3.2-11b-vision-instruct": {
+      "cached_read": null,
+      "in": 0.37,
+      "out": 0.37
+    },
+    "llama-3.2-3b": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "llama-3.2-3b-instruct": {
+      "cached_read": null,
+      "in": 0.03,
+      "out": 0.05
+    },
+    "llama-3.2-90b-vision-instruct": {
+      "cached_read": null,
+      "in": 2.04,
+      "out": 2.04
+    },
+    "llama-3.3-70b": {
+      "cached_read": null,
+      "in": 0.7,
+      "out": 2.8
+    },
+    "llama-3.3-70b-instruct": {
+      "cached_read": null,
+      "in": 0.71,
+      "out": 0.71
+    },
+    "llama-3.3-70b-versatile": {
+      "cached_read": null,
+      "in": 0.59,
+      "out": 0.79
+    },
+    "llama-3.3-8b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "llama-4-maverick": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 0.87
+    },
+    "llama-4-maverick-17b-128e-instruct-fp8": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 1.0
+    },
+    "llama-4-maverick-17b-instruct": {
+      "cached_read": null,
+      "in": 0.24,
+      "out": 0.97
+    },
+    "llama-4-scout": {
+      "cached_read": null,
+      "in": 0.08,
+      "out": 0.3
+    },
+    "llama-4-scout-17b-16e-instruct": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.78
+    },
+    "llama-4-scout-17b-16e-instruct-fp8": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "llama-4-scout-17b-instruct": {
+      "cached_read": null,
+      "in": 0.17,
+      "out": 0.66
+    },
+    "llama-guard-3-8b": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "llama-guard-4": {
+      "cached_read": null,
+      "in": 0.21,
+      "out": 0.21
+    },
+    "llama-prompt-guard-2-22m": {
+      "cached_read": null,
+      "in": 0.01,
+      "out": 0.01
+    },
+    "llama-prompt-guard-2-86m": {
+      "cached_read": null,
+      "in": 0.01,
+      "out": 0.01
+    },
+    "llama3-70b-8192": {
+      "cached_read": null,
+      "in": 0.59,
+      "out": 0.79
+    },
+    "llama3-8b-8192": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.08
+    },
+    "llama3-8b-instruct": {
+      "cached_read": null,
+      "in": 0.198,
+      "out": 0.198
+    },
+    "llama3.1-8b": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "llama3.3-70b-instruct": {
+      "cached_read": null,
+      "in": 0.65,
+      "out": 0.65
+    },
+    "llm360/k2-think": {
+      "cached_read": null,
+      "in": 0.17,
+      "out": 0.68
+    },
+    "lucidnova-rf1-100b": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 5.0
+    },
+    "lucidquery-nexus-coder": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 5.0
+    },
+    "magistral-medium-latest": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 5.0
+    },
+    "magistral-small": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "magistral-small-2506": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 1.4
+    },
+    "mai-ds-r1": {
+      "cached_read": null,
+      "in": 1.35,
+      "out": 5.4
+    },
+    "mancer/weaver": {
+      "cached_read": null,
+      "in": 0.75,
+      "out": 1.0
+    },
+    "marinaraspaghetti/nemomix-unleashed-12b": {
+      "cached_read": null,
+      "in": 0.49299999999999994,
+      "out": 0.49299999999999994
+    },
+    "meganova-ai/manta-flash-1.0": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.16
+    },
+    "meganova-ai/manta-mini-1.0": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.16
+    },
+    "meganova-ai/manta-pro-1.0": {
+      "cached_read": null,
+      "in": 0.060000000000000005,
+      "out": 0.5
+    },
+    "meituan/longcat-flash-thinking": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 1.5
+    },
+    "mercury-2": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 0.75
+    },
+    "mercury-edit-2": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 0.75
+    },
+    "meta-llama-3-1-8b-instruct-fp8": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.03
+    },
+    "meta-llama-3-70b-instruct": {
+      "cached_read": null,
+      "in": 2.68,
+      "out": 3.54
+    },
+    "meta-llama-3-8b-instruct": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.61
+    },
+    "meta-llama-3.1-405b-instruct": {
+      "cached_read": null,
+      "in": 5.33,
+      "out": 16.0
+    },
+    "meta-llama-3.1-70b-instruct": {
+      "cached_read": null,
+      "in": 2.68,
+      "out": 3.54
+    },
+    "meta-llama-3.1-8b-instruct": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.61
+    },
+    "meta-llama-3_1-8b-instruct-gguf": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "meta-llama-3_3-70b-instruct": {
+      "cached_read": null,
+      "in": 0.74,
+      "out": 0.74
+    },
+    "meta-llama/llama-3-70b-instruct": {
+      "cached_read": null,
+      "in": 0.51,
+      "out": 0.74
+    },
+    "meta-llama/llama-3-8b-instruct": {
+      "cached_read": null,
+      "in": 0.03,
+      "out": 0.04
+    },
+    "meta-llama/llama-3.1-70b-instruct": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 0.4
+    },
+    "meta-llama/llama-3.1-70b-instruct-turbo": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 0.4
+    },
+    "meta-llama/llama-3.1-8b-instruct": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.05
+    },
+    "meta-llama/llama-3.1-8b-instruct-turbo": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.03
+    },
+    "meta-llama/llama-3.2-11b-vision-instruct": {
+      "cached_read": null,
+      "in": 0.049,
+      "out": 0.049
+    },
+    "meta-llama/llama-3.2-1b-instruct": {
+      "cached_read": null,
+      "in": 0.027,
+      "out": 0.2
+    },
+    "meta-llama/llama-3.2-3b-instruct": {
+      "cached_read": null,
+      "in": 0.051,
+      "out": 0.34
+    },
+    "meta-llama/llama-3.2-3b-instruct:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "meta-llama/llama-3.2-90b-vision-instruct": {
+      "cached_read": 0.175,
+      "in": 0.35,
+      "out": 0.4
+    },
+    "meta-llama/llama-3.3-70b-instruct": {
+      "cached_read": null,
+      "in": 0.99,
+      "out": 0.99
+    },
+    "meta-llama/llama-3.3-70b-instruct-turbo": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.32
+    },
+    "meta-llama/llama-3.3-70b-instruct:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "meta-llama/llama-4-maverick": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "meta-llama/llama-4-maverick-17b-128e-instruct": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.6
+    },
+    "meta-llama/llama-4-maverick-17b-128e-instruct-fp8": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.59
+    },
+    "meta-llama/llama-4-scout": {
+      "cached_read": null,
+      "in": 0.08,
+      "out": 0.3
+    },
+    "meta-llama/llama-4-scout-17b-16e-instruct": {
+      "cached_read": null,
+      "in": 0.08,
+      "out": 0.3
+    },
+    "meta-llama/llama-guard-3-8b": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.06
+    },
+    "meta-llama/llama-guard-4-12b": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "meta-llama/llama-prompt-guard-2-22m": {
+      "cached_read": null,
+      "in": 0.03,
+      "out": 0.03
+    },
+    "meta-llama/llama-prompt-guard-2-86m": {
+      "cached_read": null,
+      "in": 0.04,
+      "out": 0.04
+    },
+    "meta-llama/meta-llama-3.1-405b-instruct-turbo": {
+      "cached_read": null,
+      "in": 3.5,
+      "out": 3.5
+    },
+    "meta-llama/meta-llama-3.1-8b-instruct": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.05
+    },
+    "meta.llama3-1-70b-instruct-v1:0": {
+      "cached_read": null,
+      "in": 0.72,
+      "out": 0.72
+    },
+    "meta.llama3-1-8b-instruct-v1:0": {
+      "cached_read": null,
+      "in": 0.22,
+      "out": 0.22
+    },
+    "meta.llama3-3-70b-instruct-v1:0": {
+      "cached_read": null,
+      "in": 0.72,
+      "out": 0.72
+    },
+    "meta.llama4-maverick-17b-instruct-v1:0": {
+      "cached_read": null,
+      "in": 0.24,
+      "out": 0.97
+    },
+    "meta.llama4-scout-17b-instruct-v1:0": {
+      "cached_read": null,
+      "in": 0.17,
+      "out": 0.66
+    },
+    "meta/esm2-650m": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "meta/esmfold": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "meta/llama-3.1-70b": {
+      "cached_read": null,
+      "in": 0.72,
+      "out": 0.72
+    },
+    "meta/llama-3.1-70b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "meta/llama-3.1-8b": {
+      "cached_read": null,
+      "in": 0.22,
+      "out": 0.22
+    },
+    "meta/llama-3.1-8b-instruct": {
+      "cached_read": null,
+      "in": 0.025,
+      "out": 0.025
+    },
+    "meta/llama-3.2-11b": {
+      "cached_read": null,
+      "in": 0.16,
+      "out": 0.16
+    },
+    "meta/llama-3.2-11b-vision-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "meta/llama-3.2-1b": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "meta/llama-3.2-1b-instruct": {
+      "cached_read": null,
+      "in": 0.01,
+      "out": 0.01
+    },
+    "meta/llama-3.2-3b": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.15
+    },
+    "meta/llama-3.2-3b-instruct": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.02
+    },
+    "meta/llama-3.2-90b": {
+      "cached_read": null,
+      "in": 0.72,
+      "out": 0.72
+    },
+    "meta/llama-3.2-90b-vision-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "meta/llama-3.3-70b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "meta/llama-3.3-70b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "meta/llama-3.3-70b-instruct-maas": {
+      "cached_read": null,
+      "in": 0.72,
+      "out": 0.72
+    },
+    "meta/llama-4-maverick": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "meta/llama-4-maverick-17b-128e-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "meta/llama-4-maverick-17b-128e-instruct-fp8": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "meta/llama-4-maverick-17b-128e-instruct-maas": {
+      "cached_read": null,
+      "in": 0.35,
+      "out": 1.15
+    },
+    "meta/llama-4-scout": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "meta/llama-4-scout-17b-16e-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "meta/llama-guard-4-12b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "meta/meta-llama-3-70b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "meta/meta-llama-3-8b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "meta/meta-llama-3.1-405b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "meta/meta-llama-3.1-70b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "meta/meta-llama-3.1-8b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "microsoft/mai-ds-r1": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "microsoft/phi-3-medium-128k-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "microsoft/phi-3-medium-4k-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "microsoft/phi-3-mini-128k-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "microsoft/phi-3-mini-4k-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "microsoft/phi-3-small-128k-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "microsoft/phi-3-small-8k-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "microsoft/phi-3.5-mini-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "microsoft/phi-3.5-moe-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "microsoft/phi-3.5-vision-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "microsoft/phi-4": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "microsoft/phi-4-mini-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "microsoft/phi-4-mini-reasoning": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "microsoft/phi-4-multimodal-instruct": {
+      "cached_read": null,
+      "in": 0.24,
+      "out": 0.47
+    },
+    "microsoft/phi-4-reasoning": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "microsoft/wizardlm-2-8x22b": {
+      "cached_read": null,
+      "in": 0.62,
+      "out": 0.62
+    },
+    "mimo-v2-flash": {
+      "cached_read": 0.01,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "mimo-v2-flash-free": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "mimo-v2-omni": {
+      "cached_read": 0.08,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "mimo-v2-omni-free": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "mimo-v2-pro": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "mimo-v2-pro-free": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "mimo-v2-tts": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "mimo-v2.5": {
+      "cached_read": 0.08,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "mimo-v2.5-free": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "mimo-v2.5-pro": {
+      "cached_read": 0.003,
+      "in": 0.4,
+      "out": 0.8
+    },
+    "mimo-v2.5-tts": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "mimo-v2.5-tts-voiceclone": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "mimo-v2.5-tts-voicedesign": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "minimax-m1": {
+      "cached_read": null,
+      "in": 0.132,
+      "out": 1.254
+    },
+    "minimax-m2": {
+      "cached_read": null,
+      "in": 0.33,
+      "out": 1.32
+    },
+    "minimax-m2-5": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "minimax-m2-7": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "minimax-m2-7-highspeed": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.4
+    },
+    "minimax-m2.1": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "minimax-m2.1-free": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "minimax-m2.1-lightning": {
+      "cached_read": null,
+      "in": 0.12,
+      "out": 0.48
+    },
+    "minimax-m2.5": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "minimax-m2.5-free": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "minimax-m2.5-highspeed": {
+      "cached_read": 0.06,
+      "in": 0.6,
+      "out": 2.4
+    },
+    "minimax-m2.7": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "minimax-m2.7-highspeed": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 4.8
+    },
+    "minimax-m25": {
+      "cached_read": 0.04,
+      "in": 0.34,
+      "out": 1.19
+    },
+    "minimax-m27": {
+      "cached_read": 0.075,
+      "in": 0.375,
+      "out": 1.5
+    },
+    "minimax-m3": {
+      "cached_read": 0.12,
+      "in": 0.6,
+      "out": 2.4
+    },
+    "minimax-m3-free": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "minimax-text-01": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 1.1
+    },
+    "minimax.minimax-m2": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "minimax.minimax-m2.1": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "minimax.minimax-m2.5": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "minimax/minimax-01": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 1.1
+    },
+    "minimax/minimax-latest": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "minimax/minimax-m1": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.2
+    },
+    "minimax/minimax-m2": {
+      "cached_read": 0.03,
+      "in": 0.255,
+      "out": 1.0
+    },
+    "minimax/minimax-m2-her": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "minimax/minimax-m2.1": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "minimax/minimax-m2.1-lightning": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 2.4
+    },
+    "minimax/minimax-m2.5": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "minimax/minimax-m2.5-highspeed": {
+      "cached_read": 0.06,
+      "in": 0.6,
+      "out": 2.4
+    },
+    "minimax/minimax-m2.5-lightning": {
+      "cached_read": 0.06,
+      "in": 0.6,
+      "out": 4.8
+    },
+    "minimax/minimax-m2.7": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "minimax/minimax-m2.7-highspeed": {
+      "cached_read": 0.06,
+      "in": 0.6,
+      "out": 2.4
+    },
+    "minimax/minimax-m2.7-turbo": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.4
+    },
+    "minimax/minimax-m3": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "minimax/minimax-m3:thinking": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "minimaxai/chat-completion/models/minimax-m2_5-high-throughput": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "minimaxai/minimax-m1-80k": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 2.2
+    },
+    "minimaxai/minimax-m2": {
+      "cached_read": null,
+      "in": 0.254,
+      "out": 1.02
+    },
+    "minimaxai/minimax-m2.1": {
+      "cached_read": null,
+      "in": 0.28,
+      "out": 1.2
+    },
+    "minimaxai/minimax-m2.5": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "minimaxai/minimax-m2.5-fast": {
+      "cached_read": 0.03,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "minimaxai/minimax-m2.5-tee": {
+      "cached_read": 0.075,
+      "in": 0.15,
+      "out": 1.2
+    },
+    "minimaxai/minimax-m2.7": {
+      "cached_read": 0.06,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "ministral-14b-2512": {
+      "cached_read": null,
+      "in": 0.33,
+      "out": 0.33
+    },
+    "ministral-3b": {
+      "cached_read": null,
+      "in": 0.04,
+      "out": 0.04
+    },
+    "ministral-3b-2512": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "ministral-3b-latest": {
+      "cached_read": null,
+      "in": 0.04,
+      "out": 0.04
+    },
+    "ministral-8b-2512": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.15
+    },
+    "ministral-8b-latest": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "mirothinker-1-7-deepresearch": {
+      "cached_read": null,
+      "in": 4.0,
+      "out": 25.0
+    },
+    "mirothinker-1-7-deepresearch-mini": {
+      "cached_read": null,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "mistral-3-14b": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "mistral-7b-instruct-v0.3": {
+      "cached_read": null,
+      "in": 0.11,
+      "out": 0.11
+    },
+    "mistral-ai/codestral-2501": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "mistral-ai/ministral-3b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "mistral-ai/mistral-large-2411": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "mistral-ai/mistral-medium-2505": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "mistral-ai/mistral-nemo": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "mistral-ai/mistral-small-2503": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "mistral-code-agent-latest": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "mistral-code-latest": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.9
+    },
+    "mistral-embed": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.0
+    },
+    "mistral-large-2411": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "mistral-large-2512": {
+      "cached_read": null,
+      "in": 1.1,
+      "out": 3.3
+    },
+    "mistral-large-latest": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "mistral-medium-2505": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "mistral-medium-2508": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "mistral-medium-2604": {
+      "cached_read": null,
+      "in": 1.5,
+      "out": 7.5
+    },
+    "mistral-medium-3.5-128b": {
+      "cached_read": null,
+      "in": 1.5,
+      "out": 7.5
+    },
+    "mistral-medium-latest": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "mistral-nemo": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.15
+    },
+    "mistral-nemo-instruct-2407": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.3
+    },
+    "mistral-saba-24b": {
+      "cached_read": null,
+      "in": 0.79,
+      "out": 0.79
+    },
+    "mistral-small": {
+      "cached_read": null,
+      "in": 0.075,
+      "out": 0.2
+    },
+    "mistral-small-2503": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "mistral-small-2506": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "mistral-small-2603": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "mistral-small-3-2-24b-instruct": {
+      "cached_read": null,
+      "in": 0.09375,
+      "out": 0.25
+    },
+    "mistral-small-3.2-24b-instruct-2506": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.31
+    },
+    "mistral-small-31-24b-instruct": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "mistral-small-4-119b": {
+      "cached_read": null,
+      "in": 0.75,
+      "out": 3.0
+    },
+    "mistral-small-latest": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "mistral-small3.2": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 2.2
+    },
+    "mistral.devstral-2-123b": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "mistral.magistral-small-2509": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "mistral.ministral-3-14b-instruct": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "mistral.ministral-3-3b-instruct": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "mistral.ministral-3-8b-instruct": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.15
+    },
+    "mistral.mistral-large-3-675b-instruct": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "mistral.pixtral-large-2502-v1:0": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "mistral.voxtral-mini-3b-2507": {
+      "cached_read": null,
+      "in": 0.04,
+      "out": 0.04
+    },
+    "mistral.voxtral-small-24b-2507": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.35
+    },
+    "mistral/codestral": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.9
+    },
+    "mistral/codestral-latest": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.9
+    },
+    "mistral/devstral-2": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "mistral/devstral-2512": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "mistral/devstral-medium-2507": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "mistral/devstral-medium-latest": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "mistral/devstral-small": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "mistral/devstral-small-2": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "mistral/devstral-small-2507": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "mistral/magistral-medium": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 5.0
+    },
+    "mistral/magistral-medium-latest": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 5.0
+    },
+    "mistral/magistral-small": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "mistral/ministral-14b": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "mistral/ministral-3b": {
+      "cached_read": null,
+      "in": 0.04,
+      "out": 0.04
+    },
+    "mistral/ministral-8b": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "mistral/mistral-large-2411": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "mistral/mistral-large-2512": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "mistral/mistral-large-3": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "mistral/mistral-large-latest": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "mistral/mistral-medium": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "mistral/mistral-medium-2505": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "mistral/mistral-medium-3.5": {
+      "cached_read": null,
+      "in": 1.5,
+      "out": 7.5
+    },
+    "mistral/mistral-medium-3.5:thinking": {
+      "cached_read": null,
+      "in": 1.5,
+      "out": 7.5
+    },
+    "mistral/mistral-medium-latest": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "mistral/mistral-nemo": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.04
+    },
+    "mistral/mistral-nemo-12b-instruct": {
+      "cached_read": null,
+      "in": 0.038,
+      "out": 0.1
+    },
+    "mistral/mistral-small": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "mistral/mistral-small-latest": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "mistral/mixtral-8x22b-instruct": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "mistral/pixtral-12b": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.15
+    },
+    "mistral/pixtral-large": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "mistral/pixtral-large-latest": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "mistralai/codestral-2508": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.9
+    },
+    "mistralai/completion/models/ministral-3-14b-reasoning-2512": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 1.7
+    },
+    "mistralai/completion/models/ministral-3-3b-reasoning-2512": {
+      "cached_read": null,
+      "in": 1.039,
+      "out": 0.54825
+    },
+    "mistralai/devstral-2-123b-instruct-2512": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 1.4
+    },
+    "mistralai/devstral-2512": {
+      "cached_read": 0.025,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "mistralai/devstral-medium": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "mistralai/devstral-small": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "mistralai/devstral-small-2-24b-instruct-2512": {
+      "cached_read": null,
+      "in": 0.12,
+      "out": 0.47
+    },
+    "mistralai/devstral-small-2505": {
+      "cached_read": 0.025,
+      "in": 0.05,
+      "out": 0.22
+    },
+    "mistralai/magistral-small-2506": {
+      "cached_read": 0.25,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "mistralai/magistral-small-2509": {
+      "cached_read": null,
+      "in": 0.59,
+      "out": 2.36
+    },
+    "mistralai/ministral-14b-2512": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "mistralai/ministral-14b-instruct-2512": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "mistralai/ministral-3b-2512": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "mistralai/ministral-8b-2512": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.15
+    },
+    "mistralai/mistral-7b-instruct-v0.1": {
+      "cached_read": null,
+      "in": 0.11,
+      "out": 0.19
+    },
+    "mistralai/mistral-7b-instruct-v03": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "mistralai/mistral-large": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "mistralai/mistral-large-2407": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "mistralai/mistral-large-2411": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "mistralai/mistral-large-2512": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "mistralai/mistral-large-3-675b-instruct-2512": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "mistralai/mistral-large-instruct-2411": {
+      "cached_read": 1.0,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "mistralai/mistral-medium-3": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "mistralai/mistral-medium-3-5": {
+      "cached_read": null,
+      "in": 1.5,
+      "out": 7.5
+    },
+    "mistralai/mistral-medium-3-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "mistralai/mistral-medium-3.1": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "mistralai/mistral-medium-3.5-128b": {
+      "cached_read": null,
+      "in": 1.65,
+      "out": 5.5
+    },
+    "mistralai/mistral-nemo": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.04
+    },
+    "mistralai/mistral-nemo-instruct-2407": {
+      "cached_read": 0.01,
+      "in": 0.02,
+      "out": 0.04
+    },
+    "mistralai/mistral-nemotron": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "mistralai/mistral-saba": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.6
+    },
+    "mistralai/mistral-small-24b-instruct-2501": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.08
+    },
+    "mistralai/mistral-small-2603": {
+      "cached_read": 0.015,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "mistralai/mistral-small-3.1-24b-instruct": {
+      "cached_read": 0.015,
+      "in": 0.35,
+      "out": 0.56
+    },
+    "mistralai/mistral-small-3.2-24b-instruct": {
+      "cached_read": 0.03,
+      "in": 0.06,
+      "out": 0.18
+    },
+    "mistralai/mistral-small-3.2-24b-instruct-2506": {
+      "cached_read": null,
+      "in": 0.33,
+      "out": 0.33
+    },
+    "mistralai/mistral-small-4-119b-2603": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 1.4
+    },
+    "mistralai/mistral-small-4-119b-2603:thinking": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 1.4
+    },
+    "mistralai/mixtral-8x22b-instruct": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "mistralai/mixtral-8x22b-instruct-v0.1": {
+      "cached_read": null,
+      "in": 0.8999999999999999,
+      "out": 0.8999999999999999
+    },
+    "mistralai/mixtral-8x7b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "mistralai/mixtral-8x7b-instruct-v0.1": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 0.27
+    },
+    "mistralai/pixtral-large-2411": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "mistralai/voxtral-small-24b-2507": {
+      "cached_read": null,
+      "in": 0.00236,
+      "out": 0.00236
+    },
+    "mixtral-8x7b-instruct-v0.1": {
+      "cached_read": null,
+      "in": 0.438,
+      "out": 0.68
+    },
+    "mlabonne/neuraldaredevil-8b-abliterated": {
+      "cached_read": null,
+      "in": 0.44,
+      "out": 0.44
+    },
+    "model-router": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.0
+    },
+    "moonshot-kimi-k2-instruct": {
+      "cached_read": null,
+      "in": 0.574,
+      "out": 2.294
+    },
+    "moonshot.kimi-k2-thinking": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.5
+    },
+    "moonshotai.kimi-k2.5": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 3.0
+    },
+    "moonshotai/chat-completion/models/kimi-k2_6": {
+      "cached_read": null,
+      "in": 0.95,
+      "out": 4.0
+    },
+    "moonshotai/kimi-k2": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 2.2
+    },
+    "moonshotai/kimi-k2-0905": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.5
+    },
+    "moonshotai/kimi-k2-instruct": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 2.0
+    },
+    "moonshotai/kimi-k2-instruct-0711": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 2.0
+    },
+    "moonshotai/kimi-k2-instruct-0905": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.5
+    },
+    "moonshotai/kimi-k2-thinking": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.5
+    },
+    "moonshotai/kimi-k2-thinking-maas": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.5
+    },
+    "moonshotai/kimi-k2-thinking-original": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.5
+    },
+    "moonshotai/kimi-k2-thinking-turbo": {
+      "cached_read": 0.15,
+      "in": 1.15,
+      "out": 8.0
+    },
+    "moonshotai/kimi-k2-thinking-turbo-original": {
+      "cached_read": null,
+      "in": 1.15,
+      "out": 8.0
+    },
+    "moonshotai/kimi-k2-turbo": {
+      "cached_read": 0.15,
+      "in": 1.15,
+      "out": 8.0
+    },
+    "moonshotai/kimi-k2.5": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 3.0
+    },
+    "moonshotai/kimi-k2.5-fast": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 2.5
+    },
+    "moonshotai/kimi-k2.5-tee": {
+      "cached_read": 0.22,
+      "in": 0.44,
+      "out": 2.0
+    },
+    "moonshotai/kimi-k2.5:thinking": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.9
+    },
+    "moonshotai/kimi-k2.6": {
+      "cached_read": 0.2,
+      "in": 0.95,
+      "out": 4.0
+    },
+    "moonshotai/kimi-k2.6-tee": {
+      "cached_read": 0.475,
+      "in": 0.95,
+      "out": 4.0
+    },
+    "moonshotai/kimi-k2.6:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "moonshotai/kimi-k2.6:thinking": {
+      "cached_read": null,
+      "in": 0.53,
+      "out": 2.73
+    },
+    "moonshotai/kimi-latest": {
+      "cached_read": 0.125,
+      "in": 0.5,
+      "out": 2.6
+    },
+    "morph-v3-fast": {
+      "cached_read": null,
+      "in": 0.8,
+      "out": 1.2
+    },
+    "morph-v3-large": {
+      "cached_read": null,
+      "in": 0.9,
+      "out": 1.9
+    },
+    "morph/morph-v3-fast": {
+      "cached_read": null,
+      "in": 0.8,
+      "out": 1.2
+    },
+    "morph/morph-v3-large": {
+      "cached_read": null,
+      "in": 0.9,
+      "out": 1.9
+    },
+    "multi-qa-mpnet-base-dot-v1": {
+      "cached_read": null,
+      "in": 0.009,
+      "out": 0.0
+    },
+    "nanogpt/coding-router": {
+      "cached_read": 0.11,
+      "in": 1.1,
+      "out": 2.2
+    },
+    "nanogpt/coding-router:high": {
+      "cached_read": 0.11,
+      "in": 1.1,
+      "out": 2.2
+    },
+    "nanogpt/coding-router:low": {
+      "cached_read": 0.028,
+      "in": 0.14,
+      "out": 0.28
+    },
+    "nanogpt/coding-router:max": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 30.0
+    },
+    "nanogpt/coding-router:medium": {
+      "cached_read": 0.028,
+      "in": 0.14,
+      "out": 0.28
+    },
+    "nemotron-3-nano-omni": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 0.9
+    },
+    "nemotron-3-super-120b-a12b": {
+      "cached_read": null,
+      "in": 0.266,
+      "out": 0.799
+    },
+    "nemotron-3-super-free": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nemotron-3-ultra-free": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nemotron-nano-12b-v2-vl": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.6
+    },
+    "neuralmagic/meta-llama-3.1-8b-instruct-fp8": {
+      "cached_read": null,
+      "in": 0.16,
+      "out": 0.27
+    },
+    "neuralmagic/mistral-nemo-instruct-2407-fp8": {
+      "cached_read": null,
+      "in": 0.49,
+      "out": 0.71
+    },
+    "neversleep/lumimaid-v0.2-70b": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 1.5
+    },
+    "nex-agi/deepseek-v3.1-nex-n1": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 1.0
+    },
+    "nothingiisreal/l3.1-70b-celeste-v0.1-bf16": {
+      "cached_read": null,
+      "in": 0.49299999999999994,
+      "out": 0.49299999999999994
+    },
+    "nousresearch/deephermes-3-mistral-24b-preview": {
+      "cached_read": 0.01225,
+      "in": 0.0245,
+      "out": 0.0978
+    },
+    "nousresearch/hermes-2-pro-llama-3-8b": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.14
+    },
+    "nousresearch/hermes-3-llama-3.1-405b": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 1.0
+    },
+    "nousresearch/hermes-3-llama-3.1-405b:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nousresearch/hermes-3-llama-3.1-70b": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.3
+    },
+    "nousresearch/hermes-4-14b": {
+      "cached_read": 0.0068,
+      "in": 0.0136,
+      "out": 0.0543
+    },
+    "nousresearch/hermes-4-405b": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "nousresearch/hermes-4-405b:thinking": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "nousresearch/hermes-4-70b": {
+      "cached_read": 0.055,
+      "in": 0.13,
+      "out": 0.4
+    },
+    "nousresearch/hermes-4-70b:thinking": {
+      "cached_read": null,
+      "in": 0.2006,
+      "out": 0.3995
+    },
+    "nova-2-lite-v1": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nova-2-pro-v1": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nova-pro-v1": {
+      "cached_read": null,
+      "in": 1.016,
+      "out": 4.061
+    },
+    "novita/deepseek-v3.2": {
+      "cached_read": 0.13,
+      "in": 0.27,
+      "out": 0.4
+    },
+    "novita/glm-5": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 3.2
+    },
+    "novita/kimi-k2.5": {
+      "cached_read": 0.1,
+      "in": 0.6,
+      "out": 3.0
+    },
+    "novita/kimi-k2.6": {
+      "cached_read": 0.16,
+      "in": 0.96,
+      "out": 4.04
+    },
+    "nvidia-nemotron-3-nano-30b-a3b": {
+      "cached_read": null,
+      "in": 0.075,
+      "out": 0.3
+    },
+    "nvidia-nemotron-3-super-120b": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.65
+    },
+    "nvidia-nemotron-cascade-2-30b-a3b": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.8
+    },
+    "nvidia.nemotron-nano-12b-v2": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.6
+    },
+    "nvidia.nemotron-nano-3-30b": {
+      "cached_read": null,
+      "in": 0.06,
+      "out": 0.24
+    },
+    "nvidia.nemotron-nano-9b-v2": {
+      "cached_read": null,
+      "in": 0.06,
+      "out": 0.23
+    },
+    "nvidia.nemotron-super-3-120b": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.65
+    },
+    "nvidia/active-speaker-detection": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia/bevformer": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia/cosmos-predict1-5b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia/cosmos-transfer1-7b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia/cosmos-transfer2_5-2b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia/deepseek-v3.2-nvfp4": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 1.65
+    },
+    "nvidia/gliner-pii": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia/llama-3.1-nemotron-70b-instruct-hf": {
+      "cached_read": null,
+      "in": 0.357,
+      "out": 0.408
+    },
+    "nvidia/llama-3.1-nemotron-safety-guard-8b-v3": {
+      "cached_read": null,
+      "in": 0.01,
+      "out": 0.01
+    },
+    "nvidia/llama-3.3-70b-instruct-fp8": {
+      "cached_read": null,
+      "in": 1.18,
+      "out": 1.18
+    },
+    "nvidia/llama-3.3-nemotron-super-49b-v1": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.15
+    },
+    "nvidia/llama-3.3-nemotron-super-49b-v1.5": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "nvidia/llama-3_1-nemotron-safety-guard-8b-v3": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia/llama-3_1-nemotron-ultra-253b-v1": {
+      "cached_read": 0.06,
+      "in": 0.6,
+      "out": 1.8
+    },
+    "nvidia/llama-3_2-nemoretriever-300m-embed-v1": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia/llama-3_3-nemotron-super-49b-v1": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia/llama-3_3-nemotron-super-49b-v1_5": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.25
+    },
+    "nvidia/llama-nemotron-embed-vl-1b-v2": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia/llama-nemotron-rerank-vl-1b-v2": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia/magpie-tts-zeroshot": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia/nemotron-120b-a12b": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.75
+    },
+    "nvidia/nemotron-3-content-safety": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia/nemotron-3-nano-30b-a3b": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.2
+    },
+    "nvidia/nemotron-3-nano-30b-a3b:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia/nemotron-3-nano-omni": {
+      "cached_read": 0.006,
+      "in": 0.06,
+      "out": 0.24
+    },
+    "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning": {
+      "cached_read": null,
+      "in": 0.105,
+      "out": 0.42
+    },
+    "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning-bf16": {
+      "cached_read": null,
+      "in": 0.13,
+      "out": 0.38
+    },
+    "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia/nemotron-3-super-120b-a12b": {
+      "cached_read": 0.1,
+      "in": 0.1,
+      "out": 0.5
+    },
+    "nvidia/nemotron-3-super-120b-a12b:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia/nemotron-3-super-120b-a12b:thinking": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.25
+    },
+    "nvidia/nemotron-3-ultra-550b-a55b": {
+      "cached_read": 0.15,
+      "in": 0.5,
+      "out": 2.5
+    },
+    "nvidia/nemotron-3-ultra-550b-a55b:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia/nemotron-3.5-content-safety:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia/nemotron-cascade-2-30b-a3b": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "nvidia/nemotron-content-safety-reasoning-4b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia/nemotron-mini-4b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia/nemotron-nano-12b-v2-vl": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.6
+    },
+    "nvidia/nemotron-nano-12b-v2-vl:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia/nemotron-nano-9b-v2": {
+      "cached_read": null,
+      "in": 0.04,
+      "out": 0.16
+    },
+    "nvidia/nemotron-nano-9b-v2:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia/nemotron-voicechat": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia/nv-embed-v1": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia/nv-embedcode-7b-v1": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia/nvidia-nemotron-3-nano-30b-a3b": {
+      "cached_read": 0.006,
+      "in": 0.06,
+      "out": 0.24
+    },
+    "nvidia/nvidia-nemotron-3-super-120b-a12b-fp8": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.8
+    },
+    "nvidia/nvidia-nemotron-nano-9b-v2": {
+      "cached_read": null,
+      "in": 0.17,
+      "out": 0.68
+    },
+    "nvidia/rerank-qa-mistral-4b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia/riva-translate-4b-instruct-v1_1": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia/sparsedrive": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia/streampetr": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia/studiovoice": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia/synthetic-video-detector": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia/usdcode": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "nvidia/usdvalidate": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "o1": {
+      "cached_read": 7.5,
+      "in": 15.0,
+      "out": 60.0
+    },
+    "o1-mini": {
+      "cached_read": 0.55,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "o1-preview": {
+      "cached_read": 8.25,
+      "in": 16.5,
+      "out": 66.0
+    },
+    "o1-pro": {
+      "cached_read": null,
+      "in": 150.0,
+      "out": 600.0
+    },
+    "o3": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "o3-deep-research": {
+      "cached_read": 2.5,
+      "in": 10.0,
+      "out": 40.0
+    },
+    "o3-mini": {
+      "cached_read": null,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "o3-pro": {
+      "cached_read": null,
+      "in": 20.0,
+      "out": 40.0
+    },
+    "o4-mini": {
+      "cached_read": null,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "o4-mini-deep-research": {
+      "cached_read": 0.5,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "olafangensan-glm-4.7-flash-heretic": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.8
+    },
+    "open-mistral-7b": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 0.25
+    },
+    "open-mistral-nemo": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.15
+    },
+    "open-mixtral-8x22b": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "open-mixtral-8x7b": {
+      "cached_read": null,
+      "in": 0.7,
+      "out": 0.7
+    },
+    "openai-gpt-4.1": {
+      "cached_read": 0.5,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "openai-gpt-4o": {
+      "cached_read": 1.25,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "openai-gpt-4o-2024-11-20": {
+      "cached_read": null,
+      "in": 3.125,
+      "out": 12.5
+    },
+    "openai-gpt-4o-mini": {
+      "cached_read": 0.075,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "openai-gpt-4o-mini-2024-07-18": {
+      "cached_read": 0.09375,
+      "in": 0.1875,
+      "out": 0.75
+    },
+    "openai-gpt-5": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "openai-gpt-5-mini": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "openai-gpt-5-nano": {
+      "cached_read": 0.005,
+      "in": 0.05,
+      "out": 0.4
+    },
+    "openai-gpt-5.1-codex-max": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "openai-gpt-5.2": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "openai-gpt-5.2-pro": {
+      "cached_read": null,
+      "in": 21.0,
+      "out": 168.0
+    },
+    "openai-gpt-5.3-codex": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "openai-gpt-5.4": {
+      "cached_read": 0.25,
+      "in": 2.5,
+      "out": 15.0
+    },
+    "openai-gpt-5.4-mini": {
+      "cached_read": 0.075,
+      "in": 0.75,
+      "out": 4.5
+    },
+    "openai-gpt-5.4-nano": {
+      "cached_read": 0.02,
+      "in": 0.2,
+      "out": 1.25
+    },
+    "openai-gpt-5.4-pro": {
+      "cached_read": null,
+      "in": 30.0,
+      "out": 180.0
+    },
+    "openai-gpt-5.5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 30.0
+    },
+    "openai-gpt-52": {
+      "cached_read": 0.219,
+      "in": 2.19,
+      "out": 17.5
+    },
+    "openai-gpt-52-codex": {
+      "cached_read": 0.219,
+      "in": 2.19,
+      "out": 17.5
+    },
+    "openai-gpt-53-codex": {
+      "cached_read": 0.219,
+      "in": 2.19,
+      "out": 17.5
+    },
+    "openai-gpt-54": {
+      "cached_read": 0.313,
+      "in": 3.13,
+      "out": 18.8
+    },
+    "openai-gpt-54-mini": {
+      "cached_read": 0.09375,
+      "in": 0.9375,
+      "out": 5.625
+    },
+    "openai-gpt-54-pro": {
+      "cached_read": null,
+      "in": 37.5,
+      "out": 225.0
+    },
+    "openai-gpt-55": {
+      "cached_read": 0.625,
+      "in": 6.25,
+      "out": 37.5
+    },
+    "openai-gpt-55-pro": {
+      "cached_read": null,
+      "in": 37.5,
+      "out": 225.0
+    },
+    "openai-gpt-image-1": {
+      "cached_read": 1.25,
+      "in": 5.0,
+      "out": 40.0
+    },
+    "openai-gpt-image-1.5": {
+      "cached_read": 1.0,
+      "in": 5.0,
+      "out": 10.0
+    },
+    "openai-gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.7
+    },
+    "openai-gpt-oss-20b": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.45
+    },
+    "openai-o1": {
+      "cached_read": 7.5,
+      "in": 15.0,
+      "out": 60.0
+    },
+    "openai-o3": {
+      "cached_read": 0.5,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "openai-o3-mini": {
+      "cached_read": 0.55,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "openai.gpt-5.4": {
+      "cached_read": 0.275,
+      "in": 2.75,
+      "out": 16.5
+    },
+    "openai.gpt-5.5": {
+      "cached_read": 0.55,
+      "in": 5.5,
+      "out": 33.0
+    },
+    "openai.gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "openai.gpt-oss-120b-1:0": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "openai.gpt-oss-20b": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.3
+    },
+    "openai.gpt-oss-20b-1:0": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.3
+    },
+    "openai.gpt-oss-safeguard-120b": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "openai.gpt-oss-safeguard-20b": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.2
+    },
+    "openai/chat-completion/models/gpt-oss-120b-high-throughput": {
+      "cached_read": null,
+      "in": 0.09,
+      "out": 0.36
+    },
+    "openai/chat-completion/models/gpt-oss-20b": {
+      "cached_read": null,
+      "in": 0.045,
+      "out": 0.18
+    },
+    "openai/chatgpt-4o-latest": {
+      "cached_read": null,
+      "in": 4.5,
+      "out": 14.0
+    },
+    "openai/codex-mini": {
+      "cached_read": 0.38,
+      "in": 1.5,
+      "out": 6.0
+    },
+    "openai/gpt-3.5-turbo": {
+      "cached_read": 1.25,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "openai/gpt-3.5-turbo-0613": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 2.0
+    },
+    "openai/gpt-3.5-turbo-16k": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 4.0
+    },
+    "openai/gpt-3.5-turbo-instruct": {
+      "cached_read": null,
+      "in": 1.5,
+      "out": 2.0
+    },
+    "openai/gpt-3.5-turbo-raw": {
+      "cached_read": null,
+      "in": 0.45,
+      "out": 1.4
+    },
+    "openai/gpt-4": {
+      "cached_read": null,
+      "in": 30.0,
+      "out": 60.0
+    },
+    "openai/gpt-4-0314": {
+      "cached_read": null,
+      "in": 30.0,
+      "out": 60.0
+    },
+    "openai/gpt-4-1106-preview": {
+      "cached_read": null,
+      "in": 10.0,
+      "out": 30.0
+    },
+    "openai/gpt-4-classic": {
+      "cached_read": null,
+      "in": 27.0,
+      "out": 54.0
+    },
+    "openai/gpt-4-classic-0314": {
+      "cached_read": null,
+      "in": 27.0,
+      "out": 54.0
+    },
+    "openai/gpt-4-turbo": {
+      "cached_read": null,
+      "in": 10.0,
+      "out": 30.0
+    },
+    "openai/gpt-4-turbo-preview": {
+      "cached_read": null,
+      "in": 10.0,
+      "out": 30.0
+    },
+    "openai/gpt-4.1": {
+      "cached_read": 0.5,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "openai/gpt-4.1-mini": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "openai/gpt-4.1-nano": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "openai/gpt-4o": {
+      "cached_read": 1.25,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "openai/gpt-4o-2024-05-13": {
+      "cached_read": null,
+      "in": 5.0,
+      "out": 15.0
+    },
+    "openai/gpt-4o-2024-08-06": {
+      "cached_read": 1.25,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "openai/gpt-4o-2024-11-20": {
+      "cached_read": 1.25,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "openai/gpt-4o-audio-preview": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "openai/gpt-4o-aug": {
+      "cached_read": 1.1,
+      "in": 2.2,
+      "out": 9.0
+    },
+    "openai/gpt-4o-mini": {
+      "cached_read": 0.08,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "openai/gpt-4o-mini-2024-07-18": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "openai/gpt-4o-mini-search": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.54
+    },
+    "openai/gpt-4o-mini-search-preview": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "openai/gpt-4o-search": {
+      "cached_read": null,
+      "in": 2.2,
+      "out": 9.0
+    },
+    "openai/gpt-4o-search-preview": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "openai/gpt-5": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "openai/gpt-5-chat": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "openai/gpt-5-chat-latest": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "openai/gpt-5-codex": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "openai/gpt-5-image": {
+      "cached_read": null,
+      "in": 10.0,
+      "out": 10.0
+    },
+    "openai/gpt-5-image-mini": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 2.0
+    },
+    "openai/gpt-5-mini": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "openai/gpt-5-nano": {
+      "cached_read": 0.005,
+      "in": 0.05,
+      "out": 0.4
+    },
+    "openai/gpt-5-pro": {
+      "cached_read": null,
+      "in": 15.0,
+      "out": 120.0
+    },
+    "openai/gpt-5.1": {
+      "cached_read": 0.13,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "openai/gpt-5.1-2025-11-13": {
+      "cached_read": null,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "openai/gpt-5.1-chat": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "openai/gpt-5.1-chat-latest": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "openai/gpt-5.1-codex": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "openai/gpt-5.1-codex-max": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "openai/gpt-5.1-codex-mini": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "openai/gpt-5.1-instant": {
+      "cached_read": 0.11,
+      "in": 1.1,
+      "out": 9.0
+    },
+    "openai/gpt-5.1-thinking": {
+      "cached_read": 0.125,
+      "in": 1.25,
+      "out": 10.0
+    },
+    "openai/gpt-5.2": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "openai/gpt-5.2-chat": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "openai/gpt-5.2-chat-latest": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "openai/gpt-5.2-codex": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "openai/gpt-5.2-instant": {
+      "cached_read": 0.16,
+      "in": 1.6,
+      "out": 13.0
+    },
+    "openai/gpt-5.2-pro": {
+      "cached_read": null,
+      "in": 21.0,
+      "out": 168.0
+    },
+    "openai/gpt-5.3-chat": {
+      "cached_read": null,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "openai/gpt-5.3-chat-latest": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "openai/gpt-5.3-codex": {
+      "cached_read": 0.175,
+      "in": 1.75,
+      "out": 14.0
+    },
+    "openai/gpt-5.3-codex-spark": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "openai/gpt-5.3-instant": {
+      "cached_read": 0.16,
+      "in": 1.6,
+      "out": 13.0
+    },
+    "openai/gpt-5.4": {
+      "cached_read": 0.25,
+      "in": 2.5,
+      "out": 15.0
+    },
+    "openai/gpt-5.4-image-2": {
+      "cached_read": 2.0,
+      "in": 8.0,
+      "out": 15.0
+    },
+    "openai/gpt-5.4-mini": {
+      "cached_read": 0.075,
+      "in": 0.75,
+      "out": 4.5
+    },
+    "openai/gpt-5.4-nano": {
+      "cached_read": 0.02,
+      "in": 0.2,
+      "out": 1.25
+    },
+    "openai/gpt-5.4-pro": {
+      "cached_read": null,
+      "in": 30.0,
+      "out": 180.0
+    },
+    "openai/gpt-5.5": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 30.0
+    },
+    "openai/gpt-5.5-pro": {
+      "cached_read": null,
+      "in": 30.0,
+      "out": 180.0
+    },
+    "openai/gpt-audio": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "openai/gpt-audio-mini": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.4
+    },
+    "openai/gpt-chat-latest": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 30.0
+    },
+    "openai/gpt-image-2": {
+      "cached_read": 1.2626,
+      "in": 5.0505,
+      "out": 32.3232
+    },
+    "openai/gpt-latest": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 30.0
+    },
+    "openai/gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.08,
+      "out": 0.44
+    },
+    "openai/gpt-oss-120b-fast": {
+      "cached_read": 0.01,
+      "in": 0.1,
+      "out": 0.5
+    },
+    "openai/gpt-oss-120b-maas": {
+      "cached_read": null,
+      "in": 0.09,
+      "out": 0.36
+    },
+    "openai/gpt-oss-120b-tee": {
+      "cached_read": 0.045,
+      "in": 0.09,
+      "out": 0.36
+    },
+    "openai/gpt-oss-120b:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "openai/gpt-oss-20b": {
+      "cached_read": null,
+      "in": 0.03,
+      "out": 0.14
+    },
+    "openai/gpt-oss-20b-maas": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.25
+    },
+    "openai/gpt-oss-20b:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "openai/gpt-oss-safeguard-20b": {
+      "cached_read": 0.037,
+      "in": 0.075,
+      "out": 0.3
+    },
+    "openai/o1": {
+      "cached_read": 7.5,
+      "in": 15.0,
+      "out": 60.0
+    },
+    "openai/o1-mini": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "openai/o1-preview": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "openai/o1-pro": {
+      "cached_read": null,
+      "in": 150.0,
+      "out": 600.0
+    },
+    "openai/o3": {
+      "cached_read": 0.5,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "openai/o3-deep-research": {
+      "cached_read": 2.5,
+      "in": 10.0,
+      "out": 40.0
+    },
+    "openai/o3-mini": {
+      "cached_read": 0.55,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "openai/o3-mini-high": {
+      "cached_read": 0.55,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "openai/o3-mini-low": {
+      "cached_read": null,
+      "in": 9.996,
+      "out": 19.992
+    },
+    "openai/o3-pro": {
+      "cached_read": null,
+      "in": 20.0,
+      "out": 80.0
+    },
+    "openai/o3-pro-2025-06-10": {
+      "cached_read": null,
+      "in": 9.996,
+      "out": 19.992
+    },
+    "openai/o4-mini": {
+      "cached_read": 0.28,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "openai/o4-mini-deep-research": {
+      "cached_read": 0.5,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "openai/o4-mini-high": {
+      "cached_read": null,
+      "in": 1.1,
+      "out": 4.4
+    },
+    "openai/whisper-large-v3": {
+      "cached_read": null,
+      "in": 0.00236,
+      "out": 0.00236
+    },
+    "openpipe/qwen3-14b-instruct": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.22
+    },
+    "openrouter/auto": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "openrouter/bodybuilder": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "openrouter/free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "openrouter/owl-alpha": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "openrouter/pareto-code": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "orcarouter/auto": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "osmosis/osmosis-structure-0.6b": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.5
+    },
+    "owl": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "paddlepaddle/paddleocr-vl": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.02
+    },
+    "paddlepaddle/paddleocr-vl-1.5": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "pamanseau/openreasoning-nemotron-32b": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "perceptron/perceptron-mk1": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 1.5
+    },
+    "perplexity/sonar": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 1.0
+    },
+    "perplexity/sonar-deep-research": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "perplexity/sonar-pro": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "perplexity/sonar-pro-search": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "perplexity/sonar-reasoning": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "perplexity/sonar-reasoning-pro": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "phi-3-medium-128k-instruct": {
+      "cached_read": null,
+      "in": 0.17,
+      "out": 0.68
+    },
+    "phi-3-medium-4k-instruct": {
+      "cached_read": null,
+      "in": 0.17,
+      "out": 0.68
+    },
+    "phi-3-mini-128k-instruct": {
+      "cached_read": null,
+      "in": 0.13,
+      "out": 0.52
+    },
+    "phi-3-mini-4k-instruct": {
+      "cached_read": null,
+      "in": 0.13,
+      "out": 0.52
+    },
+    "phi-3-small-128k-instruct": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "phi-3-small-8k-instruct": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "phi-3.5-mini-instruct": {
+      "cached_read": null,
+      "in": 0.13,
+      "out": 0.52
+    },
+    "phi-3.5-moe-instruct": {
+      "cached_read": null,
+      "in": 0.16,
+      "out": 0.64
+    },
+    "phi-4": {
+      "cached_read": null,
+      "in": 0.125,
+      "out": 0.5
+    },
+    "phi-4-mini": {
+      "cached_read": null,
+      "in": 0.075,
+      "out": 0.3
+    },
+    "phi-4-mini-instruct": {
+      "cached_read": null,
+      "in": 0.17,
+      "out": 0.68
+    },
+    "phi-4-mini-reasoning": {
+      "cached_read": null,
+      "in": 0.075,
+      "out": 0.3
+    },
+    "phi-4-multimodal": {
+      "cached_read": null,
+      "in": 0.08,
+      "out": 0.32
+    },
+    "phi-4-multimodal-instruct": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.11
+    },
+    "phi-4-reasoning": {
+      "cached_read": null,
+      "in": 0.125,
+      "out": 0.5
+    },
+    "phi-4-reasoning-plus": {
+      "cached_read": null,
+      "in": 0.125,
+      "out": 0.5
+    },
+    "pixtral-12b": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.15
+    },
+    "pixtral-12b-2409": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "pixtral-large-latest": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "poolside/laguna-m.1": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "poolside/laguna-m.1:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "poolside/laguna-xs.2": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "poolside/laguna-xs.2:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "prime-intellect/intellect-3": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 1.1
+    },
+    "primeintellect/intellect-3": {
+      "cached_read": 0.02,
+      "in": 0.2,
+      "out": 1.1
+    },
+    "pro/deepseek-ai/deepseek-r1": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 2.18
+    },
+    "pro/deepseek-ai/deepseek-v3": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 1.0
+    },
+    "pro/deepseek-ai/deepseek-v3.1-terminus": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 1.0
+    },
+    "pro/deepseek-ai/deepseek-v3.2": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 0.42
+    },
+    "pro/minimaxai/minimax-m2.1": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "pro/minimaxai/minimax-m2.5": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.22
+    },
+    "pro/moonshotai/kimi-k2-instruct-0905": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "pro/moonshotai/kimi-k2-thinking": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 2.5
+    },
+    "pro/moonshotai/kimi-k2.5": {
+      "cached_read": null,
+      "in": 0.45,
+      "out": 2.25
+    },
+    "pro/moonshotai/kimi-k2.6": {
+      "cached_read": 0.16,
+      "in": 0.95,
+      "out": 4.0
+    },
+    "pro/zai-org/glm-4.7": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "pro/zai-org/glm-5": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 3.2
+    },
+    "pro/zai-org/glm-5.1": {
+      "cached_read": null,
+      "in": 1.4,
+      "out": 4.4
+    },
+    "public/deepseek-r1": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 2.2
+    },
+    "public/deepseek-v3": {
+      "cached_read": null,
+      "in": 0.28,
+      "out": 1.1
+    },
+    "public/minimax-m25": {
+      "cached_read": null,
+      "in": 0.29,
+      "out": 1.16
+    },
+    "qvq-max": {
+      "cached_read": null,
+      "in": 1.2,
+      "out": 4.8
+    },
+    "qwen-2.5-72b-instruct": {
+      "cached_read": null,
+      "in": 0.062,
+      "out": 0.231
+    },
+    "qwen-2.5-coder-32b": {
+      "cached_read": null,
+      "in": 0.79,
+      "out": 0.79
+    },
+    "qwen-3-6-plus": {
+      "cached_read": 0.1,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "qwen-3-7-max": {
+      "cached_read": 0.27,
+      "in": 2.7,
+      "out": 8.05
+    },
+    "qwen-3-7-plus": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 2.0
+    },
+    "qwen-3.6-plus": {
+      "cached_read": 0.1,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "qwen-coder-plus": {
+      "cached_read": null,
+      "in": 0.502,
+      "out": 1.004
+    },
+    "qwen-deep-research": {
+      "cached_read": null,
+      "in": 7.742,
+      "out": 23.367
+    },
+    "qwen-doc-turbo": {
+      "cached_read": null,
+      "in": 0.087,
+      "out": 0.144
+    },
+    "qwen-flash": {
+      "cached_read": null,
+      "in": 0.022,
+      "out": 0.22
+    },
+    "qwen-image": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 2.0
+    },
+    "qwen-image-2.0": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "qwen-image-2.0-pro": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "qwen-long": {
+      "cached_read": null,
+      "in": 0.072,
+      "out": 0.287
+    },
+    "qwen-math-plus": {
+      "cached_read": null,
+      "in": 0.574,
+      "out": 1.721
+    },
+    "qwen-math-turbo": {
+      "cached_read": null,
+      "in": 0.287,
+      "out": 0.861
+    },
+    "qwen-max": {
+      "cached_read": null,
+      "in": 1.6,
+      "out": 6.4
+    },
+    "qwen-max-latest": {
+      "cached_read": null,
+      "in": 0.343,
+      "out": 1.372
+    },
+    "qwen-mt-plus": {
+      "cached_read": null,
+      "in": 2.46,
+      "out": 7.37
+    },
+    "qwen-mt-turbo": {
+      "cached_read": null,
+      "in": 0.16,
+      "out": 0.49
+    },
+    "qwen-omni-turbo": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.27
+    },
+    "qwen-omni-turbo-realtime": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 1.07
+    },
+    "qwen-plus": {
+      "cached_read": null,
+      "in": 0.12,
+      "out": 1.2
+    },
+    "qwen-plus-character": {
+      "cached_read": null,
+      "in": 0.115,
+      "out": 0.287
+    },
+    "qwen-plus-character-ja": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.4
+    },
+    "qwen-plus-latest": {
+      "cached_read": null,
+      "in": 0.115,
+      "out": 0.287
+    },
+    "qwen-qwq-32b": {
+      "cached_read": null,
+      "in": 0.29,
+      "out": 0.39
+    },
+    "qwen-turbo": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.2
+    },
+    "qwen-vl-max": {
+      "cached_read": null,
+      "in": 0.8,
+      "out": 3.2
+    },
+    "qwen-vl-ocr": {
+      "cached_read": null,
+      "in": 0.72,
+      "out": 0.72
+    },
+    "qwen-vl-plus": {
+      "cached_read": null,
+      "in": 0.21,
+      "out": 0.63
+    },
+    "qwen.qwen3-235b-a22b-2507-v1:0": {
+      "cached_read": null,
+      "in": 0.22,
+      "out": 0.88
+    },
+    "qwen.qwen3-32b-v1:0": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "qwen.qwen3-coder-30b-a3b-v1:0": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "qwen.qwen3-coder-480b-a35b-v1:0": {
+      "cached_read": null,
+      "in": 0.22,
+      "out": 1.8
+    },
+    "qwen.qwen3-coder-next": {
+      "cached_read": null,
+      "in": 0.22,
+      "out": 1.8
+    },
+    "qwen.qwen3-next-80b-a3b": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 1.4
+    },
+    "qwen.qwen3-vl-235b-a22b": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.5
+    },
+    "qwen/qwen-2.5-72b-instruct": {
+      "cached_read": null,
+      "in": 0.12,
+      "out": 0.39
+    },
+    "qwen/qwen-2.5-7b-instruct": {
+      "cached_read": null,
+      "in": 0.04,
+      "out": 0.1
+    },
+    "qwen/qwen-2.5-7b-vision-instruct": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "qwen/qwen-2.5-coder-32b-instruct": {
+      "cached_read": 0.015,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "qwen/qwen-image": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "qwen/qwen-image-edit": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "qwen/qwen-mt-plus": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 0.75
+    },
+    "qwen/qwen-plus": {
+      "cached_read": 0.08,
+      "in": 0.4,
+      "out": 1.2
+    },
+    "qwen/qwen-plus-2025-07-28": {
+      "cached_read": null,
+      "in": 0.26,
+      "out": 0.78
+    },
+    "qwen/qwen-plus-2025-07-28:thinking": {
+      "cached_read": null,
+      "in": 0.26,
+      "out": 0.78
+    },
+    "qwen/qwen2.5-14b-instruct": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "qwen/qwen2.5-32b-instruct": {
+      "cached_read": null,
+      "in": 0.18,
+      "out": 0.18
+    },
+    "qwen/qwen2.5-72b-instruct": {
+      "cached_read": null,
+      "in": 0.11,
+      "out": 0.38
+    },
+    "qwen/qwen2.5-72b-instruct-128k": {
+      "cached_read": null,
+      "in": 0.59,
+      "out": 0.59
+    },
+    "qwen/qwen2.5-7b-instruct": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.07
+    },
+    "qwen/qwen2.5-coder-32b-instruct": {
+      "cached_read": 0.0136,
+      "in": 0.0272,
+      "out": 0.1087
+    },
+    "qwen/qwen2.5-vl-32b-instruct": {
+      "cached_read": 0.02715,
+      "in": 0.0543,
+      "out": 0.2174
+    },
+    "qwen/qwen2.5-vl-72b-instruct": {
+      "cached_read": 0.075,
+      "in": 0.8,
+      "out": 0.8
+    },
+    "qwen/qwen2.5-vl-7b-instruct": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.05
+    },
+    "qwen/qwen3-14b": {
+      "cached_read": 0.025,
+      "in": 0.06,
+      "out": 0.24
+    },
+    "qwen/qwen3-235b-a22b": {
+      "cached_read": 0.15,
+      "in": 0.455,
+      "out": 1.82
+    },
+    "qwen/qwen3-235b-a22b-2507": {
+      "cached_read": null,
+      "in": 0.071,
+      "out": 0.1
+    },
+    "qwen/qwen3-235b-a22b-fp8": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.8
+    },
+    "qwen/qwen3-235b-a22b-instruct-2507": {
+      "cached_read": null,
+      "in": 0.13,
+      "out": 0.6
+    },
+    "qwen/qwen3-235b-a22b-instruct-2507-maas": {
+      "cached_read": null,
+      "in": 0.22,
+      "out": 0.88
+    },
+    "qwen/qwen3-235b-a22b-instruct-2507-tee": {
+      "cached_read": 0.05,
+      "in": 0.1,
+      "out": 0.6
+    },
+    "qwen/qwen3-235b-a22b-instruct-2507-tput": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.6
+    },
+    "qwen/qwen3-235b-a22b-thinking-2507": {
+      "cached_read": 0.055,
+      "in": 0.11,
+      "out": 0.6
+    },
+    "qwen/qwen3-235b-a22b-thinking-2507-fast": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 2.0
+    },
+    "qwen/qwen3-30b-a3b": {
+      "cached_read": 0.03,
+      "in": 0.06,
+      "out": 0.22
+    },
+    "qwen/qwen3-30b-a3b-2507": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "qwen/qwen3-30b-a3b-fp8": {
+      "cached_read": null,
+      "in": 0.09,
+      "out": 0.45
+    },
+    "qwen/qwen3-30b-a3b-instruct-2507": {
+      "cached_read": 0.04,
+      "in": 0.09,
+      "out": 0.3
+    },
+    "qwen/qwen3-30b-a3b-instruct-2507-fp8": {
+      "cached_read": null,
+      "in": 0.35,
+      "out": 1.42
+    },
+    "qwen/qwen3-30b-a3b-thinking-2507": {
+      "cached_read": null,
+      "in": 0.051,
+      "out": 0.34
+    },
+    "qwen/qwen3-32b": {
+      "cached_read": null,
+      "in": 0.09,
+      "out": 0.29
+    },
+    "qwen/qwen3-32b-fp8": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.45
+    },
+    "qwen/qwen3-32b-tee": {
+      "cached_read": 0.04,
+      "in": 0.08,
+      "out": 0.24
+    },
+    "qwen/qwen3-4b-fp8": {
+      "cached_read": null,
+      "in": 0.03,
+      "out": 0.03
+    },
+    "qwen/qwen3-8b": {
+      "cached_read": 0.05,
+      "in": 0.05,
+      "out": 0.4
+    },
+    "qwen/qwen3-8b-fp8": {
+      "cached_read": null,
+      "in": 0.035,
+      "out": 0.138
+    },
+    "qwen/qwen3-coder": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "qwen/qwen3-coder-30b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "qwen/qwen3-coder-30b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.27
+    },
+    "qwen/qwen3-coder-480b-a35b-instruct": {
+      "cached_read": null,
+      "in": 0.29,
+      "out": 1.2
+    },
+    "qwen/qwen3-coder-480b-a35b-instruct-fp8": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.8
+    },
+    "qwen/qwen3-coder-480b-a35b-instruct-turbo": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.2
+    },
+    "qwen/qwen3-coder-flash": {
+      "cached_read": 0.06,
+      "in": 0.195,
+      "out": 0.975
+    },
+    "qwen/qwen3-coder-next": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 1.5
+    },
+    "qwen/qwen3-coder-next-fp8": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.2
+    },
+    "qwen/qwen3-coder-next-tee": {
+      "cached_read": 0.06,
+      "in": 0.12,
+      "out": 0.75
+    },
+    "qwen/qwen3-coder-plus": {
+      "cached_read": 0.2,
+      "in": 0.65,
+      "out": 3.25
+    },
+    "qwen/qwen3-coder:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "qwen/qwen3-embedding-0.6b": {
+      "cached_read": null,
+      "in": 0.01,
+      "out": 0.0
+    },
+    "qwen/qwen3-embedding-4b": {
+      "cached_read": null,
+      "in": 0.01,
+      "out": 0.0
+    },
+    "qwen/qwen3-embedding-8b": {
+      "cached_read": null,
+      "in": 0.12,
+      "out": 0.12
+    },
+    "qwen/qwen3-max": {
+      "cached_read": 0.24,
+      "in": 1.2,
+      "out": 6.0
+    },
+    "qwen/qwen3-max-thinking": {
+      "cached_read": null,
+      "in": 0.78,
+      "out": 3.9
+    },
+    "qwen/qwen3-next-80b-a3b-instruct": {
+      "cached_read": 0.05,
+      "in": 0.1,
+      "out": 0.8
+    },
+    "qwen/qwen3-next-80b-a3b-instruct:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "qwen/qwen3-next-80b-a3b-thinking": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 2.0
+    },
+    "qwen/qwen3-next-80b-a3b-thinking-fast": {
+      "cached_read": 0.015,
+      "in": 0.15,
+      "out": 1.2
+    },
+    "qwen/qwen3-omni-30b-a3b-captioner": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "qwen/qwen3-omni-30b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 0.97
+    },
+    "qwen/qwen3-omni-30b-a3b-thinking": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 0.97
+    },
+    "qwen/qwen3-reranker-0.6b": {
+      "cached_read": null,
+      "in": 0.01,
+      "out": 0.01
+    },
+    "qwen/qwen3-vl-235b-a22b-instruct": {
+      "cached_read": 0.11,
+      "in": 0.2,
+      "out": 0.88
+    },
+    "qwen/qwen3-vl-235b-a22b-instruct-fp8": {
+      "cached_read": null,
+      "in": 1.64,
+      "out": 1.91
+    },
+    "qwen/qwen3-vl-235b-a22b-thinking": {
+      "cached_read": null,
+      "in": 0.26,
+      "out": 2.6
+    },
+    "qwen/qwen3-vl-30b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.24,
+      "out": 0.94
+    },
+    "qwen/qwen3-vl-30b-a3b-thinking": {
+      "cached_read": null,
+      "in": 0.13,
+      "out": 1.56
+    },
+    "qwen/qwen3-vl-32b-instruct": {
+      "cached_read": null,
+      "in": 0.104,
+      "out": 0.416
+    },
+    "qwen/qwen3-vl-32b-thinking": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 1.5
+    },
+    "qwen/qwen3-vl-8b-instruct": {
+      "cached_read": null,
+      "in": 0.08,
+      "out": 0.5
+    },
+    "qwen/qwen3-vl-8b-thinking": {
+      "cached_read": null,
+      "in": 0.117,
+      "out": 1.365
+    },
+    "qwen/qwen3-vl-embedding-8b": {
+      "cached_read": null,
+      "in": 0.09,
+      "out": 0.09
+    },
+    "qwen/qwen3.5-122b-a10b": {
+      "cached_read": null,
+      "in": 0.26,
+      "out": 2.08
+    },
+    "qwen/qwen3.5-27b": {
+      "cached_read": null,
+      "in": 0.195,
+      "out": 1.56
+    },
+    "qwen/qwen3.5-35b-a3b": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.95
+    },
+    "qwen/qwen3.5-397b-a17b": {
+      "cached_read": null,
+      "in": 0.54,
+      "out": 3.4
+    },
+    "qwen/qwen3.5-397b-a17b-fast": {
+      "cached_read": 0.06,
+      "in": 0.6,
+      "out": 3.6
+    },
+    "qwen/qwen3.5-397b-a17b-fp8": {
+      "cached_read": null,
+      "in": 0.69,
+      "out": 4.14
+    },
+    "qwen/qwen3.5-397b-a17b-tee": {
+      "cached_read": 0.195,
+      "in": 0.39,
+      "out": 2.34
+    },
+    "qwen/qwen3.5-397b-a17b-thinking": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 3.6
+    },
+    "qwen/qwen3.5-4b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "qwen/qwen3.5-9b": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.15
+    },
+    "qwen/qwen3.5-flash": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "qwen/qwen3.5-flash-02-23": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "qwen/qwen3.5-plus": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.4
+    },
+    "qwen/qwen3.5-plus-02-15": {
+      "cached_read": null,
+      "in": 0.26,
+      "out": 1.56
+    },
+    "qwen/qwen3.5-plus-20260420": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.4
+    },
+    "qwen/qwen3.5-plus-thinking": {
+      "cached_read": 0.04,
+      "in": 0.4,
+      "out": 2.4
+    },
+    "qwen/qwen3.6-27b": {
+      "cached_read": null,
+      "in": 0.325,
+      "out": 3.25
+    },
+    "qwen/qwen3.6-27b-tee": {
+      "cached_read": 0.0975,
+      "in": 0.195,
+      "out": 1.56
+    },
+    "qwen/qwen3.6-35b-a3b": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 1.0
+    },
+    "qwen/qwen3.6-35b-a3b-fp8": {
+      "cached_read": 0.056,
+      "in": 0.17,
+      "out": 1.1
+    },
+    "qwen/qwen3.6-35b-a3b:thinking": {
+      "cached_read": null,
+      "in": 0.112,
+      "out": 0.8
+    },
+    "qwen/qwen3.6-flash": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 1.5
+    },
+    "qwen/qwen3.6-max-preview": {
+      "cached_read": null,
+      "in": 1.04,
+      "out": 6.24
+    },
+    "qwen/qwen3.6-plus": {
+      "cached_read": 0.0325,
+      "in": 0.325,
+      "out": 1.95
+    },
+    "qwen/qwen3.7-max": {
+      "cached_read": 0.1625,
+      "in": 1.625,
+      "out": 4.875
+    },
+    "qwen/qwen3.7-plus": {
+      "cached_read": 0.08,
+      "in": 0.4,
+      "out": 1.6
+    },
+    "qwen/qwen3guard-gen-0.6b": {
+      "cached_read": 0.005,
+      "in": 0.01,
+      "out": 0.0109
+    },
+    "qwen/qwencoder/models/qwen3-coder-30b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.11458,
+      "out": 0.74812
+    },
+    "qwen/qwenlm/models/qwen3-30b-a3b-instruct-2507": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.5
+    },
+    "qwen/qwenlm/models/qwen3-30b-a3b-thinking-2507": {
+      "cached_read": null,
+      "in": 0.36,
+      "out": 1.3
+    },
+    "qwen/qwq-32b": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 0.4
+    },
+    "qwen/qwq-32b-preview": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "qwen2-5-14b-instruct": {
+      "cached_read": null,
+      "in": 0.35,
+      "out": 1.4
+    },
+    "qwen2-5-32b-instruct": {
+      "cached_read": null,
+      "in": 0.7,
+      "out": 2.8
+    },
+    "qwen2-5-72b-instruct": {
+      "cached_read": null,
+      "in": 1.4,
+      "out": 5.6
+    },
+    "qwen2-5-7b-instruct": {
+      "cached_read": null,
+      "in": 0.175,
+      "out": 0.7
+    },
+    "qwen2-5-coder-32b-instruct": {
+      "cached_read": null,
+      "in": 0.287,
+      "out": 0.861
+    },
+    "qwen2-5-coder-7b-instruct": {
+      "cached_read": null,
+      "in": 0.144,
+      "out": 0.287
+    },
+    "qwen2-5-math-72b-instruct": {
+      "cached_read": null,
+      "in": 0.574,
+      "out": 1.721
+    },
+    "qwen2-5-math-7b-instruct": {
+      "cached_read": null,
+      "in": 0.144,
+      "out": 0.287
+    },
+    "qwen2-5-omni-7b": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "qwen2-5-vl-32b-instruct": {
+      "cached_read": null,
+      "in": 1.4,
+      "out": 4.2
+    },
+    "qwen2-5-vl-72b-instruct": {
+      "cached_read": null,
+      "in": 2.8,
+      "out": 8.4
+    },
+    "qwen2-5-vl-7b-instruct": {
+      "cached_read": null,
+      "in": 0.35,
+      "out": 1.05
+    },
+    "qwen2.5-32b-eva-v0.2": {
+      "cached_read": null,
+      "in": 0.493,
+      "out": 0.493
+    },
+    "qwen2.5-coder-7b-fast": {
+      "cached_read": null,
+      "in": 0.03,
+      "out": 0.09
+    },
+    "qwen2.5-vl-72b-instruct": {
+      "cached_read": null,
+      "in": 1.01,
+      "out": 1.01
+    },
+    "qwen25-coder-7b": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.05
+    },
+    "qwen25-vl-72b-instruct": {
+      "cached_read": null,
+      "in": 0.69989,
+      "out": 0.69989
+    },
+    "qwen3-14b": {
+      "cached_read": null,
+      "in": 0.35,
+      "out": 1.4
+    },
+    "qwen3-235b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "qwen3-235b-a22b": {
+      "cached_read": null,
+      "in": 0.29,
+      "out": 2.86
+    },
+    "qwen3-235b-a22b-fp8": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.8
+    },
+    "qwen3-235b-a22b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "qwen3-235b-a22b-instruct-2507": {
+      "cached_read": null,
+      "in": 0.29,
+      "out": 1.143
+    },
+    "qwen3-235b-a22b-thinking": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 2.9000000000000004
+    },
+    "qwen3-235b-a22b-thinking-2507": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "qwen3-30b-a3b": {
+      "cached_read": null,
+      "in": 0.11,
+      "out": 1.08
+    },
+    "qwen3-30b-a3b-fp8": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "qwen3-30b-a3b-instruct-2507": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "qwen3-30b-a3b-thinking-2507": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "qwen3-32b": {
+      "cached_read": null,
+      "in": 0.7,
+      "out": 2.8
+    },
+    "qwen3-32b-fp8": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "qwen3-4b-fp8": {
+      "cached_read": null,
+      "in": 0.03,
+      "out": 0.03
+    },
+    "qwen3-5-35b-a3b": {
+      "cached_read": 0.15625,
+      "in": 0.3125,
+      "out": 1.25
+    },
+    "qwen3-5-397b-a17b": {
+      "cached_read": null,
+      "in": 0.75,
+      "out": 4.5
+    },
+    "qwen3-5-9b": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.15
+    },
+    "qwen3-6-27b": {
+      "cached_read": null,
+      "in": 0.325,
+      "out": 3.25
+    },
+    "qwen3-8b": {
+      "cached_read": null,
+      "in": 0.18,
+      "out": 0.7
+    },
+    "qwen3-asr-flash": {
+      "cached_read": null,
+      "in": 0.035,
+      "out": 0.035
+    },
+    "qwen3-coder": {
+      "cached_read": null,
+      "in": 0.22,
+      "out": 0.95
+    },
+    "qwen3-coder-30b-a3b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "qwen3-coder-30b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.45,
+      "out": 2.25
+    },
+    "qwen3-coder-480b-a35b-instruct": {
+      "cached_read": null,
+      "in": 0.86,
+      "out": 3.43
+    },
+    "qwen3-coder-480b-a35b-instruct-turbo": {
+      "cached_read": 0.04,
+      "in": 0.35,
+      "out": 1.5
+    },
+    "qwen3-coder-flash": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.5
+    },
+    "qwen3-coder-next": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "qwen3-coder-plus": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "qwen3-embedding-0.6b": {
+      "cached_read": null,
+      "in": 0.04,
+      "out": 0.0
+    },
+    "qwen3-embedding-4b": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "qwen3-embedding-8b": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "qwen3-livetranslate-flash-realtime": {
+      "cached_read": null,
+      "in": 10.0,
+      "out": 10.0
+    },
+    "qwen3-max": {
+      "cached_read": null,
+      "in": 1.2,
+      "out": 6.0
+    },
+    "qwen3-max-2025-09-23": {
+      "cached_read": null,
+      "in": 0.86,
+      "out": 3.43
+    },
+    "qwen3-max-2026-01-23": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "qwen3-max-preview": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "qwen3-next-80b": {
+      "cached_read": null,
+      "in": 0.35,
+      "out": 1.9
+    },
+    "qwen3-next-80b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 2.0
+    },
+    "qwen3-next-80b-a3b-thinking": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 6.0
+    },
+    "qwen3-omni-flash": {
+      "cached_read": null,
+      "in": 0.43,
+      "out": 1.66
+    },
+    "qwen3-omni-flash-realtime": {
+      "cached_read": null,
+      "in": 0.52,
+      "out": 1.99
+    },
+    "qwen3-reranker-4b": {
+      "cached_read": null,
+      "in": 0.12,
+      "out": 0.12
+    },
+    "qwen3-vl-235b-a22b": {
+      "cached_read": null,
+      "in": 0.7,
+      "out": 2.8
+    },
+    "qwen3-vl-235b-a22b-instruct": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.5
+    },
+    "qwen3-vl-235b-a22b-instruct-original": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.2
+    },
+    "qwen3-vl-235b-a22b-thinking": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 2.0
+    },
+    "qwen3-vl-30b-a3b": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.8
+    },
+    "qwen3-vl-30b-a3b-instruct": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.7
+    },
+    "qwen3-vl-30b-a3b-thinking": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 1.0
+    },
+    "qwen3-vl-8b-instruct": {
+      "cached_read": null,
+      "in": 0.08,
+      "out": 0.5
+    },
+    "qwen3-vl-flash": {
+      "cached_read": 0.0044,
+      "in": 0.022,
+      "out": 0.215
+    },
+    "qwen3-vl-plus": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 1.6
+    },
+    "qwen3.5-122b": {
+      "cached_read": null,
+      "in": 0.9,
+      "out": 3.6
+    },
+    "qwen3.5-122b-a10b": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 3.2
+    },
+    "qwen3.5-122b-a10b:thinking": {
+      "cached_read": null,
+      "in": 0.36,
+      "out": 2.88
+    },
+    "qwen3.5-27b": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 2.4
+    },
+    "qwen3.5-27b-anko": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "qwen3.5-27b-bluestar-derestricted": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "qwen3.5-27b-bluestar-derestricted-lite": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "qwen3.5-27b-bluestar-v2-derestricted": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "qwen3.5-27b-bluestar-v2-derestricted-lite": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "qwen3.5-27b-bluestar-v3-derestricted": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "qwen3.5-27b-bluestar-v3-derestricted-lite": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "qwen3.5-27b-derestricted": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "qwen3.5-27b-earica-derestricted": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "qwen3.5-27b-earica-derestricted-lite": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "qwen3.5-27b-infracelestial": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "qwen3.5-27b-marvin-dpo-v2-derestricted": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "qwen3.5-27b-marvin-dpo-v2-derestricted-lite": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "qwen3.5-27b-marvin-v2-derestricted": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "qwen3.5-27b-marvin-v2-derestricted-lite": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "qwen3.5-27b-musica-v1": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "qwen3.5-27b-nanovel-derestricted": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "qwen3.5-27b-nanovel-derestricted-lite": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "qwen3.5-27b-omega-evolution-v2.0-derestricted": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "qwen3.5-27b-omega-evolution-v2.0-derestricted-lite": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "qwen3.5-27b-omega-evolution-v2.2-derestricted": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "qwen3.5-27b-omega-evolution-v2.2-derestricted-lite": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "qwen3.5-27b-queen-derestricted": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "qwen3.5-27b-queen-derestricted-lite": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "qwen3.5-27b-rprmax-v1": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "qwen3.5-27b-vivid-durian": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "qwen3.5-27b-writer-derestricted": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "qwen3.5-27b-writer-derestricted-lite": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "qwen3.5-27b-writer-v2-derestricted": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "qwen3.5-27b-writer-v2-derestricted-lite": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.306
+    },
+    "qwen3.5-27b:thinking": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 2.16
+    },
+    "qwen3.5-35b-a3b": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "qwen3.5-35b-a3b:thinking": {
+      "cached_read": null,
+      "in": 0.225,
+      "out": 1.8
+    },
+    "qwen3.5-397b-a17b": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 3.6
+    },
+    "qwen3.5-397b-fast": {
+      "cached_read": null,
+      "in": 0.69,
+      "out": 4.14
+    },
+    "qwen3.5-9b": {
+      "cached_read": 0.008,
+      "in": 0.04,
+      "out": 0.15
+    },
+    "qwen3.5-flash": {
+      "cached_read": null,
+      "in": 0.172,
+      "out": 1.72
+    },
+    "qwen3.5-flash:thinking": {
+      "cached_read": null,
+      "in": 0.09,
+      "out": 0.36
+    },
+    "qwen3.5-omni-flash": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "qwen3.5-omni-plus": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "qwen3.5-plus": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.4
+    },
+    "qwen3.6-27b": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 3.6
+    },
+    "qwen3.6-35b-a3b": {
+      "cached_read": null,
+      "in": 0.248,
+      "out": 1.485
+    },
+    "qwen3.6-35b-fast": {
+      "cached_read": null,
+      "in": 0.29,
+      "out": 1.15
+    },
+    "qwen3.6-flash": {
+      "cached_read": 0.0169,
+      "in": 0.17,
+      "out": 1.01
+    },
+    "qwen3.6-max-preview": {
+      "cached_read": 0.1268,
+      "in": 1.27,
+      "out": 7.61
+    },
+    "qwen3.6-plus": {
+      "cached_read": 0.0282,
+      "in": 0.28,
+      "out": 1.69
+    },
+    "qwen3.6-plus-free": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "qwen3.7-max": {
+      "cached_read": 0.5,
+      "in": 2.5,
+      "out": 7.5
+    },
+    "qwen3.7-max:thinking": {
+      "cached_read": 0.25,
+      "in": 2.5,
+      "out": 7.5
+    },
+    "qwen3.7-plus": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "qwen3.7-plus:thinking": {
+      "cached_read": 0.04,
+      "in": 0.4,
+      "out": 1.6
+    },
+    "qwen35-397b-a17b": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 3.6
+    },
+    "qwen3_5-9b-mlx-4bit": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "qwen3_5-9b-q4_k_m": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "qwq-32b": {
+      "cached_read": null,
+      "in": 0.287,
+      "out": 0.861
+    },
+    "qwq-plus": {
+      "cached_read": null,
+      "in": 0.8,
+      "out": 2.4
+    },
+    "raptor-mini": {
+      "cached_read": 0.025,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "readyart/ms3.2-the-omega-directive-24b-unslop-v2.0": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 0.5
+    },
+    "rednote-hilab/dots.ocr": {
+      "cached_read": 0.005,
+      "in": 0.01,
+      "out": 0.0109
+    },
+    "rekaai/reka-edge": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "rekaai/reka-flash-3": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.2
+    },
+    "relace/relace-apply-3": {
+      "cached_read": null,
+      "in": 0.85,
+      "out": 1.25
+    },
+    "relace/relace-search": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "ring-1t": {
+      "cached_read": null,
+      "in": 0.57,
+      "out": 2.29
+    },
+    "ring-2.6-1t-free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "route-llm": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "route/deepseek-v3.2": {
+      "cached_read": null,
+      "in": 0.4928,
+      "out": 0.7392
+    },
+    "route/deepseek-v4-flash": {
+      "cached_read": 0.0028,
+      "in": 0.4928,
+      "out": 0.7392
+    },
+    "route/deepseek-v4-flash-6bit": {
+      "cached_read": 0.0028,
+      "in": 0.4928,
+      "out": 0.7392
+    },
+    "route/deepseek-v4-pro": {
+      "cached_read": 0.003625,
+      "in": 0.4928,
+      "out": 0.7392
+    },
+    "route/deepseek-v4-pro-6bit": {
+      "cached_read": 0.003625,
+      "in": 0.4928,
+      "out": 0.7392
+    },
+    "route/gemma-4-31b-it": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "route/glm-5.1": {
+      "cached_read": 0.26,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "route/glm-5.1-6bit": {
+      "cached_read": 0.26,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "route/kimi-k2.5": {
+      "cached_read": 0.1,
+      "in": 0.462,
+      "out": 2.42
+    },
+    "route/kimi-k2.6": {
+      "cached_read": 0.16,
+      "in": 0.462,
+      "out": 2.42
+    },
+    "route/kimi-k2.6-6bit": {
+      "cached_read": 0.16,
+      "in": 0.462,
+      "out": 2.42
+    },
+    "route/mimo-v2.5": {
+      "cached_read": 0.2,
+      "in": 0.45,
+      "out": 1.35
+    },
+    "route/mimo-v2.5-pro": {
+      "cached_read": 0.2,
+      "in": 0.45,
+      "out": 1.35
+    },
+    "route/mimo-v2.5-pro-6bit": {
+      "cached_read": 0.2,
+      "in": 0.45,
+      "out": 1.35
+    },
+    "route/minimax-m2.5": {
+      "cached_read": 0.03,
+      "in": 0.193,
+      "out": 1.238
+    },
+    "route/minimax-m2.5-highspeed": {
+      "cached_read": 0.06,
+      "in": 0.193,
+      "out": 1.238
+    },
+    "route/minimax-m2.7": {
+      "cached_read": 0.06,
+      "in": 0.33,
+      "out": 1.32
+    },
+    "route/minimax-m2.7-highspeed": {
+      "cached_read": 0.06,
+      "in": 0.33,
+      "out": 1.32
+    },
+    "route/mistral-large-3": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "route/mistral-medium-2505": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "route/mistral-small-2503": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "route/qwen3.6-27b": {
+      "cached_read": null,
+      "in": 1.1,
+      "out": 3.3
+    },
+    "route/qwen3.6-27b-202k": {
+      "cached_read": null,
+      "in": 1.1,
+      "out": 3.3
+    },
+    "route/step-3.5-flash": {
+      "cached_read": 0.019,
+      "in": 0.096,
+      "out": 0.288
+    },
+    "route/step-3.5-flash-2603": {
+      "cached_read": 0.02,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "route/stepfun-3.5-flash": {
+      "cached_read": 0.019,
+      "in": 0.096,
+      "out": 0.288
+    },
+    "salesforce/llama-xlam-2-70b-fc-r": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 2.5
+    },
+    "sao10k/l3-70b-euryale-v2.1": {
+      "cached_read": null,
+      "in": 1.48,
+      "out": 1.48
+    },
+    "sao10k/l3-8b-lunaris": {
+      "cached_read": null,
+      "in": 0.05,
+      "out": 0.05
+    },
+    "sao10k/l3-8b-stheno-v3.2": {
+      "cached_read": null,
+      "in": 0.2006,
+      "out": 0.2006
+    },
+    "sao10k/l3-euryale-70b": {
+      "cached_read": null,
+      "in": 1.48,
+      "out": 1.48
+    },
+    "sao10k/l3-lunaris-8b": {
+      "cached_read": null,
+      "in": 0.04,
+      "out": 0.05
+    },
+    "sao10k/l3.1-70b-euryale-v2.2": {
+      "cached_read": null,
+      "in": 0.306,
+      "out": 0.357
+    },
+    "sao10k/l3.1-70b-hanami-x1": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 3.0
+    },
+    "sao10k/l3.1-euryale-70b": {
+      "cached_read": null,
+      "in": 0.85,
+      "out": 0.85
+    },
+    "sao10k/l3.3-70b-euryale-v2.3": {
+      "cached_read": null,
+      "in": 0.49299999999999994,
+      "out": 0.49299999999999994
+    },
+    "sao10k/l3.3-euryale-70b": {
+      "cached_read": null,
+      "in": 0.65,
+      "out": 0.75
+    },
+    "sao10k/l31-70b-euryale-v2.2": {
+      "cached_read": null,
+      "in": 1.48,
+      "out": 1.48
+    },
+    "sapiens-ai/agnes-1.5-lite": {
+      "cached_read": null,
+      "in": 0.12,
+      "out": 0.6
+    },
+    "sapiens-ai/agnes-1.5-pro": {
+      "cached_read": null,
+      "in": 0.16,
+      "out": 0.8
+    },
+    "sarvam-105b": {
+      "cached_read": 0.028,
+      "in": 0.045,
+      "out": 0.177
+    },
+    "sarvam-30b": {
+      "cached_read": 0.017,
+      "in": 0.028,
+      "out": 0.111
+    },
+    "sarvamai/sarvam-m": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "seed-1-6-250615": {
+      "cached_read": 0.05,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "seed-1-6-250915": {
+      "cached_read": 0.05,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "seed-1-6-flash-250715": {
+      "cached_read": 0.015,
+      "in": 0.07,
+      "out": 0.3
+    },
+    "seed-1-8-251228": {
+      "cached_read": 0.05,
+      "in": 0.25,
+      "out": 2.0
+    },
+    "shisa-ai/shisa-v2-llama3.3-70b": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 0.5
+    },
+    "shisa-ai/shisa-v2.1-llama3.3-70b": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 0.5
+    },
+    "siliconflow/deepseek-r1-0528": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 2.18
+    },
+    "siliconflow/deepseek-v3-0324": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 1.0
+    },
+    "siliconflow/deepseek-v3.1-terminus": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 1.0
+    },
+    "siliconflow/deepseek-v3.2": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 0.42
+    },
+    "solar-mini": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.15
+    },
+    "solar-pro2": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 0.25
+    },
+    "solar-pro3": {
+      "cached_read": null,
+      "in": 0.25,
+      "out": 0.25
+    },
+    "sonar": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 1.0
+    },
+    "sonar-deep-research": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "sonar-pro": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "sonar-reasoning": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "sonar-reasoning-pro": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 8.0
+    },
+    "soob3123/amoral-gemma3-27b-v2": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.3
+    },
+    "soob3123/grayline-qwen3-8b": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.3
+    },
+    "soob3123/veiled-calla-12b": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.3
+    },
+    "speakleash/bielik-11b-v2.6-instruct": {
+      "cached_read": null,
+      "in": 0.67,
+      "out": 0.67
+    },
+    "speakleash/bielik-11b-v3.0-instruct": {
+      "cached_read": null,
+      "in": 0.67,
+      "out": 0.67
+    },
+    "stable-diffusion-3.5-large": {
+      "cached_read": null,
+      "in": 0.08,
+      "out": 0.0
+    },
+    "stealth/claude-opus-4.6": {
+      "cached_read": 0.4,
+      "in": 4.0,
+      "out": 20.0
+    },
+    "stealth/claude-opus-4.7": {
+      "cached_read": 0.4,
+      "in": 4.0,
+      "out": 20.0
+    },
+    "stealth/claude-sonnet-4.6": {
+      "cached_read": 0.24,
+      "in": 2.4,
+      "out": 12.0
+    },
+    "steelskull/l3.3-cu-mai-r1-70b": {
+      "cached_read": null,
+      "in": 0.49299999999999994,
+      "out": 0.49299999999999994
+    },
+    "steelskull/l3.3-electra-r1-70b": {
+      "cached_read": null,
+      "in": 0.69989,
+      "out": 0.69989
+    },
+    "steelskull/l3.3-ms-evalebis-70b": {
+      "cached_read": null,
+      "in": 0.49299999999999994,
+      "out": 0.49299999999999994
+    },
+    "steelskull/l3.3-ms-evayale-70b": {
+      "cached_read": null,
+      "in": 0.49299999999999994,
+      "out": 0.49299999999999994
+    },
+    "steelskull/l3.3-ms-nevoria-70b": {
+      "cached_read": null,
+      "in": 0.49299999999999994,
+      "out": 0.49299999999999994
+    },
+    "steelskull/l3.3-nevoria-r1-70b": {
+      "cached_read": null,
+      "in": 0.49299999999999994,
+      "out": 0.49299999999999994
+    },
+    "step-1-32k": {
+      "cached_read": 0.41,
+      "in": 2.05,
+      "out": 9.59
+    },
+    "step-2-16k": {
+      "cached_read": 1.04,
+      "in": 5.21,
+      "out": 16.44
+    },
+    "step-2-16k-exp": {
+      "cached_read": null,
+      "in": 7.004,
+      "out": 19.992
+    },
+    "step-2-mini": {
+      "cached_read": null,
+      "in": 0.2006,
+      "out": 0.408
+    },
+    "step-3": {
+      "cached_read": null,
+      "in": 0.2499,
+      "out": 0.6494
+    },
+    "step-3.5-flash": {
+      "cached_read": 0.019,
+      "in": 0.096,
+      "out": 0.288
+    },
+    "step-3.5-flash-2603": {
+      "cached_read": 0.02,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "step-r1-v-mini": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 11.0
+    },
+    "stepfun-ai/step-3.5-flash": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "stepfun-ai/step-3.5-flash-2603": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "stepfun-ai/step-3.7-flash": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "stepfun/step-3": {
+      "cached_read": null,
+      "in": 0.21,
+      "out": 0.57
+    },
+    "stepfun/step-3.5-flash": {
+      "cached_read": 0.02,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "stepfun/step-3.5-flash-free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "stepfun/step-3.7-flash": {
+      "cached_read": 0.04,
+      "in": 0.2,
+      "out": 1.15
+    },
+    "stepfun/step-3.7-flash:thinking": {
+      "cached_read": 0.04,
+      "in": 0.2,
+      "out": 1.15
+    },
+    "switchpoint/router": {
+      "cached_read": null,
+      "in": 0.85,
+      "out": 3.4
+    },
+    "tc-code-latest": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "tee/deepseek-v3.1": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 2.5
+    },
+    "tee/deepseek-v3.2": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.0
+    },
+    "tee/deepseek-v4-pro": {
+      "cached_read": 0.15,
+      "in": 1.5,
+      "out": 5.25
+    },
+    "tee/deepseek-v4-pro:thinking": {
+      "cached_read": 0.15,
+      "in": 1.5,
+      "out": 5.25
+    },
+    "tee/gemma-3-27b-it": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.8
+    },
+    "tee/gemma-4-26b-a4b-uncensored": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.7
+    },
+    "tee/gemma-4-31b-it": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.46
+    },
+    "tee/gemma4-31b": {
+      "cached_read": null,
+      "in": 0.45,
+      "out": 1.0
+    },
+    "tee/gemma4-31b:thinking": {
+      "cached_read": null,
+      "in": 0.45,
+      "out": 1.0
+    },
+    "tee/glm-4.7": {
+      "cached_read": null,
+      "in": 0.85,
+      "out": 3.3
+    },
+    "tee/glm-4.7-flash": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.5
+    },
+    "tee/glm-5": {
+      "cached_read": null,
+      "in": 1.2,
+      "out": 3.5
+    },
+    "tee/glm-5.1": {
+      "cached_read": 0.3,
+      "in": 1.5,
+      "out": 5.25
+    },
+    "tee/glm-5.1-thinking": {
+      "cached_read": 0.3,
+      "in": 1.5,
+      "out": 5.25
+    },
+    "tee/gpt-oss-120b": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 2.0
+    },
+    "tee/gpt-oss-20b": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.8
+    },
+    "tee/kimi-k2.5": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.9
+    },
+    "tee/kimi-k2.5-thinking": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.9
+    },
+    "tee/kimi-k2.6": {
+      "cached_read": 0.375,
+      "in": 1.5,
+      "out": 5.25
+    },
+    "tee/llama3-3-70b": {
+      "cached_read": null,
+      "in": 2.0,
+      "out": 2.0
+    },
+    "tee/minimax-m2.5": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 1.38
+    },
+    "tee/qwen2.5-vl-72b-instruct": {
+      "cached_read": null,
+      "in": 0.7,
+      "out": 0.7
+    },
+    "tee/qwen3-30b-a3b-instruct-2507": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.44999999999999996
+    },
+    "tee/qwen3.5-122b-a10b": {
+      "cached_read": null,
+      "in": 0.46,
+      "out": 3.68
+    },
+    "tee/qwen3.5-27b": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 2.4
+    },
+    "tee/qwen3.5-397b-a17b": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 3.6
+    },
+    "tee/qwen3.6-35b-a3b-uncensored": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.5
+    },
+    "tencent/hunyuan-a13b-instruct": {
+      "cached_read": null,
+      "in": 0.14,
+      "out": 0.57
+    },
+    "tencent/hunyuan-mt-7b": {
+      "cached_read": null,
+      "in": 10.0,
+      "out": 20.0
+    },
+    "tencent/hy3-preview": {
+      "cached_read": 0.029,
+      "in": 0.066,
+      "out": 0.26
+    },
+    "text-embedding-3-large": {
+      "cached_read": null,
+      "in": 0.13,
+      "out": 0.0
+    },
+    "text-embedding-3-small": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.0
+    },
+    "text-embedding-ada-002": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.0
+    },
+    "thedrummer/anubis-70b-v1": {
+      "cached_read": null,
+      "in": 0.31,
+      "out": 0.31
+    },
+    "thedrummer/anubis-70b-v1.1": {
+      "cached_read": null,
+      "in": 0.31,
+      "out": 0.31
+    },
+    "thedrummer/cydonia-24b-v2": {
+      "cached_read": null,
+      "in": 0.1003,
+      "out": 0.1207
+    },
+    "thedrummer/cydonia-24b-v4": {
+      "cached_read": null,
+      "in": 0.2006,
+      "out": 0.2414
+    },
+    "thedrummer/cydonia-24b-v4.1": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.5
+    },
+    "thedrummer/cydonia-24b-v4.3": {
+      "cached_read": null,
+      "in": 0.1003,
+      "out": 0.1207
+    },
+    "thedrummer/magidonia-24b-v4.3": {
+      "cached_read": null,
+      "in": 0.1003,
+      "out": 0.1207
+    },
+    "thedrummer/rocinante-12b": {
+      "cached_read": null,
+      "in": 0.17,
+      "out": 0.43
+    },
+    "thedrummer/rocinante-12b-v1.1": {
+      "cached_read": null,
+      "in": 0.408,
+      "out": 0.595
+    },
+    "thedrummer/skyfall-31b-v4.2": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 0.8
+    },
+    "thedrummer/skyfall-36b-v2": {
+      "cached_read": null,
+      "in": 0.55,
+      "out": 0.8
+    },
+    "thedrummer/unslopnemo-12b": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 0.4
+    },
+    "thedrummer/unslopnemo-12b-v4.1": {
+      "cached_read": null,
+      "in": 0.493,
+      "out": 0.493
+    },
+    "thudm/glm-4-32b-0414": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "thudm/glm-4-9b-0414": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "thudm/glm-z1-32b-0414": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "thudm/glm-z1-9b-0414": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "tngtech/deepseek-tng-r1t2-chimera-tee": {
+      "cached_read": 0.15,
+      "in": 0.3,
+      "out": 1.1
+    },
+    "tongyi-intent-detect-v3": {
+      "cached_read": null,
+      "in": 0.058,
+      "out": 0.144
+    },
+    "tongyi-zhiwen/qwenlong-l1-32b": {
+      "cached_read": null,
+      "in": 0.13999999999999999,
+      "out": 0.6
+    },
+    "trinity-large-preview-free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "umans-coder": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "umans-flash": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "umans-glm-5.1": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "umans-kimi-k2.6": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "umans-qwen3.6-35b-a3b": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "unbabel/m-prometheus-14b": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.2
+    },
+    "undi95/remm-slerp-l2-13b": {
+      "cached_read": null,
+      "in": 0.45,
+      "out": 0.65
+    },
+    "universal-summarizer": {
+      "cached_read": null,
+      "in": 30.0,
+      "out": 30.0
+    },
+    "unsloth/gemma-3-12b-it": {
+      "cached_read": 0.015,
+      "in": 0.03,
+      "out": 0.1
+    },
+    "unsloth/gemma-3-27b-it": {
+      "cached_read": 0.0136,
+      "in": 0.0272,
+      "out": 0.1087
+    },
+    "unsloth/gemma-3-4b-it": {
+      "cached_read": 0.005,
+      "in": 0.01,
+      "out": 0.0272
+    },
+    "unsloth/llama-3.2-1b-instruct": {
+      "cached_read": 0.005,
+      "in": 0.01,
+      "out": 0.0109
+    },
+    "unsloth/llama-3.2-3b-instruct": {
+      "cached_read": 0.005,
+      "in": 0.01,
+      "out": 0.0136
+    },
+    "unsloth/mistral-nemo-instruct-2407": {
+      "cached_read": 0.01,
+      "in": 0.02,
+      "out": 0.04
+    },
+    "upstage/solar-10_7b-instruct": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "upstage/solar-pro-3": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.6
+    },
+    "us.anthropic.claude-haiku-4-5-20251001-v1:0": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "us.anthropic.claude-opus-4-1-20250805-v1:0": {
+      "cached_read": 1.5,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "us.anthropic.claude-opus-4-5-20251101-v1:0": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "us.anthropic.claude-opus-4-6-v1": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "us.anthropic.claude-opus-4-7": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "us.anthropic.claude-opus-4-8": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "us.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "us.anthropic.claude-sonnet-4-6": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "us.deepseek.r1-v1:0": {
+      "cached_read": null,
+      "in": 1.35,
+      "out": 5.4
+    },
+    "us.meta.llama4-maverick-17b-instruct-v1:0": {
+      "cached_read": null,
+      "in": 0.24,
+      "out": 0.97
+    },
+    "us.meta.llama4-scout-17b-instruct-v1:0": {
+      "cached_read": null,
+      "in": 0.17,
+      "out": 0.66
+    },
+    "v0-1.0-md": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "v0-1.5-lg": {
+      "cached_read": null,
+      "in": 15.0,
+      "out": 75.0
+    },
+    "v0-1.5-md": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "venice-uncensored": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 0.4
+    },
+    "venice-uncensored-1-2": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.9
+    },
+    "venice-uncensored-role-play": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 2.0
+    },
+    "venice-uncensored:web": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 0.4
+    },
+    "vercel/v0-1.0-md": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "vercel/v0-1.5-md": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "volcengine/doubao-seed-1.8": {
+      "cached_read": 0.02,
+      "in": 0.11,
+      "out": 0.28
+    },
+    "volcengine/doubao-seed-2.0-code": {
+      "cached_read": null,
+      "in": 0.9,
+      "out": 4.48
+    },
+    "volcengine/doubao-seed-2.0-lite": {
+      "cached_read": 0.02,
+      "in": 0.09,
+      "out": 0.51
+    },
+    "volcengine/doubao-seed-2.0-mini": {
+      "cached_read": 0.01,
+      "in": 0.03,
+      "out": 0.28
+    },
+    "volcengine/doubao-seed-2.0-pro": {
+      "cached_read": 0.09,
+      "in": 0.45,
+      "out": 2.24
+    },
+    "volcengine/doubao-seed-code": {
+      "cached_read": 0.03,
+      "in": 0.17,
+      "out": 1.12
+    },
+    "vongolachouko/starcannon-unleashed-12b-v1.0": {
+      "cached_read": null,
+      "in": 0.49299999999999994,
+      "out": 0.49299999999999994
+    },
+    "voxtral-small-24b-2507": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.35
+    },
+    "wan2-2-t2v-a14b": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 0.0
+    },
+    "wan2.7-image": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "wan2.7-image-pro": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "whisper-large-v3": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "whisper-large-v3-turbo": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "workers-ai/@cf/ai4bharat/indictrans2-en-indic-1b": {
+      "cached_read": null,
+      "in": 0.34,
+      "out": 0.34
+    },
+    "workers-ai/@cf/aisingapore/gemma-sea-lion-v4-27b-it": {
+      "cached_read": null,
+      "in": 0.35,
+      "out": 0.56
+    },
+    "workers-ai/@cf/baai/bge-base-en-v1.5": {
+      "cached_read": null,
+      "in": 0.067,
+      "out": 0.0
+    },
+    "workers-ai/@cf/baai/bge-large-en-v1.5": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.0
+    },
+    "workers-ai/@cf/baai/bge-m3": {
+      "cached_read": null,
+      "in": 0.012,
+      "out": 0.0
+    },
+    "workers-ai/@cf/baai/bge-reranker-base": {
+      "cached_read": null,
+      "in": 0.0031,
+      "out": 0.0
+    },
+    "workers-ai/@cf/baai/bge-small-en-v1.5": {
+      "cached_read": null,
+      "in": 0.02,
+      "out": 0.0
+    },
+    "workers-ai/@cf/deepgram/aura-2-en": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "workers-ai/@cf/deepgram/aura-2-es": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "workers-ai/@cf/deepgram/nova-3": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "workers-ai/@cf/deepseek-ai/deepseek-r1-distill-qwen-32b": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 4.88
+    },
+    "workers-ai/@cf/facebook/bart-large-cnn": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "workers-ai/@cf/google/gemma-3-12b-it": {
+      "cached_read": null,
+      "in": 0.35,
+      "out": 0.56
+    },
+    "workers-ai/@cf/huggingface/distilbert-sst-2-int8": {
+      "cached_read": null,
+      "in": 0.026,
+      "out": 0.0
+    },
+    "workers-ai/@cf/ibm-granite/granite-4.0-h-micro": {
+      "cached_read": null,
+      "in": 0.017,
+      "out": 0.11
+    },
+    "workers-ai/@cf/meta/llama-2-7b-chat-fp16": {
+      "cached_read": null,
+      "in": 0.56,
+      "out": 6.67
+    },
+    "workers-ai/@cf/meta/llama-3-8b-instruct": {
+      "cached_read": null,
+      "in": 0.28,
+      "out": 0.83
+    },
+    "workers-ai/@cf/meta/llama-3-8b-instruct-awq": {
+      "cached_read": null,
+      "in": 0.12,
+      "out": 0.27
+    },
+    "workers-ai/@cf/meta/llama-3.1-8b-instruct": {
+      "cached_read": null,
+      "in": 0.28,
+      "out": 0.8299999999999998
+    },
+    "workers-ai/@cf/meta/llama-3.1-8b-instruct-awq": {
+      "cached_read": null,
+      "in": 0.12,
+      "out": 0.27
+    },
+    "workers-ai/@cf/meta/llama-3.1-8b-instruct-fp8": {
+      "cached_read": null,
+      "in": 0.15,
+      "out": 0.29
+    },
+    "workers-ai/@cf/meta/llama-3.2-11b-vision-instruct": {
+      "cached_read": null,
+      "in": 0.049,
+      "out": 0.68
+    },
+    "workers-ai/@cf/meta/llama-3.2-1b-instruct": {
+      "cached_read": null,
+      "in": 0.027,
+      "out": 0.2
+    },
+    "workers-ai/@cf/meta/llama-3.2-3b-instruct": {
+      "cached_read": null,
+      "in": 0.051,
+      "out": 0.34
+    },
+    "workers-ai/@cf/meta/llama-3.3-70b-instruct-fp8-fast": {
+      "cached_read": null,
+      "in": 0.29,
+      "out": 2.25
+    },
+    "workers-ai/@cf/meta/llama-4-scout-17b-16e-instruct": {
+      "cached_read": null,
+      "in": 0.27,
+      "out": 0.85
+    },
+    "workers-ai/@cf/meta/llama-guard-3-8b": {
+      "cached_read": null,
+      "in": 0.48,
+      "out": 0.03
+    },
+    "workers-ai/@cf/meta/m2m100-1.2b": {
+      "cached_read": null,
+      "in": 0.34,
+      "out": 0.34
+    },
+    "workers-ai/@cf/mistral/mistral-7b-instruct-v0.1": {
+      "cached_read": null,
+      "in": 0.11,
+      "out": 0.19
+    },
+    "workers-ai/@cf/mistralai/mistral-small-3.1-24b-instruct": {
+      "cached_read": null,
+      "in": 0.35,
+      "out": 0.56
+    },
+    "workers-ai/@cf/moonshotai/kimi-k2.5": {
+      "cached_read": 0.1,
+      "in": 0.6,
+      "out": 3.0
+    },
+    "workers-ai/@cf/moonshotai/kimi-k2.6": {
+      "cached_read": 0.16,
+      "in": 0.95,
+      "out": 4.0
+    },
+    "workers-ai/@cf/myshell-ai/melotts": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "workers-ai/@cf/nvidia/nemotron-3-120b-a12b": {
+      "cached_read": null,
+      "in": 0.5,
+      "out": 1.5
+    },
+    "workers-ai/@cf/openai/gpt-oss-120b": {
+      "cached_read": null,
+      "in": 0.35,
+      "out": 0.75
+    },
+    "workers-ai/@cf/openai/gpt-oss-20b": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.3
+    },
+    "workers-ai/@cf/pfnet/plamo-embedding-1b": {
+      "cached_read": null,
+      "in": 0.019,
+      "out": 0.0
+    },
+    "workers-ai/@cf/pipecat-ai/smart-turn-v2": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "workers-ai/@cf/qwen/qwen2.5-coder-32b-instruct": {
+      "cached_read": null,
+      "in": 0.66,
+      "out": 1.0
+    },
+    "workers-ai/@cf/qwen/qwen3-30b-a3b-fp8": {
+      "cached_read": null,
+      "in": 0.051,
+      "out": 0.34
+    },
+    "workers-ai/@cf/qwen/qwen3-embedding-0.6b": {
+      "cached_read": null,
+      "in": 0.012,
+      "out": 0.0
+    },
+    "workers-ai/@cf/qwen/qwq-32b": {
+      "cached_read": null,
+      "in": 0.66,
+      "out": 1.0
+    },
+    "workers-ai/@cf/zai-org/glm-4.7-flash": {
+      "cached_read": null,
+      "in": 0.06,
+      "out": 0.4
+    },
+    "writer.palmyra-x4-v1:0": {
+      "cached_read": null,
+      "in": 2.5,
+      "out": 10.0
+    },
+    "writer.palmyra-x5-v1:0": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 6.0
+    },
+    "writer/palmyra-x5": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 6.0
+    },
+    "x-ai/grok-4": {
+      "cached_read": 0.75,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "x-ai/grok-4-fast": {
+      "cached_read": 0.05,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "x-ai/grok-4.1-fast": {
+      "cached_read": 0.05,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "x-ai/grok-4.1-fast-non-reasoning": {
+      "cached_read": 0.05,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "x-ai/grok-4.2-fast": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 9.0
+    },
+    "x-ai/grok-4.2-fast-non-reasoning": {
+      "cached_read": null,
+      "in": 3.0,
+      "out": 9.0
+    },
+    "x-ai/grok-4.20": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "x-ai/grok-4.20-multi-agent": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "x-ai/grok-4.3": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "x-ai/grok-build-0.1": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 2.0
+    },
+    "x-ai/grok-code-fast-1": {
+      "cached_read": 0.02,
+      "in": 0.2,
+      "out": 1.5
+    },
+    "x-ai/grok-latest": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "xai/grok-3": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "xai/grok-3-mini": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "xai/grok-4": {
+      "cached_read": 0.75,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "xai/grok-4-1-fast-non-reasoning": {
+      "cached_read": 0.05,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "xai/grok-4-fast": {
+      "cached_read": 0.05,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "xai/grok-4-fast-non-reasoning": {
+      "cached_read": 0.05,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "xai/grok-4-fast-reasoning": {
+      "cached_read": 0.05,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "xai/grok-4.1-fast-non-reasoning": {
+      "cached_read": 0.05,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "xai/grok-4.1-fast-reasoning": {
+      "cached_read": 0.05,
+      "in": 0.2,
+      "out": 0.5
+    },
+    "xai/grok-4.20-0309-reasoning": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "xai/grok-4.20-multi-agent": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "xai/grok-4.20-multi-agent-beta": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "xai/grok-4.20-non-reasoning": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "xai/grok-4.20-non-reasoning-beta": {
+      "cached_read": 0.4,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "xai/grok-4.20-reasoning": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "xai/grok-4.20-reasoning-beta": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "xai/grok-4.3": {
+      "cached_read": 0.2,
+      "in": 1.25,
+      "out": 2.5
+    },
+    "xai/grok-build-0.1": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 2.0
+    },
+    "xai/grok-code-fast-1": {
+      "cached_read": 0.02,
+      "in": 0.2,
+      "out": 1.5
+    },
+    "xiaomi-mimo-v2.5": {
+      "cached_read": 0.088,
+      "in": 0.44,
+      "out": 2.2
+    },
+    "xiaomi-mimo-v2.5-free": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "xiaomi-mimo-v2.5-pro": {
+      "cached_read": 0.22,
+      "in": 1.1,
+      "out": 3.3
+    },
+    "xiaomi-mimo-v2.5-pro-free": {
+      "cached_read": 0.0,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "xiaomi/mimo-v2-flash": {
+      "cached_read": 0.045,
+      "in": 0.09,
+      "out": 0.29
+    },
+    "xiaomi/mimo-v2-flash-original": {
+      "cached_read": null,
+      "in": 0.102,
+      "out": 0.306
+    },
+    "xiaomi/mimo-v2-flash-thinking": {
+      "cached_read": null,
+      "in": 0.102,
+      "out": 0.306
+    },
+    "xiaomi/mimo-v2-flash-thinking-original": {
+      "cached_read": null,
+      "in": 0.102,
+      "out": 0.306
+    },
+    "xiaomi/mimo-v2-omni": {
+      "cached_read": 0.08,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "xiaomi/mimo-v2-pro": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "xiaomi/mimo-v2.5": {
+      "cached_read": 0.08,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "xiaomi/mimo-v2.5-pro": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "xiaomimimo/mimo-v2-flash": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.3
+    },
+    "xiaomimimo/mimo-v2-flash-tee": {
+      "cached_read": 0.045,
+      "in": 0.09,
+      "out": 0.29
+    },
+    "xiaomimimo/mimo-v2-pro": {
+      "cached_read": 0.4,
+      "in": 2.0,
+      "out": 6.0
+    },
+    "xiaomimimo/mimo-v2.5": {
+      "cached_read": 0.08,
+      "in": 0.4,
+      "out": 2.0
+    },
+    "xiaomimimo/mimo-v2.5-pro": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "xpersona-frieren-coder": {
+      "cached_read": 0.15,
+      "in": 1.5,
+      "out": 6.0
+    },
+    "xpersona-gpt-5.5": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 18.0
+    },
+    "yi-large": {
+      "cached_read": null,
+      "in": 3.196,
+      "out": 3.196
+    },
+    "yi-lightning": {
+      "cached_read": null,
+      "in": 0.2006,
+      "out": 0.2006
+    },
+    "yi-medium-200k": {
+      "cached_read": null,
+      "in": 2.499,
+      "out": 2.499
+    },
+    "z-ai-glm-5-turbo": {
+      "cached_read": 0.24,
+      "in": 1.2,
+      "out": 4.0
+    },
+    "z-ai-glm-5v-turbo": {
+      "cached_read": 0.3,
+      "in": 1.5,
+      "out": 5.0
+    },
+    "z-ai/glm-4-32b": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.1
+    },
+    "z-ai/glm-4.5": {
+      "cached_read": 0.175,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "z-ai/glm-4.5-air": {
+      "cached_read": 0.025,
+      "in": 0.13,
+      "out": 0.85
+    },
+    "z-ai/glm-4.5-air:free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "z-ai/glm-4.5v": {
+      "cached_read": 0.11,
+      "in": 0.6,
+      "out": 1.8
+    },
+    "z-ai/glm-4.5v:thinking": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 1.7999999999999998
+    },
+    "z-ai/glm-4.6": {
+      "cached_read": 0.175,
+      "in": 0.39,
+      "out": 1.9
+    },
+    "z-ai/glm-4.6:thinking": {
+      "cached_read": null,
+      "in": 0.4,
+      "out": 1.5
+    },
+    "z-ai/glm-4.6v": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 0.9
+    },
+    "z-ai/glm-4.6v-flash": {
+      "cached_read": 0.0043,
+      "in": 0.02,
+      "out": 0.21
+    },
+    "z-ai/glm-4.6v-flash-free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "z-ai/glm-4.7": {
+      "cached_read": 0.2,
+      "in": 0.38,
+      "out": 1.98
+    },
+    "z-ai/glm-4.7-flash": {
+      "cached_read": 0.01,
+      "in": 0.06,
+      "out": 0.4
+    },
+    "z-ai/glm-4.7-flash-free": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "z-ai/glm-4.7-flashx": {
+      "cached_read": 0.01,
+      "in": 0.07,
+      "out": 0.42
+    },
+    "z-ai/glm-5": {
+      "cached_read": null,
+      "in": 0.95,
+      "out": 3.15
+    },
+    "z-ai/glm-5-turbo": {
+      "cached_read": 0.24,
+      "in": 1.2,
+      "out": 4.0
+    },
+    "z-ai/glm-5.1": {
+      "cached_read": null,
+      "in": 1.26,
+      "out": 3.96
+    },
+    "z-ai/glm-5v-turbo": {
+      "cached_read": 0.24,
+      "in": 1.2,
+      "out": 4.0
+    },
+    "z-ai/glm-5v-turbo:thinking": {
+      "cached_read": 0.24,
+      "in": 1.2,
+      "out": 4.0
+    },
+    "z-ai/glm4.7": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "zai-glm-4.7": {
+      "cached_read": 0.0,
+      "in": 2.25,
+      "out": 2.75
+    },
+    "zai-glm-5-1": {
+      "cached_read": 0.26,
+      "in": 1.4,
+      "out": 4.4
+    },
+    "zai-glm-5.1": {
+      "cached_read": 0.183112,
+      "in": 0.845,
+      "out": 3.38
+    },
+    "zai-org-glm-4.6": {
+      "cached_read": 0.3,
+      "in": 0.85,
+      "out": 2.75
+    },
+    "zai-org-glm-4.7": {
+      "cached_read": 0.11,
+      "in": 0.55,
+      "out": 2.65
+    },
+    "zai-org-glm-4.7-flash": {
+      "cached_read": null,
+      "in": 0.125,
+      "out": 0.5
+    },
+    "zai-org-glm-5": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 3.2
+    },
+    "zai-org-glm-5-1": {
+      "cached_read": 0.325,
+      "in": 1.75,
+      "out": 5.5
+    },
+    "zai-org/autoglm-phone-9b-multilingual": {
+      "cached_read": null,
+      "in": 0.035,
+      "out": 0.138
+    },
+    "zai-org/glm-4.5": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "zai-org/glm-4.5-air": {
+      "cached_read": null,
+      "in": 0.12,
+      "out": 0.8
+    },
+    "zai-org/glm-4.5-air:thinking": {
+      "cached_read": null,
+      "in": 0.12,
+      "out": 0.8
+    },
+    "zai-org/glm-4.5-fp8": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.8
+    },
+    "zai-org/glm-4.5:thinking": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 1.3
+    },
+    "zai-org/glm-4.5v": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 1.8
+    },
+    "zai-org/glm-4.6": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "zai-org/glm-4.6-original": {
+      "cached_read": null,
+      "in": 0.35,
+      "out": 1.4
+    },
+    "zai-org/glm-4.6-turbo": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "zai-org/glm-4.6-turbo:thinking": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 3.0
+    },
+    "zai-org/glm-4.6v": {
+      "cached_read": 0.15,
+      "in": 0.3,
+      "out": 0.9
+    },
+    "zai-org/glm-4.6v-flash-original": {
+      "cached_read": null,
+      "in": 0.1,
+      "out": 0.4
+    },
+    "zai-org/glm-4.6v-original": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 0.9
+    },
+    "zai-org/glm-4.7": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "zai-org/glm-4.7-flash": {
+      "cached_read": null,
+      "in": 0.06,
+      "out": 0.4
+    },
+    "zai-org/glm-4.7-flash-original": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.4
+    },
+    "zai-org/glm-4.7-flash-original:thinking": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.4
+    },
+    "zai-org/glm-4.7-flash:thinking": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.4
+    },
+    "zai-org/glm-4.7-fp8": {
+      "cached_read": 0.14945,
+      "in": 0.2989,
+      "out": 1.1957
+    },
+    "zai-org/glm-4.7-maas": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "zai-org/glm-4.7-original": {
+      "cached_read": 0.11,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "zai-org/glm-4.7-original:thinking": {
+      "cached_read": 0.11,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "zai-org/glm-4.7-tee": {
+      "cached_read": 0.195,
+      "in": 0.39,
+      "out": 1.75
+    },
+    "zai-org/glm-4.7:thinking": {
+      "cached_read": null,
+      "in": 0.2,
+      "out": 0.8
+    },
+    "zai-org/glm-5": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 3.2
+    },
+    "zai-org/glm-5-fp8": {
+      "cached_read": 0.12,
+      "in": 0.6,
+      "out": 1.92
+    },
+    "zai-org/glm-5-maas": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 3.2
+    },
+    "zai-org/glm-5-original": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 3.2
+    },
+    "zai-org/glm-5-original:thinking": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 3.2
+    },
+    "zai-org/glm-5-tee": {
+      "cached_read": 0.475,
+      "in": 0.95,
+      "out": 2.55
+    },
+    "zai-org/glm-5-turbo": {
+      "cached_read": 0.24455,
+      "in": 0.4891,
+      "out": 1.9565
+    },
+    "zai-org/glm-5.1": {
+      "cached_read": 0.26,
+      "in": 1.4,
+      "out": 4.4
+    },
+    "zai-org/glm-5.1-fp8": {
+      "cached_read": 0.0,
+      "in": 1.4,
+      "out": 4.4
+    },
+    "zai-org/glm-5.1-tee": {
+      "cached_read": 0.525,
+      "in": 1.05,
+      "out": 3.5
+    },
+    "zai-org/glm-5.1:thinking": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 2.55
+    },
+    "zai-org/glm-5:thinking": {
+      "cached_read": null,
+      "in": 0.3,
+      "out": 2.55
+    },
+    "zai-org/glm-5v-turbo": {
+      "cached_read": null,
+      "in": 1.2,
+      "out": 4.0
+    },
+    "zai-org/glm-latest": {
+      "cached_read": 0.15,
+      "in": 0.75,
+      "out": 2.6
+    },
+    "zai.glm-4.7": {
+      "cached_read": null,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "zai.glm-4.7-flash": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.4
+    },
+    "zai.glm-5": {
+      "cached_read": null,
+      "in": 1.0,
+      "out": 3.2
+    },
+    "zai/glm-4.5": {
+      "cached_read": 0.11,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "zai/glm-4.5-air": {
+      "cached_read": 0.03,
+      "in": 0.2,
+      "out": 1.1
+    },
+    "zai/glm-4.5v": {
+      "cached_read": 0.11,
+      "in": 0.6,
+      "out": 1.8
+    },
+    "zai/glm-4.6": {
+      "cached_read": 0.11,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "zai/glm-4.6v": {
+      "cached_read": 0.05,
+      "in": 0.3,
+      "out": 0.9
+    },
+    "zai/glm-4.7": {
+      "cached_read": 0.11,
+      "in": 0.6,
+      "out": 2.2
+    },
+    "zai/glm-4.7-flash": {
+      "cached_read": null,
+      "in": 0.07,
+      "out": 0.4
+    },
+    "zai/glm-4.7-flashx": {
+      "cached_read": 0.01,
+      "in": 0.07,
+      "out": 0.4
+    },
+    "zai/glm-5": {
+      "cached_read": 0.2,
+      "in": 1.0,
+      "out": 3.2
+    },
+    "zai/glm-5-turbo": {
+      "cached_read": 0.24,
+      "in": 1.2,
+      "out": 4.0
+    },
+    "zai/glm-5.1": {
+      "cached_read": 0.26,
+      "in": 1.4,
+      "out": 4.4
+    },
+    "zai/glm-5v-turbo": {
+      "cached_read": 0.24,
+      "in": 1.2,
+      "out": 4.0
+    },
+    "zhipuai/glm-4.5": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "zhipuai/glm-4.6": {
+      "cached_read": null,
+      "in": 0.0,
+      "out": 0.0
+    },
+    "~anthropic/claude-haiku-latest": {
+      "cached_read": 0.1,
+      "in": 1.0,
+      "out": 5.0
+    },
+    "~anthropic/claude-opus-latest": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 25.0
+    },
+    "~anthropic/claude-sonnet-latest": {
+      "cached_read": 0.3,
+      "in": 3.0,
+      "out": 15.0
+    },
+    "~google/gemini-flash-latest": {
+      "cached_read": 0.05,
+      "in": 0.5,
+      "out": 3.0
+    },
+    "~google/gemini-pro-latest": {
+      "cached_read": 0.2,
+      "in": 2.0,
+      "out": 12.0
+    },
+    "~moonshotai/kimi-latest": {
+      "cached_read": 0.14,
+      "in": 0.74,
+      "out": 3.49
+    },
+    "~openai/gpt-latest": {
+      "cached_read": 0.5,
+      "in": 5.0,
+      "out": 30.0
+    },
+    "~openai/gpt-mini-latest": {
+      "cached_read": 0.075,
+      "in": 0.75,
+      "out": 4.5
+    }
+  },
+  "schema": 1,
+  "source": "https://models.dev/api.json",
+  "updated": "2026-06-08"
+}

--- a/backend/pricing_sync.py
+++ b/backend/pricing_sync.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Dev/CI-only pricing sync — fetches models.dev and regenerates pricing_data.json.
+
+⚠️  This script is the ONLY place in the project that performs outbound network
+I/O for pricing, and it is NEVER imported or run on a user machine. TokenTelemetry
+is local-first: users get fresh prices through the normal npm/git version update,
+not by phoning models.dev at runtime. See backend/pricing.py — it only reads the
+bundled, committed pricing_data.json (zero network I/O at import or runtime).
+
+Run manually:
+
+    python backend/pricing_sync.py
+
+Or on a schedule via .github/workflows/pricing-sync.yml, which opens a PR with
+the refreshed data so a maintainer can review the diff before it ships.
+
+The output JSON mirrors the structure consumed by pricing.py:
+
+    {
+      "updated":  "YYYY-MM-DD",
+      "source":   "https://models.dev/api.json",
+      "schema":   1,
+      "pricing":  { "<model_id_lower>": {"in": .., "out": .., "cached_read": ..}, ... },
+      "by_provider": { "<provider_lower>\\u0000<model_id_lower>": {...}, ... }
+    }
+
+`by_provider` keys are flattened as "provider\\x00model" because JSON object keys
+must be strings; pricing.py splits them back into the (provider, model) tuple
+used by PRICING_BY_PROVIDER.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+MODELS_DEV_URL = "https://models.dev/api.json"
+OUTPUT_PATH = Path(__file__).parent / "pricing_data.json"
+SCHEMA_VERSION = 1
+
+# Separator used to flatten (provider, model) tuples into JSON string keys.
+PROVIDER_SEP = "\x00"
+
+# Map models.dev provider ids → the lowercased provider names TokenTelemetry
+# records in sessions.billing_provider (and keys PRICING_BY_PROVIDER on).
+PROVIDER_ALIASES = {
+    "fireworks-ai": "fireworks",
+    "together-ai": "together",
+    "togetherai": "together",
+}
+
+# Sanity bounds (USD per 1M tokens). Prices outside this range are almost
+# certainly a units bug upstream (e.g. per-1K vs per-1M) — drop them rather than
+# poison the table.
+MIN_RATE = 0.0
+MAX_RATE = 10_000.0
+
+
+def _coerce_rate(value: Any) -> Optional[float]:
+    """Return a sane float rate, or None if missing/invalid/out-of-range."""
+    if value is None:
+        return None
+    try:
+        rate = float(value)
+    except (TypeError, ValueError):
+        return None
+    if rate < MIN_RATE or rate > MAX_RATE:
+        return None
+    return rate
+
+
+def _extract_rates(cost: Dict[str, Any]) -> Optional[Dict[str, Optional[float]]]:
+    """Map a models.dev `cost` object to our {in,out,cached_read} shape.
+
+    Requires at least one of input/output to be a valid number; otherwise the
+    entry carries no useful pricing and is skipped.
+    """
+    in_rate = _coerce_rate(cost.get("input"))
+    out_rate = _coerce_rate(cost.get("output"))
+    if in_rate is None and out_rate is None:
+        return None
+    return {
+        "in": in_rate,
+        "out": out_rate,
+        "cached_read": _coerce_rate(cost.get("cache_read")),
+    }
+
+
+def fetch_dataset(url: str = MODELS_DEV_URL, timeout: int = 60) -> Dict[str, Any]:
+    """Fetch the models.dev dataset. Raises a clear error if offline/bad data."""
+    req = urllib.request.Request(url, headers={"User-Agent": "tokentelemetry-pricing-sync"})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read()
+    except (urllib.error.URLError, OSError) as exc:
+        raise SystemExit(
+            f"ERROR: could not reach {url} ({exc}). "
+            "This script is maintainer/CI-only and needs network access; "
+            "the existing pricing_data.json is left untouched."
+        )
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"ERROR: {url} did not return valid JSON: {exc}")
+    if not isinstance(data, dict) or not data:
+        raise SystemExit(f"ERROR: {url} returned an unexpected/empty payload.")
+    return data
+
+
+def build_pricing(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Transform the raw models.dev dataset into our normalized pricing dict."""
+    pricing: Dict[str, Dict[str, Optional[float]]] = {}
+    by_provider: Dict[str, Dict[str, Optional[float]]] = {}
+
+    for provider_id, provider in sorted(data.items()):
+        if not isinstance(provider, dict):
+            continue
+        prov_key = PROVIDER_ALIASES.get(provider_id.lower(), provider_id.lower())
+        for model_id, model in sorted(provider.get("models", {}).items()):
+            if not isinstance(model, dict):
+                continue
+            cost = model.get("cost")
+            if not isinstance(cost, dict):
+                continue
+            rates = _extract_rates(cost)
+            if rates is None:
+                continue
+            mid = str(model_id).lower().strip()
+            if not mid:
+                continue
+            # Flat table: first provider wins for a given bare model id (providers
+            # are iterated in sorted order for determinism). Provider-keyed entry
+            # always captures the per-provider price.
+            pricing.setdefault(mid, rates)
+            by_provider[f"{prov_key}{PROVIDER_SEP}{mid}"] = rates
+
+    if not pricing:
+        raise SystemExit(
+            "ERROR: transformed dataset is empty — refusing to overwrite "
+            "pricing_data.json with garbage."
+        )
+
+    return {
+        "updated": _dt.date.today().isoformat(),
+        "source": MODELS_DEV_URL,
+        "schema": SCHEMA_VERSION,
+        "pricing": pricing,
+        "by_provider": by_provider,
+    }
+
+
+def main(argv: Optional[list] = None) -> int:
+    data = fetch_dataset()
+    result = build_pricing(data)
+    OUTPUT_PATH.write_text(
+        json.dumps(result, indent=2, sort_keys=True, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
+    print(
+        f"Wrote {OUTPUT_PATH} — {len(result['pricing'])} models, "
+        f"{len(result['by_provider'])} provider-keyed entries "
+        f"(source: {result['source']}, updated {result['updated']})."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/backend/test_pricing_data.py
+++ b/backend/test_pricing_data.py
@@ -1,0 +1,130 @@
+"""Tests for the build-time pricing overlay (Unit 3, issue #45).
+
+These live in their own file (not test_pricing.py) to avoid colliding with a
+sibling unit. They cover:
+  - the bundled pricing_data.json overlays the inline table,
+  - inline entries stay authoritative (overlay never clobbers them),
+  - a missing / garbage file degrades silently to the static tables,
+  - importing `pricing` performs NO network I/O.
+"""
+import importlib
+import json
+import socket
+import sys
+from pathlib import Path
+
+import pytest
+
+BACKEND_DIR = Path(__file__).parent
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+
+def _fresh_pricing():
+    """Import pricing.py from scratch so module-load overlay runs again."""
+    sys.modules.pop("pricing", None)
+    return importlib.import_module("pricing")
+
+
+def test_import_is_offline():
+    """Importing pricing must not open any socket (zero network I/O)."""
+    orig = socket.socket
+
+    def _blocked(*args, **kwargs):
+        raise AssertionError("pricing import attempted network I/O")
+
+    socket.socket = _blocked
+    try:
+        pricing = _fresh_pricing()
+    finally:
+        socket.socket = orig
+    assert isinstance(pricing.PRICING, dict)
+
+
+def test_overlay_expands_table():
+    """Bundled JSON should add many models beyond the inline ~50."""
+    pricing = _fresh_pricing()
+    # The inline table alone is small; with the models.dev overlay it's large.
+    assert len(pricing.PRICING) > 200
+
+
+def test_inline_entries_are_authoritative():
+    """Overlay must never clobber a curated inline entry."""
+    pricing = _fresh_pricing()
+    # claude-opus-4-7 is hand-tuned inline; assert its exact inline values.
+    assert pricing.PRICING["claude-opus-4-7"] == {
+        "in": 5.00,
+        "out": 25.00,
+        "cached_read": 0.50,
+    }
+
+
+def test_overlay_only_models_present():
+    """A model only present in the bundled dataset should be loaded."""
+    pricing = _fresh_pricing()
+    data = json.loads((BACKEND_DIR / "pricing_data.json").read_text())
+    # Find a model id in the overlay that is NOT in the inline table.
+    inline_keys = {
+        "claude-opus-4-7", "gpt-5.4", "gemini-3.1-pro",  # known inline samples
+    }
+    overlay_only = [
+        k for k in data["pricing"] if k.lower() not in pricing.PRICING or True
+    ]
+    # Pick any overlay key that isn't a known inline one and assert it resolved.
+    candidate = next(
+        k for k in data["pricing"]
+        if k.lower() not in inline_keys
+    )
+    assert candidate.lower() in pricing.PRICING
+
+
+def test_missing_file_falls_back_to_static(tmp_path, monkeypatch):
+    """Absent pricing_data.json → silent fallback to inline tables."""
+    import pricing as _p
+    missing = tmp_path / "does_not_exist.json"
+    monkeypatch.setattr(_p, "_PRICING_DATA_PATH", missing)
+    # Re-run loader against the missing path; should not raise and should keep
+    # the inline entries intact.
+    before = dict(_p.PRICING)
+    _p._load_bundled_pricing()
+    assert _p.PRICING["claude-opus-4-7"] == before["claude-opus-4-7"]
+
+
+def test_garbage_file_falls_back_to_static(tmp_path, monkeypatch):
+    """Malformed pricing_data.json → silent fallback, no exception."""
+    import pricing as _p
+    bad = tmp_path / "bad.json"
+    bad.write_text("{ this is not valid json ]]", encoding="utf-8")
+    monkeypatch.setattr(_p, "_PRICING_DATA_PATH", bad)
+    # Must not raise.
+    _p._load_bundled_pricing()
+    assert "claude-opus-4-7" in _p.PRICING
+
+
+def test_wrong_shape_file_is_ignored(tmp_path, monkeypatch):
+    """Well-formed JSON of the wrong shape is ignored, no crash."""
+    import pricing as _p
+    odd = tmp_path / "odd.json"
+    odd.write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+    monkeypatch.setattr(_p, "_PRICING_DATA_PATH", odd)
+    _p._load_bundled_pricing()
+    assert "claude-opus-4-7" in _p.PRICING
+
+
+def test_coerce_rates_rejects_bad_entries():
+    import pricing as _p
+    assert _p._coerce_rates({"in": 1.0, "out": 2.0, "cached_read": None}) == {
+        "in": 1.0, "out": 2.0, "cached_read": None,
+    }
+    assert _p._coerce_rates({"in": None, "out": None}) is None  # no priced dir
+    assert _p._coerce_rates({"in": "free", "out": 2.0}) is None  # non-numeric
+    assert _p._coerce_rates("nope") is None
+    assert _p._coerce_rates({"in": True, "out": 2.0}) is None  # bool rejected
+
+
+def test_calculate_cost_unchanged_for_inline():
+    """Sanity: cost math on an inline model is unaffected by the overlay."""
+    pricing = _fresh_pricing()
+    # gpt-5.4: in 2.50, out 15.00 per 1M.
+    cost = pricing.calculate_cost("gpt-5.4", 1_000_000, 1_000_000)
+    assert cost == pytest.approx(2.50 + 15.00)


### PR DESCRIPTION
Closes #45.

## What

The inline pricing table in `backend/pricing.py` covered ~50 models; models.dev covers 2000+. This unit broadens and freshens coverage **without** introducing any user-machine network call — TokenTelemetry stays local-first.

## How

- **`backend/pricing_sync.py`** — dev/CI-only script (never imported by the app). Fetches `https://models.dev/api.json` and regenerates `pricing_data.json` in our `{in, out, cached_read}` shape. Resilient: clear error if offline; refuses to overwrite with empty/garbage data; sanity-bounds rates.
- **`backend/pricing_data.json`** — committed snapshot generated by the script: **2328 models, 4840 provider-keyed entries**. Shipped with the package; users get fresh prices via the normal version update.
- **`backend/pricing.py`** — at import, reads the bundled JSON from `Path(__file__).parent` (never `~/.tokentelemetry`) and overlays it onto the inline `PRICING` / `PRICING_BY_PROVIDER` dicts. **Inline entries stay authoritative**; the file is also the fallback if absent/malformed. `calculate_cost()` and `_normalize_model_id()` are untouched (a sibling unit owns the rate math). **Zero network I/O at import or runtime.**
- **`.github/workflows/pricing-sync.yml`** — weekly job that runs the sync and opens a PR for maintainer review.
- **`backend/test_pricing_data.py`** — overlay applies; inline entries win; missing/garbage/wrong-shape file → silent fallback; import does no network I/O.

## Verification

- `python -m pytest backend/ -v` → 19 passed (9 new).
- Import with `socket.socket` blocked succeeds; `len(PRICING)` grows ~50 → 2350.
- `uvicorn main:app --port 8000` + `curl /analytics` → costs still compute.

## Note

`calculate_cost`'s fuzzy substring match now iterates the larger table; with short overlay ids (e.g. `o1`, `o3`) a spurious substring hit is theoretically possible, mitigated by its existing longest-key-first ordering. That function is owned by a sibling unit and intentionally left unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)