### PR TITLE
feat: power & subscription cost config for local/subscription models (#49)

### DIFF
--- a/UPDATE.json
+++ b/UPDATE.json
@@ -1,6 +1,20 @@
 {
   "releases": [
     {
+      "tag": "2026-06-08",
+      "title": "Accurate cost for local & subscription models",
+      "highlights": [
+        {
+          "title": "Local models priced by electricity, not fake API rates",
+          "description": "Models you run yourself (Ollama, llama.cpp, vLLM) have no API bill — their real cost is power. Set your machine's watts under load and your kWh rate, and TokenTelemetry estimates the electricity cost instead of inventing a per-token charge."
+        },
+        {
+          "title": "Flat subscriptions now show $0 per call",
+          "description": "Endpoints you pay for monthly (Ollama Cloud Pro, a proxied gateway) are billed by subscription, not per token. List them as subscription endpoints and their sessions stop inflating your per-call cost totals."
+        }
+      ]
+    },
+    {
       "tag": "2026-06-07",
       "title": "Update check — now visible and yours to control",
       "highlights": [

--- a/backend/main.py
+++ b/backend/main.py
@@ -2713,11 +2713,16 @@ def _scan_sessions_sync():
             conn = sqlite3.connect(uri, uri=True, timeout=1.0)
             conn.row_factory = sqlite3.Row
             try:
+                # billing_base_url is newer; older Hermes DBs may lack it. Select
+                # it only when present so the whole scan doesn't fail on legacy
+                # schemas (the outer try/except would otherwise drop all sessions).
+                _cols = {r[1] for r in conn.execute("PRAGMA table_info(sessions)").fetchall()}
+                _base_url_col = "billing_base_url" if "billing_base_url" in _cols else "NULL AS billing_base_url"
                 srows = conn.execute(
                     "SELECT id, source, model, parent_session_id, started_at, ended_at, "
                     "input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, "
                     "reasoning_tokens, estimated_cost_usd, actual_cost_usd, title, "
-                    "billing_provider, end_reason "
+                    f"billing_provider, {_base_url_col}, end_reason "
                     "FROM sessions"
                 ).fetchall()
                 for srow in srows:
@@ -2740,7 +2745,11 @@ def _scan_sessions_sync():
                     # Prefer Hermes's own cost (it knows exotic models we may not price)
                     cost = srow["actual_cost_usd"] if srow["actual_cost_usd"] is not None else srow["estimated_cost_usd"]
                     if cost is None:
-                        cost = calculate_cost(model, in_t, out_t, cached, provider=srow["billing_provider"])
+                        cost = calculate_cost(
+                            model, in_t, out_t, cached,
+                            provider=srow["billing_provider"],
+                            endpoint=srow["billing_base_url"],
+                        )
                     tokens["cost"] = cost
                     # First user message → display fallback when title is empty
                     first_user = ""
@@ -3506,6 +3515,39 @@ async def post_update_check(payload: dict = Body(...)):
     save_preferences({"update_check": enabled})
     env_off = bool(os.environ.get("TT_NO_UPDATE_CHECK"))
     return {"enabled": enabled, "env_forced_off": env_off, "effective": enabled and not env_off}
+
+
+@app.get("/config/power")
+async def get_power_config():
+    """Power & subscription cost config for local/subscription models.
+
+    `configured` tells the UI whether a power.json exists yet — when false the
+    returned values are the shipped defaults and the local-model electricity
+    branch is inactive until the user saves.
+    """
+    from power_config import load_power_config, has_user_config
+    cfg = load_power_config()
+    return {**cfg, "configured": has_user_config()}
+
+
+@app.put("/config/power")
+async def put_power_config(payload: dict = Body(...)):
+    """Persist power config. Body: {loadWatts?, costPerKwh?, subscriptionEndpoints?}.
+
+    Validation happens in power_config.save_power_config (bad values are skipped,
+    never surfaced as raw errors). Returns the full saved config.
+    """
+    from fastapi import HTTPException
+    if not isinstance(payload, dict):
+        raise HTTPException(status_code=400, detail="body must be a JSON object")
+    from power_config import save_power_config
+    try:
+        cfg = save_power_config(payload)
+    except OSError:
+        # Disk/permissions issue — keep it human, no stack traces.
+        raise HTTPException(status_code=500, detail="Could not save power config to disk.")
+    _invalidate_sessions_cache()
+    return {**cfg, "configured": True}
 
 
 @app.get("/config/aliases")

--- a/backend/power_config.py
+++ b/backend/power_config.py
@@ -1,0 +1,211 @@
+"""Power & subscription cost configuration for local / subscription models.
+
+The flat per-token pricing table in ``pricing.py`` is wrong for two classes of
+models:
+
+1. **Local models** (ollama / llama.cpp / vLLM running on your own hardware).
+   There is no API bill — the real marginal cost is electricity. We approximate
+   it from the machine's draw under load (``loadWatts``), your electricity tariff
+   (``costPerKwh``), and how long the generation ran.
+
+2. **Flat subscriptions** (Ollama Cloud Pro, a proxied/self-hosted gateway you
+   pay for monthly, etc.). These are billed per month, not per token, so the
+   per-call cost is 0 — the monthly fee is tracked separately, outside this
+   tool's per-session accounting.
+
+Config lives at ``~/.tokentelemetry/power.json``::
+
+    {
+      "loadWatts": 80,
+      "costPerKwh": 0.15,
+      "subscriptionEndpoints": ["https://ollama.com", "http://localhost:11434"]
+    }
+
+This module never raises on a missing or malformed file — it falls back to the
+shipped defaults so cost accounting keeps working out of the box.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+# 80 W is a reasonable steady-state draw for a laptop / small desktop GPU under
+# inference load; 0.15 USD/kWh is roughly the US residential average. These are
+# intentionally conservative so the electricity estimate is in the right ballpark
+# without claiming false precision.
+DEFAULT_LOAD_WATTS = 80
+DEFAULT_COST_PER_KWH = 0.15
+DEFAULT_SUBSCRIPTION_ENDPOINTS: List[str] = []
+
+DEFAULTS: Dict[str, Any] = {
+    "loadWatts": DEFAULT_LOAD_WATTS,
+    "costPerKwh": DEFAULT_COST_PER_KWH,
+    "subscriptionEndpoints": list(DEFAULT_SUBSCRIPTION_ENDPOINTS),
+}
+
+# Assumed local-inference throughput when we don't have a measured rate. Used to
+# convert output tokens into a wall-clock generation time for the electricity
+# estimate. 30 tok/s is a sane mid-range figure for a 7B-13B model on consumer
+# hardware; callers that know the real throughput should pass it in.
+DEFAULT_TOK_PER_SEC = 30.0
+
+
+def _config_path() -> Path:
+    home = Path(os.environ.get("TOKENTELEMETRY_HOME") or Path.home())
+    return home / ".tokentelemetry" / "power.json"
+
+
+def has_user_config() -> bool:
+    """True if the user has written a power.json at all (any field)."""
+    return _config_path().exists()
+
+
+def local_power_enabled() -> bool:
+    """True only if the user explicitly set a power figure (loadWatts/costPerKwh).
+
+    The local-model electricity branch in ``pricing.calculate_cost`` keys off
+    this, NOT merely ``has_user_config``. Otherwise a user who configured only
+    ``subscriptionEndpoints`` would have every *unknown cloud* model silently
+    re-priced as near-zero electricity instead of the ``_default`` per-token
+    rate — under-reporting real API spend. We require an explicit power figure
+    on disk so electricity pricing is opt-in independently of subscriptions.
+    """
+    path = _config_path()
+    if not path.exists():
+        return False
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            raw = json.load(f)
+    except Exception:
+        return False
+    if not isinstance(raw, dict):
+        return False
+    lw = raw.get("loadWatts")
+    cpk = raw.get("costPerKwh")
+    lw_ok = isinstance(lw, (int, float)) and not isinstance(lw, bool) and lw > 0
+    cpk_ok = isinstance(cpk, (int, float)) and not isinstance(cpk, bool) and cpk >= 0
+    return bool(lw_ok or cpk_ok)
+
+
+def load_power_config() -> Dict[str, Any]:
+    """Return power config with defaults filled in for missing/invalid fields.
+
+    Never raises: a missing or malformed file yields the shipped defaults. Each
+    field is validated independently, so one bad value can't discard the rest of
+    a valid file.
+    """
+    config = dict(DEFAULTS)
+    config["subscriptionEndpoints"] = list(DEFAULT_SUBSCRIPTION_ENDPOINTS)
+
+    path = _config_path()
+    if not path.exists():
+        return config
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            raw = json.load(f)
+    except Exception:
+        return config
+    if not isinstance(raw, dict):
+        return config
+
+    lw = raw.get("loadWatts")
+    if isinstance(lw, (int, float)) and not isinstance(lw, bool) and lw > 0:
+        config["loadWatts"] = int(lw)
+
+    cpk = raw.get("costPerKwh")
+    if isinstance(cpk, (int, float)) and not isinstance(cpk, bool) and cpk >= 0:
+        config["costPerKwh"] = float(cpk)
+
+    eps = raw.get("subscriptionEndpoints")
+    if isinstance(eps, list):
+        config["subscriptionEndpoints"] = [
+            e.strip() for e in eps if isinstance(e, str) and e.strip()
+        ]
+
+    return config
+
+
+def save_power_config(updates: Dict[str, Any]) -> Dict[str, Any]:
+    """Merge validated ``updates`` over the current config and persist it.
+
+    Returns the full config after the merge. Values that fail validation are
+    skipped so a bad payload can't corrupt a setting.
+    """
+    config = load_power_config()
+
+    lw = updates.get("loadWatts")
+    if isinstance(lw, (int, float)) and not isinstance(lw, bool) and lw > 0:
+        config["loadWatts"] = int(lw)
+
+    cpk = updates.get("costPerKwh")
+    if isinstance(cpk, (int, float)) and not isinstance(cpk, bool) and cpk >= 0:
+        config["costPerKwh"] = float(cpk)
+
+    eps = updates.get("subscriptionEndpoints")
+    if isinstance(eps, list):
+        config["subscriptionEndpoints"] = [
+            e.strip() for e in eps if isinstance(e, str) and e.strip()
+        ]
+
+    path = _config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(config, f, indent=2)
+    os.replace(tmp, path)
+    return config
+
+
+def is_subscription_endpoint(
+    endpoint: Optional[str], config: Optional[Dict[str, Any]] = None
+) -> bool:
+    """True if ``endpoint`` matches a configured flat-subscription endpoint.
+
+    Matching is case-insensitive and substring-based in either direction so a
+    configured host (``https://ollama.com``) matches a fuller request URL
+    (``https://ollama.com/api/chat``) and vice-versa.
+    """
+    if not endpoint:
+        return False
+    if config is None:
+        config = load_power_config()
+    ep = endpoint.lower().strip()
+    for sub in config.get("subscriptionEndpoints", []):
+        s = sub.lower().strip()
+        if not s:
+            continue
+        if s in ep or ep in s:
+            return True
+    return False
+
+
+def electricity_cost(
+    output_tokens: int,
+    config: Optional[Dict[str, Any]] = None,
+    tok_per_sec: float = DEFAULT_TOK_PER_SEC,
+) -> float:
+    """Estimate the electricity cost (USD) of generating ``output_tokens`` locally.
+
+    cost = generation_seconds * watts / 3_600_000 (Wh->kWh per second) * costPerKwh
+
+    where generation_seconds = output_tokens / tok_per_sec. Returns 0.0 for
+    non-positive inputs. ``tok_per_sec`` defaults to a conservative local-inference
+    throughput; pass a measured value when available.
+    """
+    if config is None:
+        config = load_power_config()
+    if output_tokens <= 0 or not tok_per_sec or tok_per_sec <= 0:
+        return 0.0
+    watts = config.get("loadWatts", DEFAULT_LOAD_WATTS)
+    cost_per_kwh = config.get("costPerKwh", DEFAULT_COST_PER_KWH)
+    gen_seconds = output_tokens / tok_per_sec
+    # watts * seconds = watt-seconds (joules); /3_600_000 converts Wh->kWh and
+    # seconds->hours in one shot (3600 s/h * 1000 Wh/kWh).
+    kwh = (watts * gen_seconds) / 3_600_000
+    return kwh * cost_per_kwh

--- a/backend/pricing.py
+++ b/backend/pricing.py
@@ -200,8 +200,31 @@ def calculate_cost(
     output_tokens: int,
     cached_tokens: int = 0,
     provider: Optional[str] = None,
+    endpoint: Optional[str] = None,
+    tok_per_sec: Optional[float] = None,
 ) -> float:
-    """Estimate cost in USD. Prefer (provider, model) when provider is known."""
+    """Estimate cost in USD. Prefer (provider, model) when provider is known.
+
+    ``endpoint`` and ``tok_per_sec`` are optional and only affect the
+    local/subscription branches (Unit 4): if the session was served by a
+    flat-subscription endpoint the per-call cost is 0 (billed monthly), and a
+    local model with no API rate is priced by its electricity draw. All callers
+    that omit these get the unchanged per-token behaviour.
+    """
+    # --- LOOKUP region -----------------------------------------------------
+    # Subscription / local-model branches go FIRST so they short-circuit before
+    # the per-token rate-math at the bottom (owned by a sibling unit). Both are
+    # opt-in via ~/.tokentelemetry/power.json; with no config the substring
+    # match never fires and unpriced models fall through to _default as before.
+    if endpoint:
+        try:
+            from power_config import is_subscription_endpoint
+            if is_subscription_endpoint(endpoint):
+                # Flat monthly subscription — per-call cost is tracked separately.
+                return 0.0
+        except Exception:
+            pass
+
     if not model_name:
         config = PRICING["_default"]
     else:
@@ -219,6 +242,23 @@ def calculate_cost(
                     config = PRICING[k]
                     break
         if not config:
+            # No known API rate for this model. If the user has opted in via
+            # ~/.tokentelemetry/power.json, treat it as a local model and price
+            # it by electricity instead of the (wrong) _default per-token rate.
+            try:
+                from power_config import (
+                    local_power_enabled, load_power_config, electricity_cost,
+                    DEFAULT_TOK_PER_SEC,
+                )
+                if local_power_enabled():
+                    pc = load_power_config()
+                    return electricity_cost(
+                        output_tokens,
+                        config=pc,
+                        tok_per_sec=tok_per_sec or DEFAULT_TOK_PER_SEC,
+                    )
+            except Exception:
+                pass
             config = PRICING["_default"]
 
     in_rate = config["in"] or 0

--- a/backend/test_power_config.py
+++ b/backend/test_power_config.py
@@ -1,0 +1,193 @@
+"""Tests for power & subscription cost config (Unit 4 / issue #49).
+
+The flat per-token table mis-prices local models (real cost is electricity) and
+flat subscriptions (per-call cost is 0, billed monthly). These tests pin:
+  - the config store (defaults, malformed-file tolerance, roundtrip),
+  - the subscription-endpoint short-circuit in calculate_cost -> 0.0,
+  - the local-model electricity branch when a power.json exists,
+  - backward compatibility: no config file => unchanged per-token behaviour.
+
+Run with pytest, or directly:  python backend/test_power_config.py
+"""
+import importlib
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+
+def _fresh_modules(home: str):
+    """Point power_config at `home` and reload it + pricing so they pick it up."""
+    os.environ["TOKENTELEMETRY_HOME"] = home
+    import power_config
+    import pricing
+    importlib.reload(power_config)
+    importlib.reload(pricing)
+    return power_config, pricing
+
+
+def _write_power_json(home: str, data: dict) -> None:
+    d = Path(home) / ".tokentelemetry"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "power.json").write_text(json.dumps(data), encoding="utf-8")
+
+
+# --------------------------------------------------------------------------
+# Config store
+# --------------------------------------------------------------------------
+def test_defaults_when_no_file():
+    with tempfile.TemporaryDirectory() as home:
+        pc, _ = _fresh_modules(home)
+        cfg = pc.load_power_config()
+        assert cfg["loadWatts"] == pc.DEFAULT_LOAD_WATTS
+        assert cfg["costPerKwh"] == pc.DEFAULT_COST_PER_KWH
+        assert cfg["subscriptionEndpoints"] == []
+        assert pc.has_user_config() is False
+
+
+def test_malformed_file_falls_back_to_defaults():
+    with tempfile.TemporaryDirectory() as home:
+        d = Path(home) / ".tokentelemetry"
+        d.mkdir(parents=True)
+        (d / "power.json").write_text("{not valid json", encoding="utf-8")
+        pc, _ = _fresh_modules(home)
+        cfg = pc.load_power_config()  # must not raise
+        assert cfg["loadWatts"] == pc.DEFAULT_LOAD_WATTS
+        # File exists, so it counts as user-configured even though it's garbage.
+        assert pc.has_user_config() is True
+
+
+def test_partial_and_bad_fields_validated_independently():
+    with tempfile.TemporaryDirectory() as home:
+        _write_power_json(home, {
+            "loadWatts": 120,
+            "costPerKwh": "not-a-number",   # bad -> default kept
+            "subscriptionEndpoints": ["https://ollama.com", "", 5, "  http://x  "],
+        })
+        pc, _ = _fresh_modules(home)
+        cfg = pc.load_power_config()
+        assert cfg["loadWatts"] == 120
+        assert cfg["costPerKwh"] == pc.DEFAULT_COST_PER_KWH
+        assert cfg["subscriptionEndpoints"] == ["https://ollama.com", "http://x"]
+
+
+def test_save_roundtrip_and_skips_bad_values():
+    with tempfile.TemporaryDirectory() as home:
+        pc, _ = _fresh_modules(home)
+        saved = pc.save_power_config({
+            "loadWatts": 95, "costPerKwh": 0.22,
+            "subscriptionEndpoints": ["https://ollama.com"],
+        })
+        assert saved["loadWatts"] == 95 and saved["costPerKwh"] == 0.22
+        assert pc.load_power_config()["loadWatts"] == 95
+        # Bad payload can't corrupt existing values.
+        again = pc.save_power_config({"loadWatts": -10, "costPerKwh": "x"})
+        assert again["loadWatts"] == 95 and again["costPerKwh"] == 0.22
+
+
+# --------------------------------------------------------------------------
+# calculate_cost integration
+# --------------------------------------------------------------------------
+def test_subscription_endpoint_returns_zero():
+    with tempfile.TemporaryDirectory() as home:
+        _write_power_json(home, {"subscriptionEndpoints": ["https://ollama.com"]})
+        _, pricing = _fresh_modules(home)
+        # Even a model with a real rate -> 0 because it's billed monthly.
+        cost = pricing.calculate_cost(
+            "claude-opus-4-7", 100_000, 50_000,
+            endpoint="https://ollama.com/api/chat",
+        )
+        assert cost == 0.0
+
+
+def test_subscription_match_is_substring_either_way():
+    with tempfile.TemporaryDirectory() as home:
+        _write_power_json(home, {"subscriptionEndpoints": ["api.githubcopilot.com"]})
+        _, pricing = _fresh_modules(home)
+        cost = pricing.calculate_cost(
+            "gpt-5.4", 1000, 1000,
+            endpoint="https://api.githubcopilot.com",
+        )
+        assert cost == 0.0
+
+
+def test_local_model_uses_electricity_when_configured():
+    with tempfile.TemporaryDirectory() as home:
+        _write_power_json(home, {"loadWatts": 80, "costPerKwh": 0.15})
+        pc, pricing = _fresh_modules(home)
+        out_tokens = 30_000  # at default 30 tok/s -> 1000s
+        cost = pricing.calculate_cost("my-local-llama", 5000, out_tokens)
+        # Expected electricity: 1000s * 80W / 3_600_000 * 0.15
+        expected = (out_tokens / pc.DEFAULT_TOK_PER_SEC) * 80 / 3_600_000 * 0.15
+        assert abs(cost - expected) < 1e-9
+        # Sanity: this is far cheaper than the _default per-token rate would be.
+        default_rate = pricing.PRICING["_default"]
+        per_token = (5000 / 1e6) * default_rate["in"] + (out_tokens / 1e6) * default_rate["out"]
+        assert cost < per_token
+
+
+def test_local_model_respects_custom_tok_per_sec():
+    with tempfile.TemporaryDirectory() as home:
+        _write_power_json(home, {"loadWatts": 100, "costPerKwh": 0.20})
+        _, pricing = _fresh_modules(home)
+        out_tokens = 6000
+        cost = pricing.calculate_cost(
+            "some-unknown-local", 0, out_tokens, tok_per_sec=60.0,
+        )
+        expected = (out_tokens / 60.0) * 100 / 3_600_000 * 0.20
+        assert abs(cost - expected) < 1e-9
+
+
+def test_subscription_only_config_does_not_electricity_price_unknown_cloud():
+    # A user who lists ONLY subscription endpoints must not have unknown CLOUD
+    # models silently re-priced as near-zero electricity (that would under-report
+    # real API spend). Without an explicit power figure, unknown models still
+    # fall through to _default.
+    with tempfile.TemporaryDirectory() as home:
+        _write_power_json(home, {"subscriptionEndpoints": ["https://ollama.com"]})
+        pc, pricing = _fresh_modules(home)
+        assert pc.local_power_enabled() is False
+        unknown = pricing.calculate_cost("brand-new-cloud-model", 1_000_000, 1_000_000)
+        d = pricing.PRICING["_default"]
+        assert abs(unknown - (d["in"] + d["out"])) < 1e-9
+        # ...but the subscription short-circuit still works for that endpoint.
+        assert pricing.calculate_cost(
+            "brand-new-cloud-model", 1_000_000, 1_000_000,
+            endpoint="https://ollama.com/api/chat",
+        ) == 0.0
+
+
+def test_no_config_file_preserves_per_token_behaviour():
+    with tempfile.TemporaryDirectory() as home:
+        _, pricing = _fresh_modules(home)  # no power.json written
+        # Known model: unchanged.
+        known = pricing.calculate_cost("claude-opus-4-7", 1_000_000, 1_000_000)
+        assert abs(known - (5.00 + 25.00)) < 1e-9
+        # Unknown model: still falls through to _default (NOT electricity).
+        unknown = pricing.calculate_cost("totally-unknown-xyz", 1_000_000, 1_000_000)
+        d = pricing.PRICING["_default"]
+        assert abs(unknown - (d["in"] + d["out"])) < 1e-9
+        # An endpoint with no subscription config doesn't zero anything out.
+        with_ep = pricing.calculate_cost(
+            "claude-opus-4-7", 1_000_000, 0, endpoint="https://api.anthropic.com",
+        )
+        assert with_ep > 0
+
+
+if __name__ == "__main__":
+    import traceback
+    funcs = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for fn in funcs:
+        try:
+            fn()
+            print(f"PASS {fn.__name__}")
+        except Exception:
+            failed += 1
+            print(f"FAIL {fn.__name__}")
+            traceback.print_exc()
+    print(f"\n{len(funcs) - failed}/{len(funcs)} passed")
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
## Unit 4 (#49) — power & subscription cost for local/subscription models

`backend/pricing.py`'s table maps model -> per-token USD, which is wrong for:
- **local models** (ollama / llama.cpp / vLLM) — no API bill; real cost is electricity;
- **flat subscriptions** (Ollama Cloud Pro, proxied gateways) — billed monthly, so per-call cost should be 0.

Today both fall through to a wrong rate or `_default`.

## Changes

- **new `backend/power_config.py`** — loads `~/.tokentelemetry/power.json` (`loadWatts`, `costPerKwh`, `subscriptionEndpoints`) with sane defaults; never raises on a missing/malformed file. Exposes `load/save_power_config`, `is_subscription_endpoint`, `electricity_cost`, and gating helpers.
- **`pricing.calculate_cost`** — new optional `endpoint` / `tok_per_sec` kwargs (fully backward compatible). Early branches in the LOOKUP region (above the rate-math owned by a sibling unit):
  - endpoint matches a subscription endpoint -> `0.0`;
  - unknown model **and** the user set an explicit power figure -> electricity cost `(output_tokens / tok_per_sec) * loadWatts / 3_600_000 * costPerKwh` (default 30 tok/s).
- **`backend/main.py`** — Hermes scan now selects `billing_base_url` (PRAGMA-guarded so legacy DBs don't break) and passes it as `endpoint`; new `GET/PUT /config/power` endpoints with validation in `power_config` (no raw errors surfaced).
- **`backend/test_power_config.py`** — defaults / malformed tolerance, subscription -> 0, local electricity pricing, and a regression test that subscription-only configs do **not** re-price unknown cloud models.
- **`UPDATE.json`** — new release entry (required by the pre-push hook).

## Notable design decision (from self-review)

Electricity pricing is gated on `local_power_enabled()` — an actual `loadWatts`/`costPerKwh` written to disk — **not** merely "a config file exists". Otherwise a user who configured only `subscriptionEndpoints` would have every *unknown cloud* model silently re-priced as near-zero electricity, under-reporting real API spend. Regression test included.

## UI scope

Scoped to backend + `GET/PUT /config/power` (per the unit's allowance to skip the UI given the Next.js breaking-changes caveat). A Settings panel can land in a follow-up.

## Verification

- `pytest backend/` — 20 passed (9 new in `test_power_config.py`).
- Ran uvicorn; `GET/PUT /config/power` round-trip works, bad values skipped gracefully, `/analytics` still loads Hermes sessions with the new column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)