### PR TITLE
feat(dashboard): show subscription cost disclaimer in full

### DIFF
--- a/UPDATE.json
+++ b/UPDATE.json
@@ -1,6 +1,17 @@
 {
   "releases": [
     {
+      "tag": "2026-06-08",
+      "title": "Clearer cost disclaimer — it's not a bill",
+      "highlights": [
+        {
+          "title": "Full subscription-cost disclaimer",
+          "description": "The dashboard's \"API equiv. (est.)\" figure used to cut off mid-sentence at \"Subscription users p…\". The disclaimer now shows in full, plus a persistent callout makes clear the number re-prices your usage at API list rates for comparing sessions — it is not an invoice. On a flat-fee plan like Claude Pro/Max or Copilot, your actual spend is much lower.",
+          "href": "/"
+        }
+      ]
+    },
+    {
       "tag": "2026-06-07",
       "title": "Update check — now visible and yours to control",
       "highlights": [

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -120,11 +120,20 @@ export default function Home() {
           <StatTile
             label="API equiv. (est.)"
             value={loading ? <Skeleton className="h-8 w-20" /> : formatCost(totalCost)}
-            hint="Estimated at API list prices. Subscription users pay a flat monthly fee — this is not your actual spend."
+            hint="At API list prices — for comparing sessions, not an invoice."
             icon={<DollarSign size={16} />}
             accent="var(--tt-warn)"
           />
         </div>
+        <p className="mt-3 text-[12px] leading-relaxed text-[var(--tt-fg-muted)]">
+          <span aria-hidden>💡</span>{" "}
+          <span className="font-medium text-[var(--tt-fg)]">On a subscription plan?</span>{" "}
+          The <span className="font-medium text-[var(--tt-fg)]">API equiv.</span> figure above
+          re-prices your usage at API list rates so you can compare sessions — it is{" "}
+          <span className="font-medium text-[var(--tt-fg)]">not</span> a bill. Claude Pro/Max,
+          Copilot and other flat-fee plans charge a fixed monthly price, so your actual spend is
+          much lower.
+        </p>
       </Section>
 
       {/* Connected agents — split into coding vs autonomous */}

--- a/frontend/src/components/ui/StatTile.tsx
+++ b/frontend/src/components/ui/StatTile.tsx
@@ -46,7 +46,14 @@ export function StatTile({ label, value, hint, icon, delta, accent, className }:
           </span>
         )}
       </div>
-      {hint && <div className="mt-2 text-[11px] text-[var(--tt-fg-dim)] tabular truncate">{hint}</div>}
+      {hint && (
+        <div
+          className="mt-2 text-[11px] leading-snug text-[var(--tt-fg-dim)] tabular"
+          title={typeof hint === "string" ? hint : undefined}
+        >
+          {hint}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Unit 2 of the cost-accuracy initiative (#42 follow-up). The dashboard's "API equiv. (est.)" cost tile applied a `truncate` CSS class to its hint, cutting the disclaimer mid-sentence — users saw "Estimated at API list prices. Subscription users p…" and nothing more. A subscription user (Claude Pro/Max, Copilot) seeing a large dollar figure plus a half-sentence could reasonably panic that they owe it.

## Changes

- **`StatTile.tsx`**: removed the `truncate` class from the hint so it wraps fully; added a native `title` tooltip for string hints; switched to `leading-snug` for tighter multi-line spacing. Other StatTile consumers use short single-line hints, so their layout is unchanged.
- **`page.tsx`**: shortened the per-tile hint to a concise one-liner ("At API list prices — for comparing sessions, not an invoice.") and added a persistent callout below the metric grid spelling out that the number re-prices usage at API list rates for comparing sessions and is **not** a bill — flat-fee plan users' actual spend is much lower.
- **`UPDATE.json`**: added a release highlight for the clearer disclaimer.

The sessions detail page ("· API list-price estimate", ~line 1958) was reviewed for consistency — its label is short and not truncated, so it was left unchanged.

## Verification

- `npm run build` passes.
- `npm run lint`: no new findings in the changed files (pre-existing repo-wide lint issues are untouched).
- `/code-review` (high effort): no findings.
- E2E: opened the dashboard in Chrome and confirmed both the tile hint and the persistent callout render in full — no truncation at "Subscription users p…".

🤖 Generated with [Claude Code](https://claude.com/claude-code)