### PR TITLE
fix: hermes session scanner silently drops every session

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2766,12 +2766,14 @@ def _scan_sessions_sync():
                     model = srow["model"]
                     # Prefer Hermes's own cost (it knows exotic models we may not price)
                     cost = srow["actual_cost_usd"] if srow["actual_cost_usd"] is not None else srow["estimated_cost_usd"]
+                    # Bind before the branch: it's referenced unconditionally in the
+                    # session dict below, but only computed when cost must be derived.
+                    _measured_tps = None
                     if cost is None:
                         # Only when TT has to compute the cost itself AND the session
                         # is local do we parse the agent log for a MEASURED tok/s
                         # (out/latency per call). This keeps the common path cheap —
                         # most Hermes sessions carry their own cost and skip this.
-                        _measured_tps = None
                         try:
                             from power_config import is_local_session
                             if is_local_session(model, srow["billing_base_url"], srow["billing_provider"]):
@@ -2814,8 +2816,8 @@ def _scan_sessions_sync():
                         "cost_anomaly": cost_anomaly,
                         "parent_session_id": srow["parent_session_id"],
                         "end_reason": srow["end_reason"],
-                        "provider": srow.get("billing_provider", None),
-                        "endpoint": srow.get("billing_base_url", None),
+                        "provider": srow["billing_provider"],
+                        "endpoint": srow["billing_base_url"],
                         "tok_per_sec": _measured_tps,
                     })
             finally:


### PR DESCRIPTION
## Summary
The Hermes integration's session scan threw on every row, and the block's `except Exception: pass` swallowed it — so `/sessions` returned zero `agent == "hermes"` sessions and the entire `/hermes` stats view (cost, models, sources, per-agent groups) rendered empty.

## Type of change
- [x] Bug fix

## Details
In `_scan_sessions_sync()` (the Hermes block in `backend/main.py`) there are two independent bugs, each fatal on its own, both hidden by the surrounding `except Exception: pass`:

1. **`sqlite3.Row` has no `.get()`.** `srow.get("billing_provider", None)` / `srow.get("billing_base_url", None)` raise `AttributeError` on the first row. Every other field in the same dict already uses `srow["..."]` subscripting, and both columns are always SELECTed, so they're always present. Fixed by using the subscript form.
2. **`_measured_tps` `UnboundLocalError`.** It's referenced unconditionally in the session dict (`"tok_per_sec": _measured_tps`) but only assigned inside the `if cost is None:` branch. Most Hermes sessions carry their own cost, so that branch is skipped and the name is never bound. Fixed by initializing `_measured_tps = None` before the branch (and dropping the now-redundant assignment inside it).

Because the whole per-DB loop is wrapped in `except Exception: pass`, the failure was completely silent — no log line, `last_error` stayed `null` — which is why it presents as "the Hermes stats just don't show" rather than as an error.

## How to test
1. With a Hermes install present (`~/.hermes` containing sessions), run `./start.sh`.
2. Open `/hermes` — before this change the cost / models / sources cards are empty; after, they populate.
3. Or directly: `curl -s localhost:8000/sessions | jq '[.[] | select(.agent=="hermes")] | length'` returns a non-zero count instead of `0`.

## Checklist
- [x] I tested this locally with `./start.sh`
- [x] No secrets or API keys are included
- [x] PR is focused on one change
- [ ] README or CHANGELOG updated if needed — n/a (pure bug fix; no user-facing changelog entry)

## Related issue
N/A
