### PR TITLE
feat(intelligence): efficiency scoring, AI smell detection, burn rate forecasting

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ The launcher tab works for every TT page, not just `/hermes` — Analytics, Proj
 - ⚡ **Efficiency Scoring** — 0–100 score per session measuring how productively tokens were spent *(Intelligence Layer)*
 - 🦨 **AI Smell Detection** — rule-based warnings for context rot, loop traps, tool thrash, high error rate, and massive sessions *(Intelligence Layer)*
 - 🔥 **Burn Rate Forecasting** — daily token trends projected to month-end with plan limit alerts *(Intelligence Layer)*
+- 🧬 **Prompt DNA** — correlates prompt structure (file refs, length, vagueness, task type) against efficiency scores to show what makes sessions good or bad *(Intelligence Layer)*
 - 🔒 **100% Local** — all data stays on your machine, zero cloud dependency
 - ⚡ **Zero Config** — auto-detects agents from their default log locations
 - 🆓 **Free & Open Source** — MIT licensed, forever free
@@ -242,17 +243,71 @@ Response:
 
 ---
 
+### 🧬 Prompt DNA
+
+Extracts **10 structural features** from each session's first message and computes Pearson correlation against efficiency scores, revealing which prompt habits make sessions succeed or fail.
+
+**Features extracted per prompt:**
+
+| Feature | Description |
+|---------|-------------|
+| `msg_length` | Character count |
+| `word_count` | Approximate word count |
+| `has_file_ref` | References a file path or @ mention |
+| `has_code_block` | Contains a triple-backtick block |
+| `has_markdown` | Uses `#` headers or `- / *` bullets |
+| `has_numbered_steps` | Uses `1.` / `2.` numbered lists |
+| `has_question` | Prompt ends with `?` |
+| `is_vague` | < 60 chars, no file ref, no code |
+| `is_detailed` | > 300 characters |
+| `has_context_link` | References previous session / last time / continue |
+
+**Task classification:** `fix` · `build` · `refactor` · `analyze` · `test` · `deploy` · `other` (regex-matched, first match wins).
+
+**In the UI:** a **Prompt DNA** card in the right sidebar shows the top 2 positive and top 2 negative correlates with r-values and one-line insights, plus a mini bar chart breaking down average efficiency by task type.
+
+**API:**
+```
+GET /insights/prompt-dna    → full correlation analysis over all sessions
+```
+
+Response:
+```json
+{
+  "sessions_analysed": 14,
+  "sessions_skipped": 24,
+  "correlations": [
+    {
+      "feature": "is_vague",
+      "label": "Vague / short prompt",
+      "r": -0.871,
+      "direction": "negative",
+      "insight": "Sessions with 'vague / short prompt' score 53.6 pts lower on average (13.7 vs 67.3)."
+    }
+  ],
+  "by_task_type": {
+    "other":   { "avg_efficiency": 69.7, "count": 8 },
+    "build":   { "avg_efficiency": 20.6, "count": 4 }
+  },
+  "top_positive": [...],
+  "top_negative": [...]
+}
+```
+
+---
+
 ### Implementation notes
 
-All three features live in three new standalone Python modules — no changes to existing data collection or parsing logic:
+All four features live in standalone Python modules — no changes to existing data collection or parsing logic:
 
 | Module | Responsibility |
 |--------|---------------|
 | `backend/scoring.py` | Efficiency score computation |
 | `backend/smells.py` | Smell rule evaluation |
 | `backend/forecast.py` | Daily bucketing + linear projection |
+| `backend/prompt_analysis.py` | Feature extraction + Pearson correlation |
 
-**No new required dependencies.** Everything uses Python stdlib (`math`, `datetime`, `collections`). Ollama, scipy, numpy — none needed.
+**No new required dependencies.** Everything uses Python stdlib (`math`, `datetime`, `collections`, `re`). Ollama, scipy, numpy — none needed.
 
 Smells and efficiency scores are computed in-memory after the session cache is built, so they add no I/O overhead. Forecast runs over the already-loaded session list.
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ The launcher tab works for every TT page, not just `/hermes` — Analytics, Proj
 - 🦨 **AI Smell Detection** — rule-based warnings for context rot, loop traps, tool thrash, high error rate, and massive sessions *(Intelligence Layer)*
 - 🔥 **Burn Rate Forecasting** — daily token trends projected to month-end with plan limit alerts *(Intelligence Layer)*
 - 🧬 **Prompt DNA** — correlates prompt structure (file refs, length, vagueness, task type) against efficiency scores to show what makes sessions good or bad *(Intelligence Layer)*
+- 🏆 **Multi-Model Comparison** — side-by-side efficiency ranking of every model you've used, with avg/p75/best scores and task-type filter pills *(Intelligence Layer)*
 - 🔒 **100% Local** — all data stays on your machine, zero cloud dependency
 - ⚡ **Zero Config** — auto-detects agents from their default log locations
 - 🆓 **Free & Open Source** — MIT licensed, forever free
@@ -296,9 +297,62 @@ Response:
 
 ---
 
+### 🏆 Multi-Model Comparison
+
+Side-by-side efficiency ranking of every model you've used, filterable by task type.
+
+**Stats per model:**
+
+| Stat | Description |
+|------|-------------|
+| `avg_efficiency` | Mean efficiency score across sessions |
+| `median_efficiency` | Median (robust to outliers) |
+| `p75_efficiency` | 75th percentile — typical good session for this model |
+| `best_efficiency` | Highest single session score |
+| `avg_tokens` | Average tokens per session |
+| `task_breakdown` | Per-task-type count and avg efficiency |
+
+**In the UI:** a full-width **Model comparison** section below the main grid shows ranked model rows with dual efficiency bars (avg + p75) and colour-coded task breakdown pills. Task type filter pills (All / build / refactor / analyze / other) refetch instantly.
+
+**API:**
+```
+GET /insights/model-comparison                      → all task types
+GET /insights/model-comparison?task_type=build      → build tasks only
+GET /insights/model-comparison?task_type=refactor   → refactor tasks only
+```
+
+Response:
+```json
+{
+  "task_type_filter": null,
+  "models_compared": 3,
+  "sessions_used": 13,
+  "sessions_skipped": 25,
+  "models": [
+    {
+      "model": "claude-sonnet-4-6",
+      "agent": "claude",
+      "session_count": 5,
+      "avg_efficiency": 68.4,
+      "median_efficiency": 73.6,
+      "p75_efficiency": 76.6,
+      "best_efficiency": 80.4,
+      "total_tokens": 13258141,
+      "avg_tokens": 2651628,
+      "task_breakdown": {
+        "other": { "count": 5, "avg_efficiency": 68.4 }
+      }
+    }
+  ],
+  "task_types_available": ["build", "refactor", "analyze", "other"]
+}
+```
+
+---
+
 ### Implementation notes
 
-All four features live in standalone Python modules — no changes to existing data collection or parsing logic:
+All five features live in standalone Python modules — no changes to existing data collection or parsing logic:
 
 | Module | Responsibility |
 |--------|---------------|
@@ -306,6 +360,7 @@ All four features live in standalone Python modules — no changes to existing d
 | `backend/smells.py` | Smell rule evaluation |
 | `backend/forecast.py` | Daily bucketing + linear projection |
 | `backend/prompt_analysis.py` | Feature extraction + Pearson correlation |
+| `backend/model_comparison.py` | Per-model efficiency stats + task breakdown |
 
 **No new required dependencies.** Everything uses Python stdlib (`math`, `datetime`, `collections`, `re`). Ollama, scipy, numpy — none needed.
 

--- a/README.md
+++ b/README.md
@@ -110,9 +110,151 @@ The launcher tab works for every TT page, not just `/hermes` — Analytics, Proj
 - 📁 **Per-Project Insights** — heatmap, activity timeline, agent leaderboard per codebase
 - 🧠 **Plan Capture** — view plan-mode outputs from Claude Code and other agents
 - 📈 **Model Analytics** — compare GPT-5.4 vs Claude 4.6 Sonnet vs Gemini 3.1 Flash efficiency
+- ⚡ **Efficiency Scoring** — 0–100 score per session measuring how productively tokens were spent *(Intelligence Layer)*
+- 🦨 **AI Smell Detection** — rule-based warnings for context rot, loop traps, tool thrash, high error rate, and massive sessions *(Intelligence Layer)*
+- 🔥 **Burn Rate Forecasting** — daily token trends projected to month-end with plan limit alerts *(Intelligence Layer)*
 - 🔒 **100% Local** — all data stays on your machine, zero cloud dependency
 - ⚡ **Zero Config** — auto-detects agents from their default log locations
 - 🆓 **Free & Open Source** — MIT licensed, forever free
+
+---
+
+## Intelligence Layer
+
+> **Branch:** `tokentelemetry-intelligence-layer` — pure computation on top of existing session data. No new required dependencies.
+
+Three analytical capabilities that turn raw token counts into actionable insight:
+
+---
+
+### ⚡ Agent Efficiency Score
+
+Every session now carries a **0–100 score** measuring how productively tokens were spent:
+
+```
+score = output_ratio × error_penalty × turn_penalty × 100
+```
+
+| Factor | Formula | Rationale |
+|--------|---------|-----------|
+| `output_ratio` | output tokens ÷ total tokens | More output per token = more productive work |
+| `error_penalty` | 1 ÷ (1 + errors × 0.15) | Tool failures waste tokens |
+| `turn_penalty` | 1 ÷ (1 + log(turns) × 0.18) | Fewer turns = clearer prompts |
+
+**Labels:** `good` (≥ 70) · `fair` (40–69) · `poor` (< 40)
+
+**In the UI:** a colour-coded `⚡ Score` badge appears on every row in the Recent Activity table — green, amber, or red at a glance.
+
+**API:**
+```
+GET /sessions          → each session now includes: efficiency, efficiency_label
+GET /efficiency        → all sessions sorted best-first (great for leaderboards)
+GET /efficiency?project=/path/to/repo   → filtered by project
+```
+
+---
+
+### 🦨 AI Smell Detection
+
+Rule-based detection of **5 anti-patterns** that indicate wasted tokens or a stuck agent:
+
+| Smell | Trigger | Severity |
+|-------|---------|----------|
+| `context_rot` | Session > 200 turns | warning (> 400 turns → critical) |
+| `loop_trap` | Same tool called with identical input ≥ 8 times in a row | critical |
+| `tool_thrash` | Same file read ≥ 25 times across a session | warning |
+| `high_error_rate` | Errors > 20% of turns | warning (> 40% → critical) |
+| `massive_session` | Total tokens > 2 M | warning (> 5 M → critical) |
+
+Each smell is a structured dict `{ type, title, detail, severity }` — the `detail` field explains what happened and what to do about it.
+
+**In the UI:** an `⚠` icon appears on session rows that have at least one smell — orange for warnings, red for critical. Hovering shows the count and worst severity.
+
+**API:**
+```
+GET /smells             → sessions with at least one smell (all projects)
+GET /smells?project=/path/to/repo   → filtered by project
+```
+
+Each entry:
+```json
+{
+  "session_id": "abc123",
+  "agent": "claude",
+  "project": "/Users/me/myapp",
+  "timestamp": "2026-06-09T14:30:00Z",
+  "efficiency": 42.3,
+  "smells": [
+    {
+      "type": "context_rot",
+      "title": "Context rot (247 turns)",
+      "detail": "This session ran for 247 turns. Context quality typically degrades past 200 turns — consider breaking long tasks into focused sub-sessions.",
+      "severity": "warning"
+    }
+  ]
+}
+```
+
+---
+
+### 🔥 Burn Rate Forecasting
+
+Linear projection of your token consumption toward your subscription's monthly limit:
+
+- **Daily buckets** — aggregates total tokens per calendar day over the last 60 days
+- **7-day average** used for projection (recent pace, not historical average)
+- **Trend detection** — compares last 7 days vs prior 7 days → `accelerating` / `steady` / `slowing`
+- **Days-until-limit** — how many days at current pace before hitting your plan quota
+
+**Supported plans:**
+
+| Plan | Monthly token limit |
+|------|-------------------|
+| `claude_pro` | 500 M |
+| `claude_max` | 2 B |
+| `codex_plus` | 200 M |
+| `copilot` | 100 M |
+| `api_unlimited` | No limit |
+
+**In the UI:** a **Burn Rate** card in the dashboard sidebar shows your daily rate, projected month-end total, a colour-coded progress bar (green → amber → red as you approach the limit), and an urgency alert when you're ≤ 7 days from hitting the cap.
+
+**API:**
+```
+GET /forecast                       → forecast at default plan (claude_pro)
+GET /forecast?plan=claude_max       → forecast against Claude Max 2B limit
+```
+
+Response:
+```json
+{
+  "daily_avg_7d": 18500000,
+  "daily_avg_30d": 14200000,
+  "projected_month": 412000000,
+  "used_this_month": 227000000,
+  "days_until_limit": 14,
+  "trend": "accelerating",
+  "trend_pct": 30.2,
+  "limit": 500000000,
+  "plan": "claude_pro",
+  "buckets_30d": { "2026-06-01": 15200000, "2026-06-02": 19400000, "..." : "..." }
+}
+```
+
+---
+
+### Implementation notes
+
+All three features live in three new standalone Python modules — no changes to existing data collection or parsing logic:
+
+| Module | Responsibility |
+|--------|---------------|
+| `backend/scoring.py` | Efficiency score computation |
+| `backend/smells.py` | Smell rule evaluation |
+| `backend/forecast.py` | Daily bucketing + linear projection |
+
+**No new required dependencies.** Everything uses Python stdlib (`math`, `datetime`, `collections`). Ollama, scipy, numpy — none needed.
+
+Smells and efficiency scores are computed in-memory after the session cache is built, so they add no I/O overhead. Forecast runs over the already-loaded session list.
 
 ---
 

--- a/backend/anomaly.py
+++ b/backend/anomaly.py
@@ -115,7 +115,7 @@ def detect_anomalies(sessions: list[dict]) -> dict:
                     "value":    round(float(cost), 4),
                     "baseline": round(mean_c, 4),
                     "z_score":  round(z, 2),
-                    "detail":   f"Cost ${float(cost):.2f} is {z:.1f}σ above your ${mean_c:.2f} mean",
+                    "detail":   f"Cost ${float(cost):.2f} is {z:.1f}× above your usual ${mean_c:.2f} — unusually expensive session",
                 })
 
         # Efficiency crash
@@ -128,7 +128,7 @@ def detect_anomalies(sessions: list[dict]) -> dict:
                     "value":    round(float(eff), 1),
                     "baseline": round(mean_e, 1),
                     "z_score":  round(z, 2),
-                    "detail":   f"Efficiency {float(eff):.1f} is {abs(z):.1f}σ below your {mean_e:.1f} mean",
+                    "detail":   f"Quality score {float(eff):.0f}/100 is {abs(z):.1f}× below your usual {mean_e:.0f} — this session performed poorly",
                 })
 
         # Token overflow
@@ -141,7 +141,7 @@ def detect_anomalies(sessions: list[dict]) -> dict:
                     "value":    int(tok),
                     "baseline": round(mean_t),
                     "z_score":  round(z, 2),
-                    "detail":   f"{int(tok):,} tokens is {z:.1f}σ above your {int(mean_t):,} mean",
+                    "detail":   f"Used {int(tok):,} tokens — {z:.1f}× more than your usual {int(mean_t):,} — very long session",
                 })
 
         # Waste: cost > 5× median AND efficiency < 10
@@ -153,7 +153,7 @@ def detect_anomalies(sessions: list[dict]) -> dict:
                     "value":    round(float(cost), 4),
                     "baseline": round(median_c, 4),
                     "z_score":  None,
-                    "detail":   f"${float(cost):.2f} spent for only {float(eff):.1f} efficiency — high cost, no output",
+                    "detail":   f"Spent ${float(cost):.2f} but only got a quality score of {float(eff):.0f}/100 — expensive with poor results",
                 })
 
     # Sort: critical first, then by z_score desc (or value for waste)

--- a/backend/anomaly.py
+++ b/backend/anomaly.py
@@ -1,0 +1,176 @@
+"""
+anomaly.py — Anomaly Detection
+
+Flags sessions that are statistical outliers using z-scores across three
+dimensions: cost, efficiency, and token count.
+
+Anomaly types
+-------------
+  cost_spike        z_cost > 2.0   — session cost far above your norm
+  efficiency_crash  z_eff  < -2.0  — session scored far below your norm
+  token_overflow    z_tok  > 2.5   — session consumed far more tokens than usual
+  waste             cost > 5× median AND efficiency < 10  — expensive and useless
+
+No external dependencies — pure stdlib.
+"""
+
+import math
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import Optional
+
+
+def _stats(values: list[float]) -> tuple[float, float]:
+    """Return (mean, std_dev). Returns (0, 0) if fewer than 2 values."""
+    n = len(values)
+    if n < 2:
+        return (values[0] if values else 0.0), 0.0
+    mean = sum(values) / n
+    variance = sum((x - mean) ** 2 for x in values) / n
+    return mean, math.sqrt(variance)
+
+
+def _median(values: list[float]) -> float:
+    s = sorted(values)
+    n = len(s)
+    mid = n // 2
+    return s[mid] if n % 2 else (s[mid - 1] + s[mid]) / 2.0
+
+
+def detect_anomalies(sessions: list[dict]) -> dict:
+    """
+    Detect outlier sessions and return a feed of anomalies.
+
+    Returns
+    -------
+    {
+      "anomalies": [
+        {
+          "session_id":  str,
+          "agent":       str,
+          "model":       str | null,
+          "project":     str,
+          "timestamp":   str,
+          "type":        "cost_spike" | "efficiency_crash" | "token_overflow" | "waste",
+          "severity":    "warning" | "critical",
+          "value":       float,          # the anomalous metric value
+          "baseline":    float,          # mean value for that metric
+          "z_score":     float | null,
+          "detail":      str,            # human-readable description
+        },
+        ...                              # sorted by severity then z_score desc
+      ],
+      "total_anomalies":  int,
+      "sessions_checked": int,
+      "baseline": {
+        "mean_cost":      float,
+        "mean_efficiency": float,
+        "mean_tokens":    float,
+        "median_cost":    float,
+      }
+    }
+    """
+    costs  = [float(s["cost"])             for s in sessions if s.get("cost") not in (None, 0)]
+    effs   = [float(s["efficiency"])       for s in sessions if s.get("efficiency") is not None]
+    tokens = [float((s.get("tokens") or {}).get("total", 0))
+              for s in sessions if (s.get("tokens") or {}).get("total", 0) > 0]
+
+    if len(costs) < 3 or len(effs) < 3:
+        return {
+            "anomalies": [],
+            "total_anomalies": 0,
+            "sessions_checked": len(sessions),
+            "baseline": {},
+        }
+
+    mean_c, std_c = _stats(costs)
+    mean_e, std_e = _stats(effs)
+    mean_t, std_t = _stats(tokens) if len(tokens) >= 3 else (0.0, 0.0)
+    median_c      = _median(costs)
+
+    anomalies: list[dict] = []
+
+    for s in sessions:
+        sid     = s.get("id", "")
+        agent   = s.get("agent", "")
+        model   = s.get("model")
+        project = s.get("project", "")
+        ts      = s.get("timestamp")
+        ts_str  = ts.isoformat() if hasattr(ts, "isoformat") else str(ts or "")
+
+        cost  = s.get("cost")
+        eff   = s.get("efficiency")
+        tok   = (s.get("tokens") or {}).get("total", 0)
+
+        base = dict(session_id=sid, agent=agent, model=model, project=project, timestamp=ts_str)
+
+        # Cost spike
+        if cost is not None and float(cost) > 0 and std_c > 0:
+            z = (float(cost) - mean_c) / std_c
+            if z > 2.0:
+                anomalies.append({**base,
+                    "type":     "cost_spike",
+                    "severity": "critical" if z > 3.0 else "warning",
+                    "value":    round(float(cost), 4),
+                    "baseline": round(mean_c, 4),
+                    "z_score":  round(z, 2),
+                    "detail":   f"Cost ${float(cost):.2f} is {z:.1f}σ above your ${mean_c:.2f} mean",
+                })
+
+        # Efficiency crash
+        if eff is not None and std_e > 0:
+            z = (float(eff) - mean_e) / std_e
+            if z < -2.0:
+                anomalies.append({**base,
+                    "type":     "efficiency_crash",
+                    "severity": "critical" if z < -3.0 else "warning",
+                    "value":    round(float(eff), 1),
+                    "baseline": round(mean_e, 1),
+                    "z_score":  round(z, 2),
+                    "detail":   f"Efficiency {float(eff):.1f} is {abs(z):.1f}σ below your {mean_e:.1f} mean",
+                })
+
+        # Token overflow
+        if tok > 0 and mean_t > 0 and std_t > 0:
+            z = (float(tok) - mean_t) / std_t
+            if z > 2.5:
+                anomalies.append({**base,
+                    "type":     "token_overflow",
+                    "severity": "critical" if z > 4.0 else "warning",
+                    "value":    int(tok),
+                    "baseline": round(mean_t),
+                    "z_score":  round(z, 2),
+                    "detail":   f"{int(tok):,} tokens is {z:.1f}σ above your {int(mean_t):,} mean",
+                })
+
+        # Waste: cost > 5× median AND efficiency < 10
+        if cost is not None and float(cost) > 5 * median_c and eff is not None and float(eff) < 10:
+            if not any(a["session_id"] == sid and a["type"] == "waste" for a in anomalies):
+                anomalies.append({**base,
+                    "type":     "waste",
+                    "severity": "critical",
+                    "value":    round(float(cost), 4),
+                    "baseline": round(median_c, 4),
+                    "z_score":  None,
+                    "detail":   f"${float(cost):.2f} spent for only {float(eff):.1f} efficiency — high cost, no output",
+                })
+
+    # Sort: critical first, then by z_score desc (or value for waste)
+    def _sort_key(a):
+        sev = 0 if a["severity"] == "critical" else 1
+        z   = -(a["z_score"] or 0)
+        return (sev, z)
+
+    anomalies.sort(key=_sort_key)
+
+    return {
+        "anomalies":         anomalies,
+        "total_anomalies":   len(anomalies),
+        "sessions_checked":  len(sessions),
+        "baseline": {
+            "mean_cost":       round(mean_c, 4),
+            "mean_efficiency": round(mean_e, 1),
+            "mean_tokens":     round(mean_t),
+            "median_cost":     round(median_c, 4),
+        },
+    }

--- a/backend/anomaly.py
+++ b/backend/anomaly.py
@@ -79,6 +79,7 @@ def detect_anomalies(sessions: list[dict]) -> dict:
         return {
             "anomalies": [],
             "total_anomalies": 0,
+            "affected_sessions": 0,
             "sessions_checked": len(sessions),
             "baseline": {},
         }
@@ -163,9 +164,11 @@ def detect_anomalies(sessions: list[dict]) -> dict:
 
     anomalies.sort(key=_sort_key)
 
+    affected_sessions = len({a["session_id"] for a in anomalies})
     return {
         "anomalies":         anomalies,
         "total_anomalies":   len(anomalies),
+        "affected_sessions": affected_sessions,
         "sessions_checked":  len(sessions),
         "baseline": {
             "mean_cost":       round(mean_c, 4),

--- a/backend/cost_intel.py
+++ b/backend/cost_intel.py
@@ -1,0 +1,256 @@
+"""
+cost_intel.py — Cost Intelligence
+
+Connects session cost (USD) to efficiency outcomes, exposing which models
+and task types deliver the best efficiency per dollar, and how cache usage
+affects both cost and quality.
+
+No external dependencies — pure stdlib.
+
+Returned shape
+--------------
+{
+  "by_model": [
+    {
+      "model":             "claude-sonnet-4-6",
+      "agent":             "claude",
+      "session_count":     12,
+      "avg_cost":          0.42,
+      "total_cost":        5.04,
+      "avg_efficiency":    71.3,
+      "cost_per_eff_pt":   0.0059,    # avg_cost / avg_efficiency (lower = better)
+      "avg_cache_hit_pct": 42.1,      # cached / total * 100
+    },
+    ...                               # sorted by cost_per_eff_pt ascending (best value first)
+  ],
+  "by_task_type": [
+    {
+      "task_type":       "build",
+      "session_count":   8,
+      "avg_cost":        1.21,
+      "avg_efficiency":  74.0,
+      "cost_per_eff_pt": 0.016,
+    },
+    ...
+  ],
+  "cache_tiers": [
+    {
+      "tier":            "80–100%",
+      "avg_efficiency":  72.1,
+      "avg_cost":        0.31,
+      "session_count":   7,
+    },
+    ...                               # 5 tiers: 0-20, 20-40, 40-60, 60-80, 80-100
+  ],
+  "wasteful": [
+    {
+      "session_id":  "...",
+      "model":       "...",
+      "cost":        8.40,
+      "efficiency":  4.2,
+      "task_type":   "other",
+      "waste_score": 92.1,            # cost_percentile_rank - efficiency, higher = more wasteful
+    },
+    ...                               # top-5 worst cost/efficiency ratio sessions
+  ],
+  "best_value_model":   "claude-sonnet-4-6",   # lowest cost_per_eff_pt with >= 2 sessions
+  "total_cost":          47.30,
+  "avg_cost_per_session": 1.05,
+  "avg_cache_hit_pct":   38.4,
+  "sessions_analysed":   45,
+  "sessions_skipped":     3,
+}
+"""
+
+from collections import defaultdict
+from typing import Optional
+
+
+_CACHE_TIERS = [
+    (0,  20,  "0–20%"),
+    (20, 40,  "20–40%"),
+    (40, 60,  "40–60%"),
+    (60, 80,  "60–80%"),
+    (80, 101, "80–100%"),
+]
+
+_TASK_ORDER = ["fix", "build", "refactor", "analyze", "test", "deploy", "other"]
+
+
+def _cache_hit_pct(tokens: dict) -> Optional[float]:
+    total = tokens.get("total", 0)
+    if not total:
+        return None
+    cached = tokens.get("cached", 0)
+    return round(cached / total * 100, 1)
+
+
+def _tier_label(pct: float) -> str:
+    for lo, hi, label in _CACHE_TIERS:
+        if lo <= pct < hi:
+            return label
+    return "80–100%"
+
+
+def analyse_cost(sessions: list[dict]) -> dict:
+    model_buckets: dict[str, dict] = defaultdict(lambda: {
+        "agent": "unknown",
+        "costs": [],
+        "efficiencies": [],
+        "cache_pcts": [],
+    })
+    task_buckets: dict[str, dict] = defaultdict(lambda: {
+        "costs": [],
+        "efficiencies": [],
+    })
+    tier_buckets: dict[str, dict] = defaultdict(lambda: {
+        "efficiencies": [],
+        "costs": [],
+    })
+
+    all_costs: list[float] = []
+    all_cache_pcts: list[float] = []
+
+    # For wasteful detection we need (cost, efficiency, session_id, model, task_type)
+    scoreable: list[dict] = []
+
+    analysed = 0
+    skipped  = 0
+
+    for s in sessions:
+        cost = s.get("cost")
+        eff  = s.get("efficiency")
+
+        if cost is None or eff is None:
+            skipped += 1
+            continue
+        if cost <= 0 and eff <= 0:
+            skipped += 1
+            continue
+
+        cost_f = float(cost)
+        eff_f  = float(eff)
+        model  = s.get("model") or "unknown"
+        agent  = s.get("agent") or "unknown"
+        task   = s.get("task_type") or "other"
+        tok    = s.get("tokens") or {}
+        chit   = _cache_hit_pct(tok)
+
+        model_buckets[model]["agent"] = agent
+        model_buckets[model]["costs"].append(cost_f)
+        model_buckets[model]["efficiencies"].append(eff_f)
+        if chit is not None:
+            model_buckets[model]["cache_pcts"].append(chit)
+
+        task_buckets[task]["costs"].append(cost_f)
+        task_buckets[task]["efficiencies"].append(eff_f)
+
+        if chit is not None:
+            tier = _tier_label(chit)
+            tier_buckets[tier]["efficiencies"].append(eff_f)
+            tier_buckets[tier]["costs"].append(cost_f)
+            all_cache_pcts.append(chit)
+
+        all_costs.append(cost_f)
+
+        scoreable.append({
+            "session_id": s.get("id"),
+            "model":      model,
+            "cost":       round(cost_f, 4),
+            "efficiency": eff_f,
+            "task_type":  task,
+        })
+        analysed += 1
+
+    # ── by_model ──────────────────────────────────────────────────────────────
+    by_model = []
+    for model, b in model_buckets.items():
+        costs   = b["costs"]
+        effs    = b["efficiencies"]
+        cpcts   = b["cache_pcts"]
+        avg_c   = sum(costs)   / len(costs)
+        avg_e   = sum(effs)    / len(effs)
+        cpp     = round(avg_c / avg_e, 6) if avg_e > 0 else None
+        by_model.append({
+            "model":             model,
+            "agent":             b["agent"],
+            "session_count":     len(costs),
+            "avg_cost":          round(avg_c, 4),
+            "total_cost":        round(sum(costs), 4),
+            "avg_efficiency":    round(avg_e, 1),
+            "cost_per_eff_pt":   cpp,
+            "avg_cache_hit_pct": round(sum(cpcts) / len(cpcts), 1) if cpcts else None,
+        })
+    # Sort best-value (lowest cpp) first; models with cpp=None go last
+    by_model.sort(key=lambda r: (r["cost_per_eff_pt"] is None, r["cost_per_eff_pt"] or 9999))
+
+    # ── by_task_type ──────────────────────────────────────────────────────────
+    by_task: list[dict] = []
+    for task, b in task_buckets.items():
+        costs = b["costs"]
+        effs  = b["efficiencies"]
+        avg_c = sum(costs) / len(costs)
+        avg_e = sum(effs)  / len(effs)
+        cpp   = round(avg_c / avg_e, 6) if avg_e > 0 else None
+        by_task.append({
+            "task_type":       task,
+            "session_count":   len(costs),
+            "avg_cost":        round(avg_c, 4),
+            "avg_efficiency":  round(avg_e, 1),
+            "cost_per_eff_pt": cpp,
+        })
+    # canonical task order
+    order = {t: i for i, t in enumerate(_TASK_ORDER)}
+    by_task.sort(key=lambda r: order.get(r["task_type"], 99))
+
+    # ── cache_tiers ───────────────────────────────────────────────────────────
+    cache_tiers = []
+    for lo, hi, label in _CACHE_TIERS:
+        b = tier_buckets.get(label)
+        if not b or not b["efficiencies"]:
+            continue
+        cache_tiers.append({
+            "tier":           label,
+            "avg_efficiency": round(sum(b["efficiencies"]) / len(b["efficiencies"]), 1),
+            "avg_cost":       round(sum(b["costs"]) / len(b["costs"]), 4),
+            "session_count":  len(b["efficiencies"]),
+        })
+
+    # ── wasteful sessions ─────────────────────────────────────────────────────
+    # waste_score = percentile rank of cost minus efficiency (both 0-100 scale)
+    if scoreable:
+        n   = len(scoreable)
+        sorted_costs = sorted(s["cost"] for s in scoreable)
+        cost_pct = {c: round(i / max(n - 1, 1) * 100, 1)
+                    for i, c in enumerate(sorted_costs)}
+        for s in scoreable:
+            s["waste_score"] = round(
+                cost_pct.get(s["cost"], 0) - s["efficiency"], 1
+            )
+        wasteful = sorted(scoreable, key=lambda s: -s["waste_score"])[:5]
+    else:
+        wasteful = []
+
+    # ── aggregates ────────────────────────────────────────────────────────────
+    total_cost         = round(sum(all_costs), 4)
+    avg_cost_per_sess  = round(total_cost / analysed, 4) if analysed else 0
+    avg_cache_hit_pct  = round(sum(all_cache_pcts) / len(all_cache_pcts), 1) if all_cache_pcts else None
+
+    # best_value_model: lowest cpp, >= 2 sessions
+    best_value = next(
+        (r["model"] for r in by_model if r["cost_per_eff_pt"] is not None and r["session_count"] >= 2),
+        None,
+    )
+
+    return {
+        "by_model":             by_model,
+        "by_task_type":         by_task,
+        "cache_tiers":          cache_tiers,
+        "wasteful":             wasteful,
+        "best_value_model":     best_value,
+        "total_cost":           total_cost,
+        "avg_cost_per_session": avg_cost_per_sess,
+        "avg_cache_hit_pct":    avg_cache_hit_pct,
+        "sessions_analysed":    analysed,
+        "sessions_skipped":     skipped,
+    }

--- a/backend/forecast.py
+++ b/backend/forecast.py
@@ -1,0 +1,161 @@
+﻿"""
+forecast.py — Burn Rate Forecasting
+
+Computes a linear projection of token usage to predict:
+  - Tokens on track to be used this calendar month
+  - Days until a user-configured token limit is hit
+  - Trend direction vs last week
+
+No external deps — uses only stdlib math.
+"""
+
+from datetime import datetime, timezone, timedelta
+from typing import Optional
+import math
+
+
+# Default subscription limits (tokens/month) — user can override via
+# ~/.tokentelemetry/subscription.json (not yet wired, uses defaults for now)
+PLAN_LIMITS: dict[str, int] = {
+    "claude_pro":      500_000_000,   # ~500M practical limit
+    "claude_max":    2_000_000_000,   # 5× Pro
+    "codex_plus":      200_000_000,
+    "copilot":         100_000_000,
+    "api_unlimited":            0,    # 0 = no limit
+}
+
+DEFAULT_PLAN = "claude_pro"
+
+
+def _daily_buckets(sessions: list[dict], days: int = 60) -> dict[str, int]:
+    """
+    Aggregate total tokens per calendar day (UTC) for the last `days` days.
+    Returns { "YYYY-MM-DD": token_count }.
+    """
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+    buckets: dict[str, int] = {}
+
+    for s in sessions:
+        ts_raw = s.get("timestamp")
+        if not ts_raw:
+            continue
+        try:
+            if isinstance(ts_raw, str):
+                ts = datetime.fromisoformat(ts_raw.replace("Z", "+00:00"))
+            else:
+                ts = ts_raw
+            if ts < cutoff:
+                continue
+            day_key = ts.strftime("%Y-%m-%d")
+            buckets[day_key] = buckets.get(day_key, 0) + (s.get("tokens", {}).get("total") or 0)
+        except Exception:
+            continue
+
+    return buckets
+
+
+def _linear_regression(xs: list[float], ys: list[float]) -> tuple[float, float]:
+    """Returns (slope, intercept) for simple linear regression."""
+    n = len(xs)
+    if n < 2:
+        return 0.0, ys[0] if ys else 0.0
+    mx = sum(xs) / n
+    my = sum(ys) / n
+    num   = sum((x - mx) * (y - my) for x, y in zip(xs, ys))
+    denom = sum((x - mx) ** 2 for x in xs)
+    slope = num / denom if denom != 0 else 0.0
+    return slope, my - slope * mx
+
+
+def compute_forecast(
+    sessions: list[dict],
+    plan: str = DEFAULT_PLAN,
+) -> dict:
+    """
+    Returns a forecast dict:
+    {
+      "daily_avg_7d":         int,      # avg tokens/day over last 7 days
+      "daily_avg_30d":        int,      # avg tokens/day over last 30 days
+      "projected_month":      int,      # tokens projected for current calendar month
+      "days_until_limit":     int|None, # None if no limit or won't hit
+      "trend":                str,      # "accelerating" | "steady" | "slowing"
+      "trend_pct":            float,    # % change week-over-week
+      "limit":                int,      # configured limit (0 = none)
+      "plan":                 str,
+      "buckets_30d":          dict,     # { "YYYY-MM-DD": tokens } for charting
+    }
+    """
+    limit = PLAN_LIMITS.get(plan, PLAN_LIMITS[DEFAULT_PLAN])
+    buckets_60d = _daily_buckets(sessions, days=60)
+    buckets_30d = {k: v for k, v in buckets_60d.items()
+                   if k >= (datetime.now(timezone.utc) - timedelta(days=30)).strftime("%Y-%m-%d")}
+
+    # Daily averages
+    vals_7d  = _last_n_days_values(buckets_60d, 7)
+    vals_30d = _last_n_days_values(buckets_60d, 30)
+
+    avg_7d  = int(sum(vals_7d)  / max(len(vals_7d),  1))
+    avg_30d = int(sum(vals_30d) / max(len(vals_30d), 1))
+
+    # Days left in current month
+    now = datetime.now(timezone.utc)
+    if now.month == 12:
+        next_month = now.replace(year=now.year + 1, month=1, day=1)
+    else:
+        next_month = now.replace(month=now.month + 1, day=1)
+    days_left = (next_month - now).days
+
+    # Tokens already used this month
+    month_prefix = now.strftime("%Y-%m")
+    used_this_month = sum(v for k, v in buckets_60d.items() if k.startswith(month_prefix))
+
+    # Project remaining days at 7d average
+    projected_month = used_this_month + avg_7d * days_left
+
+    # Days until limit
+    days_until_limit: Optional[int] = None
+    if limit > 0 and avg_7d > 0:
+        remaining_budget = limit - used_this_month
+        if remaining_budget <= 0:
+            days_until_limit = 0
+        else:
+            days_until_limit = max(0, int(remaining_budget / avg_7d))
+
+    # Trend: compare last 7 days vs previous 7 days
+    vals_prev7 = _last_n_days_values(buckets_60d, 14, skip=7)
+    avg_prev7 = sum(vals_prev7) / max(len(vals_prev7), 1)
+
+    if avg_prev7 > 0:
+        trend_pct = ((avg_7d - avg_prev7) / avg_prev7) * 100
+    else:
+        trend_pct = 0.0
+
+    if trend_pct > 15:
+        trend = "accelerating"
+    elif trend_pct < -15:
+        trend = "slowing"
+    else:
+        trend = "steady"
+
+    return {
+        "daily_avg_7d":     avg_7d,
+        "daily_avg_30d":    avg_30d,
+        "projected_month":  projected_month,
+        "used_this_month":  used_this_month,
+        "days_until_limit": days_until_limit,
+        "trend":            trend,
+        "trend_pct":        round(trend_pct, 1),
+        "limit":            limit,
+        "plan":             plan,
+        "buckets_30d":      buckets_30d,
+    }
+
+
+def _last_n_days_values(buckets: dict[str, int], n: int, skip: int = 0) -> list[int]:
+    """Return token values for the `n` days ending `skip` days ago."""
+    today = datetime.now(timezone.utc).date()
+    result = []
+    for i in range(skip, skip + n):
+        day = (today - timedelta(days=i + 1)).strftime("%Y-%m-%d")
+        result.append(buckets.get(day, 0))
+    return result

--- a/backend/git_context.py
+++ b/backend/git_context.py
@@ -1,0 +1,330 @@
+"""
+git_context.py — Git Integration
+
+Attaches git context to sessions by running lightweight subprocess calls.
+Finds the commit that was HEAD at (or before) the session's timestamp.
+
+Cached per (normalized_path, date_string) with a 5-minute TTL so repeated
+calls for sessions in the same project+day hit the cache instead of git.
+
+Returned per session (attached as session["git_info"]):
+  is_git          True if the project is inside a git work-tree
+  branch          current branch name (or HEAD-detached SHA)
+  commit_sha      short SHA of the commit closest to session time
+  commit_sha_full full 40-char SHA
+  commit_msg      first line of the commit message
+  commit_author   author name
+  commit_time     ISO timestamp of the commit
+  files_changed   number of files touched in that commit
+  lines_added     total insertions
+  lines_deleted   total deletions
+
+No external dependencies — pure stdlib (subprocess, pathlib, datetime).
+"""
+
+import re
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import Optional
+
+# Resolve git binary once at import time so we don't depend on PATH being
+# complete inside background-launched processes (common on Windows).
+_GIT_EXE = shutil.which("git") or "git"
+
+# Well-known Windows install locations as fallback
+if _GIT_EXE == "git":
+    for _candidate in [
+        r"C:\Program Files\Git\cmd\git.exe",
+        r"C:\Program Files (x86)\Git\cmd\git.exe",
+    ]:
+        if Path(_candidate).exists():
+            _GIT_EXE = _candidate
+            break
+
+# ── Path normalisation ────────────────────────────────────────────────────────
+
+def _normalise(path: str) -> str:
+    """Convert POSIX-style git paths like /c:/foo to Windows C:\\foo."""
+    if not path:
+        return path
+    # /c:/Users/... → C:\Users\...
+    m = re.match(r'^/([a-zA-Z]):(/.*)', path)
+    if m:
+        drive = m.group(1).upper()
+        rest = m.group(2).replace("/", "\\")
+        return f"{drive}:{rest}"
+    return path
+
+
+# ── Subprocess helper ─────────────────────────────────────────────────────────
+
+def _git(cwd: str, *args: str, timeout: int = 5) -> str:
+    """Run a git command in cwd and return stdout. Returns '' on any error."""
+    try:
+        result = subprocess.run(
+            [_GIT_EXE, "-C", cwd, *args],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        return result.stdout.strip() if result.returncode == 0 else ""
+    except Exception:
+        return ""
+
+
+# ── Cache ─────────────────────────────────────────────────────────────────────
+
+_CACHE: dict[tuple, dict] = {}
+_CACHE_TS: dict[tuple, float] = {}
+_TTL = 300  # 5 minutes
+_MAX_ENTRIES = 500
+
+
+def _cache_key(path: str, date_str: str) -> tuple:
+    return (path, date_str)
+
+
+def _cache_get(key: tuple) -> Optional[dict]:
+    if key not in _CACHE:
+        return None
+    if time.time() - _CACHE_TS[key] > _TTL:
+        del _CACHE[key]
+        del _CACHE_TS[key]
+        return None
+    return _CACHE[key]
+
+
+def _cache_set(key: tuple, value: dict) -> None:
+    if len(_CACHE) >= _MAX_ENTRIES:
+        # evict oldest
+        oldest = min(_CACHE_TS, key=lambda k: _CACHE_TS[k])
+        del _CACHE[oldest]
+        del _CACHE_TS[oldest]
+    _CACHE[key] = value
+    _CACHE_TS[key] = time.time()
+
+
+# ── Not-a-git-repo sentinel ───────────────────────────────────────────────────
+
+_NOT_GIT = {
+    "is_git": False,
+    "branch": None,
+    "commit_sha": None,
+    "commit_sha_full": None,
+    "commit_msg": None,
+    "commit_author": None,
+    "commit_time": None,
+    "files_changed": 0,
+    "lines_added": 0,
+    "lines_deleted": 0,
+}
+
+
+# ── Main entry point ──────────────────────────────────────────────────────────
+
+def get_git_info(project: str, timestamp: Optional[str] = None) -> dict:
+    """
+    Return git context for a session.
+
+    Parameters
+    ----------
+    project   : project directory path (may be POSIX-style /c:/...)
+    timestamp : ISO 8601 timestamp of the session (used to find the right commit)
+
+    Returns
+    -------
+    dict with keys described in module docstring.
+    """
+    path = _normalise(project or "")
+    if not path or not Path(path).exists():
+        return _NOT_GIT
+
+    # Date portion of timestamp → cache granularity is one day per project
+    # timestamp may be a datetime object or an ISO string
+    if hasattr(timestamp, "isoformat"):
+        timestamp = timestamp.isoformat()
+    date_str = (timestamp or "")[:10] or "current"
+    key = _cache_key(path, date_str)
+    cached = _cache_get(key)
+    if cached is not None:
+        return cached
+
+    # Check if inside a git work-tree
+    inside = _git(path, "rev-parse", "--is-inside-work-tree")
+    if inside != "true":
+        result = dict(_NOT_GIT)
+        _cache_set(key, result)
+        return result
+
+    # Get branch
+    branch = _git(path, "branch", "--show-current") or \
+             _git(path, "rev-parse", "--short", "HEAD")
+
+    # Find commit at or before the session timestamp
+    if timestamp and len(timestamp) >= 19:
+        # Normalize to git-acceptable format
+        iso_ts = timestamp[:19].replace("T", " ")
+        log_out = _git(
+            path,
+            "log",
+            f"--before={iso_ts}",
+            "-1",
+            "--format=%H|%h|%s|%aI|%an",
+        )
+    else:
+        log_out = ""
+
+    # Fall back to current HEAD if no commit found before timestamp
+    if not log_out:
+        log_out = _git(path, "log", "-1", "--format=%H|%h|%s|%aI|%an")
+
+    if not log_out:
+        result = {**_NOT_GIT, "is_git": True, "branch": branch}
+        _cache_set(key, result)
+        return result
+
+    parts = log_out.split("|", 4)
+    full_sha   = parts[0] if len(parts) > 0 else ""
+    short_sha  = parts[1] if len(parts) > 1 else full_sha[:7]
+    msg        = parts[2] if len(parts) > 2 else ""
+    commit_ts  = parts[3] if len(parts) > 3 else ""
+    author     = parts[4] if len(parts) > 4 else ""
+
+    # Diff stats for that commit: lines added / deleted / files changed
+    # diff-tree --numstat -r outputs: sha\nadded\tdeleted\tfile\n...
+    files_changed = 0
+    lines_added = 0
+    lines_deleted = 0
+
+    if full_sha:
+        numstat = _git(path, "diff-tree", "--numstat", "-r", full_sha)
+        for line in numstat.splitlines():
+            cols = line.split("\t")
+            if len(cols) >= 2 and cols[0].lstrip("-").isdigit():
+                try:
+                    lines_added   += int(cols[0]) if cols[0] != "-" else 0
+                    lines_deleted += int(cols[1]) if cols[1] != "-" else 0
+                    files_changed += 1
+                except ValueError:
+                    pass
+
+    result = {
+        "is_git":          True,
+        "branch":          branch or None,
+        "commit_sha":      short_sha or None,
+        "commit_sha_full": full_sha or None,
+        "commit_msg":      msg or None,
+        "commit_author":   author or None,
+        "commit_time":     commit_ts or None,
+        "files_changed":   files_changed,
+        "lines_added":     lines_added,
+        "lines_deleted":   lines_deleted,
+    }
+    _cache_set(key, result)
+    return result
+
+
+# ── Git summary across sessions ───────────────────────────────────────────────
+
+def git_summary(sessions: list[dict]) -> dict:
+    """
+    Aggregate git context across all sessions, grouped by project.
+
+    Returns
+    -------
+    {
+      "projects": [
+        {
+          "project":      str,
+          "branch":       str | null,
+          "session_count": int,
+          "total_files_changed": int,
+          "total_lines_added":   int,
+          "total_lines_deleted": int,
+          "net_lines":           int,   # added - deleted
+          "latest_commit_sha":   str | null,
+          "latest_commit_msg":   str | null,
+          "latest_commit_time":  str | null,
+          "avg_files_per_session": float,
+        }
+      ],
+      "total_lines_added":   int,
+      "total_lines_deleted": int,
+      "total_files_changed": int,
+      "git_sessions":        int,     # sessions that are inside a git repo
+      "non_git_sessions":    int,
+    }
+    """
+    from collections import defaultdict
+
+    buckets: dict[str, dict] = {}
+
+    for s in sessions:
+        gi = s.get("git_info")
+        if not gi or not gi.get("is_git"):
+            continue
+        proj = s.get("project", "")
+        if proj not in buckets:
+            buckets[proj] = {
+                "project":          proj,
+                "branch":           gi.get("branch"),
+                "sessions":         [],
+                "files_changed":    0,
+                "lines_added":      0,
+                "lines_deleted":    0,
+                "latest_commit_sha":  None,
+                "latest_commit_msg":  None,
+                "latest_commit_time": None,
+            }
+        b = buckets[proj]
+        b["sessions"].append(s)
+        b["files_changed"] += gi.get("files_changed", 0)
+        b["lines_added"]   += gi.get("lines_added", 0)
+        b["lines_deleted"] += gi.get("lines_deleted", 0)
+
+        # Track latest commit
+        ct = gi.get("commit_time") or ""
+        if ct and (not b["latest_commit_time"] or ct > b["latest_commit_time"]):
+            b["latest_commit_time"] = ct
+            b["latest_commit_sha"]  = gi.get("commit_sha")
+            b["latest_commit_msg"]  = gi.get("commit_msg")
+        # Keep most recent branch
+        if gi.get("branch"):
+            b["branch"] = gi["branch"]
+
+    projects = []
+    total_added = total_deleted = total_files = 0
+    git_sessions = 0
+
+    for proj, b in sorted(buckets.items(), key=lambda x: -len(x[1]["sessions"])):
+        n = len(b["sessions"])
+        git_sessions += n
+        total_added   += b["lines_added"]
+        total_deleted += b["lines_deleted"]
+        total_files   += b["files_changed"]
+        projects.append({
+            "project":              proj,
+            "branch":               b["branch"],
+            "session_count":        n,
+            "total_files_changed":  b["files_changed"],
+            "total_lines_added":    b["lines_added"],
+            "total_lines_deleted":  b["lines_deleted"],
+            "net_lines":            b["lines_added"] - b["lines_deleted"],
+            "latest_commit_sha":    b["latest_commit_sha"],
+            "latest_commit_msg":    b["latest_commit_msg"],
+            "latest_commit_time":   b["latest_commit_time"],
+            "avg_files_per_session": round(b["files_changed"] / n, 1) if n else 0,
+        })
+
+    non_git = len(sessions) - git_sessions
+
+    return {
+        "projects":            projects,
+        "total_lines_added":   total_added,
+        "total_lines_deleted": total_deleted,
+        "total_files_changed": total_files,
+        "git_sessions":        git_sessions,
+        "non_git_sessions":    non_git,
+    }

--- a/backend/main.py
+++ b/backend/main.py
@@ -3055,6 +3055,7 @@ from git_context import get_git_info, git_summary
 from trends import compute_trends
 from time_intel import analyse_time
 from tool_footprint import analyse_tool_footprint
+from cost_intel import analyse_cost
 import logging as _logging
 
 _log = _logging.getLogger("tokentelemetry.cache")
@@ -3225,6 +3226,18 @@ async def get_trends(days: int = 60, project: Optional[str] = None):
     if project:
         sessions = [s for s in sessions if s.get("project") == project]
     return compute_trends(sessions, days=days)
+
+
+@app.get("/insights/cost")
+async def get_cost_intel(project: Optional[str] = None):
+    """
+    Cost Intelligence: efficiency per dollar, best-value model, cache-tier
+    analysis, and wasteful session detection.
+    """
+    sessions = await get_sessions_cached()
+    if project:
+        sessions = [s for s in sessions if s.get("project") == project]
+    return analyse_cost(sessions)
 
 
 @app.get("/insights/time")

--- a/backend/main.py
+++ b/backend/main.py
@@ -3056,6 +3056,9 @@ from trends import compute_trends
 from time_intel import analyse_time
 from tool_footprint import analyse_tool_footprint
 from cost_intel import analyse_cost
+from anomaly import detect_anomalies
+from recommendations import generate_recommendations
+from project_health import compute_project_health
 import logging as _logging
 
 _log = _logging.getLogger("tokentelemetry.cache")
@@ -3226,6 +3229,42 @@ async def get_trends(days: int = 60, project: Optional[str] = None):
     if project:
         sessions = [s for s in sessions if s.get("project") == project]
     return compute_trends(sessions, days=days)
+
+
+@app.get("/insights/anomalies")
+async def get_anomalies(project: Optional[str] = None):
+    """
+    Anomaly detection: sessions that are statistical outliers in cost,
+    efficiency, or token usage. Uses z-scores with configurable thresholds.
+    """
+    sessions = await get_sessions_cached()
+    if project:
+        sessions = [s for s in sessions if s.get("project") == project]
+    return detect_anomalies(sessions)
+
+
+@app.get("/insights/recommendations")
+async def get_recommendations(project: Optional[str] = None):
+    """
+    AI recommendations: cross-module actionable insights synthesising
+    cost, timing, prompt DNA, tool footprint, trends, and smell patterns.
+    """
+    sessions = await get_sessions_cached()
+    if project:
+        sessions = [s for s in sessions if s.get("project") == project]
+    return generate_recommendations(sessions)
+
+
+@app.get("/insights/project-health")
+async def get_project_health(project: Optional[str] = None):
+    """
+    Project health scores: per-project composite 0–100 score (A–F grade)
+    combining efficiency, smell rate, recent trend, and cost value.
+    """
+    sessions = await get_sessions_cached()
+    if project:
+        sessions = [s for s in sessions if s.get("project") == project]
+    return compute_project_health(sessions)
 
 
 @app.get("/insights/cost")

--- a/backend/main.py
+++ b/backend/main.py
@@ -3006,6 +3006,21 @@ def _scan_sessions_sync():
 
     # Global sort by timestamp descending
     sessions.sort(key=lambda x: x["timestamp"], reverse=True)
+
+    # ── Intelligence layer: efficiency score + smell detection ───────────────
+    for s in sessions:
+        try:
+            score = score_session(s)
+            s["efficiency"] = score
+            s["efficiency_label"] = score_label(score)
+        except Exception:
+            s["efficiency"] = None
+            s["efficiency_label"] = "unknown"
+        try:
+            s["smells"] = detect_smells(s)
+        except Exception:
+            s["smells"] = []
+
     return sessions
 
 
@@ -3019,6 +3034,9 @@ def _scan_sessions_sync():
 import asyncio as _asyncio
 import time as _time
 from pricing import calculate_cost, PRICING, PRICING_UPDATED
+from scoring import score_session, score_label
+from smells import detect_smells
+from forecast import compute_forecast
 import logging as _logging
 
 _log = _logging.getLogger("tokentelemetry.cache")
@@ -3087,6 +3105,68 @@ async def get_sessions(fresh: bool = False):
 async def get_pricing():
     """Return the static pricing table and the date it was last refreshed."""
     return {"updated": PRICING_UPDATED, "models": PRICING}
+
+
+@app.get("/forecast")
+async def get_forecast(plan: str = "claude_pro"):
+    """
+    Burn-rate forecast: daily token averages, projected monthly usage,
+    days until plan limit, and trend direction.
+    plan: claude_pro | claude_max | codex_plus | copilot | api_unlimited
+    """
+    sessions = await get_sessions_cached()
+    return compute_forecast(sessions, plan=plan)
+
+
+@app.get("/smells")
+async def get_smells(project: Optional[str] = None):
+    """
+    Return sessions that have at least one AI smell warning.
+    Each entry: { session_id, agent, project, timestamp, smells: [...] }
+    """
+    sessions = await get_sessions_cached()
+    result = []
+    for s in sessions:
+        if project and s.get("project") != project:
+            continue
+        smells = s.get("smells") or []
+        if not smells:
+            continue
+        result.append({
+            "session_id": s.get("id"),
+            "agent":      s.get("agent"),
+            "project":    s.get("project"),
+            "timestamp":  s.get("timestamp"),
+            "efficiency": s.get("efficiency"),
+            "smells":     smells,
+        })
+    return result
+
+
+@app.get("/efficiency")
+async def get_efficiency(project: Optional[str] = None):
+    """
+    Return efficiency scores for all sessions, sorted best-first.
+    Useful for leaderboard views and detecting worst-performing sessions.
+    """
+    sessions = await get_sessions_cached()
+    result = []
+    for s in sessions:
+        if project and s.get("project") != project:
+            continue
+        score = s.get("efficiency")
+        if score is None:
+            continue
+        result.append({
+            "session_id":       s.get("id"),
+            "agent":            s.get("agent"),
+            "project":          s.get("project"),
+            "timestamp":        s.get("timestamp"),
+            "efficiency":       score,
+            "efficiency_label": s.get("efficiency_label"),
+        })
+    result.sort(key=lambda x: x["efficiency"], reverse=True)
+    return result
 
 
 @app.get("/remote-access")

--- a/backend/main.py
+++ b/backend/main.py
@@ -3007,7 +3007,7 @@ def _scan_sessions_sync():
     # Global sort by timestamp descending
     sessions.sort(key=lambda x: x["timestamp"], reverse=True)
 
-    # ── Intelligence layer: efficiency score + smell detection ───────────────
+    # ── Intelligence layer: efficiency score + smell detection + prompt DNA ──
     for s in sessions:
         try:
             score = score_session(s)
@@ -3020,6 +3020,14 @@ def _scan_sessions_sync():
             s["smells"] = detect_smells(s)
         except Exception:
             s["smells"] = []
+        try:
+            msg = (s.get("display") or s.get("text") or "").strip()
+            feats = extract_features(msg)
+            s["task_type"] = feats["task_type"]
+            s["prompt_features"] = feats
+        except Exception:
+            s["task_type"] = "other"
+            s["prompt_features"] = {}
 
     return sessions
 
@@ -3037,6 +3045,7 @@ from pricing import calculate_cost, PRICING, PRICING_UPDATED
 from scoring import score_session, score_label
 from smells import detect_smells
 from forecast import compute_forecast
+from prompt_analysis import extract_features, analyse_prompt_dna
 import logging as _logging
 
 _log = _logging.getLogger("tokentelemetry.cache")
@@ -3167,6 +3176,19 @@ async def get_efficiency(project: Optional[str] = None):
         })
     result.sort(key=lambda x: x["efficiency"], reverse=True)
     return result
+
+
+@app.get("/insights/prompt-dna")
+async def get_prompt_dna(project: Optional[str] = None):
+    """
+    Prompt DNA: correlate prompt features with efficiency scores.
+    Returns top positive/negative traits, per-task-type breakdown,
+    and full Pearson correlation table.
+    """
+    sessions = await get_sessions_cached()
+    if project:
+        sessions = [s for s in sessions if s.get("project") == project]
+    return analyse_prompt_dna(sessions)
 
 
 @app.get("/remote-access")

--- a/backend/main.py
+++ b/backend/main.py
@@ -3053,6 +3053,8 @@ from prompt_analysis import extract_features, analyse_prompt_dna
 from model_comparison import compare_models
 from git_context import get_git_info, git_summary
 from trends import compute_trends
+from time_intel import analyse_time
+from tool_footprint import analyse_tool_footprint
 import logging as _logging
 
 _log = _logging.getLogger("tokentelemetry.cache")
@@ -3223,6 +3225,32 @@ async def get_trends(days: int = 60, project: Optional[str] = None):
     if project:
         sessions = [s for s in sessions if s.get("project") == project]
     return compute_trends(sessions, days=days)
+
+
+@app.get("/insights/time")
+async def get_time_intel(project: Optional[str] = None):
+    """
+    Time Intelligence: efficiency by hour-of-day and day-of-week.
+    Returns peak/worst hour, peak/worst day, peak period (morning/afternoon/
+    evening/night), and per-bucket stats for heatmap/bar visualisations.
+    """
+    sessions = await get_sessions_cached()
+    if project:
+        sessions = [s for s in sessions if s.get("project") == project]
+    return analyse_time(sessions)
+
+
+@app.get("/insights/tool-footprint")
+async def get_tool_footprint(project: Optional[str] = None):
+    """
+    Tool Footprint: how toolset size and composition correlate with efficiency.
+    Returns by-size buckets, per-category presence effect, and top-15 tools
+    by session frequency with their average efficiency scores.
+    """
+    sessions = await get_sessions_cached()
+    if project:
+        sessions = [s for s in sessions if s.get("project") == project]
+    return analyse_tool_footprint(sessions)
 
 
 @app.get("/insights/model-comparison")

--- a/backend/main.py
+++ b/backend/main.py
@@ -3028,6 +3028,10 @@ def _scan_sessions_sync():
         except Exception:
             s["task_type"] = "other"
             s["prompt_features"] = {}
+        try:
+            s["git_info"] = get_git_info(s.get("project", ""), s.get("timestamp"))
+        except Exception:
+            s["git_info"] = {"is_git": False}
 
     return sessions
 
@@ -3047,6 +3051,7 @@ from smells import detect_smells
 from forecast import compute_forecast
 from prompt_analysis import extract_features, analyse_prompt_dna
 from model_comparison import compare_models
+from git_context import get_git_info, git_summary
 import logging as _logging
 
 _log = _logging.getLogger("tokentelemetry.cache")
@@ -3190,6 +3195,20 @@ async def get_prompt_dna(project: Optional[str] = None):
     if project:
         sessions = [s for s in sessions if s.get("project") == project]
     return analyse_prompt_dna(sessions)
+
+
+
+@app.get("/insights/git-summary")
+async def get_git_summary(project: Optional[str] = None):
+    """
+    Git activity summary grouped by project.
+    Returns per-project: branch, latest commit, total files/lines changed
+    across all sessions that sit inside a git work-tree.
+    """
+    sessions = await get_sessions_cached()
+    if project:
+        sessions = [s for s in sessions if s.get("project") == project]
+    return git_summary(sessions)
 
 
 @app.get("/insights/model-comparison")

--- a/backend/main.py
+++ b/backend/main.py
@@ -3046,6 +3046,7 @@ from scoring import score_session, score_label
 from smells import detect_smells
 from forecast import compute_forecast
 from prompt_analysis import extract_features, analyse_prompt_dna
+from model_comparison import compare_models
 import logging as _logging
 
 _log = _logging.getLogger("tokentelemetry.cache")
@@ -3189,6 +3190,26 @@ async def get_prompt_dna(project: Optional[str] = None):
     if project:
         sessions = [s for s in sessions if s.get("project") == project]
     return analyse_prompt_dna(sessions)
+
+
+@app.get("/insights/model-comparison")
+async def get_model_comparison(
+    task_type: Optional[str] = None,
+    project: Optional[str] = None,
+):
+    """
+    Multi-model efficiency comparison.
+    Groups sessions by model name, computes avg/median/p75/best efficiency,
+    token stats, and per-task-type breakdown.
+
+    Query params:
+      task_type  filter to a single task type (fix|build|refactor|analyze|test|deploy|other)
+      project    filter to a single project path
+    """
+    sessions = await get_sessions_cached()
+    if project:
+        sessions = [s for s in sessions if s.get("project") == project]
+    return compare_models(sessions, task_type=task_type)
 
 
 @app.get("/remote-access")

--- a/backend/main.py
+++ b/backend/main.py
@@ -3052,6 +3052,7 @@ from forecast import compute_forecast
 from prompt_analysis import extract_features, analyse_prompt_dna
 from model_comparison import compare_models
 from git_context import get_git_info, git_summary
+from trends import compute_trends
 import logging as _logging
 
 _log = _logging.getLogger("tokentelemetry.cache")
@@ -3209,6 +3210,19 @@ async def get_git_summary(project: Optional[str] = None):
     if project:
         sessions = [s for s in sessions if s.get("project") == project]
     return git_summary(sessions)
+
+
+@app.get("/insights/trends")
+async def get_trends(days: int = 60, project: Optional[str] = None):
+    """
+    Session efficiency trends over the last N calendar days (default 60).
+    Returns per-day buckets with rolling 7-day average, trend direction,
+    current streak, best/worst days, and week-over-week delta.
+    """
+    sessions = await get_sessions_cached()
+    if project:
+        sessions = [s for s in sessions if s.get("project") == project]
+    return compute_trends(sessions, days=days)
 
 
 @app.get("/insights/model-comparison")

--- a/backend/model_comparison.py
+++ b/backend/model_comparison.py
@@ -1,0 +1,180 @@
+"""
+model_comparison.py — Multi-Model Comparison
+
+Groups sessions by model name and computes efficiency and token statistics,
+optionally filtered to a single task type.
+
+No external dependencies — pure stdlib.
+
+Returned per model:
+  model              exact model name string from the session
+  agent              agent key (claude, codex, copilot, ...)
+  session_count      number of sessions with an efficiency score
+  avg_efficiency     mean efficiency score (0–100)
+  median_efficiency  median efficiency score
+  p75_efficiency     75th-percentile efficiency score
+  best_efficiency    highest single session score
+  total_tokens       sum of all token counts
+  avg_tokens         average tokens per session
+  task_breakdown     { task_type: { count, avg_efficiency } }
+"""
+
+import math
+from collections import defaultdict
+from typing import Optional
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def _median(vals: list[float]) -> float:
+    if not vals:
+        return 0.0
+    s = sorted(vals)
+    n = len(s)
+    mid = n // 2
+    return s[mid] if n % 2 else (s[mid - 1] + s[mid]) / 2.0
+
+
+def _percentile(vals: list[float], p: float) -> float:
+    """Return the p-th percentile of vals (0–100). Linear interpolation."""
+    if not vals:
+        return 0.0
+    s = sorted(vals)
+    n = len(s)
+    idx = (p / 100.0) * (n - 1)
+    lo = int(idx)
+    hi = min(lo + 1, n - 1)
+    frac = idx - lo
+    return s[lo] + frac * (s[hi] - s[lo])
+
+
+# ── main ─────────────────────────────────────────────────────────────────────
+
+_TASK_ORDER = ["fix", "build", "refactor", "analyze", "test", "deploy", "other"]
+
+
+def compare_models(
+    sessions: list[dict],
+    task_type: Optional[str] = None,
+) -> dict:
+    """
+    Compute per-model efficiency stats.
+
+    Parameters
+    ----------
+    sessions   : list of session dicts (already enriched with efficiency + task_type)
+    task_type  : if provided, restrict to sessions whose task_type matches
+
+    Returns
+    -------
+    {
+      "task_type_filter": str | null,
+      "models_compared":  int,
+      "sessions_used":    int,
+      "sessions_skipped": int,
+      "models": [
+        {
+          "model":           str,
+          "agent":           str,
+          "session_count":   int,
+          "avg_efficiency":  float,
+          "median_efficiency": float,
+          "p75_efficiency":  float,
+          "best_efficiency": float,
+          "total_tokens":    int,
+          "avg_tokens":      int,
+          "task_breakdown":  { task_type: { "count": int, "avg_efficiency": float } }
+        },
+        ...                             # sorted by avg_efficiency descending
+      ],
+      "task_types_available": [str]     # all task types seen in the full dataset
+    }
+    """
+    # Collect all task types before filtering
+    all_task_types: set[str] = set()
+    for s in sessions:
+        tt = s.get("task_type") or "other"
+        all_task_types.add(tt)
+
+    task_types_available = [t for t in _TASK_ORDER if t in all_task_types] + \
+                           sorted(all_task_types - set(_TASK_ORDER))
+
+    # Buckets: model_name → { agent, efficiency_scores, token_counts, task_buckets }
+    buckets: dict[str, dict] = {}
+    sessions_used = 0
+    sessions_skipped = 0
+
+    for s in sessions:
+        model = s.get("model")
+        if not model:
+            sessions_skipped += 1
+            continue
+
+        eff = s.get("efficiency")
+        if eff is None:
+            sessions_skipped += 1
+            continue
+
+        tt = s.get("task_type") or "other"
+        if task_type and task_type != "all" and tt != task_type:
+            sessions_skipped += 1
+            continue
+
+        sessions_used += 1
+        if model not in buckets:
+            buckets[model] = {
+                "agent":      s.get("agent", "unknown"),
+                "efficiency": [],
+                "tokens":     [],
+                "tasks":      defaultdict(list),
+            }
+        b = buckets[model]
+        b["efficiency"].append(float(eff))
+        b["tokens"].append(int(s.get("tokens", {}).get("total", 0) if s.get("tokens") else 0))
+        b["tasks"][tt].append(float(eff))
+
+    if not buckets:
+        return {
+            "task_type_filter":      task_type,
+            "models_compared":       0,
+            "sessions_used":         sessions_used,
+            "sessions_skipped":      sessions_skipped,
+            "models":                [],
+            "task_types_available":  task_types_available,
+            "note": "No sessions with both a model name and an efficiency score found.",
+        }
+
+    models = []
+    for model, b in buckets.items():
+        scores = b["efficiency"]
+        tokens = b["tokens"]
+        task_breakdown = {}
+        for tt, effs in sorted(b["tasks"].items()):
+            task_breakdown[tt] = {
+                "count":          len(effs),
+                "avg_efficiency": round(sum(effs) / len(effs), 1),
+            }
+
+        models.append({
+            "model":             model,
+            "agent":             b["agent"],
+            "session_count":     len(scores),
+            "avg_efficiency":    round(sum(scores) / len(scores), 1),
+            "median_efficiency": round(_median(scores), 1),
+            "p75_efficiency":    round(_percentile(scores, 75), 1),
+            "best_efficiency":   round(max(scores), 1),
+            "total_tokens":      sum(tokens),
+            "avg_tokens":        round(sum(tokens) / len(tokens)) if tokens else 0,
+            "task_breakdown":    task_breakdown,
+        })
+
+    models.sort(key=lambda m: -m["avg_efficiency"])
+
+    return {
+        "task_type_filter":     task_type,
+        "models_compared":      len(models),
+        "sessions_used":        sessions_used,
+        "sessions_skipped":     sessions_skipped,
+        "models":               models,
+        "task_types_available": task_types_available,
+    }

--- a/backend/project_health.py
+++ b/backend/project_health.py
@@ -1,0 +1,217 @@
+"""
+project_health.py — Project Health Score
+
+Computes a composite 0–100 health score per project by aggregating
+efficiency, smell rate, recent trend, and cost efficiency signals.
+
+Grade bands
+-----------
+  A  80–100   Excellent
+  B  60–79    Good
+  C  40–59    Fair
+  D  20–39    Needs attention
+  F   0–19    Critical
+
+No external dependencies — pure stdlib.
+"""
+
+from collections import defaultdict
+from datetime import datetime, timezone, timedelta
+from typing import Optional
+
+
+def _grade(score: float) -> str:
+    if score >= 80: return "A"
+    if score >= 60: return "B"
+    if score >= 40: return "C"
+    if score >= 20: return "D"
+    return "F"
+
+
+def _date_str(ts) -> Optional[str]:
+    if ts is None:
+        return None
+    if hasattr(ts, "strftime"):
+        return ts.strftime("%Y-%m-%d")
+    try:
+        return str(ts)[:10]
+    except Exception:
+        return None
+
+
+def compute_project_health(sessions: list[dict]) -> dict:
+    """
+    Compute per-project composite health scores.
+
+    Returns
+    -------
+    {
+      "projects": [
+        {
+          "project":           str,
+          "session_count":     int,
+          "health_score":      float,      # 0–100 composite
+          "grade":             "A"|"B"|"C"|"D"|"F",
+          "avg_efficiency":    float,
+          "smell_rate":        float,      # 0–100 (% sessions with smells)
+          "recent_efficiency": float|null, # last 7 days avg
+          "trend":             "up"|"flat"|"down"|null,
+          "cost_per_eff_pt":   float|null,
+          "components": {
+            "efficiency":    float,        # 0–100 sub-score
+            "smell_free":    float,        # 0–100 sub-score
+            "recent_trend":  float,        # 0–100 sub-score
+            "cost_value":    float,        # 0–100 sub-score
+          }
+        },
+        ...                                # sorted by health_score desc
+      ],
+      "total_projects":   int,
+      "healthy_projects": int,             # grade A or B
+      "at_risk_projects": int,             # grade D or F
+    }
+    """
+    today = datetime.now(timezone.utc).date()
+    cutoff_recent = today - timedelta(days=7)
+
+    # Bucket per project
+    buckets: dict[str, dict] = defaultdict(lambda: {
+        "effs":         [],
+        "smells":       [],       # list of bool (has_smell)
+        "recent_effs":  [],
+        "older_effs":   [],
+        "costs":        [],
+    })
+
+    for s in sessions:
+        proj = s.get("project", "")
+        if not proj:
+            continue
+        eff = s.get("efficiency")
+        if eff is None:
+            continue
+
+        eff_f = float(eff)
+        b = buckets[proj]
+        b["effs"].append(eff_f)
+
+        has_smell = bool(s.get("smells"))
+        b["smells"].append(has_smell)
+
+        # recent vs older split
+        ds = _date_str(s.get("timestamp"))
+        try:
+            d = datetime.strptime(ds, "%Y-%m-%d").date() if ds else None
+        except Exception:
+            d = None
+
+        if d and d >= cutoff_recent:
+            b["recent_effs"].append(eff_f)
+        else:
+            b["older_effs"].append(eff_f)
+
+        cost = s.get("cost")
+        if cost is not None and float(cost) > 0:
+            b["costs"].append(float(cost))
+
+    # Collect per-model cost_per_eff_pt across all sessions for normalisation
+    all_cpp = []
+    proj_cpp_raw: dict[str, Optional[float]] = {}
+    for proj, b in buckets.items():
+        if b["costs"] and b["effs"]:
+            avg_c = sum(b["costs"]) / len(b["costs"])
+            avg_e = sum(b["effs"]) / len(b["effs"])
+            cpp   = avg_c / avg_e if avg_e > 0 else None
+            proj_cpp_raw[proj] = cpp
+            if cpp is not None:
+                all_cpp.append(cpp)
+        else:
+            proj_cpp_raw[proj] = None
+
+    max_cpp = max(all_cpp) if all_cpp else 1.0
+
+    projects = []
+    for proj, b in buckets.items():
+        n = len(b["effs"])
+        if n == 0:
+            continue
+
+        avg_eff   = sum(b["effs"]) / n
+        smell_rate = round(sum(b["smells"]) / n * 100, 1) if b["smells"] else 0.0
+
+        recent_avg = (sum(b["recent_effs"]) / len(b["recent_effs"])
+                      if b["recent_effs"] else None)
+        older_avg  = (sum(b["older_effs"])  / len(b["older_effs"])
+                      if b["older_effs"]  else None)
+
+        if recent_avg is not None and older_avg is not None:
+            diff = recent_avg - older_avg
+            trend = "up" if diff >= 5 else "down" if diff <= -5 else "flat"
+        elif recent_avg is not None:
+            trend = "flat"
+        else:
+            trend = None
+
+        cpp = proj_cpp_raw.get(proj)
+
+        # ── Sub-scores (each 0–100) ────────────────────────────────────────
+        # 1. Efficiency score: direct 0-100
+        c_eff = avg_eff
+
+        # 2. Smell-free: 100 - smell_rate
+        c_smell = 100 - smell_rate
+
+        # 3. Recent trend:
+        #    recent > older+5 → 80–100, equal ±5 → 50, recent < older-5 → 0–40
+        if recent_avg is not None and older_avg is not None:
+            ratio = (recent_avg - older_avg) / max(older_avg, 1) * 100
+            c_trend = max(0, min(100, 50 + ratio * 2))
+        elif recent_avg is not None:
+            c_trend = min(100, recent_avg)
+        else:
+            c_trend = 50.0  # neutral if no recent data
+
+        # 4. Cost value: lower cpp = higher score; cpp=0 (no cost data) → neutral 60
+        if cpp is not None and max_cpp > 0:
+            c_cost = max(0, 100 - (cpp / max_cpp * 100))
+        else:
+            c_cost = 60.0
+
+        # Weights
+        health_score = round(
+            c_eff   * 0.40 +
+            c_smell * 0.25 +
+            c_trend * 0.20 +
+            c_cost  * 0.15,
+            1,
+        )
+
+        projects.append({
+            "project":           proj,
+            "session_count":     n,
+            "health_score":      health_score,
+            "grade":             _grade(health_score),
+            "avg_efficiency":    round(avg_eff, 1),
+            "smell_rate":        smell_rate,
+            "recent_efficiency": round(recent_avg, 1) if recent_avg is not None else None,
+            "trend":             trend,
+            "cost_per_eff_pt":   round(cpp, 6) if cpp is not None else None,
+            "components": {
+                "efficiency":   round(c_eff, 1),
+                "smell_free":   round(c_smell, 1),
+                "recent_trend": round(c_trend, 1),
+                "cost_value":   round(c_cost, 1),
+            },
+        })
+
+    projects.sort(key=lambda p: -p["health_score"])
+
+    healthy = sum(1 for p in projects if p["grade"] in ("A", "B"))
+    at_risk = sum(1 for p in projects if p["grade"] in ("D", "F"))
+
+    return {
+        "projects":         projects,
+        "total_projects":   len(projects),
+        "healthy_projects": healthy,
+        "at_risk_projects": at_risk,
+    }

--- a/backend/prompt_analysis.py
+++ b/backend/prompt_analysis.py
@@ -1,0 +1,252 @@
+"""
+prompt_analysis.py — Prompt DNA
+
+Extracts structural and semantic features from session prompts and
+correlates them with efficiency scores to surface what makes sessions
+good or bad.
+
+No external dependencies — pure stdlib.
+
+Features extracted per session:
+  msg_length        character count of first message
+  word_count        approximate word count
+  has_file_ref      @ mentions or path strings
+  has_code_block    triple-backtick fenced code
+  has_markdown      # headers or bullet lists
+  has_numbered_steps   lines like "1. ", "2. "
+  has_question      ends with ?
+  is_vague          very short (< 60 chars), no file refs
+  is_detailed       > 300 chars
+  has_context_link  references previous session / last time / above
+  task_type         build | fix | analyze | refactor | explain | review | other
+"""
+
+import re
+import math
+from typing import Optional
+
+
+# ── Task type patterns ───────────────────────────────────────────────────────
+
+_TASK_PATTERNS: list[tuple[str, str]] = [
+    ("fix",      r"\b(fix|bug|error|crash|broken|issue|wrong|fail|not work)\b"),
+    ("build",    r"\b(build|create|make|implement|add|write|develop|set up|setup|generate)\b"),
+    ("refactor", r"\b(refactor|clean|improve|optimis|optimiz|restructure|rewrite|simplif)\b"),
+    ("analyze",  r"\b(analyz|analyse|review|check|inspect|audit|understand|explain|why|how does)\b"),
+    ("test",     r"\b(test|spec|coverage|unit test|integration|e2e|assert)\b"),
+    ("deploy",   r"\b(deploy|release|publish|ship|push|ci|cd|pipeline)\b"),
+]
+
+
+def classify_task(text: str) -> str:
+    """Return the dominant task type for a message."""
+    lower = text.lower()
+    for task, pattern in _TASK_PATTERNS:
+        if re.search(pattern, lower):
+            return task
+    return "other"
+
+
+# ── Feature extraction ───────────────────────────────────────────────────────
+
+def extract_features(msg: str) -> dict:
+    """Extract a dict of boolean / numeric features from a prompt string."""
+    if not msg or not msg.strip():
+        return _empty_features()
+
+    msg = msg.strip()
+    lower = msg.lower()
+
+    msg_length   = len(msg)
+    word_count   = len(msg.split())
+
+    has_file_ref      = bool(re.search(r'[@\\\/][^\s]{3,}', msg) or
+                              re.search(r'\b\w+\.\w{2,4}\b', msg))
+    has_code_block    = "```" in msg
+    has_markdown      = bool(re.search(r'^#{1,3}\s', msg, re.MULTILINE) or
+                              re.search(r'^[-*]\s', msg, re.MULTILINE))
+    has_numbered_steps = bool(re.search(r'^\d+[\.\)]\s', msg, re.MULTILINE))
+    has_question      = msg.rstrip().endswith("?")
+    is_vague          = msg_length < 60 and not has_file_ref and not has_code_block
+    is_detailed       = msg_length > 300
+    has_context_link  = bool(re.search(
+        r'\b(previous|last session|last time|above|earlier|follow.?up|continue|handoff)\b',
+        lower
+    ))
+
+    return {
+        "msg_length":        msg_length,
+        "word_count":        word_count,
+        "has_file_ref":      int(has_file_ref),
+        "has_code_block":    int(has_code_block),
+        "has_markdown":      int(has_markdown),
+        "has_numbered_steps": int(has_numbered_steps),
+        "has_question":      int(has_question),
+        "is_vague":          int(is_vague),
+        "is_detailed":       int(is_detailed),
+        "has_context_link":  int(has_context_link),
+        "task_type":         classify_task(msg),
+    }
+
+
+def _empty_features() -> dict:
+    return {
+        "msg_length": 0, "word_count": 0,
+        "has_file_ref": 0, "has_code_block": 0, "has_markdown": 0,
+        "has_numbered_steps": 0, "has_question": 0,
+        "is_vague": 0, "is_detailed": 0, "has_context_link": 0,
+        "task_type": "other",
+    }
+
+
+# ── Pearson correlation (no scipy) ────────────────────────────────────────────
+
+def _pearson(xs: list[float], ys: list[float]) -> float:
+    """Return Pearson r for two equal-length lists. Returns 0 if undefined."""
+    n = len(xs)
+    if n < 3:
+        return 0.0
+    mx = sum(xs) / n
+    my = sum(ys) / n
+    num   = sum((x - mx) * (y - my) for x, y in zip(xs, ys))
+    den_x = math.sqrt(sum((x - mx) ** 2 for x in xs))
+    den_y = math.sqrt(sum((y - my) ** 2 for y in ys))
+    if den_x == 0 or den_y == 0:
+        return 0.0
+    return num / (den_x * den_y)
+
+
+# ── Main analysis ─────────────────────────────────────────────────────────────
+
+_NUMERIC_FEATURES = [
+    "msg_length", "word_count", "has_file_ref", "has_code_block",
+    "has_markdown", "has_numbered_steps", "has_question",
+    "is_vague", "is_detailed", "has_context_link",
+]
+
+_FEATURE_LABELS = {
+    "msg_length":        "Long prompt",
+    "word_count":        "High word count",
+    "has_file_ref":      "References a file or path",
+    "has_code_block":    "Includes a code block",
+    "has_markdown":      "Uses markdown headers/bullets",
+    "has_numbered_steps": "Uses numbered steps",
+    "has_question":      "Ends with a question",
+    "is_vague":          "Vague / short prompt",
+    "is_detailed":       "Detailed prompt (>300 chars)",
+    "has_context_link":  "References a previous session",
+}
+
+
+def analyse_prompt_dna(sessions: list[dict]) -> dict:
+    """
+    Run Prompt DNA analysis over a list of sessions.
+
+    Returns:
+    {
+      "sessions_analysed": int,
+      "sessions_skipped":  int,     # no prompt text or no efficiency score
+      "correlations": [             # sorted by |r|, strongest first
+        { "feature": str, "label": str, "r": float,
+          "direction": "positive"|"negative",
+          "insight": str }
+      ],
+      "by_task_type": {             # avg efficiency per task type
+        "build": { "avg_efficiency": float, "count": int },
+        ...
+      },
+      "top_positive":  [...],       # top 3 positive correlates
+      "top_negative":  [...],       # top 3 negative correlates
+    }
+    """
+    rows: list[tuple[dict, float]] = []
+
+    for s in sessions:
+        score = s.get("efficiency")
+        if score is None:
+            continue
+        msg = (s.get("display") or s.get("text") or "").strip()
+        if not msg:
+            continue
+        rows.append((extract_features(msg), score))
+
+    skipped = len(sessions) - len(rows)
+
+    if len(rows) < 3:
+        return {
+            "sessions_analysed": len(rows),
+            "sessions_skipped":  skipped,
+            "correlations":      [],
+            "by_task_type":      {},
+            "top_positive":      [],
+            "top_negative":      [],
+            "note": "Not enough sessions with both a prompt and an efficiency score to compute correlations (need ≥ 3).",
+        }
+
+    # Compute Pearson r for each numeric feature vs efficiency
+    efficiency_vals = [r for _, r in rows]
+    correlations = []
+    for feat in _NUMERIC_FEATURES:
+        feat_vals = [f[feat] for f, _ in rows]
+        r = round(_pearson(feat_vals, efficiency_vals), 3)
+        if abs(r) < 0.05:          # ignore noise
+            continue
+        direction = "positive" if r > 0 else "negative"
+        label = _FEATURE_LABELS[feat]
+        insight = _make_insight(feat, r, rows)
+        correlations.append({
+            "feature":   feat,
+            "label":     label,
+            "r":         r,
+            "direction": direction,
+            "insight":   insight,
+        })
+
+    correlations.sort(key=lambda x: -abs(x["r"]))
+
+    # Per-task-type breakdown
+    task_buckets: dict[str, list[float]] = {}
+    for feats, score in rows:
+        tt = feats["task_type"]
+        task_buckets.setdefault(tt, []).append(score)
+
+    by_task_type = {
+        tt: {
+            "avg_efficiency": round(sum(scores) / len(scores), 1),
+            "count":          len(scores),
+        }
+        for tt, scores in sorted(task_buckets.items(), key=lambda x: -sum(x[1]) / len(x[1]))
+    }
+
+    top_positive = [c for c in correlations if c["direction"] == "positive"][:3]
+    top_negative = [c for c in correlations if c["direction"] == "negative"][:3]
+
+    return {
+        "sessions_analysed": len(rows),
+        "sessions_skipped":  skipped,
+        "correlations":      correlations,
+        "by_task_type":      by_task_type,
+        "top_positive":      top_positive,
+        "top_negative":      top_negative,
+    }
+
+
+def _make_insight(feat: str, r: float, rows: list[tuple[dict, float]]) -> str:
+    """Generate a one-line human insight for a feature correlation."""
+    present   = [score for feats, score in rows if feats[feat]]
+    absent    = [score for feats, score in rows if not feats[feat]]
+    avg_p = sum(present) / len(present) if present else 0
+    avg_a = sum(absent)  / len(absent)  if absent  else 0
+    diff  = abs(avg_p - avg_a)
+    label = _FEATURE_LABELS[feat]
+
+    if r > 0:
+        return (
+            f"Sessions with '{label.lower()}' score {diff:.1f} pts higher on average "
+            f"({avg_p:.1f} vs {avg_a:.1f})."
+        )
+    else:
+        return (
+            f"Sessions with '{label.lower()}' score {diff:.1f} pts lower on average "
+            f"({avg_p:.1f} vs {avg_a:.1f})."
+        )

--- a/backend/recommendations.py
+++ b/backend/recommendations.py
@@ -1,0 +1,273 @@
+"""
+recommendations.py — AI Recommendations Engine
+
+Cross-references all intelligence modules (cost, time, prompt DNA, smells,
+tool footprint, trends) to generate specific, actionable text recommendations.
+
+Each recommendation has:
+  category  — cost | quality | timing | prompt | tools | health
+  priority  — high | medium | low
+  title     — short headline
+  detail    — actionable sentence with concrete numbers
+  impact    — estimated efficiency gain or cost saving (if computable)
+
+No external dependencies — pure stdlib.
+"""
+
+from collections import defaultdict
+from typing import Optional
+
+# Lazy imports at call time to avoid circular deps
+def _run_analysis(sessions: list[dict]) -> dict:
+    from prompt_analysis   import analyse_prompt_dna, extract_features
+    from model_comparison  import compare_models
+    from cost_intel        import analyse_cost
+    from time_intel        import analyse_time
+    from tool_footprint    import analyse_tool_footprint
+    from trends            import compute_trends
+    from smells            import detect_smells
+
+    # Attach features / smells if not already on the sessions
+    enriched = []
+    for s in sessions:
+        s2 = dict(s)
+        if "task_type" not in s2 or "prompt_features" not in s2:
+            try:
+                feats = extract_features(s2)
+                s2["task_type"]       = feats.pop("task_type", s2.get("task_type", "other"))
+                s2["prompt_features"] = feats
+            except Exception:
+                pass
+        if "smells" not in s2:
+            try:
+                s2["smells"] = detect_smells(s2)
+            except Exception:
+                s2["smells"] = []
+        enriched.append(s2)
+
+    return {
+        "dna":   analyse_prompt_dna(enriched),
+        "cost":  analyse_cost(enriched),
+        "time":  analyse_time(enriched),
+        "tools": analyse_tool_footprint(enriched),
+        "trend": compute_trends(enriched, days=30),
+        "model": compare_models(enriched),
+        "sessions": enriched,
+    }
+
+
+def generate_recommendations(sessions: list[dict]) -> dict:
+    """
+    Generate actionable recommendations by cross-referencing all modules.
+
+    Returns
+    -------
+    {
+      "recommendations": [
+        {
+          "id":       str,                  # stable slug
+          "category": "cost"|"quality"|"timing"|"prompt"|"tools"|"health",
+          "priority": "high"|"medium"|"low",
+          "title":    str,
+          "detail":   str,
+          "impact":   str | null,           # e.g. "Save ~$8/session" or "+12 pts efficiency"
+        },
+        ...                                 # sorted by priority (high first)
+      ],
+      "total":         int,
+      "high_count":    int,
+      "medium_count":  int,
+      "low_count":     int,
+    }
+    """
+    if len(sessions) < 5:
+        return {"recommendations": [], "total": 0, "high_count": 0, "medium_count": 0, "low_count": 0}
+
+    try:
+        data = _run_analysis(sessions)
+    except Exception:
+        return {"recommendations": [], "total": 0, "high_count": 0, "medium_count": 0, "low_count": 0}
+
+    recs: list[dict] = []
+
+    def add(id_, category, priority, title, detail, impact=None):
+        recs.append(dict(id=id_, category=category, priority=priority,
+                         title=title, detail=detail, impact=impact))
+
+    # ── Cost recommendations ───────────────────────────────────────────────
+    cost_data  = data["cost"]
+    by_model   = cost_data.get("by_model", [])
+    valid_models = [m for m in by_model if m.get("cost_per_eff_pt") and m["session_count"] >= 2]
+
+    if len(valid_models) >= 2:
+        best  = valid_models[0]
+        worst = valid_models[-1]
+        ratio = (worst["cost_per_eff_pt"] or 1) / (best["cost_per_eff_pt"] or 1)
+        if ratio >= 5:
+            saving = round((worst["avg_cost"] - best["avg_cost"]), 2)
+            add("cost_model_switch", "cost", "high",
+                f"Replace {worst['model']} — {ratio:.0f}× worse value",
+                f"{worst['model']} costs ${worst['cost_per_eff_pt']:.3f}/eff-pt vs "
+                f"${best['cost_per_eff_pt']:.3f}/eff-pt for {best['model']}. "
+                f"Switch for similar tasks to save ~${abs(saving):.2f}/session.",
+                impact=f"Save ~${abs(saving):.2f}/session" if saving > 0 else None)
+
+    wasteful = cost_data.get("wasteful", [])
+    if len(wasteful) >= 3:
+        models_wasted = list({w["model"] for w in wasteful[:3]})
+        total_wasted  = sum(w["cost"] for w in wasteful[:5])
+        add("cost_wasteful", "cost", "high" if total_wasted > 20 else "medium",
+            f"${total_wasted:.2f} spent on low-efficiency sessions",
+            f"Your top 5 expensive flops (avg efficiency {sum(w['efficiency'] for w in wasteful[:5])/5:.1f}) "
+            f"cost ${total_wasted:.2f} total. "
+            f"Review what went wrong in these {', '.join(models_wasted[:2])} sessions.",
+            impact=f"Recover ~${total_wasted:.2f}")
+
+    cache_tiers = cost_data.get("cache_tiers", [])
+    high_cache  = next((t for t in cache_tiers if "80" in t["tier"]), None)
+    low_cache   = next((t for t in cache_tiers if "0–20" in t["tier"] or "0-20" in t["tier"]), None)
+    if high_cache and low_cache and low_cache["avg_efficiency"] > high_cache["avg_efficiency"] + 15:
+        add("cost_cache_insight", "cost", "low",
+            "Low-cache sessions score higher — they're your deep work",
+            f"Sessions with 0–20% cache hit average {low_cache['avg_efficiency']:.0f} efficiency "
+            f"vs {high_cache['avg_efficiency']:.0f} for 80–100% cached. "
+            f"High-cache sessions are likely quick edits — optimise deep work sessions for quality.",
+            impact=None)
+
+    # ── Quality / prompt recommendations ──────────────────────────────────
+    dna = data["dna"]
+    top_neg = dna.get("top_negative", [])
+    top_pos = dna.get("top_positive", [])
+
+    for feat in top_neg[:2]:
+        r_abs = abs(feat.get("r", 0))
+        if r_abs >= 0.3:
+            impact_pts = round(r_abs * 50)
+            add(f"prompt_avoid_{feat['feature']}", "prompt",
+                "high" if r_abs >= 0.5 else "medium",
+                f"Avoid '{feat['label']}' prompts",
+                feat.get("insight", f"Sessions with '{feat['label']}' score lower on efficiency."),
+                impact=f"+{impact_pts} pts efficiency on average")
+
+    for feat in top_pos[:1]:
+        r_abs = abs(feat.get("r", 0))
+        if r_abs >= 0.3:
+            add(f"prompt_boost_{feat['feature']}", "prompt", "medium",
+                f"More '{feat['label']}' prompts",
+                feat.get("insight", f"Sessions with '{feat['label']}' score higher."),
+                impact=f"+{round(r_abs * 40)} pts efficiency")
+
+    # ── Timing recommendations ─────────────────────────────────────────────
+    time_data  = data["time"]
+    peak_hour  = time_data.get("peak_hour")
+    worst_hour = time_data.get("worst_hour")
+    overall_eff = dna.get("sessions_analysed") and None  # placeholder
+    sessions_list = data["sessions"]
+    all_effs = [float(s["efficiency"]) for s in sessions_list if s.get("efficiency") is not None]
+    overall_avg = round(sum(all_effs) / len(all_effs), 1) if all_effs else 50
+
+    if peak_hour and peak_hour["session_count"] >= 2:
+        diff = peak_hour["avg_efficiency"] - overall_avg
+        if diff >= 15:
+            add("timing_peak_hour", "timing", "medium",
+                f"Schedule deep work at {peak_hour['label']}",
+                f"Sessions starting at {peak_hour['label']} average {peak_hour['avg_efficiency']:.1f} efficiency "
+                f"— {diff:.0f} pts above your {overall_avg:.1f} overall mean. "
+                f"Block this time for complex tasks.",
+                impact=f"+{diff:.0f} pts efficiency")
+
+    if worst_hour and worst_hour["session_count"] >= 2 and worst_hour["avg_efficiency"] < 20:
+        add("timing_avoid_hour", "timing", "low",
+            f"Avoid starting sessions at {worst_hour['label']}",
+            f"Sessions at {worst_hour['label']} average only {worst_hour['avg_efficiency']:.1f} efficiency. "
+            f"Consider wrapping up rather than starting new tasks at this hour.",
+            impact=None)
+
+    peak_dow = time_data.get("peak_dow")
+    worst_dow = time_data.get("worst_dow")
+    if peak_dow and peak_dow["session_count"] >= 2 and worst_dow and worst_dow["session_count"] >= 2:
+        diff = peak_dow["avg_efficiency"] - worst_dow["avg_efficiency"]
+        if diff >= 20:
+            add("timing_best_day", "timing", "low",
+                f"{peak_dow['label']} is your best day (+{diff:.0f} pts over {worst_dow['label']})",
+                f"{peak_dow['label']} sessions average {peak_dow['avg_efficiency']:.1f} vs "
+                f"{worst_dow['avg_efficiency']:.1f} on {worst_dow['label']}.",
+                impact=None)
+
+    # ── Tool recommendations ───────────────────────────────────────────────
+    tools_data   = data["tools"]
+    by_size      = tools_data.get("by_size", [])
+    optimal_range = tools_data.get("optimal_range")
+
+    if len(by_size) >= 2:
+        lean    = next((b for b in by_size if b["label"] == "lean"),    None)
+        bloated = next((b for b in by_size if b["label"] == "bloated"), None)
+        heavy   = next((b for b in by_size if b["label"] == "heavy"),   None)
+        best_sz = max(by_size, key=lambda b: b["avg_efficiency"])
+        worst_sz = min(by_size, key=lambda b: b["avg_efficiency"])
+        diff = best_sz["avg_efficiency"] - worst_sz["avg_efficiency"]
+        if diff >= 20 and best_sz["bucket"] != worst_sz["bucket"]:
+            add("tools_optimal_size", "tools", "medium",
+                f"Optimal toolset size: {best_sz['bucket']} tools ({best_sz['label']})",
+                f"Sessions with {best_sz['bucket']} tools average {best_sz['avg_efficiency']:.1f} efficiency "
+                f"vs {worst_sz['avg_efficiency']:.1f} for {worst_sz['bucket']} — "
+                f"a {diff:.0f}-pt gap. Aim for {best_sz['label']} tool configurations.",
+                impact=f"+{diff:.0f} pts efficiency")
+
+    # ── Health / trend recommendations ─────────────────────────────────────
+    trend_data = data["trend"]
+    trend = trend_data.get("trend")
+    delta = trend_data.get("trend_delta", 0)
+
+    if trend == "declining" and delta <= -10:
+        add("health_declining", "health", "high",
+            f"Efficiency declining — down {abs(delta):.1f} pts week-over-week",
+            f"Your 7-day average has dropped {abs(delta):.1f} pts vs the prior week. "
+            f"Review recent sessions for common smell patterns (context rot, loop traps).",
+            impact=None)
+    elif trend == "improving" and delta >= 10:
+        add("health_improving", "health", "low",
+            f"Efficiency improving — up {delta:.1f} pts week-over-week",
+            f"Your recent sessions average {delta:.1f} pts higher than the prior week. "
+            f"Keep up the current patterns.",
+            impact=f"+{delta:.1f} pts WoW")
+
+    # ── Smell recommendations ──────────────────────────────────────────────
+    from smells import detect_smells as _detect_smells
+    smell_counts: dict[str, int] = defaultdict(int)
+    for s in sessions:
+        for sm in (s.get("smells") or []):
+            smell_counts[sm.get("type", "")] += 1
+
+    if smell_counts:
+        top_smell, top_count = max(smell_counts.items(), key=lambda x: x[1])
+        pct = round(top_count / max(len(sessions), 1) * 100)
+        smell_labels = {
+            "context_rot":   "Context rot — sessions accumulating too much old context",
+            "loop_trap":     "Loop traps — repeated similar patterns without progress",
+            "tool_thrash":   "Tool thrash — excessive tool retries",
+            "high_error":    "High error rate",
+            "massive_session": "Oversized sessions",
+        }
+        if pct >= 20:
+            add(f"smell_{top_smell}", "health", "medium",
+                f"{smell_labels.get(top_smell, top_smell)} in {pct}% of sessions",
+                f"'{smell_labels.get(top_smell, top_smell)}' was detected in {top_count} of your "
+                f"{len(sessions)} sessions ({pct}%). This pattern correlates with lower efficiency.",
+                impact=None)
+
+    # Sort: high → medium → low
+    priority_order = {"high": 0, "medium": 1, "low": 2}
+    recs.sort(key=lambda r: priority_order.get(r["priority"], 3))
+
+    counts = {"high": 0, "medium": 0, "low": 0}
+    for r in recs:
+        counts[r["priority"]] = counts.get(r["priority"], 0) + 1
+
+    return {
+        "recommendations": recs,
+        "total":        len(recs),
+        "high_count":   counts["high"],
+        "medium_count": counts["medium"],
+        "low_count":    counts["low"],
+    }

--- a/backend/recommendations.py
+++ b/backend/recommendations.py
@@ -111,10 +111,10 @@ def generate_recommendations(sessions: list[dict]) -> dict:
             else:
                 impact_str = f"+{eff_gain:.0f} pts efficiency"
             add("cost_model_switch", "cost", "high",
-                f"Replace {worst['model']} — {ratio:.0f}× worse value",
-                f"{worst['model']} costs ${worst['cost_per_eff_pt']:.3f}/eff-pt vs "
-                f"${best['cost_per_eff_pt']:.3f}/eff-pt for {best['model']}. "
-                f"Switch for similar tasks to gain ~{eff_gain:.0f} pts efficiency per session.",
+                f"{worst['model']} gives {ratio:.0f}× less output for the same cost — switch to {best['model']}",
+                f"{worst['model']} costs ${worst['cost_per_eff_pt']:.3f} per quality point vs "
+                f"${best['cost_per_eff_pt']:.3f} for {best['model']}. "
+                f"Switching models for similar tasks could improve your quality score by ~{eff_gain:.0f} points.",
                 impact=impact_str)
 
     wasteful = cost_data.get("wasteful", [])
@@ -122,10 +122,10 @@ def generate_recommendations(sessions: list[dict]) -> dict:
         models_wasted = list({w["model"] for w in wasteful[:3]})
         total_wasted  = sum(w["cost"] for w in wasteful[:5])
         add("cost_wasteful", "cost", "high" if total_wasted > 20 else "medium",
-            f"${total_wasted:.2f} spent on low-efficiency sessions",
-            f"Your top 5 expensive flops (avg efficiency {sum(w['efficiency'] for w in wasteful[:5])/5:.1f}) "
-            f"cost ${total_wasted:.2f} total. "
-            f"Review what went wrong in these {', '.join(models_wasted[:2])} sessions.",
+            f"${total_wasted:.2f} spent on sessions that got poor results",
+            f"Your top 5 most expensive sessions had an average quality score of only {sum(w['efficiency'] for w in wasteful[:5])/5:.0f}/100, "
+            f"costing ${total_wasted:.2f} total. "
+            f"Review what went wrong in these {', '.join(models_wasted[:2])} sessions to avoid repeating it.",
             impact=f"Recover ~${total_wasted:.2f}")
 
     cache_tiers = cost_data.get("cache_tiers", [])
@@ -133,10 +133,10 @@ def generate_recommendations(sessions: list[dict]) -> dict:
     low_cache   = next((t for t in cache_tiers if "0–20" in t["tier"] or "0-20" in t["tier"]), None)
     if high_cache and low_cache and low_cache["avg_efficiency"] > high_cache["avg_efficiency"] + 15:
         add("cost_cache_insight", "cost", "low",
-            "Low-cache sessions score higher — they're your deep work",
-            f"Sessions with 0–20% cache hit average {low_cache['avg_efficiency']:.0f} efficiency "
-            f"vs {high_cache['avg_efficiency']:.0f} for 80–100% cached. "
-            f"High-cache sessions are likely quick edits — optimise deep work sessions for quality.",
+            "Fresh-start sessions do better quality work — they're your deep focus tasks",
+            f"Sessions where the AI starts fresh (little memory reuse) average {low_cache['avg_efficiency']:.0f}/100 quality "
+            f"vs {high_cache['avg_efficiency']:.0f}/100 for heavily cached sessions. "
+            f"High-cache sessions are likely quick edits — save important tasks for fresh sessions.",
             impact=None)
 
     # ── Quality / prompt recommendations ──────────────────────────────────
@@ -213,11 +213,11 @@ def generate_recommendations(sessions: list[dict]) -> dict:
         diff = best_sz["avg_efficiency"] - worst_sz["avg_efficiency"]
         if diff >= 20 and best_sz["bucket"] != worst_sz["bucket"]:
             add("tools_optimal_size", "tools", "medium",
-                f"Optimal toolset size: {best_sz['bucket']} tools ({best_sz['label']})",
-                f"Sessions with {best_sz['bucket']} tools average {best_sz['avg_efficiency']:.1f} efficiency "
-                f"vs {worst_sz['avg_efficiency']:.1f} for {worst_sz['bucket']} — "
-                f"a {diff:.0f}-pt gap. Aim for {best_sz['label']} tool configurations.",
-                impact=f"+{diff:.0f} pts efficiency")
+                f"Sweet spot: {best_sz['bucket']} tools gives the best results",
+                f"Sessions with {best_sz['bucket']} tools score {best_sz['avg_efficiency']:.0f}/100 quality "
+                f"vs only {worst_sz['avg_efficiency']:.0f}/100 for {worst_sz['bucket']} tools — "
+                f"a {diff:.0f}-point difference. Try to stay in the {best_sz['label'].lower()} range.",
+                impact=f"+{diff:.0f} pts quality")
 
     # ── Health / trend recommendations ─────────────────────────────────────
     trend_data = data["trend"]
@@ -226,16 +226,16 @@ def generate_recommendations(sessions: list[dict]) -> dict:
 
     if trend == "declining" and delta <= -10:
         add("health_declining", "health", "high",
-            f"Efficiency declining — down {abs(delta):.1f} pts week-over-week",
-            f"Your 7-day average has dropped {abs(delta):.1f} pts vs the prior week. "
-            f"Review recent sessions for common smell patterns (context rot, loop traps).",
+            f"Quality is going down — dropped {abs(delta):.1f} points vs last week",
+            f"Your average quality score has dropped {abs(delta):.1f} points compared to the prior week. "
+            f"Check your recent sessions — common causes are running too many tools or sessions that ran too long.",
             impact=None)
     elif trend == "improving" and delta >= 10:
         add("health_improving", "health", "low",
-            f"Efficiency improving — up {delta:.1f} pts week-over-week",
-            f"Your recent sessions average {delta:.1f} pts higher than the prior week. "
-            f"Keep up the current patterns.",
-            impact=f"+{delta:.1f} pts WoW")
+            f"Quality is improving — up {delta:.1f} points vs last week",
+            f"Your recent sessions are scoring {delta:.1f} points higher than the prior week. "
+            f"Keep doing what you're doing!",
+            impact=f"+{delta:.1f} pts")
 
     # ── Smell recommendations ──────────────────────────────────────────────
     from smells import detect_smells as _detect_smells
@@ -248,17 +248,17 @@ def generate_recommendations(sessions: list[dict]) -> dict:
         top_smell, top_count = max(smell_counts.items(), key=lambda x: x[1])
         pct = round(top_count / max(len(sessions), 1) * 100)
         smell_labels = {
-            "context_rot":   "Context rot — sessions accumulating too much old context",
-            "loop_trap":     "Loop traps — repeated similar patterns without progress",
-            "tool_thrash":   "Tool thrash — excessive tool retries",
-            "high_error":    "High error rate",
-            "massive_session": "Oversized sessions",
+            "context_rot":     "Too much old context building up",
+            "loop_trap":       "AI repeating itself without making progress",
+            "tool_thrash":     "AI retrying tools too many times",
+            "high_error":      "High error rate",
+            "massive_session": "Sessions running way too long",
         }
         if pct >= 20:
             add(f"smell_{top_smell}", "health", "medium",
-                f"{smell_labels.get(top_smell, top_smell)} in {pct}% of sessions",
+                f"{smell_labels.get(top_smell, top_smell)} — happening in {pct}% of sessions",
                 f"'{smell_labels.get(top_smell, top_smell)}' was detected in {top_count} of your "
-                f"{len(sessions)} sessions ({pct}%). This pattern correlates with lower efficiency.",
+                f"{len(sessions)} sessions ({pct}%). This pattern tends to lower the quality score.",
                 impact=None)
 
     # Sort: high → medium → low

--- a/backend/recommendations.py
+++ b/backend/recommendations.py
@@ -105,12 +105,17 @@ def generate_recommendations(sessions: list[dict]) -> dict:
         ratio = (worst["cost_per_eff_pt"] or 1) / (best["cost_per_eff_pt"] or 1)
         if ratio >= 5:
             saving = round((worst["avg_cost"] - best["avg_cost"]), 2)
+            eff_gain = round(best["avg_efficiency"] - worst["avg_efficiency"], 0)
+            if saving > 0:
+                impact_str = f"Save ~${saving:.2f}/session"
+            else:
+                impact_str = f"+{eff_gain:.0f} pts efficiency"
             add("cost_model_switch", "cost", "high",
                 f"Replace {worst['model']} — {ratio:.0f}× worse value",
                 f"{worst['model']} costs ${worst['cost_per_eff_pt']:.3f}/eff-pt vs "
                 f"${best['cost_per_eff_pt']:.3f}/eff-pt for {best['model']}. "
-                f"Switch for similar tasks to save ~${abs(saving):.2f}/session.",
-                impact=f"Save ~${abs(saving):.2f}/session" if saving > 0 else None)
+                f"Switch for similar tasks to gain ~{eff_gain:.0f} pts efficiency per session.",
+                impact=impact_str)
 
     wasteful = cost_data.get("wasteful", [])
     if len(wasteful) >= 3:

--- a/backend/scoring.py
+++ b/backend/scoring.py
@@ -1,0 +1,59 @@
+﻿"""
+scoring.py — Agent Efficiency Score
+
+Computes a 0–100 score for a session based on how productively
+tokens were used. Higher = more output per token, fewer errors, fewer turns.
+
+Formula:
+  output_ratio  = output_tokens / total_tokens      (more output = productive)
+  error_penalty = 1 / (1 + errors * 0.15)           (errors hurt)
+  turn_penalty  = 1 / (1 + log1p(turns) * 0.18)     (fewer turns = clearer prompts)
+  score = output_ratio * error_penalty * turn_penalty * 100
+"""
+
+import math
+from typing import Optional
+
+
+def efficiency_score(
+    input_tokens: int,
+    output_tokens: int,
+    total_tokens: int,
+    turns: int,
+    error_count: int,
+) -> Optional[float]:
+    """
+    Returns a 0.0–100.0 efficiency score, or None if there is not enough data.
+    """
+    if total_tokens <= 0 or output_tokens < 0:
+        return None
+
+    output_ratio  = output_tokens / total_tokens
+    error_penalty = 1.0 / (1.0 + max(error_count, 0) * 0.15)
+    turn_penalty  = 1.0 / (1.0 + math.log1p(max(turns, 1)) * 0.18)
+
+    raw = output_ratio * error_penalty * turn_penalty * 100.0
+    return round(min(max(raw, 0.0), 100.0), 1)
+
+
+def score_label(score: Optional[float]) -> str:
+    """Human-readable label for the score."""
+    if score is None:
+        return "unknown"
+    if score >= 70:
+        return "good"
+    if score >= 40:
+        return "fair"
+    return "poor"
+
+
+def score_session(session: dict) -> Optional[float]:
+    """Convenience wrapper — pass a raw session dict from main.py."""
+    tokens = session.get("tokens") or {}
+    return efficiency_score(
+        input_tokens  = tokens.get("input", 0) or 0,
+        output_tokens = tokens.get("output", 0) or 0,
+        total_tokens  = tokens.get("total", 0) or 0,
+        turns         = session.get("turns", 1) or 1,
+        error_count   = session.get("error_count", 0) or 0,
+    )

--- a/backend/smells.py
+++ b/backend/smells.py
@@ -1,0 +1,132 @@
+﻿"""
+smells.py — AI Smell Detector
+
+Rule-based detection of inefficient or problematic AI usage patterns.
+All checks run over the parsed session dict and return a list of warnings.
+
+Smells detected:
+  context_rot      — session > 200 turns (context quality degrades)
+  loop_trap        — same bash/tool command failing repeatedly (agent stuck)
+  tool_thrash      — same file read many times (should be pinned as context)
+  high_error_rate  — error count > 20% of turns
+  massive_session  — total tokens > 2M (consider chunking the task)
+"""
+
+from typing import Any
+
+
+# ── thresholds (easy to tune) ────────────────────────────────────────────────
+CONTEXT_ROT_TURNS    = 200
+LOOP_TRAP_REPEATS    = 8      # same tool+input hash N times in a row
+TOOL_THRASH_READS    = 25     # same file read across whole session
+HIGH_ERROR_THRESHOLD = 0.20   # error_count / turns
+MASSIVE_TOKEN_LIMIT  = 2_000_000
+
+
+def detect_smells(session: dict) -> list[dict[str, Any]]:
+    """
+    Returns a list of smell dicts:
+      { "type": str, "title": str, "detail": str, "severity": "warning"|"critical" }
+    Empty list = clean session.
+    """
+    warnings: list[dict[str, Any]] = []
+
+    tokens     = session.get("tokens") or {}
+    turns      = session.get("turns") or 0
+    errors     = session.get("error_count") or 0
+    total_tok  = tokens.get("total") or 0
+    tool_calls = session.get("tool_calls_detail") or []   # list of {name, input_hash}
+    file_reads = session.get("file_read_paths") or []     # list of path strings
+
+    # 1. Context rot
+    if turns > CONTEXT_ROT_TURNS:
+        warnings.append({
+            "type":     "context_rot",
+            "title":    f"Context rot ({turns} turns)",
+            "detail":   (
+                f"This session ran for {turns} turns. "
+                "Context quality typically degrades past 200 turns — "
+                "consider breaking long tasks into focused sub-sessions."
+            ),
+            "severity": "warning" if turns < 400 else "critical",
+        })
+
+    # 2. Loop trap — consecutive repeated (tool, input_hash) pairs
+    if tool_calls:
+        max_streak = _max_consecutive_repeat(
+            [(t.get("name", ""), t.get("input_hash", "")) for t in tool_calls]
+        )
+        if max_streak >= LOOP_TRAP_REPEATS:
+            warnings.append({
+                "type":     "loop_trap",
+                "title":    f"Possible loop trap ({max_streak}× repeated tool call)",
+                "detail":   (
+                    f"The same tool was called with identical input {max_streak} times "
+                    "consecutively. The agent may be stuck — manual intervention or a "
+                    "clearer prompt may be needed."
+                ),
+                "severity": "critical",
+            })
+
+    # 3. Tool thrash — same file read many times
+    if file_reads:
+        from collections import Counter
+        counts = Counter(file_reads)
+        thrashed = [(f, n) for f, n in counts.items() if n >= TOOL_THRASH_READS]
+        for fpath, n in sorted(thrashed, key=lambda x: -x[1])[:3]:
+            short = fpath.replace("\\", "/").split("/")[-1]
+            warnings.append({
+                "type":     "tool_thrash",
+                "title":    f'Tool thrash on "{short}" ({n}× reads)',
+                "detail":   (
+                    f'"{fpath}" was read {n} times. '
+                    "Adding it to the agent context at session start would reduce "
+                    "redundant reads and save tokens."
+                ),
+                "severity": "warning",
+            })
+
+    # 4. High error rate
+    if turns > 5 and errors > 0:
+        rate = errors / turns
+        if rate >= HIGH_ERROR_THRESHOLD:
+            warnings.append({
+                "type":     "high_error_rate",
+                "title":    f"High error rate ({errors} errors / {turns} turns = {rate:.0%})",
+                "detail":   (
+                    f"{errors} tool errors occurred across {turns} turns ({rate:.0%}). "
+                    "This often indicates a mismatch between the agent's assumptions "
+                    "and the actual environment. Check tool permissions and paths."
+                ),
+                "severity": "warning" if rate < 0.4 else "critical",
+            })
+
+    # 5. Massive session
+    if total_tok > MASSIVE_TOKEN_LIMIT:
+        m = total_tok / 1_000_000
+        warnings.append({
+            "type":     "massive_session",
+            "title":    f"Massive session ({m:.1f}M tokens)",
+            "detail":   (
+                f"This session consumed {m:.1f}M tokens. "
+                "Breaking large tasks into smaller focused sessions improves "
+                "model accuracy and reduces cost."
+            ),
+            "severity": "warning" if total_tok < 5_000_000 else "critical",
+        })
+
+    return warnings
+
+
+def _max_consecutive_repeat(items: list) -> int:
+    """Return the longest run of identical consecutive items."""
+    if not items:
+        return 0
+    max_run = current_run = 1
+    for i in range(1, len(items)):
+        if items[i] == items[i - 1]:
+            current_run += 1
+            max_run = max(max_run, current_run)
+        else:
+            current_run = 1
+    return max_run

--- a/backend/time_intel.py
+++ b/backend/time_intel.py
@@ -1,0 +1,156 @@
+"""
+time_intel.py — Time Intelligence
+
+Analyses when sessions are most efficient by bucketing on hour-of-day and
+day-of-week, then surfaces peak windows and productivity patterns.
+
+No external dependencies — pure stdlib.
+
+Returned shape
+--------------
+{
+  "by_hour": [
+    {
+      "hour":           9,              # 0–23 (UTC hour of session start)
+      "label":          "9 AM",
+      "avg_efficiency": 74.2,
+      "session_count":  5,
+      "total_tokens":   183000,
+    },
+    ...                                 # only hours that have at least one session
+  ],
+  "by_dow": [
+    {
+      "dow":            0,              # 0=Mon … 6=Sun
+      "label":          "Mon",
+      "avg_efficiency": 68.1,
+      "session_count":  8,
+      "total_tokens":   310000,
+    },
+    ...
+  ],
+  "peak_hour":   { "hour": 9, "label": "9 AM",  "avg_efficiency": 74.2 },
+  "worst_hour":  { "hour": 23, "label": "11 PM", "avg_efficiency": 18.0 },
+  "peak_dow":    { "dow": 1, "label": "Tue",     "avg_efficiency": 79.0 },
+  "worst_dow":   { "dow": 5, "label": "Sat",     "avg_efficiency": 22.0 },
+  "peak_period": "morning",             # morning | afternoon | evening | night
+  "sessions_analysed": 44,
+  "sessions_skipped":   3,             # no timestamp or no efficiency
+}
+"""
+
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import Optional
+
+_DOW_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+
+_HOUR_FMT = {
+    0: "12 AM", 1: "1 AM",  2: "2 AM",  3: "3 AM",  4: "4 AM",  5: "5 AM",
+    6: "6 AM",  7: "7 AM",  8: "8 AM",  9: "9 AM",  10: "10 AM", 11: "11 AM",
+    12: "12 PM", 13: "1 PM", 14: "2 PM", 15: "3 PM", 16: "4 PM", 17: "5 PM",
+    18: "6 PM", 19: "7 PM", 20: "8 PM", 21: "9 PM", 22: "10 PM", 23: "11 PM",
+}
+
+
+def _period(hour: int) -> str:
+    if 5 <= hour < 12:   return "morning"
+    if 12 <= hour < 17:  return "afternoon"
+    if 17 <= hour < 21:  return "evening"
+    return "night"
+
+
+def _parse_ts(ts) -> Optional[datetime]:
+    if ts is None:
+        return None
+    if isinstance(ts, datetime):
+        return ts if ts.tzinfo else ts.replace(tzinfo=timezone.utc)
+    try:
+        s = str(ts)
+        dt = datetime.fromisoformat(s.replace("Z", "+00:00"))
+        return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+    except Exception:
+        return None
+
+
+def analyse_time(sessions: list[dict]) -> dict:
+    hour_buckets: dict[int, dict] = defaultdict(lambda: {"scores": [], "tokens": 0})
+    dow_buckets:  dict[int, dict] = defaultdict(lambda: {"scores": [], "tokens": 0})
+
+    analysed = 0
+    skipped  = 0
+
+    for s in sessions:
+        eff = s.get("efficiency")
+        if eff is None:
+            skipped += 1
+            continue
+        dt = _parse_ts(s.get("timestamp"))
+        if dt is None:
+            skipped += 1
+            continue
+
+        hour = dt.hour
+        dow  = dt.weekday()   # 0=Mon
+        tok  = s.get("tokens")
+        total_tok = int(tok.get("total", 0)) if isinstance(tok, dict) else 0
+
+        hour_buckets[hour]["scores"].append(float(eff))
+        hour_buckets[hour]["tokens"] += total_tok
+        dow_buckets[dow]["scores"].append(float(eff))
+        dow_buckets[dow]["tokens"] += total_tok
+        analysed += 1
+
+    def _row_hour(h: int) -> dict:
+        b = hour_buckets[h]
+        avg = round(sum(b["scores"]) / len(b["scores"]), 1)
+        return {
+            "hour":           h,
+            "label":          _HOUR_FMT[h],
+            "avg_efficiency": avg,
+            "session_count":  len(b["scores"]),
+            "total_tokens":   b["tokens"],
+        }
+
+    def _row_dow(d: int) -> dict:
+        b = dow_buckets[d]
+        avg = round(sum(b["scores"]) / len(b["scores"]), 1)
+        return {
+            "dow":            d,
+            "label":          _DOW_LABELS[d],
+            "avg_efficiency": avg,
+            "session_count":  len(b["scores"]),
+            "total_tokens":   b["tokens"],
+        }
+
+    by_hour = sorted([_row_hour(h) for h in hour_buckets], key=lambda r: r["hour"])
+    by_dow  = sorted([_row_dow(d)  for d in dow_buckets],  key=lambda r: r["dow"])
+
+    peak_hour  = max(by_hour, key=lambda r: r["avg_efficiency"], default=None) if by_hour else None
+    worst_hour = min(by_hour, key=lambda r: r["avg_efficiency"], default=None) if by_hour else None
+    peak_dow   = max(by_dow,  key=lambda r: r["avg_efficiency"], default=None) if by_dow  else None
+    worst_dow  = min(by_dow,  key=lambda r: r["avg_efficiency"], default=None) if by_dow  else None
+
+    # Peak period — weighted average efficiency per period
+    period_scores: dict[str, list] = defaultdict(list)
+    for row in by_hour:
+        period_scores[_period(row["hour"])].extend(
+            [row["avg_efficiency"]] * row["session_count"]
+        )
+    best_period = max(
+        period_scores,
+        key=lambda p: sum(period_scores[p]) / len(period_scores[p]) if period_scores[p] else 0,
+        default="morning",
+    ) if period_scores else "morning"
+
+    return {
+        "by_hour":            by_hour,
+        "by_dow":             by_dow,
+        "peak_hour":          peak_hour,
+        "worst_hour":         worst_hour,
+        "peak_dow":           peak_dow,
+        "worst_dow":          worst_dow,
+        "peak_period":        best_period,
+        "sessions_analysed":  analysed,
+        "sessions_skipped":   skipped,
+    }

--- a/backend/tool_footprint.py
+++ b/backend/tool_footprint.py
@@ -1,0 +1,185 @@
+"""
+tool_footprint.py — Tool Footprint Intelligence
+
+Analyses how the number and composition of available tools in a session
+correlates with efficiency. Uses the mcp_tools list already stored on
+each session object.
+
+Categories
+----------
+A tool name is classified as:
+  core    — Read, Edit, Write, Glob, Grep, Bash, PowerShell (fundamental FS/shell)
+  agent   — Agent, Task*, Spawn, SubAgent  (multi-agent orchestration)
+  browser — mcp__Claude_in_Chrome__*, mcp__computer-use__*  (UI/browser)
+  mcp     — any other mcp__* tool  (third-party MCP integrations)
+  meta    — Skill, ToolSearch, Notification*, Schedule*  (harness meta-tools)
+
+No external dependencies — pure stdlib.
+
+Returned shape
+--------------
+{
+  "by_size": [
+    {
+      "bucket":         "1–5",
+      "avg_efficiency": 72.1,
+      "session_count":  6,
+      "label":          "lean",        # lean | standard | heavy | bloated
+    },
+    ...
+  ],
+  "by_category_presence": {
+    "core":    { "with": { "avg": 71.2, "n": 30 }, "without": { "avg": 41.0, "n": 14 } },
+    "agent":   { "with": ...,  "without": ... },
+    "browser": { "with": ...,  "without": ... },
+    "mcp":     { "with": ...,  "without": ... },
+    "meta":    { "with": ...,  "without": ... },
+  },
+  "top_tools": [            # tools present in the most sessions
+    { "tool": "Bash", "session_count": 38, "avg_efficiency": 65.0 },
+    ...                     # top 15
+  ],
+  "optimal_range": "1–5",   # bucket label with highest avg_efficiency
+  "sessions_analysed": 44,
+  "sessions_skipped":  3,
+}
+"""
+
+from collections import defaultdict
+from typing import Optional
+
+
+_CORE_TOOLS  = {"Read", "Edit", "Write", "Glob", "Grep", "Bash", "PowerShell"}
+_AGENT_TOOLS = {"Agent", "SubAgent", "Spawn", "TaskCreate", "TaskUpdate",
+                "TaskStop", "TaskGet", "TaskList", "TaskOutput"}
+_META_TOOLS  = {"Skill", "ToolSearch", "Notification", "ScheduleWakeup",
+                "CronCreate", "CronDelete", "CronList", "PushNotification",
+                "Monitor", "RemoteTrigger", "EnterPlanMode", "ExitPlanMode"}
+
+_BUCKETS = [
+    (1,  5,  "1–5",   "lean"),
+    (6,  15, "6–15",  "standard"),
+    (16, 30, "16–30", "heavy"),
+    (31, 999,"31+",   "bloated"),
+]
+
+
+def _categorise(tool: str) -> str:
+    if tool in _CORE_TOOLS:
+        return "core"
+    if tool in _AGENT_TOOLS:
+        return "agent"
+    if "computer-use" in tool or "Claude_in_Chrome" in tool:
+        return "browser"
+    if tool.startswith("mcp__"):
+        return "mcp"
+    return "meta"
+
+
+def _bucket_label(n: int) -> tuple[str, str]:
+    for lo, hi, label, kind in _BUCKETS:
+        if lo <= n <= hi:
+            return label, kind
+    return "31+", "bloated"
+
+
+def analyse_tool_footprint(sessions: list[dict]) -> dict:
+    size_buckets: dict[str, dict] = {}   # label -> {scores, kind}
+    for lo, hi, label, kind in _BUCKETS:
+        size_buckets[label] = {"scores": [], "kind": kind}
+
+    # per-tool: {scores: [], count: 0}
+    tool_data: dict[str, dict] = defaultdict(lambda: {"scores": [], "count": 0})
+
+    # category presence: { cat: {with: [], without: []} }
+    cat_data: dict[str, dict] = {
+        c: {"with": [], "without": []}
+        for c in ("core", "agent", "browser", "mcp", "meta")
+    }
+
+    analysed = 0
+    skipped  = 0
+
+    for s in sessions:
+        eff = s.get("efficiency")
+        if eff is None:
+            skipped += 1
+            continue
+        tools = s.get("mcp_tools") or []
+        if not isinstance(tools, list):
+            skipped += 1
+            continue
+
+        eff_f = float(eff)
+        n = len(tools)
+        bucket_label, _ = _bucket_label(n)
+        size_buckets[bucket_label]["scores"].append(eff_f)
+
+        # per-tool tracking
+        seen_cats: set[str] = set()
+        for t in tools:
+            tool_data[t]["scores"].append(eff_f)
+            tool_data[t]["count"] += 1
+            seen_cats.add(_categorise(t))
+
+        # category presence
+        for cat in cat_data:
+            if cat in seen_cats:
+                cat_data[cat]["with"].append(eff_f)
+            else:
+                cat_data[cat]["without"].append(eff_f)
+
+        analysed += 1
+
+    # Build by_size (only non-empty buckets, in order)
+    by_size = []
+    for lo, hi, label, kind in _BUCKETS:
+        b = size_buckets[label]
+        if not b["scores"]:
+            continue
+        by_size.append({
+            "bucket":         label,
+            "avg_efficiency": round(sum(b["scores"]) / len(b["scores"]), 1),
+            "session_count":  len(b["scores"]),
+            "label":          kind,
+        })
+
+    optimal_range = max(by_size, key=lambda r: r["avg_efficiency"])["bucket"] if by_size else None
+
+    # by_category_presence
+    def _stats(scores: list) -> Optional[dict]:
+        if not scores:
+            return None
+        return {"avg": round(sum(scores) / len(scores), 1), "n": len(scores)}
+
+    by_category = {}
+    for cat, d in cat_data.items():
+        if not d["with"] and not d["without"]:
+            continue
+        by_category[cat] = {
+            "with":    _stats(d["with"]),
+            "without": _stats(d["without"]),
+        }
+
+    # Top tools by session count, with avg efficiency
+    top_tools = sorted(
+        [
+            {
+                "tool":          t,
+                "session_count": d["count"],
+                "avg_efficiency": round(sum(d["scores"]) / len(d["scores"]), 1) if d["scores"] else 0,
+                "category":      _categorise(t),
+            }
+            for t, d in tool_data.items()
+        ],
+        key=lambda r: -r["session_count"],
+    )[:15]
+
+    return {
+        "by_size":              by_size,
+        "by_category_presence": by_category,
+        "top_tools":            top_tools,
+        "optimal_range":        optimal_range,
+        "sessions_analysed":    analysed,
+        "sessions_skipped":     skipped,
+    }

--- a/backend/trends.py
+++ b/backend/trends.py
@@ -1,0 +1,175 @@
+"""
+trends.py — Session Trends Intelligence
+
+Buckets sessions by calendar day and computes efficiency time-series data
+so the dashboard can show whether you're improving, steady, or declining.
+
+No external dependencies — pure stdlib.
+
+Returned shape
+--------------
+{
+  "days": [
+    {
+      "date":          "2026-05-20",      # YYYY-MM-DD
+      "avg_efficiency": 73.4,
+      "session_count":  3,
+      "total_tokens":   245000,
+      "best":           89.1,
+      "worst":          52.0,
+      "rolling_7d":     68.2,             # null for first 6 days with data
+    },
+    ...                                   # sorted ascending by date (last 60 days)
+  ],
+  "trend":           "improving",         # improving | steady | declining
+  "trend_delta":     +8.3,               # last-7d avg minus prior-7d avg
+  "overall_avg":     65.7,
+  "current_streak":  4,                   # consecutive days ending today with avg >= 60
+  "best_day":        { "date": "2026-05-28", "avg_efficiency": 89.1 },
+  "worst_day":       { "date": "2026-05-12", "avg_efficiency": 21.0 },
+  "total_sessions":  47,
+  "days_with_data":  22,
+  "week_over_week":  +8.3,               # same as trend_delta, convenience alias
+}
+"""
+
+from collections import defaultdict
+from datetime import datetime, timezone, timedelta
+from typing import Optional
+
+
+def _today_utc() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+def _date_str(ts) -> Optional[str]:
+    """Extract YYYY-MM-DD from a session timestamp (datetime or ISO string)."""
+    if ts is None:
+        return None
+    if hasattr(ts, "strftime"):
+        return ts.strftime("%Y-%m-%d")
+    try:
+        s = str(ts)
+        return s[:10] if len(s) >= 10 else None
+    except Exception:
+        return None
+
+
+def compute_trends(sessions: list[dict], days: int = 60) -> dict:
+    """
+    Compute daily efficiency trends over the last `days` calendar days.
+
+    Parameters
+    ----------
+    sessions : enriched session dicts (must have 'efficiency' and 'timestamp')
+    days     : how many calendar days back to include (default 60)
+    """
+    today = datetime.now(timezone.utc).date()
+    cutoff = today - timedelta(days=days - 1)
+
+    # Bucket: date_str -> list of efficiency scores + token totals
+    buckets: dict[str, dict] = defaultdict(lambda: {
+        "scores": [],
+        "tokens": 0,
+    })
+
+    for s in sessions:
+        eff = s.get("efficiency")
+        if eff is None:
+            continue
+        date_s = _date_str(s.get("timestamp"))
+        if not date_s:
+            continue
+        try:
+            d = datetime.strptime(date_s, "%Y-%m-%d").date()
+        except Exception:
+            continue
+        if d < cutoff or d > today:
+            continue
+        b = buckets[date_s]
+        b["scores"].append(float(eff))
+        tok = s.get("tokens")
+        if isinstance(tok, dict):
+            b["tokens"] += int(tok.get("total", 0))
+
+    # Build ordered list of all days in range (including empty days)
+    day_list = []
+    for i in range(days):
+        d = cutoff + timedelta(days=i)
+        day_list.append(d.strftime("%Y-%m-%d"))
+
+    # Build per-day rows (only include days that have data)
+    rows_with_data = []
+    for date_s in day_list:
+        b = buckets.get(date_s)
+        if not b or not b["scores"]:
+            continue
+        scores = b["scores"]
+        rows_with_data.append({
+            "date":           date_s,
+            "avg_efficiency": round(sum(scores) / len(scores), 1),
+            "session_count":  len(scores),
+            "total_tokens":   b["tokens"],
+            "best":           round(max(scores), 1),
+            "worst":          round(min(scores), 1),
+            "rolling_7d":     None,  # filled in below
+        })
+
+    # Compute 7-day rolling average (over days that have data, looking back by
+    # calendar date rather than by row index so gaps don't skew the window).
+    date_to_avg = {r["date"]: r["avg_efficiency"] for r in rows_with_data}
+    for row in rows_with_data:
+        d = datetime.strptime(row["date"], "%Y-%m-%d").date()
+        window = []
+        for j in range(7):
+            past = (d - timedelta(days=j)).strftime("%Y-%m-%d")
+            if past in date_to_avg:
+                window.append(date_to_avg[past])
+        row["rolling_7d"] = round(sum(window) / len(window), 1) if window else None
+
+    # Trend: compare last 7 data-days vs prior 7 data-days
+    recent_7 = [r["avg_efficiency"] for r in rows_with_data[-7:]]
+    prior_7  = [r["avg_efficiency"] for r in rows_with_data[-14:-7]]
+    recent_avg = sum(recent_7) / len(recent_7) if recent_7 else None
+    prior_avg  = sum(prior_7)  / len(prior_7)  if prior_7  else None
+
+    if recent_avg is not None and prior_avg is not None:
+        delta = round(recent_avg - prior_avg, 1)
+        if delta >= 5:
+            trend = "improving"
+        elif delta <= -5:
+            trend = "declining"
+        else:
+            trend = "steady"
+    else:
+        delta = 0.0
+        trend = "steady"
+
+    # Current streak: consecutive most-recent days with avg_efficiency >= 60
+    streak = 0
+    for row in reversed(rows_with_data):
+        if row["avg_efficiency"] >= 60:
+            streak += 1
+        else:
+            break
+
+    # Best / worst days
+    best_day  = max(rows_with_data, key=lambda r: r["avg_efficiency"], default=None)
+    worst_day = min(rows_with_data, key=lambda r: r["avg_efficiency"], default=None)
+
+    all_scores = [r["avg_efficiency"] for r in rows_with_data]
+    overall_avg = round(sum(all_scores) / len(all_scores), 1) if all_scores else None
+    total_sessions = sum(r["session_count"] for r in rows_with_data)
+
+    return {
+        "days":           rows_with_data,
+        "trend":          trend,
+        "trend_delta":    delta,
+        "week_over_week": delta,
+        "overall_avg":    overall_avg,
+        "current_streak": streak,
+        "best_day":       {"date": best_day["date"],  "avg_efficiency": best_day["avg_efficiency"]}  if best_day  else None,
+        "worst_day":      {"date": worst_day["date"], "avg_efficiency": worst_day["avg_efficiency"]} if worst_day else None,
+        "total_sessions": total_sessions,
+        "days_with_data": len(rows_with_data),
+    }

--- a/backend/trends.py
+++ b/backend/trends.py
@@ -143,7 +143,7 @@ def compute_trends(sessions: list[dict], days: int = 60) -> dict:
             trend = "steady"
     else:
         delta = 0.0
-        trend = "steady"
+        trend = "new"
 
     # Current streak: consecutive most-recent days with avg_efficiency >= 60
     streak = 0

--- a/frontend/src/app/intelligence/page.tsx
+++ b/frontend/src/app/intelligence/page.tsx
@@ -71,18 +71,21 @@ interface Anomaly {
 interface AnomalyResponse {
   anomalies: Anomaly[];
   total_anomalies: number;
+  affected_sessions: number;
   sessions_checked: number;
   baseline: { mean_cost: number; mean_efficiency: number; mean_tokens: number; median_cost: number };
 }
 
-interface TrendDay { date: string; avg_efficiency: number; session_count: number; rolling_7d: number | null; }
+interface TrendDay { date: string; avg_efficiency: number; session_count: number; total_tokens: number; best: number; worst: number; rolling_7d: number | null; }
 interface TrendsResponse {
   days: TrendDay[];
   trend: string;
   trend_delta: number;
+  week_over_week: number;
   overall_avg: number | null;
   current_streak: number;
   best_day: { date: string; avg_efficiency: number } | null;
+  worst_day: { date: string; avg_efficiency: number } | null;
   days_with_data: number;
   total_sessions: number;
 }
@@ -94,7 +97,7 @@ interface ModelRow {
   task_breakdown: Record<string, { count: number; avg_efficiency: number }>;
 }
 interface ModelComparisonResponse {
-  models_compared: number; sessions_used: number; sessions_skipped: number;
+  task_type_filter: string | null; models_compared: number; sessions_used: number; sessions_skipped: number;
   models: ModelRow[]; task_types_available: string[];
 }
 
@@ -105,26 +108,27 @@ interface CostModelRow {
 }
 interface CostCacheTier { tier: string; avg_efficiency: number; avg_cost: number; session_count: number; }
 interface CostWasteful { session_id: string; model: string; cost: number; efficiency: number; task_type: string; waste_score: number; }
+interface CostTaskRow { task_type: string; session_count: number; avg_cost: number; avg_efficiency: number; cost_per_eff_pt: number | null; }
 interface CostIntelResponse {
-  by_model: CostModelRow[]; cache_tiers: CostCacheTier[]; wasteful: CostWasteful[];
+  by_model: CostModelRow[]; by_task_type: CostTaskRow[]; cache_tiers: CostCacheTier[]; wasteful: CostWasteful[];
   best_value_model: string | null; total_cost: number; avg_cost_per_session: number;
-  avg_cache_hit_pct: number | null; sessions_analysed: number;
+  avg_cache_hit_pct: number | null; sessions_analysed: number; sessions_skipped: number;
 }
 
-interface TimeHourRow { hour: number; label: string; avg_efficiency: number; session_count: number; }
+interface TimeHourRow { hour: number; label: string; avg_efficiency: number; session_count: number; total_tokens: number; }
 interface TimeDowRow { dow: number; label: string; avg_efficiency: number; session_count: number; }
 interface TimeIntelResponse {
   by_hour: TimeHourRow[]; by_dow: TimeDowRow[];
   peak_hour: TimeHourRow | null; worst_hour: TimeHourRow | null;
-  peak_dow: TimeDowRow | null; peak_period: string;
-  sessions_analysed: number;
+  peak_dow: TimeDowRow | null; worst_dow: TimeDowRow | null; peak_period: string;
+  sessions_analysed: number; sessions_skipped: number;
 }
 
 interface ToolSizeBucket { bucket: string; avg_efficiency: number; session_count: number; label: string; }
 interface ToolRow { tool: string; session_count: number; avg_efficiency: number; category: string; }
 interface ToolFootprintResponse {
   by_size: ToolSizeBucket[]; top_tools: ToolRow[];
-  optimal_range: string | null; sessions_analysed: number;
+  optimal_range: string | null; sessions_analysed: number; sessions_skipped: number;
 }
 
 interface DnaCorrelation { feature: string; label: string; r: number; direction: string; insight: string; }
@@ -140,7 +144,7 @@ interface GitProjectSummary {
   project: string; branch: string | null; session_count: number;
   total_files_changed: number; total_lines_added: number; total_lines_deleted: number;
   net_lines: number; latest_commit_sha: string | null; latest_commit_msg: string | null;
-  avg_files_per_session: number;
+  latest_commit_time: string | null; avg_files_per_session: number;
 }
 interface GitSummaryResponse {
   projects: GitProjectSummary[]; total_lines_added: number; total_lines_deleted: number;
@@ -348,7 +352,7 @@ export default function IntelligencePage() {
       {(anomalyRes.data?.total_anomalies ?? 0) > 0 && (
         <Section
           title="Anomaly detection"
-          description={`${anomalyRes.data!.total_anomalies} anomalies detected across ${anomalyRes.data!.sessions_checked} sessions`}
+          description={`${anomalyRes.data!.total_anomalies} signals across ${anomalyRes.data!.affected_sessions ?? anomalyRes.data!.total_anomalies} sessions · ${anomalyRes.data!.sessions_checked} checked`}
         >
           <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
             {anomalyRes.data!.anomalies.map((a, i) => (
@@ -388,8 +392,8 @@ export default function IntelligencePage() {
       {/* ── Session Trends ────────────────────────────────────────── */}
       {(trendsRes.data?.days_with_data ?? 0) >= 2 && (() => {
         const td = trendsRes.data!;
-        const trendColor = td.trend === "improving" ? "#4ade80" : td.trend === "declining" ? "#f87171" : "#facc15";
-        const trendIcon  = td.trend === "improving" ? "↑" : td.trend === "declining" ? "↓" : "→";
+        const trendColor = td.trend === "improving" ? "#4ade80" : td.trend === "declining" ? "#f87171" : td.trend === "new" ? "#60a5fa" : "#facc15";
+        const trendIcon  = td.trend === "improving" ? "↑" : td.trend === "declining" ? "↓" : td.trend === "new" ? "✦" : "→";
         return (
           <Section
             title="Session trends"
@@ -782,7 +786,8 @@ export default function IntelligencePage() {
                       <GitCommit size={10} className="text-[var(--tt-fg-faint)] mt-0.5 shrink-0" />
                       <div className="min-w-0">
                         <span className="font-mono text-[10px] text-[var(--tt-brand)]">{p.latest_commit_sha}</span>
-                        <span className="ml-1.5 text-[10px] text-[var(--tt-fg-muted)] truncate block" title={p.latest_commit_msg ?? ""}>{p.latest_commit_msg}</span>
+                        {p.latest_commit_time && <span className="ml-1.5 text-[10px] text-[var(--tt-fg-faint)]">{new Date(p.latest_commit_time).toLocaleDateString("en-US", { month: "short", day: "numeric" })}</span>}
+                        <span className="mt-0.5 text-[10px] text-[var(--tt-fg-muted)] truncate block" title={p.latest_commit_msg ?? ""}>{p.latest_commit_msg}</span>
                       </div>
                     </div>
                   )}

--- a/frontend/src/app/intelligence/page.tsx
+++ b/frontend/src/app/intelligence/page.tsx
@@ -156,11 +156,14 @@ interface GitSummaryResponse {
 const effColor  = (v: number) => v >= 70 ? "#4ade80" : v >= 40 ? "#facc15" : "#f87171";
 const barFill   = effColor;
 const fmtCost   = (v: number) => v >= 1 ? `$${v.toFixed(2)}` : `$${v.toFixed(4)}`;
-const fmtCpp    = (v: number | null) => v === null ? "—" : v < 0.01 ? `$${v.toFixed(5)}/pt` : `$${v.toFixed(3)}/pt`;
+const fmtCpp    = (v: number | null) => v === null ? "—" : v < 0.01 ? `$${v.toFixed(5)} /quality pt` : `$${v.toFixed(3)} /quality pt`;
 const shortProj = (p: string) => p.split(/[/\\]/).pop() || p;
 
 const PRIORITY_COLOR: Record<string, string> = {
   high: "#f87171", medium: "#facc15", low: "#4ade80",
+};
+const PRIORITY_LABEL: Record<string, string> = {
+  high: "Urgent", medium: "Suggested", low: "Optional",
 };
 const CAT_ICON: Record<string, React.ReactNode> = {
   cost:    <DollarSign size={13} />,
@@ -170,15 +173,46 @@ const CAT_ICON: Record<string, React.ReactNode> = {
   tools:   <Wrench size={13} />,
   health:  <Activity size={13} />,
 };
+const CAT_LABEL: Record<string, string> = {
+  cost: "Cost", quality: "Quality", timing: "Timing",
+  prompt: "Prompt style", tools: "Tools", health: "Health",
+};
 const ANOMALY_ICON: Record<string, React.ReactNode> = {
   cost_spike:       <DollarSign size={13} className="text-red-400" />,
   efficiency_crash: <TrendingDown size={13} className="text-red-400" />,
   token_overflow:   <Zap size={13} className="text-yellow-400" />,
   waste:            <AlertTriangle size={13} className="text-red-400" />,
 };
+const ANOMALY_LABEL: Record<string, string> = {
+  cost_spike:       "Unusually expensive",
+  efficiency_crash: "Very low quality",
+  token_overflow:   "Used way too many tokens",
+  waste:            "High cost, poor results",
+};
+const TREND_LABEL: Record<string, string> = {
+  improving: "Getting better", declining: "Going down",
+  steady: "Consistent", new: "Just started",
+};
+const SIZE_LABEL: Record<string, string> = {
+  lean:     "Minimal (1–10)",
+  standard: "Normal (11–20)",
+  heavy:    "Extended (21–30)",
+  bloated:  "Full toolkit (31+)",
+};
+const TOOL_CAT_LABEL: Record<string, string> = {
+  core: "built-in", agent: "agent", browser: "web", mcp: "plugin", meta: "system",
+};
 const GRADE_COLOR: Record<string, string> = {
   A: "#4ade80", B: "#60a5fa", C: "#facc15", D: "#fb923c", F: "#f87171",
 };
+
+function rStrength(r: number): { label: string; color: string } {
+  const abs = Math.abs(r);
+  if (abs >= 0.7) return { label: "Very strong link", color: r > 0 ? "#4ade80" : "#f87171" };
+  if (abs >= 0.5) return { label: "Strong link",      color: r > 0 ? "#86efac" : "#fca5a5" };
+  if (abs >= 0.3) return { label: "Moderate link",    color: r > 0 ? "#a3e635" : "#fb923c" };
+  return             { label: "Weak link",             color: "#94a3b8" };
+}
 
 // ── Page ──────────────────────────────────────────────────────────────────────
 
@@ -230,7 +264,7 @@ export default function IntelligencePage() {
       <PageHeader
         eyebrow="Intelligence Layer"
         title="Intelligence"
-        description="Cross-session analytics, recommendations, and health signals across all your AI coding agents."
+        description="Understand how well your AI agents are working — spot problems, find patterns, and get suggestions to improve."
         icon={<Brain size={20} strokeWidth={2.25} />}
         actions={
           <Badge variant="success" size="sm" className="h-9 px-2.5">
@@ -243,11 +277,21 @@ export default function IntelligencePage() {
         }
       />
 
+      {/* Quality score legend */}
+      <div className="px-4 py-3 rounded-xl bg-[var(--tt-surface-raised)] border border-[var(--tt-border)] flex items-center gap-3 text-xs text-[var(--tt-fg-muted)]">
+        <div className="w-20 h-2 rounded-full shrink-0" style={{ background: "linear-gradient(to right, #f87171, #facc15, #4ade80)" }} />
+        <span>
+          <span className="font-semibold text-[var(--tt-fg)]">Quality score (0–100):</span>
+          {" "}measures how effectively your AI session used its budget to get results — considers tokens, cost, errors, and output quality.
+          {" "}<span className="text-emerald-400">Green ≥70 = great</span> · <span className="text-yellow-400">Yellow 40–69 = average</span> · <span className="text-red-400">Red &lt;40 = poor</span>
+        </span>
+      </div>
+
       {/* ── Recommendations ──────────────────────────────────────── */}
       {(recRes.data?.total ?? 0) > 0 && (
         <Section
-          title="Recommendations"
-          description={`${recRes.data!.total} actionable insights · ${recRes.data!.high_count} high priority`}
+          title="Suggested improvements"
+          description={`${recRes.data!.total} things to try · ${recRes.data!.high_count} urgent · tap any card for details`}
         >
           <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
             {recRes.data!.recommendations.map((rec) => (
@@ -258,15 +302,15 @@ export default function IntelligencePage() {
                       {CAT_ICON[rec.category] ?? <Activity size={13} />}
                     </span>
                     <span
-                      className="text-[10px] px-1.5 py-0.5 rounded-full capitalize font-semibold"
+                      className="text-[10px] px-1.5 py-0.5 rounded-full font-semibold"
                       style={{
                         background: (PRIORITY_COLOR[rec.priority] ?? "#94a3b8") + "22",
                         color: PRIORITY_COLOR[rec.priority] ?? "#94a3b8",
                       }}
                     >
-                      {rec.priority}
+                      {PRIORITY_LABEL[rec.priority] ?? rec.priority}
                     </span>
-                    <span className="text-[10px] text-[var(--tt-fg-faint)] capitalize">{rec.category}</span>
+                    <span className="text-[10px] text-[var(--tt-fg-faint)]">{CAT_LABEL[rec.category] ?? rec.category}</span>
                   </div>
                   {rec.impact && (
                     <span className="text-[10px] text-emerald-400 font-semibold shrink-0">{rec.impact}</span>
@@ -283,8 +327,8 @@ export default function IntelligencePage() {
       {/* ── Project Health ────────────────────────────────────────── */}
       {(healthRes.data?.total_projects ?? 0) >= 2 && (
         <Section
-          title="Project health"
-          description={`${healthRes.data!.total_projects} projects · ${healthRes.data!.healthy_projects} healthy · ${healthRes.data!.at_risk_projects} at risk`}
+          title="Project health scores"
+          description={`How well your AI sessions are going for each project — ${healthRes.data!.total_projects} projects · ${healthRes.data!.healthy_projects} doing well · ${healthRes.data!.at_risk_projects} need attention`}
         >
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
             {healthRes.data!.projects.map((p) => {
@@ -318,10 +362,10 @@ export default function IntelligencePage() {
                   {/* Components */}
                   <div className="grid grid-cols-2 gap-x-3 gap-y-1">
                     {([
-                      ["Efficiency", p.components.efficiency],
-                      ["Smell-free", p.components.smell_free],
-                      ["Trend",      p.components.recent_trend],
-                      ["Cost value", p.components.cost_value],
+                      ["Work quality",    p.components.efficiency],
+                      ["Consistency",     p.components.smell_free],
+                      ["Getting better",  p.components.recent_trend],
+                      ["Cost value",      p.components.cost_value],
                     ] as [string, number][]).map(([label, val]) => (
                       <div key={label} className="flex items-center justify-between text-[10px]">
                         <span className="text-[var(--tt-fg-faint)]">{label}</span>
@@ -337,7 +381,7 @@ export default function IntelligencePage() {
                       {p.trend === "down" && <TrendingDown size={10} className="text-red-400" />}
                       {p.trend === "flat" && <Minus size={10} className="text-[var(--tt-fg-faint)]" />}
                       <span className="text-[var(--tt-fg-muted)]">
-                        {p.recent_efficiency !== null ? `${p.recent_efficiency} recent` : "no recent data"}
+                        {p.recent_efficiency !== null ? `Recent quality: ${p.recent_efficiency}/100` : "no recent data"}
                       </span>
                     </div>
                   )}
@@ -351,8 +395,8 @@ export default function IntelligencePage() {
       {/* ── Anomaly Detection ─────────────────────────────────────── */}
       {(anomalyRes.data?.total_anomalies ?? 0) > 0 && (
         <Section
-          title="Anomaly detection"
-          description={`${anomalyRes.data!.total_anomalies} signals across ${anomalyRes.data!.affected_sessions ?? anomalyRes.data!.total_anomalies} sessions · ${anomalyRes.data!.sessions_checked} checked`}
+          title="Unusual sessions"
+          description={`Found ${anomalyRes.data!.total_anomalies} unusual events in ${anomalyRes.data!.affected_sessions ?? anomalyRes.data!.total_anomalies} of your ${anomalyRes.data!.sessions_checked} sessions — these stand out from your normal patterns`}
         >
           <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
             {anomalyRes.data!.anomalies.map((a, i) => (
@@ -361,20 +405,20 @@ export default function IntelligencePage() {
                   <div className="flex items-center gap-2">
                     {ANOMALY_ICON[a.type] ?? <AlertCircle size={13} className="text-yellow-400" />}
                     <span
-                      className={`text-[10px] px-1.5 py-0.5 rounded-full font-semibold capitalize ${
+                      className={`text-[10px] px-1.5 py-0.5 rounded-full font-semibold ${
                         a.severity === "critical"
                           ? "bg-red-500/20 text-red-400"
                           : "bg-yellow-500/20 text-yellow-400"
                       }`}
                     >
-                      {a.severity}
+                      {a.severity === "critical" ? "Serious" : "Watch out"}
                     </span>
-                    <span className="text-[10px] text-[var(--tt-fg-faint)] capitalize">
-                      {a.type.replace(/_/g, " ")}
+                    <span className="text-[10px] text-[var(--tt-fg-faint)]">
+                      {ANOMALY_LABEL[a.type] ?? a.type.replace(/_/g, " ")}
                     </span>
                   </div>
                   {a.z_score !== null && (
-                    <span className="text-[10px] font-mono text-[var(--tt-fg-faint)]">{a.z_score.toFixed(1)}σ</span>
+                    <span className="text-[10px] font-mono text-[var(--tt-fg-faint)]">{a.z_score.toFixed(1)}× above normal</span>
                   )}
                 </div>
                 <div className="text-[12px] text-[var(--tt-fg)] leading-snug">{a.detail}</div>
@@ -396,8 +440,8 @@ export default function IntelligencePage() {
         const trendIcon  = td.trend === "improving" ? "↑" : td.trend === "declining" ? "↓" : td.trend === "new" ? "✦" : "→";
         return (
           <Section
-            title="Session trends"
-            description={`Efficiency over the last ${trendsDays} days · ${td.days_with_data} active days · ${td.total_sessions} sessions`}
+            title="Your quality over time"
+            description={`How well your AI sessions have performed over the last ${trendsDays} days · ${td.days_with_data} active days · ${td.total_sessions} sessions`}
           >
             <Card className="space-y-4">
               <div className="flex flex-wrap items-center gap-3">
@@ -406,25 +450,25 @@ export default function IntelligencePage() {
                   style={{ background: trendColor + "22", color: trendColor, border: `1px solid ${trendColor}44` }}
                 >
                   <span className="text-sm leading-none">{trendIcon}</span>
-                  <span className="capitalize">{td.trend}</span>
+                  <span>{TREND_LABEL[td.trend] ?? td.trend}</span>
                   {Math.abs(td.trend_delta) >= 1 && (
-                    <span className="opacity-80 font-mono">{td.trend_delta > 0 ? "+" : ""}{td.trend_delta.toFixed(1)} pts WoW</span>
+                    <span className="opacity-80 font-mono">{td.trend_delta > 0 ? "+" : ""}{td.trend_delta.toFixed(1)} pts vs last week</span>
                   )}
                 </div>
                 {td.overall_avg !== null && (
                   <div className="text-xs text-[var(--tt-fg-muted)] px-2 py-1 rounded bg-[var(--tt-surface-raised)]">
-                    Avg <span className="font-semibold text-[var(--tt-fg)]">{td.overall_avg.toFixed(1)}</span>
+                    Average quality: <span className="font-semibold text-[var(--tt-fg)]">{td.overall_avg.toFixed(0)}/100</span>
                   </div>
                 )}
                 {td.current_streak >= 2 && (
                   <div className="flex items-center gap-1 text-xs px-2 py-1 rounded bg-[var(--tt-surface-raised)] text-amber-400">
                     <Flame size={11} /><span className="font-semibold">{td.current_streak}d</span>
-                    <span className="text-[var(--tt-fg-faint)]">streak</span>
+                    <span className="text-[var(--tt-fg-faint)]">good-day streak</span>
                   </div>
                 )}
                 {td.best_day && (
                   <div className="text-xs text-[var(--tt-fg-muted)] px-2 py-1 rounded bg-[var(--tt-surface-raised)]">
-                    Best <span className="font-semibold text-emerald-400">{td.best_day.avg_efficiency.toFixed(1)}</span>
+                    Best day: <span className="font-semibold text-emerald-400">{td.best_day.avg_efficiency.toFixed(0)}/100</span>
                     <span className="ml-1 text-[var(--tt-fg-faint)]">on {formatDate(td.best_day.date)}</span>
                   </div>
                 )}
@@ -448,8 +492,8 @@ export default function IntelligencePage() {
                     <ReTooltip contentStyle={{ background: "var(--tt-surface)", border: "1px solid var(--tt-border)", borderRadius: 8, fontSize: 12, color: "var(--tt-fg)" }}
                       labelFormatter={(l) => formatDate(String(l))}
                       formatter={(value, name) => {
-                        const v = typeof value === "number" ? value.toFixed(1) : String(value);
-                        return [v, name === "avg_efficiency" ? "Avg efficiency" : "7d rolling avg"];
+                        const v = typeof value === "number" ? `${value.toFixed(0)}/100` : String(value);
+                        return [v, name === "avg_efficiency" ? "Quality score" : "7-day trend line"];
                       }} />
                     <ReferenceLine y={60} stroke="var(--tt-fg-faint)" strokeDasharray="4 4" strokeOpacity={0.5} />
                     <Bar dataKey="avg_efficiency" radius={[3, 3, 0, 0]} maxBarSize={32}>
@@ -460,11 +504,11 @@ export default function IntelligencePage() {
                 </ResponsiveContainer>
               </div>
               <div className="flex items-center gap-4 text-[10px] text-[var(--tt-fg-faint)]">
-                {[["#4ade80","Good (≥70)"],["#facc15","Fair (40–69)"],["#f87171","Poor (<40)"]].map(([c,l])=>(
+                {[["#4ade80","Excellent (≥70)"],["#facc15","Average (40–69)"],["#f87171","Needs work (<40)"]].map(([c,l])=>(
                   <div key={l} className="flex items-center gap-1.5"><div className="w-3 h-3 rounded-sm opacity-85" style={{background:c}}/>{l}</div>
                 ))}
                 <div className="flex items-center gap-1.5 ml-2">
-                  <div className="w-6 h-0.5 rounded" style={{background:"var(--tt-brand)"}}/> 7d rolling avg
+                  <div className="w-6 h-0.5 rounded" style={{background:"var(--tt-brand)"}}/> 7-day trend line
                 </div>
               </div>
             </Card>
@@ -475,8 +519,8 @@ export default function IntelligencePage() {
       {/* ── Model Comparison ──────────────────────────────────────── */}
       {modelComparison && modelComparison.models_compared > 0 && (
         <Section
-          title="Model comparison"
-          description={`${modelComparison.models_compared} models · ${modelComparison.sessions_used} sessions`}
+          title="Which AI model works best for you"
+          description={`Ranking ${modelComparison.models_compared} AI models across ${modelComparison.sessions_used} real sessions — quality score shows how well each model actually got things done`}
         >
           <Card className="space-y-4">
             {/* Task filter pills */}
@@ -487,7 +531,7 @@ export default function IntelligencePage() {
                   style={{
                     background: modelTaskFilter === tt ? "var(--tt-brand)" : "var(--tt-surface-raised)",
                     color: modelTaskFilter === tt ? "var(--tt-bg)" : "var(--tt-fg-muted)",
-                  }}>{tt === "all" ? "All tasks" : tt}</button>
+                  }}>{tt === "all" ? "All task types" : tt}</button>
               ))}
             </div>
             {/* Model rows */}
@@ -497,19 +541,25 @@ export default function IntelligencePage() {
                   <div className="flex items-center gap-2">
                     <span className="text-[10px] text-[var(--tt-fg-faint)] w-4 tabular shrink-0">#{i + 1}</span>
                     <span className="font-mono text-[12px] text-[var(--tt-fg)] flex-1 truncate">{m.model}</span>
-                    <span className="text-[10px] text-[var(--tt-fg-faint)]">×{m.session_count}</span>
-                    <span className="font-mono text-[12px] tabular shrink-0" style={{ color: effColor(m.avg_efficiency) }}>{m.avg_efficiency.toFixed(1)}</span>
+                    <span className="text-[10px] text-[var(--tt-fg-faint)]">{m.session_count} sessions</span>
+                    <span className="font-mono text-[12px] tabular shrink-0" style={{ color: effColor(m.avg_efficiency) }}>
+                      {m.avg_efficiency.toFixed(0)}<span className="text-[10px] opacity-60">/100</span>
+                    </span>
                   </div>
                   <div className="flex gap-1 h-2">
-                    <div className="flex-1 bg-[var(--tt-surface-raised)] rounded overflow-hidden">
+                    <div className="flex-1 bg-[var(--tt-surface-raised)] rounded overflow-hidden" title="Average quality">
                       <div className="h-full rounded" style={{ width: `${m.avg_efficiency}%`, background: effColor(m.avg_efficiency), opacity: 0.7 }} />
                     </div>
-                    <div className="flex-1 bg-[var(--tt-surface-raised)] rounded overflow-hidden">
+                    <div className="flex-1 bg-[var(--tt-surface-raised)] rounded overflow-hidden" title="Top 25% quality">
                       <div className="h-full rounded" style={{ width: `${m.p75_efficiency}%`, background: effColor(m.p75_efficiency), opacity: 0.45 }} />
                     </div>
                   </div>
                 </div>
               ))}
+            </div>
+            <div className="flex items-center gap-4 text-[10px] text-[var(--tt-fg-faint)]">
+              <div className="flex items-center gap-1.5"><div className="w-8 h-2 rounded opacity-70 bg-emerald-400" /> Average quality (left bar)</div>
+              <div className="flex items-center gap-1.5"><div className="w-8 h-2 rounded opacity-45 bg-emerald-400" /> Best 25% sessions (right bar)</div>
             </div>
           </Card>
         </Section>
@@ -518,36 +568,42 @@ export default function IntelligencePage() {
       {/* ── Prompt DNA ────────────────────────────────────────────── */}
       {dnaRes.data && dnaRes.data.sessions_analysed >= 3 && (
         <Section
-          title="Prompt DNA"
-          description={`${dnaRes.data.sessions_analysed} sessions analysed · prompt structure vs efficiency correlations`}
+          title="What makes your prompts work"
+          description={`Patterns found in ${dnaRes.data.sessions_analysed} sessions — these prompt habits consistently lead to better or worse AI results`}
         >
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
             <Card className="space-y-3">
-              <div className="text-xs font-semibold text-emerald-400 uppercase tracking-wide">Boosts efficiency</div>
+              <div className="text-xs font-semibold text-emerald-400 uppercase tracking-wide">What works well</div>
               <div className="space-y-2">
-                {dnaRes.data.top_positive.slice(0, 3).map((c) => (
-                  <div key={c.feature} className="space-y-1">
-                    <div className="flex items-center justify-between text-xs">
-                      <span className="text-[var(--tt-fg-muted)]">{c.label}</span>
-                      <span className="font-mono text-emerald-400">r={c.r.toFixed(2)}</span>
+                {dnaRes.data.top_positive.slice(0, 3).map((c) => {
+                  const { label: rl, color: rc } = rStrength(c.r);
+                  return (
+                    <div key={c.feature} className="space-y-1">
+                      <div className="flex items-center justify-between text-xs gap-2">
+                        <span className="text-[var(--tt-fg-muted)]">{c.label}</span>
+                        <span className="text-[10px] px-1.5 py-0.5 rounded-full shrink-0" style={{ background: rc + "22", color: rc }}>{rl}</span>
+                      </div>
+                      <div className="text-[11px] text-[var(--tt-fg-faint)]">{c.insight}</div>
                     </div>
-                    <div className="text-[11px] text-[var(--tt-fg-faint)]">{c.insight}</div>
-                  </div>
-                ))}
+                  );
+                })}
               </div>
             </Card>
             <Card className="space-y-3">
-              <div className="text-xs font-semibold text-red-400 uppercase tracking-wide">Hurts efficiency</div>
+              <div className="text-xs font-semibold text-red-400 uppercase tracking-wide">What to avoid</div>
               <div className="space-y-2">
-                {dnaRes.data.top_negative.slice(0, 3).map((c) => (
-                  <div key={c.feature} className="space-y-1">
-                    <div className="flex items-center justify-between text-xs">
-                      <span className="text-[var(--tt-fg-muted)]">{c.label}</span>
-                      <span className="font-mono text-red-400">r={c.r.toFixed(2)}</span>
+                {dnaRes.data.top_negative.slice(0, 3).map((c) => {
+                  const { label: rl, color: rc } = rStrength(c.r);
+                  return (
+                    <div key={c.feature} className="space-y-1">
+                      <div className="flex items-center justify-between text-xs gap-2">
+                        <span className="text-[var(--tt-fg-muted)]">{c.label}</span>
+                        <span className="text-[10px] px-1.5 py-0.5 rounded-full shrink-0" style={{ background: rc + "22", color: rc }}>{rl}</span>
+                      </div>
+                      <div className="text-[11px] text-[var(--tt-fg-faint)]">{c.insight}</div>
                     </div>
-                    <div className="text-[11px] text-[var(--tt-fg-faint)]">{c.insight}</div>
-                  </div>
-                ))}
+                  );
+                })}
               </div>
             </Card>
           </div>
@@ -560,13 +616,13 @@ export default function IntelligencePage() {
         const maxCpp = Math.max(...ci.by_model.filter(r => r.cost_per_eff_pt !== null).map(r => r.cost_per_eff_pt as number), 0.001);
         return (
           <Section
-            title="Cost intelligence"
-            description={`${fmtCost(ci.total_cost)} total · ${ci.sessions_analysed} sessions · ${ci.avg_cache_hit_pct?.toFixed(0) ?? "—"}% avg cache hit`}
+            title="Cost breakdown"
+            description={`${fmtCost(ci.total_cost)} total spent · ${ci.sessions_analysed} sessions · ${ci.avg_cache_hit_pct?.toFixed(0) ?? "—"}% of tokens served from cache`}
           >
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
               <Card className="space-y-3">
                 <div className="text-xs font-semibold text-[var(--tt-fg-dim)] uppercase tracking-wide">
-                  Cost per efficiency point <span className="normal-case font-normal text-[var(--tt-fg-faint)]">(lower = better)</span>
+                  Value for money by model <span className="normal-case font-normal text-[var(--tt-fg-faint)]">(shorter bar = better deal)</span>
                 </div>
                 <div className="space-y-2.5">
                   {ci.by_model.map((m) => (
@@ -577,7 +633,7 @@ export default function IntelligencePage() {
                           <span className="text-[10px] text-[var(--tt-fg-faint)]">×{m.session_count}</span>
                         </div>
                         <div className="flex items-center gap-3 shrink-0 ml-2">
-                          <span className="text-[10px]" style={{ color: effColor(m.avg_efficiency) }}>{m.avg_efficiency.toFixed(1)} eff</span>
+                          <span className="text-[10px]" style={{ color: effColor(m.avg_efficiency) }}>Quality: {m.avg_efficiency.toFixed(0)}/100</span>
                           <span className="text-[11px] font-mono tabular">{fmtCpp(m.cost_per_eff_pt)}</span>
                         </div>
                       </div>
@@ -597,7 +653,7 @@ export default function IntelligencePage() {
               <div className="space-y-4">
                 {ci.cache_tiers.length >= 2 && (
                   <Card className="space-y-3">
-                    <div className="text-xs font-semibold text-[var(--tt-fg-dim)] uppercase tracking-wide">Cache hit rate vs efficiency</div>
+                    <div className="text-xs font-semibold text-[var(--tt-fg-dim)] uppercase tracking-wide">Prompt memory reuse — does it affect quality?</div>
                     <div className="space-y-1.5">
                       {ci.cache_tiers.map((t) => (
                         <div key={t.tier} className="flex items-center gap-2">
@@ -616,7 +672,7 @@ export default function IntelligencePage() {
                 {ci.wasteful.length > 0 && (
                   <Card className="space-y-3">
                     <div className="text-xs font-semibold text-[var(--tt-fg-dim)] uppercase tracking-wide flex items-center gap-1.5">
-                      <AlertTriangle size={11} className="text-red-400" /> Expensive flops
+                      <AlertTriangle size={11} className="text-red-400" /> Money spent, poor results
                     </div>
                     <div className="space-y-2">
                       {ci.wasteful.map((w) => (
@@ -624,7 +680,7 @@ export default function IntelligencePage() {
                           <span className="font-mono text-[10px] text-[var(--tt-fg-faint)] shrink-0">{w.session_id.slice(0, 8)}</span>
                           <span className="font-mono text-[10px] text-[var(--tt-fg)] truncate flex-1">{w.model}</span>
                           <span className="text-[11px] font-mono text-red-400 tabular shrink-0">{fmtCost(w.cost)}</span>
-                          <span className="text-[10px] tabular shrink-0" style={{ color: effColor(w.efficiency) }}>{w.efficiency.toFixed(1)}</span>
+                          <span className="text-[10px] tabular shrink-0" style={{ color: effColor(w.efficiency) }}>quality: {w.efficiency.toFixed(0)}/100</span>
                         </div>
                       ))}
                     </div>
@@ -640,37 +696,37 @@ export default function IntelligencePage() {
       {(timeRes.data?.sessions_analysed ?? 0) >= 3 && (() => {
         const ti = timeRes.data!;
         return (
-          <Section title="Time intelligence" description={`When you code best · ${ti.sessions_analysed} sessions`}>
+          <Section title="Best time to use AI" description={`When your AI sessions score highest — based on ${ti.sessions_analysed} sessions. Use this to schedule your important work.`}>
             <div className="flex flex-wrap gap-3 mb-4">
               {ti.peak_hour && (
                 <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-[var(--tt-surface-raised)] text-xs">
-                  <span className="text-emerald-400 font-semibold">Peak hour</span>
+                  <span className="text-emerald-400 font-semibold">Best hour</span>
                   <span className="font-mono text-[var(--tt-fg)]">{ti.peak_hour.label}</span>
-                  <span className="text-[var(--tt-fg-faint)]">{ti.peak_hour.avg_efficiency.toFixed(1)} avg</span>
+                  <span className="text-[var(--tt-fg-faint)]">score: {ti.peak_hour.avg_efficiency.toFixed(0)}/100</span>
                 </div>
               )}
               {ti.peak_dow && (
                 <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-[var(--tt-surface-raised)] text-xs">
-                  <span className="text-emerald-400 font-semibold">Peak day</span>
+                  <span className="text-emerald-400 font-semibold">Best day</span>
                   <span className="font-mono text-[var(--tt-fg)]">{ti.peak_dow.label}</span>
-                  <span className="text-[var(--tt-fg-faint)]">{ti.peak_dow.avg_efficiency.toFixed(1)} avg</span>
+                  <span className="text-[var(--tt-fg-faint)]">score: {ti.peak_dow.avg_efficiency.toFixed(0)}/100</span>
                 </div>
               )}
               <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-[var(--tt-surface-raised)] text-xs">
-                <span className="text-[var(--tt-fg-muted)]">Best period</span>
+                <span className="text-[var(--tt-fg-muted)]">Best time of day</span>
                 <span className="font-semibold capitalize">{periodEmoji[ti.peak_period] ?? ""} {ti.peak_period}</span>
               </div>
               {ti.worst_hour && (
                 <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-[var(--tt-surface-raised)] text-xs">
-                  <span className="text-red-400 font-semibold">Avoid</span>
+                  <span className="text-red-400 font-semibold">Worst hour</span>
                   <span className="font-mono text-[var(--tt-fg)]">{ti.worst_hour.label}</span>
-                  <span className="text-[var(--tt-fg-faint)]">{ti.worst_hour.avg_efficiency.toFixed(1)} avg</span>
+                  <span className="text-[var(--tt-fg-faint)]">score: {ti.worst_hour.avg_efficiency.toFixed(0)}/100</span>
                 </div>
               )}
             </div>
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
               <Card className="space-y-2">
-                <div className="text-xs font-semibold text-[var(--tt-fg-dim)] uppercase tracking-wide">By hour of day</div>
+                <div className="text-xs font-semibold text-[var(--tt-fg-dim)] uppercase tracking-wide">Quality score by hour of day</div>
                 <div style={{ height: 180 }}>
                   <ResponsiveContainer width="100%" height="100%">
                     <ComposedChart data={ti.by_hour} margin={{ top: 4, right: 4, bottom: 0, left: -20 }}>
@@ -678,7 +734,7 @@ export default function IntelligencePage() {
                       <XAxis dataKey="label" tick={{ fill: "var(--tt-fg-faint)", fontSize: 9 }} tickLine={false} axisLine={false} interval={0} angle={-45} textAnchor="end" height={36} />
                       <YAxis domain={[0, 100]} tick={{ fill: "var(--tt-fg-faint)", fontSize: 9 }} tickLine={false} axisLine={false} tickCount={4} />
                       <ReTooltip contentStyle={{ background: "var(--tt-surface)", border: "1px solid var(--tt-border)", borderRadius: 8, fontSize: 11, color: "var(--tt-fg)" }}
-                        formatter={(v, n) => [typeof v === "number" ? v.toFixed(1) : v, n === "avg_efficiency" ? "Avg efficiency" : String(n)]} />
+                        formatter={(v, n) => [typeof v === "number" ? `${v.toFixed(0)}/100` : v, n === "avg_efficiency" ? "Average quality" : String(n)]} />
                       <ReferenceLine y={60} stroke="var(--tt-fg-faint)" strokeDasharray="4 4" strokeOpacity={0.4} />
                       <Bar dataKey="avg_efficiency" radius={[3, 3, 0, 0]} maxBarSize={28}>
                         {ti.by_hour.map((row) => <Cell key={row.hour} fill={barFill(row.avg_efficiency)} fillOpacity={0.85} />)}
@@ -688,7 +744,7 @@ export default function IntelligencePage() {
                 </div>
               </Card>
               <Card className="space-y-2">
-                <div className="text-xs font-semibold text-[var(--tt-fg-dim)] uppercase tracking-wide">By day of week</div>
+                <div className="text-xs font-semibold text-[var(--tt-fg-dim)] uppercase tracking-wide">Quality score by day of week</div>
                 <div style={{ height: 180 }}>
                   <ResponsiveContainer width="100%" height="100%">
                     <ComposedChart data={ti.by_dow} margin={{ top: 4, right: 4, bottom: 0, left: -20 }}>
@@ -696,7 +752,7 @@ export default function IntelligencePage() {
                       <XAxis dataKey="label" tick={{ fill: "var(--tt-fg-faint)", fontSize: 10 }} tickLine={false} axisLine={false} />
                       <YAxis domain={[0, 100]} tick={{ fill: "var(--tt-fg-faint)", fontSize: 9 }} tickLine={false} axisLine={false} tickCount={4} />
                       <ReTooltip contentStyle={{ background: "var(--tt-surface)", border: "1px solid var(--tt-border)", borderRadius: 8, fontSize: 11, color: "var(--tt-fg)" }}
-                        formatter={(v, n) => [typeof v === "number" ? v.toFixed(1) : v, n === "avg_efficiency" ? "Avg efficiency" : String(n)]} />
+                        formatter={(v, n) => [typeof v === "number" ? `${v.toFixed(0)}/100` : v, n === "avg_efficiency" ? "Average quality" : String(n)]} />
                       <ReferenceLine y={60} stroke="var(--tt-fg-faint)" strokeDasharray="4 4" strokeOpacity={0.4} />
                       <Bar dataKey="avg_efficiency" radius={[3, 3, 0, 0]} maxBarSize={40}>
                         {ti.by_dow.map((row) => <Cell key={row.dow} fill={barFill(row.avg_efficiency)} fillOpacity={0.85} />)}
@@ -714,12 +770,12 @@ export default function IntelligencePage() {
       {(toolRes.data?.sessions_analysed ?? 0) >= 3 && (() => {
         const tf = toolRes.data!;
         return (
-          <Section title="Tool footprint" description={`Toolset size and composition vs efficiency · ${tf.sessions_analysed} sessions`}>
+          <Section title="How many tools makes AI better?" description={`Does giving your AI more tools improve results? Based on ${tf.sessions_analysed} sessions — longer bar = higher quality`}>
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
               <Card className="space-y-3">
                 <div className="text-xs font-semibold text-[var(--tt-fg-dim)] uppercase tracking-wide">
-                  Efficiency by toolset size
-                  {tf.optimal_range && <span className="ml-2 normal-case font-normal text-[var(--tt-fg-faint)]">· optimal: <span className="font-semibold text-[var(--tt-fg)]">{tf.optimal_range} tools</span></span>}
+                  Quality score by number of tools
+                  {tf.optimal_range && <span className="ml-2 normal-case font-normal text-[var(--tt-fg-faint)]">· sweet spot: <span className="font-semibold text-[var(--tt-fg)]">{tf.optimal_range} tools</span></span>}
                 </div>
                 <div className="space-y-2">
                   {tf.by_size.map((b) => (
@@ -728,26 +784,30 @@ export default function IntelligencePage() {
                       <div className="flex-1 h-5 bg-[var(--tt-surface-raised)] rounded overflow-hidden">
                         <div className="h-full rounded" style={{ width: `${b.avg_efficiency}%`, background: sizeColor[b.label] ?? "#60a5fa", opacity: 0.8 }} />
                       </div>
-                      <div className="w-10 text-right text-[11px] font-mono tabular shrink-0">{b.avg_efficiency.toFixed(1)}</div>
-                      <div className="w-8 text-right text-[10px] text-[var(--tt-fg-faint)] tabular shrink-0">{b.session_count}s</div>
-                      <span className="text-[10px] px-1.5 py-0.5 rounded-full capitalize shrink-0"
-                        style={{ background: (sizeColor[b.label] ?? "#60a5fa") + "22", color: sizeColor[b.label] ?? "#60a5fa" }}>{b.label}</span>
+                      <div className="w-10 text-right text-[11px] font-mono tabular shrink-0">{b.avg_efficiency.toFixed(0)}</div>
+                      <div className="w-8 text-right text-[10px] text-[var(--tt-fg-faint)] tabular shrink-0">{b.session_count}×</div>
+                      <span className="text-[10px] px-1.5 py-0.5 rounded-full shrink-0"
+                        style={{ background: (sizeColor[b.label] ?? "#60a5fa") + "22", color: sizeColor[b.label] ?? "#60a5fa" }}>
+                        {SIZE_LABEL[b.label] ?? b.label}
+                      </span>
                     </div>
                   ))}
                 </div>
               </Card>
               <Card className="space-y-3">
-                <div className="text-xs font-semibold text-[var(--tt-fg-dim)] uppercase tracking-wide">Top tools by frequency</div>
+                <div className="text-xs font-semibold text-[var(--tt-fg-dim)] uppercase tracking-wide">Tools your AI uses most</div>
                 <div className="space-y-1 overflow-y-auto" style={{ maxHeight: 220 }}>
                   {tf.top_tools.map((t, i) => (
                     <div key={t.tool} className="flex items-center gap-2 py-1 border-b border-[var(--tt-border)] last:border-0">
                       <span className="text-[10px] text-[var(--tt-fg-faint)] w-4 tabular shrink-0">{i + 1}</span>
-                      <span className="text-[10px] px-1 py-0.5 rounded shrink-0 capitalize"
-                        style={{ background: (catColor[t.category] ?? "#94a3b8") + "22", color: catColor[t.category] ?? "#94a3b8" }}>{t.category}</span>
+                      <span className="text-[10px] px-1 py-0.5 rounded shrink-0"
+                        style={{ background: (catColor[t.category] ?? "#94a3b8") + "22", color: catColor[t.category] ?? "#94a3b8" }}>
+                        {TOOL_CAT_LABEL[t.category] ?? t.category}
+                      </span>
                       <span className="text-[11px] truncate flex-1 font-mono" title={t.tool}>{shortTool(t.tool)}</span>
-                      <span className="text-[10px] text-[var(--tt-fg-faint)] tabular shrink-0">{t.session_count}s</span>
+                      <span className="text-[10px] text-[var(--tt-fg-faint)] tabular shrink-0">{t.session_count}×</span>
                       <span className="text-[10px] font-mono tabular shrink-0 w-10 text-right"
-                        style={{ color: effColor(t.avg_efficiency) }}>{t.avg_efficiency.toFixed(1)}</span>
+                        style={{ color: effColor(t.avg_efficiency) }}>{t.avg_efficiency.toFixed(0)}/100</span>
                     </div>
                   ))}
                 </div>
@@ -760,8 +820,8 @@ export default function IntelligencePage() {
       {/* ── Repository Activity ───────────────────────────────────── */}
       {(gitRes.data?.git_sessions ?? 0) > 0 && (
         <Section
-          title="Repository activity"
-          description={`${gitRes.data!.git_sessions} git-tracked sessions · +${gitRes.data!.total_lines_added.toLocaleString()} / −${gitRes.data!.total_lines_deleted.toLocaleString()} lines across ${gitRes.data!.projects.length} repos`}
+          title="Code changes across your repos"
+          description={`${gitRes.data!.git_sessions} sessions that changed real code · +${gitRes.data!.total_lines_added.toLocaleString()} lines added / −${gitRes.data!.total_lines_deleted.toLocaleString()} lines removed across ${gitRes.data!.projects.length} repos`}
         >
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
             {gitRes.data!.projects.filter(p => p.session_count > 0).map((p) => {
@@ -779,7 +839,7 @@ export default function IntelligencePage() {
                         </div>
                       )}
                     </div>
-                    <span className="text-[10px] tabular text-[var(--tt-fg-dim)] whitespace-nowrap shrink-0">{p.session_count} sess</span>
+                    <span className="text-[10px] tabular text-[var(--tt-fg-dim)] whitespace-nowrap shrink-0">{p.session_count} sessions</span>
                   </div>
                   {p.latest_commit_sha && (
                     <div className="flex items-start gap-1.5">

--- a/frontend/src/app/intelligence/page.tsx
+++ b/frontend/src/app/intelligence/page.tsx
@@ -1,0 +1,807 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import {
+  Brain, Zap, AlertTriangle, TrendingUp, TrendingDown, Minus,
+  GitBranch, GitCommit, Plus, Flame, DollarSign, Sparkles,
+  BarChart3, Activity, CheckCircle, XCircle, AlertCircle,
+  ArrowUpRight, Clock, Target, Wrench,
+} from "lucide-react";
+import {
+  ComposedChart, Bar, Line, XAxis, YAxis, CartesianGrid,
+  Tooltip as ReTooltip, ResponsiveContainer, ReferenceLine, Cell,
+} from "recharts";
+
+import { useResource } from "@/lib/api";
+import {
+  PageHeader, Section, Card, CardTitle, Badge, Button, EmptyState,
+} from "@/components/ui";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface Recommendation {
+  id: string;
+  category: string;
+  priority: "high" | "medium" | "low";
+  title: string;
+  detail: string;
+  impact: string | null;
+}
+interface RecommendationsResponse {
+  recommendations: Recommendation[];
+  total: number;
+  high_count: number;
+  medium_count: number;
+  low_count: number;
+}
+
+interface HealthComponents { efficiency: number; smell_free: number; recent_trend: number; cost_value: number; }
+interface ProjectHealth {
+  project: string;
+  session_count: number;
+  health_score: number;
+  grade: string;
+  avg_efficiency: number;
+  smell_rate: number;
+  recent_efficiency: number | null;
+  trend: "up" | "flat" | "down" | null;
+  cost_per_eff_pt: number | null;
+  components: HealthComponents;
+}
+interface ProjectHealthResponse {
+  projects: ProjectHealth[];
+  total_projects: number;
+  healthy_projects: number;
+  at_risk_projects: number;
+}
+
+interface Anomaly {
+  session_id: string;
+  agent: string;
+  model: string | null;
+  project: string;
+  timestamp: string;
+  type: "cost_spike" | "efficiency_crash" | "token_overflow" | "waste";
+  severity: "warning" | "critical";
+  value: number;
+  baseline: number;
+  z_score: number | null;
+  detail: string;
+}
+interface AnomalyResponse {
+  anomalies: Anomaly[];
+  total_anomalies: number;
+  sessions_checked: number;
+  baseline: { mean_cost: number; mean_efficiency: number; mean_tokens: number; median_cost: number };
+}
+
+interface TrendDay { date: string; avg_efficiency: number; session_count: number; rolling_7d: number | null; }
+interface TrendsResponse {
+  days: TrendDay[];
+  trend: string;
+  trend_delta: number;
+  overall_avg: number | null;
+  current_streak: number;
+  best_day: { date: string; avg_efficiency: number } | null;
+  days_with_data: number;
+  total_sessions: number;
+}
+
+interface ModelRow {
+  model: string; agent: string; session_count: number;
+  avg_efficiency: number; median_efficiency: number; p75_efficiency: number;
+  best_efficiency: number; total_tokens: number; avg_tokens: number;
+  task_breakdown: Record<string, { count: number; avg_efficiency: number }>;
+}
+interface ModelComparisonResponse {
+  models_compared: number; sessions_used: number; sessions_skipped: number;
+  models: ModelRow[]; task_types_available: string[];
+}
+
+interface CostModelRow {
+  model: string; agent: string; session_count: number;
+  avg_cost: number; total_cost: number; avg_efficiency: number;
+  cost_per_eff_pt: number | null; avg_cache_hit_pct: number | null;
+}
+interface CostCacheTier { tier: string; avg_efficiency: number; avg_cost: number; session_count: number; }
+interface CostWasteful { session_id: string; model: string; cost: number; efficiency: number; task_type: string; waste_score: number; }
+interface CostIntelResponse {
+  by_model: CostModelRow[]; cache_tiers: CostCacheTier[]; wasteful: CostWasteful[];
+  best_value_model: string | null; total_cost: number; avg_cost_per_session: number;
+  avg_cache_hit_pct: number | null; sessions_analysed: number;
+}
+
+interface TimeHourRow { hour: number; label: string; avg_efficiency: number; session_count: number; }
+interface TimeDowRow { dow: number; label: string; avg_efficiency: number; session_count: number; }
+interface TimeIntelResponse {
+  by_hour: TimeHourRow[]; by_dow: TimeDowRow[];
+  peak_hour: TimeHourRow | null; worst_hour: TimeHourRow | null;
+  peak_dow: TimeDowRow | null; peak_period: string;
+  sessions_analysed: number;
+}
+
+interface ToolSizeBucket { bucket: string; avg_efficiency: number; session_count: number; label: string; }
+interface ToolRow { tool: string; session_count: number; avg_efficiency: number; category: string; }
+interface ToolFootprintResponse {
+  by_size: ToolSizeBucket[]; top_tools: ToolRow[];
+  optimal_range: string | null; sessions_analysed: number;
+}
+
+interface DnaCorrelation { feature: string; label: string; r: number; direction: string; insight: string; }
+interface PromptDnaResponse {
+  sessions_analysed: number;
+  correlations: DnaCorrelation[];
+  by_task_type: Record<string, { avg_efficiency: number; count: number }>;
+  top_positive: DnaCorrelation[];
+  top_negative: DnaCorrelation[];
+}
+
+interface GitProjectSummary {
+  project: string; branch: string | null; session_count: number;
+  total_files_changed: number; total_lines_added: number; total_lines_deleted: number;
+  net_lines: number; latest_commit_sha: string | null; latest_commit_msg: string | null;
+  avg_files_per_session: number;
+}
+interface GitSummaryResponse {
+  projects: GitProjectSummary[]; total_lines_added: number; total_lines_deleted: number;
+  total_files_changed: number; git_sessions: number; non_git_sessions: number;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const effColor  = (v: number) => v >= 70 ? "#4ade80" : v >= 40 ? "#facc15" : "#f87171";
+const barFill   = effColor;
+const fmtCost   = (v: number) => v >= 1 ? `$${v.toFixed(2)}` : `$${v.toFixed(4)}`;
+const fmtCpp    = (v: number | null) => v === null ? "—" : v < 0.01 ? `$${v.toFixed(5)}/pt` : `$${v.toFixed(3)}/pt`;
+const shortProj = (p: string) => p.split(/[/\\]/).pop() || p;
+
+const PRIORITY_COLOR: Record<string, string> = {
+  high: "#f87171", medium: "#facc15", low: "#4ade80",
+};
+const CAT_ICON: Record<string, React.ReactNode> = {
+  cost:    <DollarSign size={13} />,
+  quality: <Target size={13} />,
+  timing:  <Clock size={13} />,
+  prompt:  <Sparkles size={13} />,
+  tools:   <Wrench size={13} />,
+  health:  <Activity size={13} />,
+};
+const ANOMALY_ICON: Record<string, React.ReactNode> = {
+  cost_spike:       <DollarSign size={13} className="text-red-400" />,
+  efficiency_crash: <TrendingDown size={13} className="text-red-400" />,
+  token_overflow:   <Zap size={13} className="text-yellow-400" />,
+  waste:            <AlertTriangle size={13} className="text-red-400" />,
+};
+const GRADE_COLOR: Record<string, string> = {
+  A: "#4ade80", B: "#60a5fa", C: "#facc15", D: "#fb923c", F: "#f87171",
+};
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+
+export default function IntelligencePage() {
+  const recRes    = useResource<RecommendationsResponse>("/insights/recommendations", { pollMs: 120_000 });
+  const healthRes = useResource<ProjectHealthResponse>("/insights/project-health", { pollMs: 120_000 });
+  const anomalyRes = useResource<AnomalyResponse>("/insights/anomalies", { pollMs: 60_000 });
+  const dnaRes    = useResource<PromptDnaResponse>("/insights/prompt-dna", { pollMs: 120_000 });
+  const gitRes    = useResource<GitSummaryResponse>("/insights/git-summary", { pollMs: 60_000 });
+  const timeRes   = useResource<TimeIntelResponse>("/insights/time", { pollMs: 120_000 });
+  const toolRes   = useResource<ToolFootprintResponse>("/insights/tool-footprint", { pollMs: 120_000 });
+  const costRes   = useResource<CostIntelResponse>("/insights/cost", { pollMs: 120_000 });
+
+  const [trendsDays, setTrendsDays] = useState<30 | 60>(30);
+  const trendsRes = useResource<TrendsResponse>(`/insights/trends?days=${trendsDays}`, { pollMs: 120_000 });
+
+  const [modelTaskFilter, setModelTaskFilter] = useState<string>("all");
+  const [modelComparison, setModelComparison] = useState<ModelComparisonResponse | null>(null);
+  useEffect(() => {
+    const url = modelTaskFilter === "all"
+      ? "/insights/model-comparison"
+      : `/insights/model-comparison?task_type=${modelTaskFilter}`;
+    fetch(`http://localhost:8000${url}`)
+      .then(r => r.json())
+      .then(d => setModelComparison(d))
+      .catch(() => {});
+  }, [modelTaskFilter]);
+
+  const periodEmoji: Record<string, string> = { morning: "🌅", afternoon: "☀️", evening: "🌆", night: "🌙" };
+
+  const sizeColor: Record<string, string> = { lean: "#4ade80", standard: "#60a5fa", heavy: "#facc15", bloated: "#f87171" };
+  const catColor: Record<string, string>  = { core: "#4ade80", agent: "#a78bfa", browser: "#60a5fa", mcp: "#fb923c", meta: "#94a3b8" };
+
+  const shortTool = (t: string) => {
+    if (t.startsWith("mcp__")) {
+      const parts = t.split("__");
+      return parts[parts.length - 1].replace(/_/g, " ");
+    }
+    return t;
+  };
+
+  const formatDate = (d: string) => {
+    const dt = new Date(d + "T12:00:00Z");
+    return dt.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  };
+
+  return (
+    <div className="px-8 py-8 max-w-[1600px] mx-auto space-y-10 pb-20">
+      <PageHeader
+        eyebrow="Intelligence Layer"
+        title="Intelligence"
+        description="Cross-session analytics, recommendations, and health signals across all your AI coding agents."
+        icon={<Brain size={20} strokeWidth={2.25} />}
+        actions={
+          <Badge variant="success" size="sm" className="h-9 px-2.5">
+            <span className="relative flex w-1.5 h-1.5">
+              <span className="absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-60 animate-ping" />
+              <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-emerald-400" />
+            </span>
+            Live
+          </Badge>
+        }
+      />
+
+      {/* ── Recommendations ──────────────────────────────────────── */}
+      {(recRes.data?.total ?? 0) > 0 && (
+        <Section
+          title="Recommendations"
+          description={`${recRes.data!.total} actionable insights · ${recRes.data!.high_count} high priority`}
+        >
+          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
+            {recRes.data!.recommendations.map((rec) => (
+              <Card key={rec.id} className="space-y-2.5">
+                <div className="flex items-start justify-between gap-2">
+                  <div className="flex items-center gap-2">
+                    <span style={{ color: PRIORITY_COLOR[rec.priority] ?? "#94a3b8" }}>
+                      {CAT_ICON[rec.category] ?? <Activity size={13} />}
+                    </span>
+                    <span
+                      className="text-[10px] px-1.5 py-0.5 rounded-full capitalize font-semibold"
+                      style={{
+                        background: (PRIORITY_COLOR[rec.priority] ?? "#94a3b8") + "22",
+                        color: PRIORITY_COLOR[rec.priority] ?? "#94a3b8",
+                      }}
+                    >
+                      {rec.priority}
+                    </span>
+                    <span className="text-[10px] text-[var(--tt-fg-faint)] capitalize">{rec.category}</span>
+                  </div>
+                  {rec.impact && (
+                    <span className="text-[10px] text-emerald-400 font-semibold shrink-0">{rec.impact}</span>
+                  )}
+                </div>
+                <div className="text-[13px] font-semibold text-[var(--tt-fg)] leading-snug">{rec.title}</div>
+                <div className="text-[11px] text-[var(--tt-fg-muted)] leading-relaxed">{rec.detail}</div>
+              </Card>
+            ))}
+          </div>
+        </Section>
+      )}
+
+      {/* ── Project Health ────────────────────────────────────────── */}
+      {(healthRes.data?.total_projects ?? 0) >= 2 && (
+        <Section
+          title="Project health"
+          description={`${healthRes.data!.total_projects} projects · ${healthRes.data!.healthy_projects} healthy · ${healthRes.data!.at_risk_projects} at risk`}
+        >
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
+            {healthRes.data!.projects.map((p) => {
+              const gc = GRADE_COLOR[p.grade] ?? "#94a3b8";
+              return (
+                <Card key={p.project} className="space-y-3">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      <div className="font-mono text-[11px] font-semibold text-[var(--tt-fg)] truncate" title={p.project}>
+                        {shortProj(p.project)}
+                      </div>
+                      <div className="text-[10px] text-[var(--tt-fg-faint)] mt-0.5">{p.session_count} sessions</div>
+                    </div>
+                    <div
+                      className="shrink-0 w-10 h-10 rounded-xl flex flex-col items-center justify-center font-bold text-lg leading-none"
+                      style={{ background: gc + "22", color: gc, border: `1.5px solid ${gc}44` }}
+                    >
+                      <span>{p.grade}</span>
+                      <span className="text-[9px] font-normal opacity-70">{p.health_score.toFixed(0)}</span>
+                    </div>
+                  </div>
+
+                  {/* Score bar */}
+                  <div className="h-1.5 bg-[var(--tt-surface-raised)] rounded overflow-hidden">
+                    <div
+                      className="h-full rounded transition-all"
+                      style={{ width: `${p.health_score}%`, background: gc, opacity: 0.8 }}
+                    />
+                  </div>
+
+                  {/* Components */}
+                  <div className="grid grid-cols-2 gap-x-3 gap-y-1">
+                    {([
+                      ["Efficiency", p.components.efficiency],
+                      ["Smell-free", p.components.smell_free],
+                      ["Trend",      p.components.recent_trend],
+                      ["Cost value", p.components.cost_value],
+                    ] as [string, number][]).map(([label, val]) => (
+                      <div key={label} className="flex items-center justify-between text-[10px]">
+                        <span className="text-[var(--tt-fg-faint)]">{label}</span>
+                        <span className="font-mono tabular" style={{ color: effColor(val) }}>{val.toFixed(0)}</span>
+                      </div>
+                    ))}
+                  </div>
+
+                  {/* Trend badge */}
+                  {p.trend && (
+                    <div className="flex items-center gap-1.5 text-[10px]">
+                      {p.trend === "up"   && <TrendingUp  size={10} className="text-emerald-400" />}
+                      {p.trend === "down" && <TrendingDown size={10} className="text-red-400" />}
+                      {p.trend === "flat" && <Minus size={10} className="text-[var(--tt-fg-faint)]" />}
+                      <span className="text-[var(--tt-fg-muted)]">
+                        {p.recent_efficiency !== null ? `${p.recent_efficiency} recent` : "no recent data"}
+                      </span>
+                    </div>
+                  )}
+                </Card>
+              );
+            })}
+          </div>
+        </Section>
+      )}
+
+      {/* ── Anomaly Detection ─────────────────────────────────────── */}
+      {(anomalyRes.data?.total_anomalies ?? 0) > 0 && (
+        <Section
+          title="Anomaly detection"
+          description={`${anomalyRes.data!.total_anomalies} anomalies detected across ${anomalyRes.data!.sessions_checked} sessions`}
+        >
+          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
+            {anomalyRes.data!.anomalies.map((a, i) => (
+              <Card key={`${a.session_id}-${a.type}-${i}`} className="space-y-2">
+                <div className="flex items-center justify-between gap-2">
+                  <div className="flex items-center gap-2">
+                    {ANOMALY_ICON[a.type] ?? <AlertCircle size={13} className="text-yellow-400" />}
+                    <span
+                      className={`text-[10px] px-1.5 py-0.5 rounded-full font-semibold capitalize ${
+                        a.severity === "critical"
+                          ? "bg-red-500/20 text-red-400"
+                          : "bg-yellow-500/20 text-yellow-400"
+                      }`}
+                    >
+                      {a.severity}
+                    </span>
+                    <span className="text-[10px] text-[var(--tt-fg-faint)] capitalize">
+                      {a.type.replace(/_/g, " ")}
+                    </span>
+                  </div>
+                  {a.z_score !== null && (
+                    <span className="text-[10px] font-mono text-[var(--tt-fg-faint)]">{a.z_score.toFixed(1)}σ</span>
+                  )}
+                </div>
+                <div className="text-[12px] text-[var(--tt-fg)] leading-snug">{a.detail}</div>
+                <div className="flex items-center gap-3 text-[10px] text-[var(--tt-fg-faint)]">
+                  <span className="font-mono">{a.session_id.slice(0, 8)}</span>
+                  {a.model && <span className="truncate">{a.model}</span>}
+                  <span className="ml-auto truncate">{shortProj(a.project)}</span>
+                </div>
+              </Card>
+            ))}
+          </div>
+        </Section>
+      )}
+
+      {/* ── Session Trends ────────────────────────────────────────── */}
+      {(trendsRes.data?.days_with_data ?? 0) >= 2 && (() => {
+        const td = trendsRes.data!;
+        const trendColor = td.trend === "improving" ? "#4ade80" : td.trend === "declining" ? "#f87171" : "#facc15";
+        const trendIcon  = td.trend === "improving" ? "↑" : td.trend === "declining" ? "↓" : "→";
+        return (
+          <Section
+            title="Session trends"
+            description={`Efficiency over the last ${trendsDays} days · ${td.days_with_data} active days · ${td.total_sessions} sessions`}
+          >
+            <Card className="space-y-4">
+              <div className="flex flex-wrap items-center gap-3">
+                <div
+                  className="flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-semibold"
+                  style={{ background: trendColor + "22", color: trendColor, border: `1px solid ${trendColor}44` }}
+                >
+                  <span className="text-sm leading-none">{trendIcon}</span>
+                  <span className="capitalize">{td.trend}</span>
+                  {Math.abs(td.trend_delta) >= 1 && (
+                    <span className="opacity-80 font-mono">{td.trend_delta > 0 ? "+" : ""}{td.trend_delta.toFixed(1)} pts WoW</span>
+                  )}
+                </div>
+                {td.overall_avg !== null && (
+                  <div className="text-xs text-[var(--tt-fg-muted)] px-2 py-1 rounded bg-[var(--tt-surface-raised)]">
+                    Avg <span className="font-semibold text-[var(--tt-fg)]">{td.overall_avg.toFixed(1)}</span>
+                  </div>
+                )}
+                {td.current_streak >= 2 && (
+                  <div className="flex items-center gap-1 text-xs px-2 py-1 rounded bg-[var(--tt-surface-raised)] text-amber-400">
+                    <Flame size={11} /><span className="font-semibold">{td.current_streak}d</span>
+                    <span className="text-[var(--tt-fg-faint)]">streak</span>
+                  </div>
+                )}
+                {td.best_day && (
+                  <div className="text-xs text-[var(--tt-fg-muted)] px-2 py-1 rounded bg-[var(--tt-surface-raised)]">
+                    Best <span className="font-semibold text-emerald-400">{td.best_day.avg_efficiency.toFixed(1)}</span>
+                    <span className="ml-1 text-[var(--tt-fg-faint)]">on {formatDate(td.best_day.date)}</span>
+                  </div>
+                )}
+                <div className="ml-auto flex items-center gap-1 text-xs">
+                  {([30, 60] as const).map((n) => (
+                    <button key={n} onClick={() => setTrendsDays(n)} className="px-2.5 py-1 rounded transition-colors"
+                      style={{
+                        background: trendsDays === n ? "var(--tt-brand)" : "var(--tt-surface-raised)",
+                        color: trendsDays === n ? "var(--tt-bg)" : "var(--tt-fg-muted)",
+                        fontWeight: trendsDays === n ? 600 : 400,
+                      }}>{n}d</button>
+                  ))}
+                </div>
+              </div>
+              <div style={{ height: 200 }}>
+                <ResponsiveContainer width="100%" height="100%">
+                  <ComposedChart data={td.days} margin={{ top: 4, right: 8, bottom: 0, left: -16 }}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="var(--tt-border)" vertical={false} />
+                    <XAxis dataKey="date" tickFormatter={formatDate} tick={{ fill: "var(--tt-fg-faint)", fontSize: 10 }} tickLine={false} axisLine={false} interval="preserveStartEnd" />
+                    <YAxis domain={[0, 100]} tick={{ fill: "var(--tt-fg-faint)", fontSize: 10 }} tickLine={false} axisLine={false} tickCount={5} />
+                    <ReTooltip contentStyle={{ background: "var(--tt-surface)", border: "1px solid var(--tt-border)", borderRadius: 8, fontSize: 12, color: "var(--tt-fg)" }}
+                      labelFormatter={(l) => formatDate(String(l))}
+                      formatter={(value, name) => {
+                        const v = typeof value === "number" ? value.toFixed(1) : String(value);
+                        return [v, name === "avg_efficiency" ? "Avg efficiency" : "7d rolling avg"];
+                      }} />
+                    <ReferenceLine y={60} stroke="var(--tt-fg-faint)" strokeDasharray="4 4" strokeOpacity={0.5} />
+                    <Bar dataKey="avg_efficiency" radius={[3, 3, 0, 0]} maxBarSize={32}>
+                      {td.days.map((day) => <Cell key={day.date} fill={barFill(day.avg_efficiency)} fillOpacity={0.85} />)}
+                    </Bar>
+                    <Line type="monotone" dataKey="rolling_7d" stroke="var(--tt-brand)" strokeWidth={2} dot={false} connectNulls />
+                  </ComposedChart>
+                </ResponsiveContainer>
+              </div>
+              <div className="flex items-center gap-4 text-[10px] text-[var(--tt-fg-faint)]">
+                {[["#4ade80","Good (≥70)"],["#facc15","Fair (40–69)"],["#f87171","Poor (<40)"]].map(([c,l])=>(
+                  <div key={l} className="flex items-center gap-1.5"><div className="w-3 h-3 rounded-sm opacity-85" style={{background:c}}/>{l}</div>
+                ))}
+                <div className="flex items-center gap-1.5 ml-2">
+                  <div className="w-6 h-0.5 rounded" style={{background:"var(--tt-brand)"}}/> 7d rolling avg
+                </div>
+              </div>
+            </Card>
+          </Section>
+        );
+      })()}
+
+      {/* ── Model Comparison ──────────────────────────────────────── */}
+      {modelComparison && modelComparison.models_compared > 0 && (
+        <Section
+          title="Model comparison"
+          description={`${modelComparison.models_compared} models · ${modelComparison.sessions_used} sessions`}
+        >
+          <Card className="space-y-4">
+            {/* Task filter pills */}
+            <div className="flex flex-wrap gap-1.5">
+              {["all", ...(modelComparison.task_types_available ?? [])].map((tt) => (
+                <button key={tt} onClick={() => setModelTaskFilter(tt)}
+                  className="px-2.5 py-1 rounded-full text-[11px] font-medium capitalize transition-colors"
+                  style={{
+                    background: modelTaskFilter === tt ? "var(--tt-brand)" : "var(--tt-surface-raised)",
+                    color: modelTaskFilter === tt ? "var(--tt-bg)" : "var(--tt-fg-muted)",
+                  }}>{tt === "all" ? "All tasks" : tt}</button>
+              ))}
+            </div>
+            {/* Model rows */}
+            <div className="space-y-3">
+              {modelComparison.models.map((m, i) => (
+                <div key={m.model} className="space-y-1.5">
+                  <div className="flex items-center gap-2">
+                    <span className="text-[10px] text-[var(--tt-fg-faint)] w-4 tabular shrink-0">#{i + 1}</span>
+                    <span className="font-mono text-[12px] text-[var(--tt-fg)] flex-1 truncate">{m.model}</span>
+                    <span className="text-[10px] text-[var(--tt-fg-faint)]">×{m.session_count}</span>
+                    <span className="font-mono text-[12px] tabular shrink-0" style={{ color: effColor(m.avg_efficiency) }}>{m.avg_efficiency.toFixed(1)}</span>
+                  </div>
+                  <div className="flex gap-1 h-2">
+                    <div className="flex-1 bg-[var(--tt-surface-raised)] rounded overflow-hidden">
+                      <div className="h-full rounded" style={{ width: `${m.avg_efficiency}%`, background: effColor(m.avg_efficiency), opacity: 0.7 }} />
+                    </div>
+                    <div className="flex-1 bg-[var(--tt-surface-raised)] rounded overflow-hidden">
+                      <div className="h-full rounded" style={{ width: `${m.p75_efficiency}%`, background: effColor(m.p75_efficiency), opacity: 0.45 }} />
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </Card>
+        </Section>
+      )}
+
+      {/* ── Prompt DNA ────────────────────────────────────────────── */}
+      {dnaRes.data && dnaRes.data.sessions_analysed >= 3 && (
+        <Section
+          title="Prompt DNA"
+          description={`${dnaRes.data.sessions_analysed} sessions analysed · prompt structure vs efficiency correlations`}
+        >
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            <Card className="space-y-3">
+              <div className="text-xs font-semibold text-emerald-400 uppercase tracking-wide">Boosts efficiency</div>
+              <div className="space-y-2">
+                {dnaRes.data.top_positive.slice(0, 3).map((c) => (
+                  <div key={c.feature} className="space-y-1">
+                    <div className="flex items-center justify-between text-xs">
+                      <span className="text-[var(--tt-fg-muted)]">{c.label}</span>
+                      <span className="font-mono text-emerald-400">r={c.r.toFixed(2)}</span>
+                    </div>
+                    <div className="text-[11px] text-[var(--tt-fg-faint)]">{c.insight}</div>
+                  </div>
+                ))}
+              </div>
+            </Card>
+            <Card className="space-y-3">
+              <div className="text-xs font-semibold text-red-400 uppercase tracking-wide">Hurts efficiency</div>
+              <div className="space-y-2">
+                {dnaRes.data.top_negative.slice(0, 3).map((c) => (
+                  <div key={c.feature} className="space-y-1">
+                    <div className="flex items-center justify-between text-xs">
+                      <span className="text-[var(--tt-fg-muted)]">{c.label}</span>
+                      <span className="font-mono text-red-400">r={c.r.toFixed(2)}</span>
+                    </div>
+                    <div className="text-[11px] text-[var(--tt-fg-faint)]">{c.insight}</div>
+                  </div>
+                ))}
+              </div>
+            </Card>
+          </div>
+        </Section>
+      )}
+
+      {/* ── Cost Intelligence ─────────────────────────────────────── */}
+      {(costRes.data?.sessions_analysed ?? 0) >= 2 && (() => {
+        const ci = costRes.data!;
+        const maxCpp = Math.max(...ci.by_model.filter(r => r.cost_per_eff_pt !== null).map(r => r.cost_per_eff_pt as number), 0.001);
+        return (
+          <Section
+            title="Cost intelligence"
+            description={`${fmtCost(ci.total_cost)} total · ${ci.sessions_analysed} sessions · ${ci.avg_cache_hit_pct?.toFixed(0) ?? "—"}% avg cache hit`}
+          >
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+              <Card className="space-y-3">
+                <div className="text-xs font-semibold text-[var(--tt-fg-dim)] uppercase tracking-wide">
+                  Cost per efficiency point <span className="normal-case font-normal text-[var(--tt-fg-faint)]">(lower = better)</span>
+                </div>
+                <div className="space-y-2.5">
+                  {ci.by_model.map((m) => (
+                    <div key={m.model} className="space-y-1">
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-1.5 min-w-0">
+                          <span className="font-mono text-[11px] text-[var(--tt-fg)] truncate">{m.model}</span>
+                          <span className="text-[10px] text-[var(--tt-fg-faint)]">×{m.session_count}</span>
+                        </div>
+                        <div className="flex items-center gap-3 shrink-0 ml-2">
+                          <span className="text-[10px]" style={{ color: effColor(m.avg_efficiency) }}>{m.avg_efficiency.toFixed(1)} eff</span>
+                          <span className="text-[11px] font-mono tabular">{fmtCpp(m.cost_per_eff_pt)}</span>
+                        </div>
+                      </div>
+                      {m.cost_per_eff_pt !== null && (
+                        <div className="h-1.5 bg-[var(--tt-surface-raised)] rounded overflow-hidden">
+                          <div className="h-full rounded" style={{
+                            width: `${Math.min((m.cost_per_eff_pt / maxCpp) * 100, 100)}%`,
+                            background: m.cost_per_eff_pt / maxCpp < 0.3 ? "#4ade80" : m.cost_per_eff_pt / maxCpp < 0.7 ? "#facc15" : "#f87171",
+                            opacity: 0.8,
+                          }} />
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </Card>
+              <div className="space-y-4">
+                {ci.cache_tiers.length >= 2 && (
+                  <Card className="space-y-3">
+                    <div className="text-xs font-semibold text-[var(--tt-fg-dim)] uppercase tracking-wide">Cache hit rate vs efficiency</div>
+                    <div className="space-y-1.5">
+                      {ci.cache_tiers.map((t) => (
+                        <div key={t.tier} className="flex items-center gap-2">
+                          <div className="w-16 text-[10px] text-[var(--tt-fg-faint)] tabular shrink-0">{t.tier}</div>
+                          <div className="flex-1 h-4 bg-[var(--tt-surface-raised)] rounded overflow-hidden">
+                            <div className="h-full rounded" style={{ width: `${t.avg_efficiency}%`, background: effColor(t.avg_efficiency), opacity: 0.75 }} />
+                          </div>
+                          <span className="text-[11px] font-mono w-8 text-right tabular" style={{ color: effColor(t.avg_efficiency) }}>{t.avg_efficiency.toFixed(0)}</span>
+                          <span className="text-[10px] text-[var(--tt-fg-faint)] w-14 text-right tabular shrink-0">{fmtCost(t.avg_cost)}</span>
+                          <span className="text-[10px] text-[var(--tt-fg-faint)] shrink-0">×{t.session_count}</span>
+                        </div>
+                      ))}
+                    </div>
+                  </Card>
+                )}
+                {ci.wasteful.length > 0 && (
+                  <Card className="space-y-3">
+                    <div className="text-xs font-semibold text-[var(--tt-fg-dim)] uppercase tracking-wide flex items-center gap-1.5">
+                      <AlertTriangle size={11} className="text-red-400" /> Expensive flops
+                    </div>
+                    <div className="space-y-2">
+                      {ci.wasteful.map((w) => (
+                        <div key={w.session_id} className="flex items-center gap-2 py-1 border-b border-[var(--tt-border)] last:border-0">
+                          <span className="font-mono text-[10px] text-[var(--tt-fg-faint)] shrink-0">{w.session_id.slice(0, 8)}</span>
+                          <span className="font-mono text-[10px] text-[var(--tt-fg)] truncate flex-1">{w.model}</span>
+                          <span className="text-[11px] font-mono text-red-400 tabular shrink-0">{fmtCost(w.cost)}</span>
+                          <span className="text-[10px] tabular shrink-0" style={{ color: effColor(w.efficiency) }}>{w.efficiency.toFixed(1)}</span>
+                        </div>
+                      ))}
+                    </div>
+                  </Card>
+                )}
+              </div>
+            </div>
+          </Section>
+        );
+      })()}
+
+      {/* ── Time Intelligence ─────────────────────────────────────── */}
+      {(timeRes.data?.sessions_analysed ?? 0) >= 3 && (() => {
+        const ti = timeRes.data!;
+        return (
+          <Section title="Time intelligence" description={`When you code best · ${ti.sessions_analysed} sessions`}>
+            <div className="flex flex-wrap gap-3 mb-4">
+              {ti.peak_hour && (
+                <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-[var(--tt-surface-raised)] text-xs">
+                  <span className="text-emerald-400 font-semibold">Peak hour</span>
+                  <span className="font-mono text-[var(--tt-fg)]">{ti.peak_hour.label}</span>
+                  <span className="text-[var(--tt-fg-faint)]">{ti.peak_hour.avg_efficiency.toFixed(1)} avg</span>
+                </div>
+              )}
+              {ti.peak_dow && (
+                <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-[var(--tt-surface-raised)] text-xs">
+                  <span className="text-emerald-400 font-semibold">Peak day</span>
+                  <span className="font-mono text-[var(--tt-fg)]">{ti.peak_dow.label}</span>
+                  <span className="text-[var(--tt-fg-faint)]">{ti.peak_dow.avg_efficiency.toFixed(1)} avg</span>
+                </div>
+              )}
+              <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-[var(--tt-surface-raised)] text-xs">
+                <span className="text-[var(--tt-fg-muted)]">Best period</span>
+                <span className="font-semibold capitalize">{periodEmoji[ti.peak_period] ?? ""} {ti.peak_period}</span>
+              </div>
+              {ti.worst_hour && (
+                <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-[var(--tt-surface-raised)] text-xs">
+                  <span className="text-red-400 font-semibold">Avoid</span>
+                  <span className="font-mono text-[var(--tt-fg)]">{ti.worst_hour.label}</span>
+                  <span className="text-[var(--tt-fg-faint)]">{ti.worst_hour.avg_efficiency.toFixed(1)} avg</span>
+                </div>
+              )}
+            </div>
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+              <Card className="space-y-2">
+                <div className="text-xs font-semibold text-[var(--tt-fg-dim)] uppercase tracking-wide">By hour of day</div>
+                <div style={{ height: 180 }}>
+                  <ResponsiveContainer width="100%" height="100%">
+                    <ComposedChart data={ti.by_hour} margin={{ top: 4, right: 4, bottom: 0, left: -20 }}>
+                      <CartesianGrid strokeDasharray="3 3" stroke="var(--tt-border)" vertical={false} />
+                      <XAxis dataKey="label" tick={{ fill: "var(--tt-fg-faint)", fontSize: 9 }} tickLine={false} axisLine={false} interval={0} angle={-45} textAnchor="end" height={36} />
+                      <YAxis domain={[0, 100]} tick={{ fill: "var(--tt-fg-faint)", fontSize: 9 }} tickLine={false} axisLine={false} tickCount={4} />
+                      <ReTooltip contentStyle={{ background: "var(--tt-surface)", border: "1px solid var(--tt-border)", borderRadius: 8, fontSize: 11, color: "var(--tt-fg)" }}
+                        formatter={(v, n) => [typeof v === "number" ? v.toFixed(1) : v, n === "avg_efficiency" ? "Avg efficiency" : String(n)]} />
+                      <ReferenceLine y={60} stroke="var(--tt-fg-faint)" strokeDasharray="4 4" strokeOpacity={0.4} />
+                      <Bar dataKey="avg_efficiency" radius={[3, 3, 0, 0]} maxBarSize={28}>
+                        {ti.by_hour.map((row) => <Cell key={row.hour} fill={barFill(row.avg_efficiency)} fillOpacity={0.85} />)}
+                      </Bar>
+                    </ComposedChart>
+                  </ResponsiveContainer>
+                </div>
+              </Card>
+              <Card className="space-y-2">
+                <div className="text-xs font-semibold text-[var(--tt-fg-dim)] uppercase tracking-wide">By day of week</div>
+                <div style={{ height: 180 }}>
+                  <ResponsiveContainer width="100%" height="100%">
+                    <ComposedChart data={ti.by_dow} margin={{ top: 4, right: 4, bottom: 0, left: -20 }}>
+                      <CartesianGrid strokeDasharray="3 3" stroke="var(--tt-border)" vertical={false} />
+                      <XAxis dataKey="label" tick={{ fill: "var(--tt-fg-faint)", fontSize: 10 }} tickLine={false} axisLine={false} />
+                      <YAxis domain={[0, 100]} tick={{ fill: "var(--tt-fg-faint)", fontSize: 9 }} tickLine={false} axisLine={false} tickCount={4} />
+                      <ReTooltip contentStyle={{ background: "var(--tt-surface)", border: "1px solid var(--tt-border)", borderRadius: 8, fontSize: 11, color: "var(--tt-fg)" }}
+                        formatter={(v, n) => [typeof v === "number" ? v.toFixed(1) : v, n === "avg_efficiency" ? "Avg efficiency" : String(n)]} />
+                      <ReferenceLine y={60} stroke="var(--tt-fg-faint)" strokeDasharray="4 4" strokeOpacity={0.4} />
+                      <Bar dataKey="avg_efficiency" radius={[3, 3, 0, 0]} maxBarSize={40}>
+                        {ti.by_dow.map((row) => <Cell key={row.dow} fill={barFill(row.avg_efficiency)} fillOpacity={0.85} />)}
+                      </Bar>
+                    </ComposedChart>
+                  </ResponsiveContainer>
+                </div>
+              </Card>
+            </div>
+          </Section>
+        );
+      })()}
+
+      {/* ── Tool Footprint ────────────────────────────────────────── */}
+      {(toolRes.data?.sessions_analysed ?? 0) >= 3 && (() => {
+        const tf = toolRes.data!;
+        return (
+          <Section title="Tool footprint" description={`Toolset size and composition vs efficiency · ${tf.sessions_analysed} sessions`}>
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+              <Card className="space-y-3">
+                <div className="text-xs font-semibold text-[var(--tt-fg-dim)] uppercase tracking-wide">
+                  Efficiency by toolset size
+                  {tf.optimal_range && <span className="ml-2 normal-case font-normal text-[var(--tt-fg-faint)]">· optimal: <span className="font-semibold text-[var(--tt-fg)]">{tf.optimal_range} tools</span></span>}
+                </div>
+                <div className="space-y-2">
+                  {tf.by_size.map((b) => (
+                    <div key={b.bucket} className="flex items-center gap-2">
+                      <div className="w-16 text-[11px] text-[var(--tt-fg-muted)] tabular shrink-0">{b.bucket}</div>
+                      <div className="flex-1 h-5 bg-[var(--tt-surface-raised)] rounded overflow-hidden">
+                        <div className="h-full rounded" style={{ width: `${b.avg_efficiency}%`, background: sizeColor[b.label] ?? "#60a5fa", opacity: 0.8 }} />
+                      </div>
+                      <div className="w-10 text-right text-[11px] font-mono tabular shrink-0">{b.avg_efficiency.toFixed(1)}</div>
+                      <div className="w-8 text-right text-[10px] text-[var(--tt-fg-faint)] tabular shrink-0">{b.session_count}s</div>
+                      <span className="text-[10px] px-1.5 py-0.5 rounded-full capitalize shrink-0"
+                        style={{ background: (sizeColor[b.label] ?? "#60a5fa") + "22", color: sizeColor[b.label] ?? "#60a5fa" }}>{b.label}</span>
+                    </div>
+                  ))}
+                </div>
+              </Card>
+              <Card className="space-y-3">
+                <div className="text-xs font-semibold text-[var(--tt-fg-dim)] uppercase tracking-wide">Top tools by frequency</div>
+                <div className="space-y-1 overflow-y-auto" style={{ maxHeight: 220 }}>
+                  {tf.top_tools.map((t, i) => (
+                    <div key={t.tool} className="flex items-center gap-2 py-1 border-b border-[var(--tt-border)] last:border-0">
+                      <span className="text-[10px] text-[var(--tt-fg-faint)] w-4 tabular shrink-0">{i + 1}</span>
+                      <span className="text-[10px] px-1 py-0.5 rounded shrink-0 capitalize"
+                        style={{ background: (catColor[t.category] ?? "#94a3b8") + "22", color: catColor[t.category] ?? "#94a3b8" }}>{t.category}</span>
+                      <span className="text-[11px] truncate flex-1 font-mono" title={t.tool}>{shortTool(t.tool)}</span>
+                      <span className="text-[10px] text-[var(--tt-fg-faint)] tabular shrink-0">{t.session_count}s</span>
+                      <span className="text-[10px] font-mono tabular shrink-0 w-10 text-right"
+                        style={{ color: effColor(t.avg_efficiency) }}>{t.avg_efficiency.toFixed(1)}</span>
+                    </div>
+                  ))}
+                </div>
+              </Card>
+            </div>
+          </Section>
+        );
+      })()}
+
+      {/* ── Repository Activity ───────────────────────────────────── */}
+      {(gitRes.data?.git_sessions ?? 0) > 0 && (
+        <Section
+          title="Repository activity"
+          description={`${gitRes.data!.git_sessions} git-tracked sessions · +${gitRes.data!.total_lines_added.toLocaleString()} / −${gitRes.data!.total_lines_deleted.toLocaleString()} lines across ${gitRes.data!.projects.length} repos`}
+        >
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
+            {gitRes.data!.projects.filter(p => p.session_count > 0).map((p) => {
+              const projName = p.project.split(/[/\\]/).pop() || p.project;
+              const hasStats = p.total_lines_added > 0 || p.total_lines_deleted > 0;
+              const netColor = p.net_lines > 0 ? "#4ade80" : p.net_lines < 0 ? "#f87171" : "var(--tt-fg-faint)";
+              return (
+                <Card key={p.project} className="space-y-3">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      <div className="font-mono text-[12px] font-semibold text-[var(--tt-fg)] truncate" title={p.project}>{projName}</div>
+                      {p.branch && (
+                        <div className="flex items-center gap-1 mt-0.5 text-[10px] text-[var(--tt-fg-faint)]">
+                          <GitBranch size={9} /><span className="truncate">{p.branch}</span>
+                        </div>
+                      )}
+                    </div>
+                    <span className="text-[10px] tabular text-[var(--tt-fg-dim)] whitespace-nowrap shrink-0">{p.session_count} sess</span>
+                  </div>
+                  {p.latest_commit_sha && (
+                    <div className="flex items-start gap-1.5">
+                      <GitCommit size={10} className="text-[var(--tt-fg-faint)] mt-0.5 shrink-0" />
+                      <div className="min-w-0">
+                        <span className="font-mono text-[10px] text-[var(--tt-brand)]">{p.latest_commit_sha}</span>
+                        <span className="ml-1.5 text-[10px] text-[var(--tt-fg-muted)] truncate block" title={p.latest_commit_msg ?? ""}>{p.latest_commit_msg}</span>
+                      </div>
+                    </div>
+                  )}
+                  {hasStats && (
+                    <div className="flex items-center gap-3 pt-1 border-t border-[var(--tt-border)]">
+                      <div className="flex items-center gap-1 text-[10px] text-emerald-400"><Plus size={9}/><span className="tabular">{p.total_lines_added.toLocaleString()}</span></div>
+                      <div className="flex items-center gap-1 text-[10px] text-red-400"><Minus size={9}/><span className="tabular">{p.total_lines_deleted.toLocaleString()}</span></div>
+                      <div className="flex items-center gap-1 text-[10px]" style={{ color: netColor }}>
+                        <span className="tabular font-medium">{p.net_lines > 0 ? "+" : ""}{p.net_lines.toLocaleString()} net</span>
+                      </div>
+                      <div className="ml-auto text-[10px] text-[var(--tt-fg-faint)] tabular">{p.total_files_changed} files</div>
+                    </div>
+                  )}
+                </Card>
+              );
+            })}
+          </div>
+        </Section>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -620,7 +620,7 @@ function ActivityLoading() {
 
 interface SnapRec { total: number; high_count: number; }
 interface SnapHealth { healthy_projects: number; at_risk_projects: number; total_projects: number; }
-interface SnapAnomaly { total_anomalies: number; }
+interface SnapAnomaly { total_anomalies: number; affected_sessions: number; }
 
 function IntelligenceSnapshot() {
   const recRes    = useResource<SnapRec>("/insights/recommendations", { pollMs: 120_000 });
@@ -669,8 +669,8 @@ function IntelligenceSnapshot() {
                 <AlertTriangle size={15} className="text-yellow-400" />
               </div>
               <div>
-                <div className="text-sm font-semibold text-[var(--tt-fg)]">{anomaly.total_anomalies} anomalies</div>
-                <div className="text-[11px] text-[var(--tt-fg-faint)]">detected this cycle</div>
+                <div className="text-sm font-semibold text-[var(--tt-fg)]">{anomaly.affected_sessions ?? anomaly.total_anomalies} sessions flagged</div>
+                <div className="text-[11px] text-[var(--tt-fg-faint)]">{anomaly.total_anomalies} signals total</div>
               </div>
             </div>
           )}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -6,7 +6,7 @@ import { usePathname } from "next/navigation";
 import { format } from "date-fns";
 import {
   Activity, Clock, TrendingUp, Folders, DollarSign, Cpu, ArrowUpRight, Radio, Terminal,
-  Zap, AlertTriangle, Flame, TrendingDown, Sparkles, BarChart3, GitBranch, GitCommit, Plus, Minus, Brain,
+  Zap, AlertTriangle, Flame, TrendingDown, BarChart3, GitBranch, GitCommit, Plus, Minus, Brain,
 } from "lucide-react";
 
 import { useResource } from "@/lib/api";
@@ -21,10 +21,6 @@ import {
   PageHeader, StatTile, Section, Card, CardHeader, CardTitle, CardEyebrow,
   Table, THead, TBody, TR, TH, TD, AgentBadge, Badge, Button, EmptyState, Skeleton,
 } from "@/components/ui";
-import {
-  ComposedChart, Bar, Line, XAxis, YAxis, CartesianGrid,
-  Tooltip as ReTooltip, ResponsiveContainer, ReferenceLine, Cell,
-} from "recharts";
 
 interface Smell {
   type: string;
@@ -67,23 +63,6 @@ interface ForecastResponse {
   buckets_30d: Record<string, number>;
 }
 
-interface DnaCorrelation {
-  feature: string;
-  label: string;
-  r: number;
-  direction: "positive" | "negative";
-  insight: string;
-}
-
-interface PromptDnaResponse {
-  sessions_analysed: number;
-  sessions_skipped: number;
-  correlations: DnaCorrelation[];
-  by_task_type: Record<string, { avg_efficiency: number; count: number }>;
-  top_positive: DnaCorrelation[];
-  top_negative: DnaCorrelation[];
-}
-
 interface ModelRow {
   model: string;
   agent: string;
@@ -95,15 +74,6 @@ interface ModelRow {
   total_tokens: number;
   avg_tokens: number;
   task_breakdown: Record<string, { count: number; avg_efficiency: number }>;
-}
-
-interface ModelComparisonResponse {
-  task_type_filter: string | null;
-  models_compared: number;
-  sessions_used: number;
-  sessions_skipped: number;
-  models: ModelRow[];
-  task_types_available: string[];
 }
 
 interface GitInfo {
@@ -129,138 +99,6 @@ interface GitProjectSummary {
   avg_files_per_session: number;
 }
 
-interface GitSummaryResponse {
-  projects: GitProjectSummary[];
-  total_lines_added: number;
-  total_lines_deleted: number;
-  total_files_changed: number;
-  git_sessions: number;
-  non_git_sessions: number;
-}
-
-interface TrendDay {
-  date: string;
-  avg_efficiency: number;
-  session_count: number;
-  total_tokens: number;
-  best: number;
-  worst: number;
-  rolling_7d: number | null;
-}
-
-interface TrendsResponse {
-  days: TrendDay[];
-  trend: "improving" | "steady" | "declining";
-  trend_delta: number;
-  week_over_week: number;
-  overall_avg: number | null;
-  current_streak: number;
-  best_day: { date: string; avg_efficiency: number } | null;
-  worst_day: { date: string; avg_efficiency: number } | null;
-  total_sessions: number;
-  days_with_data: number;
-}
-
-interface TimeHourRow {
-  hour: number;
-  label: string;
-  avg_efficiency: number;
-  session_count: number;
-}
-
-interface TimeDowRow {
-  dow: number;
-  label: string;
-  avg_efficiency: number;
-  session_count: number;
-}
-
-interface TimeIntelResponse {
-  by_hour: TimeHourRow[];
-  by_dow: TimeDowRow[];
-  peak_hour: TimeHourRow | null;
-  worst_hour: TimeHourRow | null;
-  peak_dow: TimeDowRow | null;
-  worst_dow: TimeDowRow | null;
-  peak_period: string;
-  sessions_analysed: number;
-  sessions_skipped: number;
-}
-
-interface ToolSizeBucket {
-  bucket: string;
-  avg_efficiency: number;
-  session_count: number;
-  label: string;
-}
-
-interface ToolRow {
-  tool: string;
-  session_count: number;
-  avg_efficiency: number;
-  category: string;
-}
-
-interface ToolFootprintResponse {
-  by_size: ToolSizeBucket[];
-  by_category_presence: Record<string, {
-    with: { avg: number; n: number } | null;
-    without: { avg: number; n: number } | null;
-  }>;
-  top_tools: ToolRow[];
-  optimal_range: string | null;
-  sessions_analysed: number;
-  sessions_skipped: number;
-}
-
-interface CostModelRow {
-  model: string;
-  agent: string;
-  session_count: number;
-  avg_cost: number;
-  total_cost: number;
-  avg_efficiency: number;
-  cost_per_eff_pt: number | null;
-  avg_cache_hit_pct: number | null;
-}
-
-interface CostTaskRow {
-  task_type: string;
-  session_count: number;
-  avg_cost: number;
-  avg_efficiency: number;
-  cost_per_eff_pt: number | null;
-}
-
-interface CostCacheTier {
-  tier: string;
-  avg_efficiency: number;
-  avg_cost: number;
-  session_count: number;
-}
-
-interface CostWasteful {
-  session_id: string;
-  model: string;
-  cost: number;
-  efficiency: number;
-  task_type: string;
-  waste_score: number;
-}
-
-interface CostIntelResponse {
-  by_model: CostModelRow[];
-  by_task_type: CostTaskRow[];
-  cache_tiers: CostCacheTier[];
-  wasteful: CostWasteful[];
-  best_value_model: string | null;
-  total_cost: number;
-  avg_cost_per_session: number;
-  avg_cache_hit_pct: number | null;
-  sessions_analysed: number;
-  sessions_skipped: number;
-}
-
 interface AnalyticsResponse {
   by_model?: Record<string, { total: number; session_count: number; agent: string }>;
   pricing_updated?: string;
@@ -274,7 +112,6 @@ export default function Home() {
   const analyticsRes = useResource<AnalyticsResponse>("/analytics", { pollMs: 30_000 });
   const billingRes   = useResource<BillingConfig>("/config/billing", { pollMs: 60_000 });
   const forecastRes  = useResource<ForecastResponse>("/forecast?plan=claude_pro", { pollMs: 60_000 });
-  const dnaRes       = useResource<PromptDnaResponse>("/insights/prompt-dna", { pollMs: 120_000 });
 
   const sessions = (sessionsRes.data ?? []).slice().sort((a, b) => {
     const ta = new Date(a.timestamp).getTime();
@@ -716,127 +553,6 @@ export default function Home() {
                   {fc.days_until_limit === null && (
                     <div className="text-[10px] text-[var(--tt-fg-faint)]">
                       On track — no limit exceeded at current pace
-                    </div>
-                  )}
-                </div>
-              </Card>
-            );
-          })()}
-
-          {/* Prompt DNA card */}
-          {(() => {
-            const dna = dnaRes.data;
-            if (!dna && dnaRes.loading) return (
-              <Card>
-                <CardHeader>
-                  <CardTitle><Sparkles size={14} className="text-purple-400" />Prompt DNA</CardTitle>
-                </CardHeader>
-                <Skeleton className="h-24 w-full" />
-              </Card>
-            );
-            if (!dna || dna.sessions_analysed < 3) return null;
-            const topPos = dna.top_positive.slice(0, 2);
-            const topNeg = dna.top_negative.slice(0, 2);
-            const taskRows = Object.entries(dna.by_task_type).sort((a, b) => b[1].avg_efficiency - a[1].avg_efficiency);
-            const maxEff = Math.max(...taskRows.map(([, v]) => v.avg_efficiency), 1);
-            return (
-              <Card>
-                <CardHeader>
-                  <CardTitle>
-                    <Sparkles size={14} className="text-purple-400" />
-                    Prompt DNA
-                  </CardTitle>
-                  <CardEyebrow>{dna.sessions_analysed} sessions</CardEyebrow>
-                </CardHeader>
-
-                <div className="space-y-4">
-                  {/* Positive correlates */}
-                  {topPos.length > 0 && (
-                    <div>
-                      <div className="text-[10px] uppercase tracking-[0.18em] text-[var(--tt-fg-faint)] mb-2">
-                        Boosts efficiency
-                      </div>
-                      <div className="space-y-1.5">
-                        {topPos.map((c) => (
-                          <div
-                            key={c.feature}
-                            className="group relative rounded-md px-2.5 py-2"
-                            style={{ backgroundColor: "#4ade8012", border: "1px solid #4ade8025" }}
-                            title={c.insight}
-                          >
-                            <div className="flex items-center justify-between gap-2">
-                              <span className="text-[11px] text-[#4ade80] font-medium truncate">{c.label}</span>
-                              <span className="text-[10px] tabular font-semibold text-[#4ade80] shrink-0">
-                                r={c.r.toFixed(2)}
-                              </span>
-                            </div>
-                            <div className="mt-1 text-[9px] leading-snug text-[var(--tt-fg-faint)] line-clamp-2">
-                              {c.insight}
-                            </div>
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-
-                  {/* Negative correlates */}
-                  {topNeg.length > 0 && (
-                    <div>
-                      <div className="text-[10px] uppercase tracking-[0.18em] text-[var(--tt-fg-faint)] mb-2">
-                        Hurts efficiency
-                      </div>
-                      <div className="space-y-1.5">
-                        {topNeg.map((c) => (
-                          <div
-                            key={c.feature}
-                            className="group relative rounded-md px-2.5 py-2"
-                            style={{ backgroundColor: "#f8717112", border: "1px solid #f8717125" }}
-                            title={c.insight}
-                          >
-                            <div className="flex items-center justify-between gap-2">
-                              <span className="text-[11px] text-[#f87171] font-medium truncate">{c.label}</span>
-                              <span className="text-[10px] tabular font-semibold text-[#f87171] shrink-0">
-                                r={c.r.toFixed(2)}
-                              </span>
-                            </div>
-                            <div className="mt-1 text-[9px] leading-snug text-[var(--tt-fg-faint)] line-clamp-2">
-                              {c.insight}
-                            </div>
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-
-                  {/* Task type breakdown */}
-                  {taskRows.length > 0 && (
-                    <div>
-                      <div className="text-[10px] uppercase tracking-[0.18em] text-[var(--tt-fg-faint)] mb-2">
-                        By task type
-                      </div>
-                      <div className="space-y-2">
-                        {taskRows.map(([tt, { avg_efficiency, count }]) => {
-                          const pct = (avg_efficiency / maxEff) * 100;
-                          const barColor = avg_efficiency >= 70 ? "#4ade80" : avg_efficiency >= 40 ? "#f59e0b" : "#f87171";
-                          return (
-                            <div key={tt} className="space-y-1">
-                              <div className="flex items-center justify-between text-[10px]">
-                                <span className="capitalize text-[var(--tt-fg-muted)]">{tt}</span>
-                                <span className="tabular text-[var(--tt-fg-faint)]">
-                                  {avg_efficiency.toFixed(0)}
-                                  <span className="text-[var(--tt-fg-dim)]"> / {count}</span>
-                                </span>
-                              </div>
-                              <div className="h-1 rounded-full tt-tint-1 overflow-hidden">
-                                <div
-                                  className="h-full rounded-full transition-[width] duration-500"
-                                  style={{ width: `${pct}%`, backgroundColor: barColor }}
-                                />
-                              </div>
-                            </div>
-                          );
-                        })}
-                      </div>
                     </div>
                   )}
                 </div>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -6,7 +6,7 @@ import { usePathname } from "next/navigation";
 import { format } from "date-fns";
 import {
   Activity, Clock, TrendingUp, Folders, DollarSign, Cpu, ArrowUpRight, Radio, Terminal,
-  Zap, AlertTriangle, Flame, TrendingDown,
+  Zap, AlertTriangle, Flame, TrendingDown, Sparkles,
 } from "lucide-react";
 
 import { useResource } from "@/lib/api";
@@ -62,6 +62,23 @@ interface ForecastResponse {
   buckets_30d: Record<string, number>;
 }
 
+interface DnaCorrelation {
+  feature: string;
+  label: string;
+  r: number;
+  direction: "positive" | "negative";
+  insight: string;
+}
+
+interface PromptDnaResponse {
+  sessions_analysed: number;
+  sessions_skipped: number;
+  correlations: DnaCorrelation[];
+  by_task_type: Record<string, { avg_efficiency: number; count: number }>;
+  top_positive: DnaCorrelation[];
+  top_negative: DnaCorrelation[];
+}
+
 interface AnalyticsResponse {
   by_model?: Record<string, { total: number; session_count: number; agent: string }>;
   pricing_updated?: string;
@@ -75,6 +92,7 @@ export default function Home() {
   const analyticsRes = useResource<AnalyticsResponse>("/analytics", { pollMs: 30_000 });
   const billingRes   = useResource<BillingConfig>("/config/billing", { pollMs: 60_000 });
   const forecastRes  = useResource<ForecastResponse>("/forecast?plan=claude_pro", { pollMs: 60_000 });
+  const dnaRes       = useResource<PromptDnaResponse>("/insights/prompt-dna", { pollMs: 120_000 });
 
   const sessions = (sessionsRes.data ?? []).slice().sort((a, b) => {
     const ta = new Date(a.timestamp).getTime();
@@ -507,6 +525,127 @@ export default function Home() {
                   {fc.days_until_limit === null && (
                     <div className="text-[10px] text-[var(--tt-fg-faint)]">
                       On track — no limit exceeded at current pace
+                    </div>
+                  )}
+                </div>
+              </Card>
+            );
+          })()}
+
+          {/* Prompt DNA card */}
+          {(() => {
+            const dna = dnaRes.data;
+            if (!dna && dnaRes.loading) return (
+              <Card>
+                <CardHeader>
+                  <CardTitle><Sparkles size={14} className="text-purple-400" />Prompt DNA</CardTitle>
+                </CardHeader>
+                <Skeleton className="h-24 w-full" />
+              </Card>
+            );
+            if (!dna || dna.sessions_analysed < 3) return null;
+            const topPos = dna.top_positive.slice(0, 2);
+            const topNeg = dna.top_negative.slice(0, 2);
+            const taskRows = Object.entries(dna.by_task_type).sort((a, b) => b[1].avg_efficiency - a[1].avg_efficiency);
+            const maxEff = Math.max(...taskRows.map(([, v]) => v.avg_efficiency), 1);
+            return (
+              <Card>
+                <CardHeader>
+                  <CardTitle>
+                    <Sparkles size={14} className="text-purple-400" />
+                    Prompt DNA
+                  </CardTitle>
+                  <CardEyebrow>{dna.sessions_analysed} sessions</CardEyebrow>
+                </CardHeader>
+
+                <div className="space-y-4">
+                  {/* Positive correlates */}
+                  {topPos.length > 0 && (
+                    <div>
+                      <div className="text-[10px] uppercase tracking-[0.18em] text-[var(--tt-fg-faint)] mb-2">
+                        Boosts efficiency
+                      </div>
+                      <div className="space-y-1.5">
+                        {topPos.map((c) => (
+                          <div
+                            key={c.feature}
+                            className="group relative rounded-md px-2.5 py-2"
+                            style={{ backgroundColor: "#4ade8012", border: "1px solid #4ade8025" }}
+                            title={c.insight}
+                          >
+                            <div className="flex items-center justify-between gap-2">
+                              <span className="text-[11px] text-[#4ade80] font-medium truncate">{c.label}</span>
+                              <span className="text-[10px] tabular font-semibold text-[#4ade80] shrink-0">
+                                r={c.r.toFixed(2)}
+                              </span>
+                            </div>
+                            <div className="mt-1 text-[9px] leading-snug text-[var(--tt-fg-faint)] line-clamp-2">
+                              {c.insight}
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Negative correlates */}
+                  {topNeg.length > 0 && (
+                    <div>
+                      <div className="text-[10px] uppercase tracking-[0.18em] text-[var(--tt-fg-faint)] mb-2">
+                        Hurts efficiency
+                      </div>
+                      <div className="space-y-1.5">
+                        {topNeg.map((c) => (
+                          <div
+                            key={c.feature}
+                            className="group relative rounded-md px-2.5 py-2"
+                            style={{ backgroundColor: "#f8717112", border: "1px solid #f8717125" }}
+                            title={c.insight}
+                          >
+                            <div className="flex items-center justify-between gap-2">
+                              <span className="text-[11px] text-[#f87171] font-medium truncate">{c.label}</span>
+                              <span className="text-[10px] tabular font-semibold text-[#f87171] shrink-0">
+                                r={c.r.toFixed(2)}
+                              </span>
+                            </div>
+                            <div className="mt-1 text-[9px] leading-snug text-[var(--tt-fg-faint)] line-clamp-2">
+                              {c.insight}
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Task type breakdown */}
+                  {taskRows.length > 0 && (
+                    <div>
+                      <div className="text-[10px] uppercase tracking-[0.18em] text-[var(--tt-fg-faint)] mb-2">
+                        By task type
+                      </div>
+                      <div className="space-y-2">
+                        {taskRows.map(([tt, { avg_efficiency, count }]) => {
+                          const pct = (avg_efficiency / maxEff) * 100;
+                          const barColor = avg_efficiency >= 70 ? "#4ade80" : avg_efficiency >= 40 ? "#f59e0b" : "#f87171";
+                          return (
+                            <div key={tt} className="space-y-1">
+                              <div className="flex items-center justify-between text-[10px]">
+                                <span className="capitalize text-[var(--tt-fg-muted)]">{tt}</span>
+                                <span className="tabular text-[var(--tt-fg-faint)]">
+                                  {avg_efficiency.toFixed(0)}
+                                  <span className="text-[var(--tt-fg-dim)]"> / {count}</span>
+                                </span>
+                              </div>
+                              <div className="h-1 rounded-full tt-tint-1 overflow-hidden">
+                                <div
+                                  className="h-full rounded-full transition-[width] duration-500"
+                                  style={{ width: `${pct}%`, backgroundColor: barColor }}
+                                />
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
                     </div>
                   )}
                 </div>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -6,6 +6,7 @@ import { usePathname } from "next/navigation";
 import { format } from "date-fns";
 import {
   Activity, Clock, TrendingUp, Folders, DollarSign, Cpu, ArrowUpRight, Radio, Terminal,
+  Zap, AlertTriangle, Flame, TrendingDown,
 } from "lucide-react";
 
 import { useResource } from "@/lib/api";
@@ -21,6 +22,13 @@ import {
   Table, THead, TBody, TR, TH, TD, AgentBadge, Badge, Button, EmptyState, Skeleton,
 } from "@/components/ui";
 
+interface Smell {
+  type: string;
+  title: string;
+  detail: string;
+  severity: "warning" | "critical";
+}
+
 interface Session {
   id: string;
   agent: string;
@@ -30,12 +38,28 @@ interface Session {
   text?: string;
   tokens?: { input: number; output: number; cached: number; total: number };
   cost?: number;
+  efficiency?: number | null;
+  efficiency_label?: "good" | "fair" | "poor" | "unknown";
+  smells?: Smell[];
   /** Copilot-only: cli / vscode */
   copilot_source?: string;
   /** Antigravity-only: cli / ide / app */
   antigravity_source?: string;
   /** Hermes-only: cli / telegram / cron / etc. */
   source_subtype?: string;
+}
+
+interface ForecastResponse {
+  daily_avg_7d: number;
+  daily_avg_30d: number;
+  projected_month: number;
+  used_this_month: number;
+  days_until_limit: number | null;
+  trend: "accelerating" | "steady" | "slowing";
+  trend_pct: number;
+  limit: number;
+  plan: string;
+  buckets_30d: Record<string, number>;
 }
 
 interface AnalyticsResponse {
@@ -46,10 +70,11 @@ interface AnalyticsResponse {
 
 export default function Home() {
   const pathname = usePathname();
-  const sessionsRes = useResource<Session[]>("/sessions", { pollMs: 15_000, initial: [] });
-  const agentsRes   = useResource<string[]>("/agents", { pollMs: 30_000, initial: [] });
+  const sessionsRes  = useResource<Session[]>("/sessions", { pollMs: 15_000, initial: [] });
+  const agentsRes    = useResource<string[]>("/agents", { pollMs: 30_000, initial: [] });
   const analyticsRes = useResource<AnalyticsResponse>("/analytics", { pollMs: 30_000 });
-  const billingRes  = useResource<BillingConfig>("/config/billing", { pollMs: 60_000 });
+  const billingRes   = useResource<BillingConfig>("/config/billing", { pollMs: 60_000 });
+  const forecastRes  = useResource<ForecastResponse>("/forecast?plan=claude_pro", { pollMs: 60_000 });
 
   const sessions = (sessionsRes.data ?? []).slice().sort((a, b) => {
     const ta = new Date(a.timestamp).getTime();
@@ -249,17 +274,42 @@ export default function Home() {
                     <TH className="pl-5">Agent</TH>
                     <TH>Project</TH>
                     <TH>Context</TH>
+                    <TH className="text-right">
+                      <span className="flex items-center justify-end gap-1">
+                        <Zap size={10} className="text-[var(--tt-brand)]" />
+                        Score
+                      </span>
+                    </TH>
                     <TH className="text-right pr-5">Time</TH>
                   </TR>
                 </THead>
                 <TBody>
-                  {sessions.slice(0, 50).map((s, i) => (
+                  {sessions.slice(0, 50).map((s, i) => {
+                    const smellCount = s.smells?.length ?? 0;
+                    const hasCritical = s.smells?.some((w) => w.severity === "critical") ?? false;
+                    const effLabel = s.efficiency_label;
+                    const effScore = s.efficiency;
+                    const effColor =
+                      effLabel === "good"  ? "#22c55e" :
+                      effLabel === "fair"  ? "#f59e0b" :
+                      effLabel === "poor"  ? "#ef4444" : "var(--tt-fg-faint)";
+                    return (
                     <TR key={`${s.agent}-${s.id}-${i}`} interactive>
                       <TD className="pl-5">
                         <Link href={`/sessions/${s.id}?agent=${s.agent}&from=${encodeURIComponent(pathname)}`} className="flex items-center gap-1.5">
                           <AgentBadge agent={s.agent} />
                           {s.agent === "copilot" && <CopilotSourceBadge source={s.copilot_source} size="xs" />}
                           {s.agent === "antigravity" && <AntigravitySourceBadge source={s.antigravity_source} size="xs" />}
+                          {smellCount > 0 && (
+                            <span
+                              title={`${smellCount} smell${smellCount > 1 ? "s" : ""} detected${hasCritical ? " (critical)" : ""}`}
+                              className="ml-0.5 flex items-center gap-0.5"
+                              style={{ color: hasCritical ? "#ef4444" : "#f59e0b" }}
+                            >
+                              <AlertTriangle size={10} />
+                              {smellCount > 1 && <span className="text-[9px] font-semibold leading-none">{smellCount}</span>}
+                            </span>
+                          )}
                         </Link>
                       </TD>
                       <TD className="font-mono text-[12px] text-[var(--tt-fg-muted)] max-w-[160px] truncate" title={s.agent === "hermes" ? `Hermes source: ${s.source_subtype || "unknown"}` : s.project}>
@@ -278,6 +328,26 @@ export default function Home() {
                           )}
                         </Link>
                       </TD>
+                      <TD className="text-right">
+                        <Link href={`/sessions/${s.id}?agent=${s.agent}&from=${encodeURIComponent(pathname)}`} className="flex justify-end">
+                          {effScore != null ? (
+                            <span
+                              className="inline-flex items-center gap-0.5 rounded px-1.5 py-0.5 text-[10px] font-semibold tabular leading-none"
+                              style={{
+                                backgroundColor: `${effColor}18`,
+                                color: effColor,
+                                border: `1px solid ${effColor}30`,
+                              }}
+                              title={`Efficiency: ${effScore}/100 (${effLabel})`}
+                            >
+                              <Zap size={8} />
+                              {effScore}
+                            </span>
+                          ) : (
+                            <span className="text-[10px] text-[var(--tt-fg-faint)]">—</span>
+                          )}
+                        </Link>
+                      </TD>
                       <TD className="text-right pr-5 tabular text-[11px] text-[var(--tt-fg-muted)] group-hover:text-[var(--tt-brand)] transition-colors">
                         <Link href={`/sessions/${s.id}?agent=${s.agent}&from=${encodeURIComponent(pathname)}`} className="block">
                           <div>{format(new Date(s.timestamp), "HH:mm:ss")}</div>
@@ -287,7 +357,8 @@ export default function Home() {
                         </Link>
                       </TD>
                     </TR>
-                  ))}
+                    );
+                  })}
                 </TBody>
               </Table>
             </div>
@@ -344,6 +415,104 @@ export default function Home() {
               <ArrowUpRight size={12} />
             </Link>
           </Card>
+
+          {/* Burn Rate Forecast card */}
+          {(() => {
+            const fc = forecastRes.data;
+            if (!fc && forecastRes.loading) return (
+              <Card>
+                <CardHeader>
+                  <CardTitle><Flame size={14} className="text-orange-400" />Burn rate</CardTitle>
+                </CardHeader>
+                <Skeleton className="h-16 w-full" />
+              </Card>
+            );
+            if (!fc) return null;
+            const trendIcon =
+              fc.trend === "accelerating" ? <TrendingUp size={11} className="text-red-400" /> :
+              fc.trend === "slowing"      ? <TrendingDown size={11} className="text-emerald-400" /> :
+                                           <span className="w-2.5 h-0.5 rounded bg-[var(--tt-fg-faint)]" />;
+            const trendColor =
+              fc.trend === "accelerating" ? "#f87171" :
+              fc.trend === "slowing"      ? "#4ade80" : "var(--tt-fg-dim)";
+            const dailyM = (fc.daily_avg_7d / 1e6).toFixed(1);
+            const projM  = (fc.projected_month / 1e6).toFixed(0);
+            const limitM = fc.limit > 0 ? (fc.limit / 1e6).toFixed(0) : null;
+            const pctUsed = fc.limit > 0
+              ? Math.min((fc.used_this_month / fc.limit) * 100, 100)
+              : null;
+            const urgentLimit = fc.days_until_limit != null && fc.days_until_limit <= 7;
+            return (
+              <Card>
+                <CardHeader>
+                  <CardTitle>
+                    <Flame size={14} className="text-orange-400" />
+                    Burn rate
+                  </CardTitle>
+                  <CardEyebrow className="flex items-center gap-1" style={{ color: trendColor }}>
+                    {trendIcon}
+                    {fc.trend}
+                    {Math.abs(fc.trend_pct) >= 5 && (
+                      <span className="ml-0.5">({fc.trend_pct > 0 ? "+" : ""}{fc.trend_pct.toFixed(0)}%)</span>
+                    )}
+                  </CardEyebrow>
+                </CardHeader>
+
+                <div className="space-y-3">
+                  {/* Daily rate */}
+                  <div className="flex items-end justify-between">
+                    <div>
+                      <div className="text-[22px] font-semibold tabular text-[var(--tt-fg)] leading-none">{dailyM}M</div>
+                      <div className="text-[10px] uppercase tracking-[0.16em] text-[var(--tt-fg-faint)] mt-0.5">tokens / day (7d avg)</div>
+                    </div>
+                    <div className="text-right">
+                      <div className="text-[13px] font-medium tabular text-[var(--tt-fg-muted)]">{projM}M</div>
+                      <div className="text-[10px] text-[var(--tt-fg-faint)]">proj. this month</div>
+                    </div>
+                  </div>
+
+                  {/* Limit bar */}
+                  {pctUsed != null && limitM && (
+                    <div className="space-y-1">
+                      <div className="flex justify-between text-[10px] text-[var(--tt-fg-faint)]">
+                        <span>{(fc.used_this_month / 1e6).toFixed(0)}M used</span>
+                        <span>{limitM}M limit (Claude Pro)</span>
+                      </div>
+                      <div className="h-1.5 rounded-full tt-tint-1 overflow-hidden">
+                        <div
+                          className="h-full rounded-full transition-[width] duration-700"
+                          style={{
+                            width: `${pctUsed}%`,
+                            backgroundColor: pctUsed > 80 ? "#f87171" : pctUsed > 50 ? "#f59e0b" : "#4ade80",
+                          }}
+                        />
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Days until limit */}
+                  {fc.days_until_limit != null && (
+                    <div
+                      className="flex items-center gap-1.5 rounded-md px-2.5 py-2 text-[11px] font-medium"
+                      style={{
+                        backgroundColor: urgentLimit ? "#ef444420" : "#f59e0b12",
+                        color: urgentLimit ? "#f87171" : "#f59e0b",
+                        border: `1px solid ${urgentLimit ? "#ef444430" : "#f59e0b25"}`,
+                      }}
+                    >
+                      <AlertTriangle size={11} />
+                      Limit in ~{fc.days_until_limit} day{fc.days_until_limit !== 1 ? "s" : ""} at current pace
+                    </div>
+                  )}
+                  {fc.days_until_limit === null && (
+                    <div className="text-[10px] text-[var(--tt-fg-faint)]">
+                      On track — no limit exceeded at current pace
+                    </div>
+                  )}
+                </div>
+              </Card>
+            );
+          })()}
 
           {modelRows.length > 0 && (
             <Card>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -213,6 +213,54 @@ interface ToolFootprintResponse {
   sessions_skipped: number;
 }
 
+interface CostModelRow {
+  model: string;
+  agent: string;
+  session_count: number;
+  avg_cost: number;
+  total_cost: number;
+  avg_efficiency: number;
+  cost_per_eff_pt: number | null;
+  avg_cache_hit_pct: number | null;
+}
+
+interface CostTaskRow {
+  task_type: string;
+  session_count: number;
+  avg_cost: number;
+  avg_efficiency: number;
+  cost_per_eff_pt: number | null;
+}
+
+interface CostCacheTier {
+  tier: string;
+  avg_efficiency: number;
+  avg_cost: number;
+  session_count: number;
+}
+
+interface CostWasteful {
+  session_id: string;
+  model: string;
+  cost: number;
+  efficiency: number;
+  task_type: string;
+  waste_score: number;
+}
+
+interface CostIntelResponse {
+  by_model: CostModelRow[];
+  by_task_type: CostTaskRow[];
+  cache_tiers: CostCacheTier[];
+  wasteful: CostWasteful[];
+  best_value_model: string | null;
+  total_cost: number;
+  avg_cost_per_session: number;
+  avg_cache_hit_pct: number | null;
+  sessions_analysed: number;
+  sessions_skipped: number;
+}
+
 interface AnalyticsResponse {
   by_model?: Record<string, { total: number; session_count: number; agent: string }>;
   pricing_updated?: string;
@@ -232,6 +280,7 @@ export default function Home() {
   const trendsRes    = useResource<TrendsResponse>(`/insights/trends?days=${trendsDays}`, { pollMs: 120_000 });
   const timeRes      = useResource<TimeIntelResponse>("/insights/time", { pollMs: 120_000 });
   const toolRes      = useResource<ToolFootprintResponse>("/insights/tool-footprint", { pollMs: 120_000 });
+  const costRes      = useResource<CostIntelResponse>("/insights/cost", { pollMs: 120_000 });
 
   const sessions = (sessionsRes.data ?? []).slice().sort((a, b) => {
     const ta = new Date(a.timestamp).getTime();
@@ -1440,6 +1489,165 @@ export default function Home() {
                   ))}
                 </div>
               </Card>
+            </div>
+          </Section>
+        );
+      })()}
+
+      {/* ── Cost Intelligence ─────────────────────────────────── */}
+      {(costRes.data?.sessions_analysed ?? 0) >= 2 && (() => {
+        const ci = costRes.data!;
+
+        const fmtCost = (v: number) =>
+          v >= 1 ? `$${v.toFixed(2)}` : `$${v.toFixed(4)}`;
+
+        const fmtCpp = (v: number | null) => {
+          if (v === null) return "—";
+          if (v < 0.01) return `$${v.toFixed(5)}/pt`;
+          return `$${v.toFixed(3)}/pt`;
+        };
+
+        const effColor = (v: number) =>
+          v >= 70 ? "#4ade80" : v >= 40 ? "#facc15" : "#f87171";
+
+        // max cpp for bar scaling
+        const maxCpp = Math.max(
+          ...ci.by_model.filter(r => r.cost_per_eff_pt !== null).map(r => r.cost_per_eff_pt as number),
+          0.001,
+        );
+
+        return (
+          <Section
+            title="Cost intelligence"
+            description={`${fmtCost(ci.total_cost)} total spend · ${ci.sessions_analysed} sessions · ${ci.avg_cache_hit_pct?.toFixed(0) ?? "—"}% avg cache hit`}
+          >
+            {/* Stats strip */}
+            <div className="flex flex-wrap gap-3 mb-4">
+              <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-[var(--tt-surface-raised)] text-xs">
+                <DollarSign size={12} className="text-emerald-400" />
+                <span className="text-[var(--tt-fg-muted)]">Total spend</span>
+                <span className="font-semibold text-[var(--tt-fg)]">{fmtCost(ci.total_cost)}</span>
+              </div>
+              <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-[var(--tt-surface-raised)] text-xs">
+                <span className="text-[var(--tt-fg-muted)]">Avg / session</span>
+                <span className="font-semibold text-[var(--tt-fg)]">{fmtCost(ci.avg_cost_per_session)}</span>
+              </div>
+              {ci.best_value_model && (
+                <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-[var(--tt-surface-raised)] text-xs">
+                  <span className="text-emerald-400 font-semibold">Best value</span>
+                  <span className="font-mono text-[var(--tt-fg)]">{ci.best_value_model}</span>
+                </div>
+              )}
+              {ci.avg_cache_hit_pct !== null && (
+                <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-[var(--tt-surface-raised)] text-xs">
+                  <span className="text-[var(--tt-fg-muted)]">Cache hit</span>
+                  <span className="font-semibold text-[var(--tt-fg)]">{ci.avg_cache_hit_pct.toFixed(0)}%</span>
+                </div>
+              )}
+            </div>
+
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+              {/* By model — cost per efficiency point */}
+              <Card className="space-y-3">
+                <div className="text-xs font-semibold text-[var(--tt-fg-dim)] uppercase tracking-wide">
+                  Cost per efficiency point <span className="normal-case font-normal text-[var(--tt-fg-faint)]">(lower = better value)</span>
+                </div>
+                <div className="space-y-2.5">
+                  {ci.by_model.map((m) => (
+                    <div key={m.model} className="space-y-1">
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-1.5 min-w-0">
+                          <span className="font-mono text-[11px] text-[var(--tt-fg)] truncate">{m.model}</span>
+                          <span className="text-[10px] text-[var(--tt-fg-faint)]">×{m.session_count}</span>
+                        </div>
+                        <div className="flex items-center gap-3 shrink-0 ml-2">
+                          <span className="text-[10px]" style={{ color: effColor(m.avg_efficiency) }}>
+                            {m.avg_efficiency.toFixed(1)} eff
+                          </span>
+                          <span className="text-[11px] font-mono text-[var(--tt-fg-muted)] tabular">
+                            {fmtCpp(m.cost_per_eff_pt)}
+                          </span>
+                        </div>
+                      </div>
+                      {m.cost_per_eff_pt !== null && (
+                        <div className="h-1.5 bg-[var(--tt-surface-raised)] rounded overflow-hidden">
+                          <div
+                            className="h-full rounded"
+                            style={{
+                              width: `${Math.min((m.cost_per_eff_pt / maxCpp) * 100, 100)}%`,
+                              background: m.cost_per_eff_pt / maxCpp < 0.3
+                                ? "#4ade80"
+                                : m.cost_per_eff_pt / maxCpp < 0.7
+                                ? "#facc15"
+                                : "#f87171",
+                              opacity: 0.8,
+                            }}
+                          />
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </Card>
+
+              {/* Right column: cache tiers + wasteful */}
+              <div className="space-y-4">
+                {/* Cache tier analysis */}
+                {ci.cache_tiers.length >= 2 && (
+                  <Card className="space-y-3">
+                    <div className="text-xs font-semibold text-[var(--tt-fg-dim)] uppercase tracking-wide">
+                      Cache hit rate vs efficiency
+                    </div>
+                    <div className="space-y-1.5">
+                      {ci.cache_tiers.map((t) => (
+                        <div key={t.tier} className="flex items-center gap-2">
+                          <div className="w-16 text-[10px] text-[var(--tt-fg-faint)] tabular shrink-0">{t.tier}</div>
+                          <div className="flex-1 h-4 bg-[var(--tt-surface-raised)] rounded overflow-hidden">
+                            <div
+                              className="h-full rounded"
+                              style={{
+                                width: `${t.avg_efficiency}%`,
+                                background: effColor(t.avg_efficiency),
+                                opacity: 0.75,
+                              }}
+                            />
+                          </div>
+                          <span className="text-[11px] font-mono w-8 text-right tabular" style={{ color: effColor(t.avg_efficiency) }}>
+                            {t.avg_efficiency.toFixed(0)}
+                          </span>
+                          <span className="text-[10px] text-[var(--tt-fg-faint)] w-14 text-right tabular shrink-0">
+                            {fmtCost(t.avg_cost)}
+                          </span>
+                          <span className="text-[10px] text-[var(--tt-fg-faint)] shrink-0">×{t.session_count}</span>
+                        </div>
+                      ))}
+                    </div>
+                  </Card>
+                )}
+
+                {/* Wasteful sessions */}
+                {ci.wasteful.length > 0 && (
+                  <Card className="space-y-3">
+                    <div className="text-xs font-semibold text-[var(--tt-fg-dim)] uppercase tracking-wide flex items-center gap-1.5">
+                      <AlertTriangle size={11} className="text-red-400" />
+                      Expensive flops
+                      <span className="normal-case font-normal text-[var(--tt-fg-faint)]">high cost, low efficiency</span>
+                    </div>
+                    <div className="space-y-2">
+                      {ci.wasteful.map((w) => (
+                        <div key={w.session_id} className="flex items-center gap-2 py-1 border-b border-[var(--tt-border)] last:border-0">
+                          <span className="font-mono text-[10px] text-[var(--tt-fg-faint)] shrink-0">{w.session_id.slice(0, 8)}</span>
+                          <span className="font-mono text-[10px] text-[var(--tt-fg)] truncate flex-1">{w.model}</span>
+                          <span className="text-[11px] font-mono text-red-400 tabular shrink-0">{fmtCost(w.cost)}</span>
+                          <span className="text-[10px] tabular shrink-0" style={{ color: effColor(w.efficiency) }}>
+                            {w.efficiency.toFixed(1)}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  </Card>
+                )}
+              </div>
             </div>
           </Section>
         );

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -6,7 +6,7 @@ import { usePathname } from "next/navigation";
 import { format } from "date-fns";
 import {
   Activity, Clock, TrendingUp, Folders, DollarSign, Cpu, ArrowUpRight, Radio, Terminal,
-  Zap, AlertTriangle, Flame, TrendingDown, Sparkles, BarChart3,
+  Zap, AlertTriangle, Flame, TrendingDown, Sparkles, BarChart3, GitBranch, GitCommit, Plus, Minus,
 } from "lucide-react";
 
 import { useResource } from "@/lib/api";
@@ -47,6 +47,7 @@ interface Session {
   antigravity_source?: string;
   /** Hermes-only: cli / telegram / cron / etc. */
   source_subtype?: string;
+  git_info?: GitInfo;
 }
 
 interface ForecastResponse {
@@ -101,6 +102,38 @@ interface ModelComparisonResponse {
   task_types_available: string[];
 }
 
+interface GitInfo {
+  is_git: boolean;
+  branch: string | null;
+  commit_sha: string | null;
+  commit_msg: string | null;
+  files_changed: number;
+  lines_added: number;
+  lines_deleted: number;
+}
+
+interface GitProjectSummary {
+  project: string;
+  branch: string | null;
+  session_count: number;
+  total_files_changed: number;
+  total_lines_added: number;
+  total_lines_deleted: number;
+  net_lines: number;
+  latest_commit_sha: string | null;
+  latest_commit_msg: string | null;
+  avg_files_per_session: number;
+}
+
+interface GitSummaryResponse {
+  projects: GitProjectSummary[];
+  total_lines_added: number;
+  total_lines_deleted: number;
+  total_files_changed: number;
+  git_sessions: number;
+  non_git_sessions: number;
+}
+
 interface AnalyticsResponse {
   by_model?: Record<string, { total: number; session_count: number; agent: string }>;
   pricing_updated?: string;
@@ -115,6 +148,7 @@ export default function Home() {
   const billingRes   = useResource<BillingConfig>("/config/billing", { pollMs: 60_000 });
   const forecastRes  = useResource<ForecastResponse>("/forecast?plan=claude_pro", { pollMs: 60_000 });
   const dnaRes       = useResource<PromptDnaResponse>("/insights/prompt-dna", { pollMs: 120_000 });
+  const gitRes       = useResource<GitSummaryResponse>("/insights/git-summary", { pollMs: 60_000 });
 
   const sessions = (sessionsRes.data ?? []).slice().sort((a, b) => {
     const ta = new Date(a.timestamp).getTime();
@@ -366,12 +400,20 @@ export default function Home() {
                           )}
                         </Link>
                       </TD>
-                      <TD className="font-mono text-[12px] text-[var(--tt-fg-muted)] max-w-[160px] truncate" title={s.agent === "hermes" ? `Hermes source: ${s.source_subtype || "unknown"}` : s.project}>
-                        <Link href={`/sessions/${s.id}?agent=${s.agent}&from=${encodeURIComponent(pathname)}`} className="block truncate">
-                          {s.agent === "hermes" ? (
-                            <SourceBadge source={s.source_subtype} size="xs" />
-                          ) : (
-                            s.project.split("/").pop()
+                      <TD className="font-mono text-[12px] text-[var(--tt-fg-muted)] max-w-[180px]" title={s.agent === "hermes" ? `Hermes source: ${s.source_subtype || "unknown"}` : s.project}>
+                        <Link href={`/sessions/${s.id}?agent=${s.agent}&from=${encodeURIComponent(pathname)}`} className="flex flex-col gap-0.5 truncate">
+                          <span className="truncate">
+                            {s.agent === "hermes" ? (
+                              <SourceBadge source={s.source_subtype} size="xs" />
+                            ) : (
+                              s.project.split(/[/\\]/).pop()
+                            )}
+                          </span>
+                          {s.git_info?.is_git && s.git_info.branch && (
+                            <span className="flex items-center gap-0.5 text-[9px] text-[var(--tt-fg-faint)]">
+                              <GitBranch size={8} />
+                              <span className="truncate max-w-[120px]">{s.git_info.branch}</span>
+                            </span>
                           )}
                         </Link>
                       </TD>
@@ -889,6 +931,77 @@ export default function Home() {
               </div>
             )}
           </Card>
+        </Section>
+      )}
+      {/* ── Git Activity ──────────────────────────────────────── */}
+      {(gitRes.data?.git_sessions ?? 0) > 0 && (
+        <Section
+          title="Repository activity"
+          description={`${gitRes.data!.git_sessions} git-tracked sessions · +${gitRes.data!.total_lines_added.toLocaleString()} / −${gitRes.data!.total_lines_deleted.toLocaleString()} lines across ${gitRes.data!.projects.length} repos`}
+        >
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
+            {gitRes.data!.projects.filter(p => p.session_count > 0).map((p) => {
+              const projName = p.project.split(/[/\\]/).pop() || p.project;
+              const hasStats = p.total_lines_added > 0 || p.total_lines_deleted > 0;
+              const netColor = p.net_lines > 0 ? "#4ade80" : p.net_lines < 0 ? "#f87171" : "var(--tt-fg-faint)";
+              return (
+                <Card key={p.project} className="space-y-3">
+                  {/* Header */}
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      <div className="font-mono text-[12px] font-semibold text-[var(--tt-fg)] truncate" title={p.project}>
+                        {projName}
+                      </div>
+                      {p.branch && (
+                        <div className="flex items-center gap-1 mt-0.5 text-[10px] text-[var(--tt-fg-faint)]">
+                          <GitBranch size={9} />
+                          <span className="truncate">{p.branch}</span>
+                        </div>
+                      )}
+                    </div>
+                    <span className="text-[10px] tabular text-[var(--tt-fg-dim)] whitespace-nowrap shrink-0">
+                      {p.session_count} sess
+                    </span>
+                  </div>
+
+                  {/* Latest commit */}
+                  {p.latest_commit_sha && (
+                    <div className="flex items-start gap-1.5">
+                      <GitCommit size={10} className="text-[var(--tt-fg-faint)] mt-0.5 shrink-0" />
+                      <div className="min-w-0">
+                        <span className="font-mono text-[10px] text-[var(--tt-brand)]">{p.latest_commit_sha}</span>
+                        <span className="ml-1.5 text-[10px] text-[var(--tt-fg-muted)] truncate block" title={p.latest_commit_msg ?? ""}>
+                          {p.latest_commit_msg}
+                        </span>
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Line stats */}
+                  {hasStats && (
+                    <div className="flex items-center gap-3 pt-1 border-t border-[var(--tt-border)]">
+                      <div className="flex items-center gap-1 text-[10px] text-emerald-400">
+                        <Plus size={9} />
+                        <span className="tabular">{p.total_lines_added.toLocaleString()}</span>
+                      </div>
+                      <div className="flex items-center gap-1 text-[10px] text-red-400">
+                        <Minus size={9} />
+                        <span className="tabular">{p.total_lines_deleted.toLocaleString()}</span>
+                      </div>
+                      <div className="flex items-center gap-1 text-[10px]" style={{ color: netColor }}>
+                        <span className="tabular font-medium">
+                          {p.net_lines > 0 ? "+" : ""}{p.net_lines.toLocaleString()} net
+                        </span>
+                      </div>
+                      <div className="ml-auto text-[10px] text-[var(--tt-fg-faint)] tabular">
+                        {p.total_files_changed} files
+                      </div>
+                    </div>
+                  )}
+                </Card>
+              );
+            })}
+          </div>
         </Section>
       )}
     </div>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -6,7 +6,7 @@ import { usePathname } from "next/navigation";
 import { format } from "date-fns";
 import {
   Activity, Clock, TrendingUp, Folders, DollarSign, Cpu, ArrowUpRight, Radio, Terminal,
-  Zap, AlertTriangle, Flame, TrendingDown, Sparkles,
+  Zap, AlertTriangle, Flame, TrendingDown, Sparkles, BarChart3,
 } from "lucide-react";
 
 import { useResource } from "@/lib/api";
@@ -79,6 +79,28 @@ interface PromptDnaResponse {
   top_negative: DnaCorrelation[];
 }
 
+interface ModelRow {
+  model: string;
+  agent: string;
+  session_count: number;
+  avg_efficiency: number;
+  median_efficiency: number;
+  p75_efficiency: number;
+  best_efficiency: number;
+  total_tokens: number;
+  avg_tokens: number;
+  task_breakdown: Record<string, { count: number; avg_efficiency: number }>;
+}
+
+interface ModelComparisonResponse {
+  task_type_filter: string | null;
+  models_compared: number;
+  sessions_used: number;
+  sessions_skipped: number;
+  models: ModelRow[];
+  task_types_available: string[];
+}
+
 interface AnalyticsResponse {
   by_model?: Record<string, { total: number; session_count: number; agent: string }>;
   pricing_updated?: string;
@@ -122,6 +144,20 @@ export default function Home() {
     window.addEventListener("storage", check);
     return () => window.removeEventListener("storage", check);
   }, []);
+
+  const [modelTaskFilter, setModelTaskFilter] = useState<string>("all");
+  const [modelComparison, setModelComparison] = useState<ModelComparisonResponse | null>(null);
+  const [modelCompLoading, setModelCompLoading] = useState(true);
+  useEffect(() => {
+    setModelCompLoading(true);
+    const url = modelTaskFilter === "all"
+      ? "/insights/model-comparison"
+      : `/insights/model-comparison?task_type=${modelTaskFilter}`;
+    fetch(`http://localhost:8000${url}`)
+      .then((r) => r.json())
+      .then((d) => { setModelComparison(d); setModelCompLoading(false); })
+      .catch(() => setModelCompLoading(false));
+  }, [modelTaskFilter]);
 
   return (
     <div className="px-8 py-8 max-w-[1600px] mx-auto space-y-10 pb-20">
@@ -687,6 +723,174 @@ export default function Home() {
           )}
         </div>
       </div>
+
+      {/* ── Model Comparison ─────────────────────────────────────── */}
+      {(modelComparison?.models_compared ?? 0) > 0 && (
+        <Section
+          title="Model comparison"
+          description="Efficiency breakdown across models — how productively each model converts tokens into output."
+        >
+          <Card padding="none" className="overflow-hidden">
+            {/* Filter pills */}
+            <div className="flex items-center gap-2 px-5 py-3 border-b border-[var(--tt-border)] overflow-x-auto">
+              <BarChart3 size={12} className="text-[var(--tt-brand)] shrink-0" />
+              <span className="text-[10px] uppercase tracking-[0.18em] text-[var(--tt-fg-faint)] shrink-0 mr-1">
+                Task type
+              </span>
+              {["all", ...(modelComparison?.task_types_available ?? [])].map((tt) => (
+                <button
+                  key={tt}
+                  onClick={() => setModelTaskFilter(tt)}
+                  className="shrink-0 rounded-full px-2.5 py-0.5 text-[10px] font-medium capitalize transition-colors"
+                  style={{
+                    backgroundColor: modelTaskFilter === tt
+                      ? "var(--tt-brand)"
+                      : "var(--tt-tint-1, rgba(255,255,255,0.05))",
+                    color: modelTaskFilter === tt
+                      ? "white"
+                      : "var(--tt-fg-muted)",
+                    border: `1px solid ${modelTaskFilter === tt ? "var(--tt-brand)" : "var(--tt-border)"}`,
+                  }}
+                >
+                  {tt}
+                </button>
+              ))}
+              <span className="ml-auto text-[10px] text-[var(--tt-fg-faint)] whitespace-nowrap shrink-0">
+                {modelComparison?.sessions_used ?? 0} sessions
+              </span>
+            </div>
+
+            {/* Model rows */}
+            {modelCompLoading ? (
+              <div className="p-5 space-y-4">
+                {[1, 2, 3].map((i) => <Skeleton key={i} className="h-14 w-full" />)}
+              </div>
+            ) : (modelComparison?.models ?? []).length === 0 ? (
+              <div className="py-10 text-center text-[12px] text-[var(--tt-fg-faint)]">
+                No sessions match this filter.
+              </div>
+            ) : (
+              <div className="divide-y divide-[var(--tt-border)]">
+                {(modelComparison?.models ?? []).map((m, rank) => {
+                  const meta = getAgent(m.agent);
+                  const effColor =
+                    m.avg_efficiency >= 70 ? "#22c55e" :
+                    m.avg_efficiency >= 40 ? "#f59e0b" : "#ef4444";
+                  const bestInSet = modelComparison!.models[0].avg_efficiency || 1;
+                  const barPct = (m.avg_efficiency / bestInSet) * 100;
+                  const p75Pct = (m.p75_efficiency / bestInSet) * 100;
+                  return (
+                    <div key={m.model} className="px-5 py-4 flex items-center gap-4 hover:bg-[var(--tt-sunken)] transition-colors">
+                      {/* Rank */}
+                      <span
+                        className="w-5 h-5 rounded-full grid place-items-center text-[10px] font-bold shrink-0"
+                        style={{
+                          backgroundColor: rank === 0 ? `${meta.hex}22` : "var(--tt-tint-1,rgba(255,255,255,0.05))",
+                          color: rank === 0 ? meta.hex : "var(--tt-fg-faint)",
+                        }}
+                      >
+                        {rank + 1}
+                      </span>
+
+                      {/* Model name + agent */}
+                      <div className="min-w-0 w-44 shrink-0">
+                        <div className="font-mono text-[12px] text-[var(--tt-fg)] truncate" title={m.model}>
+                          {m.model}
+                        </div>
+                        <div
+                          className="text-[10px] uppercase tracking-[0.14em] mt-0.5"
+                          style={{ color: meta.hex }}
+                        >
+                          {m.agent}
+                        </div>
+                      </div>
+
+                      {/* Bars */}
+                      <div className="flex-1 min-w-0 space-y-1.5">
+                        {/* Avg bar */}
+                        <div className="flex items-center gap-2">
+                          <span className="text-[9px] uppercase tracking-wider text-[var(--tt-fg-faint)] w-6 shrink-0">avg</span>
+                          <div className="flex-1 h-2 rounded-full tt-tint-1 overflow-hidden">
+                            <div
+                              className="h-full rounded-full transition-[width] duration-700"
+                              style={{ width: `${barPct}%`, backgroundColor: effColor }}
+                            />
+                          </div>
+                          <span
+                            className="text-[11px] font-semibold tabular shrink-0 w-8 text-right"
+                            style={{ color: effColor }}
+                          >
+                            {m.avg_efficiency}
+                          </span>
+                        </div>
+                        {/* P75 bar */}
+                        <div className="flex items-center gap-2">
+                          <span className="text-[9px] uppercase tracking-wider text-[var(--tt-fg-faint)] w-6 shrink-0">p75</span>
+                          <div className="flex-1 h-1 rounded-full tt-tint-1 overflow-hidden">
+                            <div
+                              className="h-full rounded-full transition-[width] duration-700"
+                              style={{ width: `${p75Pct}%`, backgroundColor: `${effColor}88` }}
+                            />
+                          </div>
+                          <span className="text-[10px] tabular text-[var(--tt-fg-faint)] shrink-0 w-8 text-right">
+                            {m.p75_efficiency}
+                          </span>
+                        </div>
+                      </div>
+
+                      {/* Stats */}
+                      <div className="flex items-center gap-4 shrink-0 ml-2">
+                        <div className="text-center hidden sm:block">
+                          <div className="text-[11px] font-semibold tabular text-[var(--tt-fg)]">
+                            {m.best_efficiency}
+                          </div>
+                          <div className="text-[9px] uppercase tracking-wider text-[var(--tt-fg-faint)]">best</div>
+                        </div>
+                        <div className="text-center">
+                          <div className="text-[11px] tabular text-[var(--tt-fg-muted)]">
+                            {m.session_count}
+                          </div>
+                          <div className="text-[9px] uppercase tracking-wider text-[var(--tt-fg-faint)]">sess</div>
+                        </div>
+                        <div className="text-center hidden md:block">
+                          <div className="text-[11px] tabular text-[var(--tt-fg-muted)]">
+                            {(m.avg_tokens / 1_000).toFixed(0)}k
+                          </div>
+                          <div className="text-[9px] uppercase tracking-wider text-[var(--tt-fg-faint)]">avg tok</div>
+                        </div>
+                        {/* Task breakdown pills */}
+                        <div className="hidden lg:flex items-center gap-1 flex-wrap max-w-[180px]">
+                          {Object.entries(m.task_breakdown)
+                            .sort((a, b) => b[1].count - a[1].count)
+                            .slice(0, 3)
+                            .map(([tt, { count, avg_efficiency: te }]) => {
+                              const tc = te >= 70 ? "#22c55e" : te >= 40 ? "#f59e0b" : "#ef4444";
+                              return (
+                                <span
+                                  key={tt}
+                                  title={`${tt}: ${te} avg efficiency (${count} sessions)`}
+                                  className="inline-flex items-center gap-0.5 rounded px-1.5 py-0.5 text-[9px] font-medium capitalize"
+                                  style={{
+                                    backgroundColor: `${tc}12`,
+                                    color: tc,
+                                    border: `1px solid ${tc}30`,
+                                  }}
+                                >
+                                  {tt}
+                                  <span className="opacity-70">{count}</span>
+                                </span>
+                              );
+                            })}
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </Card>
+        </Section>
+      )}
     </div>
   );
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -161,6 +161,58 @@ interface TrendsResponse {
   days_with_data: number;
 }
 
+interface TimeHourRow {
+  hour: number;
+  label: string;
+  avg_efficiency: number;
+  session_count: number;
+}
+
+interface TimeDowRow {
+  dow: number;
+  label: string;
+  avg_efficiency: number;
+  session_count: number;
+}
+
+interface TimeIntelResponse {
+  by_hour: TimeHourRow[];
+  by_dow: TimeDowRow[];
+  peak_hour: TimeHourRow | null;
+  worst_hour: TimeHourRow | null;
+  peak_dow: TimeDowRow | null;
+  worst_dow: TimeDowRow | null;
+  peak_period: string;
+  sessions_analysed: number;
+  sessions_skipped: number;
+}
+
+interface ToolSizeBucket {
+  bucket: string;
+  avg_efficiency: number;
+  session_count: number;
+  label: string;
+}
+
+interface ToolRow {
+  tool: string;
+  session_count: number;
+  avg_efficiency: number;
+  category: string;
+}
+
+interface ToolFootprintResponse {
+  by_size: ToolSizeBucket[];
+  by_category_presence: Record<string, {
+    with: { avg: number; n: number } | null;
+    without: { avg: number; n: number } | null;
+  }>;
+  top_tools: ToolRow[];
+  optimal_range: string | null;
+  sessions_analysed: number;
+  sessions_skipped: number;
+}
+
 interface AnalyticsResponse {
   by_model?: Record<string, { total: number; session_count: number; agent: string }>;
   pricing_updated?: string;
@@ -178,6 +230,8 @@ export default function Home() {
   const gitRes       = useResource<GitSummaryResponse>("/insights/git-summary", { pollMs: 60_000 });
   const [trendsDays, setTrendsDays] = useState<30 | 60>(30);
   const trendsRes    = useResource<TrendsResponse>(`/insights/trends?days=${trendsDays}`, { pollMs: 120_000 });
+  const timeRes      = useResource<TimeIntelResponse>("/insights/time", { pollMs: 120_000 });
+  const toolRes      = useResource<ToolFootprintResponse>("/insights/tool-footprint", { pollMs: 120_000 });
 
   const sessions = (sessionsRes.data ?? []).slice().sort((a, b) => {
     const ta = new Date(a.timestamp).getTime();
@@ -1189,6 +1243,207 @@ export default function Home() {
           </div>
         </Section>
       )}
+      {/* ── Time Intelligence ─────────────────────────────────── */}
+      {(timeRes.data?.sessions_analysed ?? 0) >= 3 && (() => {
+        const ti = timeRes.data!;
+        const barColor = (v: number) => v >= 70 ? "#4ade80" : v >= 40 ? "#facc15" : "#f87171";
+        const periodEmoji: Record<string, string> = {
+          morning: "🌅", afternoon: "☀️", evening: "🌆", night: "🌙",
+        };
+
+        return (
+          <Section
+            title="Time intelligence"
+            description={`When you code best · ${ti.sessions_analysed} sessions analysed`}
+          >
+            {/* Stats strip */}
+            <div className="flex flex-wrap gap-3 mb-4">
+              {ti.peak_hour && (
+                <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-[var(--tt-surface-raised)] text-xs">
+                  <span className="text-emerald-400 font-semibold">Peak hour</span>
+                  <span className="text-[var(--tt-fg)] font-mono">{ti.peak_hour.label}</span>
+                  <span className="text-[var(--tt-fg-faint)]">{ti.peak_hour.avg_efficiency.toFixed(1)} avg</span>
+                </div>
+              )}
+              {ti.peak_dow && (
+                <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-[var(--tt-surface-raised)] text-xs">
+                  <span className="text-emerald-400 font-semibold">Peak day</span>
+                  <span className="text-[var(--tt-fg)] font-mono">{ti.peak_dow.label}</span>
+                  <span className="text-[var(--tt-fg-faint)]">{ti.peak_dow.avg_efficiency.toFixed(1)} avg</span>
+                </div>
+              )}
+              <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-[var(--tt-surface-raised)] text-xs">
+                <span className="text-[var(--tt-fg-muted)]">Best period</span>
+                <span className="text-[var(--tt-fg)] font-semibold capitalize">
+                  {periodEmoji[ti.peak_period] ?? ""} {ti.peak_period}
+                </span>
+              </div>
+              {ti.worst_hour && (
+                <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-[var(--tt-surface-raised)] text-xs">
+                  <span className="text-red-400 font-semibold">Avoid</span>
+                  <span className="text-[var(--tt-fg)] font-mono">{ti.worst_hour.label}</span>
+                  <span className="text-[var(--tt-fg-faint)]">{ti.worst_hour.avg_efficiency.toFixed(1)} avg</span>
+                </div>
+              )}
+            </div>
+
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+              {/* By hour of day */}
+              <Card className="space-y-2">
+                <div className="text-xs font-semibold text-[var(--tt-fg-dim)] uppercase tracking-wide">By hour of day</div>
+                <div style={{ height: 180 }}>
+                  <ResponsiveContainer width="100%" height="100%">
+                    <ComposedChart data={ti.by_hour} margin={{ top: 4, right: 4, bottom: 0, left: -20 }}>
+                      <CartesianGrid strokeDasharray="3 3" stroke="var(--tt-border)" vertical={false} />
+                      <XAxis
+                        dataKey="label"
+                        tick={{ fill: "var(--tt-fg-faint)", fontSize: 9 }}
+                        tickLine={false}
+                        axisLine={false}
+                        interval={0}
+                        angle={-45}
+                        textAnchor="end"
+                        height={36}
+                      />
+                      <YAxis domain={[0, 100]} tick={{ fill: "var(--tt-fg-faint)", fontSize: 9 }} tickLine={false} axisLine={false} tickCount={4} />
+                      <ReTooltip
+                        contentStyle={{ background: "var(--tt-surface)", border: "1px solid var(--tt-border)", borderRadius: 8, fontSize: 11, color: "var(--tt-fg)" }}
+                        formatter={(v, n) => [typeof v === "number" ? v.toFixed(1) : v, n === "avg_efficiency" ? "Avg efficiency" : String(n)]}
+                      />
+                      <ReferenceLine y={60} stroke="var(--tt-fg-faint)" strokeDasharray="4 4" strokeOpacity={0.4} />
+                      <Bar dataKey="avg_efficiency" radius={[3, 3, 0, 0]} maxBarSize={28}>
+                        {ti.by_hour.map((row) => (
+                          <Cell key={row.hour} fill={barColor(row.avg_efficiency)} fillOpacity={0.85} />
+                        ))}
+                      </Bar>
+                    </ComposedChart>
+                  </ResponsiveContainer>
+                </div>
+              </Card>
+
+              {/* By day of week */}
+              <Card className="space-y-2">
+                <div className="text-xs font-semibold text-[var(--tt-fg-dim)] uppercase tracking-wide">By day of week</div>
+                <div style={{ height: 180 }}>
+                  <ResponsiveContainer width="100%" height="100%">
+                    <ComposedChart data={ti.by_dow} margin={{ top: 4, right: 4, bottom: 0, left: -20 }}>
+                      <CartesianGrid strokeDasharray="3 3" stroke="var(--tt-border)" vertical={false} />
+                      <XAxis dataKey="label" tick={{ fill: "var(--tt-fg-faint)", fontSize: 10 }} tickLine={false} axisLine={false} />
+                      <YAxis domain={[0, 100]} tick={{ fill: "var(--tt-fg-faint)", fontSize: 9 }} tickLine={false} axisLine={false} tickCount={4} />
+                      <ReTooltip
+                        contentStyle={{ background: "var(--tt-surface)", border: "1px solid var(--tt-border)", borderRadius: 8, fontSize: 11, color: "var(--tt-fg)" }}
+                        formatter={(v, n) => [typeof v === "number" ? v.toFixed(1) : v, n === "avg_efficiency" ? "Avg efficiency" : String(n)]}
+                      />
+                      <ReferenceLine y={60} stroke="var(--tt-fg-faint)" strokeDasharray="4 4" strokeOpacity={0.4} />
+                      <Bar dataKey="avg_efficiency" radius={[3, 3, 0, 0]} maxBarSize={40}>
+                        {ti.by_dow.map((row) => (
+                          <Cell key={row.dow} fill={barColor(row.avg_efficiency)} fillOpacity={0.85} />
+                        ))}
+                      </Bar>
+                    </ComposedChart>
+                  </ResponsiveContainer>
+                </div>
+              </Card>
+            </div>
+          </Section>
+        );
+      })()}
+
+      {/* ── Tool Footprint ────────────────────────────────────── */}
+      {(toolRes.data?.sessions_analysed ?? 0) >= 3 && (() => {
+        const tf = toolRes.data!;
+        const sizeColor: Record<string, string> = {
+          lean: "#4ade80", standard: "#60a5fa", heavy: "#facc15", bloated: "#f87171",
+        };
+        const catColor: Record<string, string> = {
+          core: "#4ade80", agent: "#a78bfa", browser: "#60a5fa", mcp: "#fb923c", meta: "#94a3b8",
+        };
+        const shortTool = (t: string) => {
+          if (t.startsWith("mcp__")) {
+            const parts = t.split("__");
+            return parts[parts.length - 1].replace(/_/g, " ");
+          }
+          return t;
+        };
+
+        return (
+          <Section
+            title="Tool footprint"
+            description={`How toolset size and composition affect efficiency · ${tf.sessions_analysed} sessions`}
+          >
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+              {/* By toolset size */}
+              <Card className="space-y-3">
+                <div className="text-xs font-semibold text-[var(--tt-fg-dim)] uppercase tracking-wide">
+                  Efficiency by toolset size
+                  {tf.optimal_range && (
+                    <span className="ml-2 normal-case font-normal text-[var(--tt-fg-faint)]">
+                      · optimal: <span className="font-semibold text-[var(--tt-fg)]">{tf.optimal_range} tools</span>
+                    </span>
+                  )}
+                </div>
+                <div className="space-y-2">
+                  {tf.by_size.map((b) => (
+                    <div key={b.bucket} className="flex items-center gap-2">
+                      <div className="w-16 text-[11px] text-[var(--tt-fg-muted)] tabular shrink-0">{b.bucket}</div>
+                      <div className="flex-1 h-5 bg-[var(--tt-surface-raised)] rounded overflow-hidden">
+                        <div
+                          className="h-full rounded transition-all"
+                          style={{
+                            width: `${b.avg_efficiency}%`,
+                            background: sizeColor[b.label] ?? "#60a5fa",
+                            opacity: 0.8,
+                          }}
+                        />
+                      </div>
+                      <div className="w-10 text-right text-[11px] font-mono text-[var(--tt-fg)] tabular shrink-0">
+                        {b.avg_efficiency.toFixed(1)}
+                      </div>
+                      <div className="w-8 text-right text-[10px] text-[var(--tt-fg-faint)] tabular shrink-0">
+                        {b.session_count}s
+                      </div>
+                      <span
+                        className="text-[10px] px-1.5 py-0.5 rounded-full capitalize shrink-0"
+                        style={{ background: (sizeColor[b.label] ?? "#60a5fa") + "22", color: sizeColor[b.label] ?? "#60a5fa" }}
+                      >
+                        {b.label}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </Card>
+
+              {/* Top tools */}
+              <Card className="space-y-3">
+                <div className="text-xs font-semibold text-[var(--tt-fg-dim)] uppercase tracking-wide">Top tools by frequency</div>
+                <div className="space-y-1 overflow-y-auto" style={{ maxHeight: 220 }}>
+                  {tf.top_tools.map((t, i) => (
+                    <div key={t.tool} className="flex items-center gap-2 py-1 border-b border-[var(--tt-border)] last:border-0">
+                      <span className="text-[10px] text-[var(--tt-fg-faint)] w-4 tabular shrink-0">{i + 1}</span>
+                      <span
+                        className="text-[10px] px-1 py-0.5 rounded shrink-0 capitalize"
+                        style={{ background: (catColor[t.category] ?? "#94a3b8") + "22", color: catColor[t.category] ?? "#94a3b8" }}
+                      >
+                        {t.category}
+                      </span>
+                      <span className="text-[11px] text-[var(--tt-fg)] truncate flex-1 font-mono" title={t.tool}>
+                        {shortTool(t.tool)}
+                      </span>
+                      <span className="text-[10px] text-[var(--tt-fg-faint)] tabular shrink-0">{t.session_count}s</span>
+                      <span
+                        className="text-[10px] font-mono tabular shrink-0 w-10 text-right"
+                        style={{ color: t.avg_efficiency >= 70 ? "#4ade80" : t.avg_efficiency >= 40 ? "#facc15" : "#f87171" }}
+                      >
+                        {t.avg_efficiency.toFixed(1)}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </Card>
+            </div>
+          </Section>
+        );
+      })()}
     </div>
   );
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -21,6 +21,10 @@ import {
   PageHeader, StatTile, Section, Card, CardHeader, CardTitle, CardEyebrow,
   Table, THead, TBody, TR, TH, TD, AgentBadge, Badge, Button, EmptyState, Skeleton,
 } from "@/components/ui";
+import {
+  ComposedChart, Bar, Line, XAxis, YAxis, CartesianGrid,
+  Tooltip as ReTooltip, ResponsiveContainer, ReferenceLine, Cell,
+} from "recharts";
 
 interface Smell {
   type: string;
@@ -134,6 +138,29 @@ interface GitSummaryResponse {
   non_git_sessions: number;
 }
 
+interface TrendDay {
+  date: string;
+  avg_efficiency: number;
+  session_count: number;
+  total_tokens: number;
+  best: number;
+  worst: number;
+  rolling_7d: number | null;
+}
+
+interface TrendsResponse {
+  days: TrendDay[];
+  trend: "improving" | "steady" | "declining";
+  trend_delta: number;
+  week_over_week: number;
+  overall_avg: number | null;
+  current_streak: number;
+  best_day: { date: string; avg_efficiency: number } | null;
+  worst_day: { date: string; avg_efficiency: number } | null;
+  total_sessions: number;
+  days_with_data: number;
+}
+
 interface AnalyticsResponse {
   by_model?: Record<string, { total: number; session_count: number; agent: string }>;
   pricing_updated?: string;
@@ -149,6 +176,8 @@ export default function Home() {
   const forecastRes  = useResource<ForecastResponse>("/forecast?plan=claude_pro", { pollMs: 60_000 });
   const dnaRes       = useResource<PromptDnaResponse>("/insights/prompt-dna", { pollMs: 120_000 });
   const gitRes       = useResource<GitSummaryResponse>("/insights/git-summary", { pollMs: 60_000 });
+  const [trendsDays, setTrendsDays] = useState<30 | 60>(30);
+  const trendsRes    = useResource<TrendsResponse>(`/insights/trends?days=${trendsDays}`, { pollMs: 120_000 });
 
   const sessions = (sessionsRes.data ?? []).slice().sort((a, b) => {
     const ta = new Date(a.timestamp).getTime();
@@ -933,6 +962,162 @@ export default function Home() {
           </Card>
         </Section>
       )}
+      {/* ── Session Trends ────────────────────────────────────── */}
+      {(trendsRes.data?.days_with_data ?? 0) >= 2 && (() => {
+        const td = trendsRes.data!;
+        const trendColor = td.trend === "improving" ? "#4ade80" : td.trend === "declining" ? "#f87171" : "#facc15";
+        const trendIcon = td.trend === "improving" ? "↑" : td.trend === "declining" ? "↓" : "→";
+        const formatDate = (d: string) => {
+          const dt = new Date(d + "T12:00:00Z");
+          return dt.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+        };
+        const barColor = (val: number) =>
+          val >= 70 ? "#4ade80" : val >= 40 ? "#facc15" : "#f87171";
+
+        return (
+          <Section
+            title="Session trends"
+            description={`Efficiency over the last ${trendsDays} days · ${td.days_with_data} active days · ${td.total_sessions} sessions`}
+          >
+            <Card className="space-y-4">
+              {/* Header row: trend badge + stats chips + day toggle */}
+              <div className="flex flex-wrap items-center gap-3">
+                {/* Trend badge */}
+                <div
+                  className="flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-semibold"
+                  style={{ background: trendColor + "22", color: trendColor, border: `1px solid ${trendColor}44` }}
+                >
+                  <span className="text-sm leading-none">{trendIcon}</span>
+                  <span className="capitalize">{td.trend}</span>
+                  {Math.abs(td.trend_delta) >= 1 && (
+                    <span className="opacity-80 font-mono">
+                      {td.trend_delta > 0 ? "+" : ""}{td.trend_delta.toFixed(1)} pts WoW
+                    </span>
+                  )}
+                </div>
+
+                {/* Overall avg chip */}
+                {td.overall_avg !== null && (
+                  <div className="text-xs text-[var(--tt-fg-muted)] px-2 py-1 rounded bg-[var(--tt-surface-raised)]">
+                    Avg <span className="font-semibold text-[var(--tt-fg)]">{td.overall_avg.toFixed(1)}</span>
+                  </div>
+                )}
+
+                {/* Streak chip */}
+                {td.current_streak >= 2 && (
+                  <div className="flex items-center gap-1 text-xs px-2 py-1 rounded bg-[var(--tt-surface-raised)] text-amber-400">
+                    <Flame size={11} />
+                    <span className="font-semibold">{td.current_streak}d</span>
+                    <span className="text-[var(--tt-fg-faint)]">streak</span>
+                  </div>
+                )}
+
+                {/* Best day chip */}
+                {td.best_day && (
+                  <div className="text-xs text-[var(--tt-fg-muted)] px-2 py-1 rounded bg-[var(--tt-surface-raised)]">
+                    Best <span className="font-semibold text-emerald-400">{td.best_day.avg_efficiency.toFixed(1)}</span>
+                    <span className="ml-1 text-[var(--tt-fg-faint)]">on {formatDate(td.best_day.date)}</span>
+                  </div>
+                )}
+
+                {/* Day range toggle */}
+                <div className="ml-auto flex items-center gap-1 text-xs">
+                  {([30, 60] as const).map((n) => (
+                    <button
+                      key={n}
+                      onClick={() => setTrendsDays(n)}
+                      className="px-2.5 py-1 rounded transition-colors"
+                      style={{
+                        background: trendsDays === n ? "var(--tt-brand)" : "var(--tt-surface-raised)",
+                        color: trendsDays === n ? "var(--tt-bg)" : "var(--tt-fg-muted)",
+                        fontWeight: trendsDays === n ? 600 : 400,
+                      }}
+                    >
+                      {n}d
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {/* Chart */}
+              <div style={{ height: 200 }}>
+                <ResponsiveContainer width="100%" height="100%">
+                  <ComposedChart data={td.days} margin={{ top: 4, right: 8, bottom: 0, left: -16 }}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="var(--tt-border)" vertical={false} />
+                    <XAxis
+                      dataKey="date"
+                      tickFormatter={formatDate}
+                      tick={{ fill: "var(--tt-fg-faint)", fontSize: 10 }}
+                      tickLine={false}
+                      axisLine={false}
+                      interval="preserveStartEnd"
+                    />
+                    <YAxis
+                      domain={[0, 100]}
+                      tick={{ fill: "var(--tt-fg-faint)", fontSize: 10 }}
+                      tickLine={false}
+                      axisLine={false}
+                      tickCount={5}
+                    />
+                    <ReTooltip
+                      contentStyle={{
+                        background: "var(--tt-surface)",
+                        border: "1px solid var(--tt-border)",
+                        borderRadius: 8,
+                        fontSize: 12,
+                        color: "var(--tt-fg)",
+                      }}
+                      labelFormatter={(l) => formatDate(String(l))}
+                      formatter={(value, name) => {
+                        const v = typeof value === "number" ? value.toFixed(1) : String(value);
+                        if (name === "avg_efficiency") return [v, "Avg efficiency"];
+                        if (name === "rolling_7d") return [v, "7d rolling avg"];
+                        return [v, String(name)];
+                      }}
+                    />
+                    {/* 60pt "good" threshold line */}
+                    <ReferenceLine y={60} stroke="var(--tt-fg-faint)" strokeDasharray="4 4" strokeOpacity={0.5} />
+                    <Bar dataKey="avg_efficiency" radius={[3, 3, 0, 0]} maxBarSize={32}>
+                      {td.days.map((day) => (
+                        <Cell key={day.date} fill={barColor(day.avg_efficiency)} fillOpacity={0.85} />
+                      ))}
+                    </Bar>
+                    <Line
+                      type="monotone"
+                      dataKey="rolling_7d"
+                      stroke="var(--tt-brand)"
+                      strokeWidth={2}
+                      dot={false}
+                      connectNulls
+                    />
+                  </ComposedChart>
+                </ResponsiveContainer>
+              </div>
+
+              {/* Legend */}
+              <div className="flex items-center gap-4 text-[10px] text-[var(--tt-fg-faint)]">
+                <div className="flex items-center gap-1.5">
+                  <div className="w-3 h-3 rounded-sm bg-emerald-400 opacity-85" />
+                  Good (≥70)
+                </div>
+                <div className="flex items-center gap-1.5">
+                  <div className="w-3 h-3 rounded-sm bg-yellow-400 opacity-85" />
+                  Fair (40–69)
+                </div>
+                <div className="flex items-center gap-1.5">
+                  <div className="w-3 h-3 rounded-sm bg-red-400 opacity-85" />
+                  Poor (&lt;40)
+                </div>
+                <div className="flex items-center gap-1.5 ml-2">
+                  <div className="w-6 h-0.5 rounded" style={{ background: "var(--tt-brand)" }} />
+                  7d rolling avg
+                </div>
+              </div>
+            </Card>
+          </Section>
+        );
+      })()}
+
       {/* ── Git Activity ──────────────────────────────────────── */}
       {(gitRes.data?.git_sessions ?? 0) > 0 && (
         <Section

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -6,7 +6,7 @@ import { usePathname } from "next/navigation";
 import { format } from "date-fns";
 import {
   Activity, Clock, TrendingUp, Folders, DollarSign, Cpu, ArrowUpRight, Radio, Terminal,
-  Zap, AlertTriangle, Flame, TrendingDown, Sparkles, BarChart3, GitBranch, GitCommit, Plus, Minus,
+  Zap, AlertTriangle, Flame, TrendingDown, Sparkles, BarChart3, GitBranch, GitCommit, Plus, Minus, Brain,
 } from "lucide-react";
 
 import { useResource } from "@/lib/api";
@@ -275,12 +275,6 @@ export default function Home() {
   const billingRes   = useResource<BillingConfig>("/config/billing", { pollMs: 60_000 });
   const forecastRes  = useResource<ForecastResponse>("/forecast?plan=claude_pro", { pollMs: 60_000 });
   const dnaRes       = useResource<PromptDnaResponse>("/insights/prompt-dna", { pollMs: 120_000 });
-  const gitRes       = useResource<GitSummaryResponse>("/insights/git-summary", { pollMs: 60_000 });
-  const [trendsDays, setTrendsDays] = useState<30 | 60>(30);
-  const trendsRes    = useResource<TrendsResponse>(`/insights/trends?days=${trendsDays}`, { pollMs: 120_000 });
-  const timeRes      = useResource<TimeIntelResponse>("/insights/time", { pollMs: 120_000 });
-  const toolRes      = useResource<ToolFootprintResponse>("/insights/tool-footprint", { pollMs: 120_000 });
-  const costRes      = useResource<CostIntelResponse>("/insights/cost", { pollMs: 120_000 });
 
   const sessions = (sessionsRes.data ?? []).slice().sort((a, b) => {
     const ta = new Date(a.timestamp).getTime();
@@ -311,19 +305,6 @@ export default function Home() {
     return () => window.removeEventListener("storage", check);
   }, []);
 
-  const [modelTaskFilter, setModelTaskFilter] = useState<string>("all");
-  const [modelComparison, setModelComparison] = useState<ModelComparisonResponse | null>(null);
-  const [modelCompLoading, setModelCompLoading] = useState(true);
-  useEffect(() => {
-    setModelCompLoading(true);
-    const url = modelTaskFilter === "all"
-      ? "/insights/model-comparison"
-      : `/insights/model-comparison?task_type=${modelTaskFilter}`;
-    fetch(`http://localhost:8000${url}`)
-      .then((r) => r.json())
-      .then((d) => { setModelComparison(d); setModelCompLoading(false); })
-      .catch(() => setModelCompLoading(false));
-  }, [modelTaskFilter]);
 
   return (
     <div className="px-8 py-8 max-w-[1600px] mx-auto space-y-10 pb-20">
@@ -898,760 +879,8 @@ export default function Home() {
         </div>
       </div>
 
-      {/* ── Model Comparison ─────────────────────────────────────── */}
-      {(modelComparison?.models_compared ?? 0) > 0 && (
-        <Section
-          title="Model comparison"
-          description="Efficiency breakdown across models — how productively each model converts tokens into output."
-        >
-          <Card padding="none" className="overflow-hidden">
-            {/* Filter pills */}
-            <div className="flex items-center gap-2 px-5 py-3 border-b border-[var(--tt-border)] overflow-x-auto">
-              <BarChart3 size={12} className="text-[var(--tt-brand)] shrink-0" />
-              <span className="text-[10px] uppercase tracking-[0.18em] text-[var(--tt-fg-faint)] shrink-0 mr-1">
-                Task type
-              </span>
-              {["all", ...(modelComparison?.task_types_available ?? [])].map((tt) => (
-                <button
-                  key={tt}
-                  onClick={() => setModelTaskFilter(tt)}
-                  className="shrink-0 rounded-full px-2.5 py-0.5 text-[10px] font-medium capitalize transition-colors"
-                  style={{
-                    backgroundColor: modelTaskFilter === tt
-                      ? "var(--tt-brand)"
-                      : "var(--tt-tint-1, rgba(255,255,255,0.05))",
-                    color: modelTaskFilter === tt
-                      ? "white"
-                      : "var(--tt-fg-muted)",
-                    border: `1px solid ${modelTaskFilter === tt ? "var(--tt-brand)" : "var(--tt-border)"}`,
-                  }}
-                >
-                  {tt}
-                </button>
-              ))}
-              <span className="ml-auto text-[10px] text-[var(--tt-fg-faint)] whitespace-nowrap shrink-0">
-                {modelComparison?.sessions_used ?? 0} sessions
-              </span>
-            </div>
-
-            {/* Model rows */}
-            {modelCompLoading ? (
-              <div className="p-5 space-y-4">
-                {[1, 2, 3].map((i) => <Skeleton key={i} className="h-14 w-full" />)}
-              </div>
-            ) : (modelComparison?.models ?? []).length === 0 ? (
-              <div className="py-10 text-center text-[12px] text-[var(--tt-fg-faint)]">
-                No sessions match this filter.
-              </div>
-            ) : (
-              <div className="divide-y divide-[var(--tt-border)]">
-                {(modelComparison?.models ?? []).map((m, rank) => {
-                  const meta = getAgent(m.agent);
-                  const effColor =
-                    m.avg_efficiency >= 70 ? "#22c55e" :
-                    m.avg_efficiency >= 40 ? "#f59e0b" : "#ef4444";
-                  const bestInSet = modelComparison!.models[0].avg_efficiency || 1;
-                  const barPct = (m.avg_efficiency / bestInSet) * 100;
-                  const p75Pct = (m.p75_efficiency / bestInSet) * 100;
-                  return (
-                    <div key={m.model} className="px-5 py-4 flex items-center gap-4 hover:bg-[var(--tt-sunken)] transition-colors">
-                      {/* Rank */}
-                      <span
-                        className="w-5 h-5 rounded-full grid place-items-center text-[10px] font-bold shrink-0"
-                        style={{
-                          backgroundColor: rank === 0 ? `${meta.hex}22` : "var(--tt-tint-1,rgba(255,255,255,0.05))",
-                          color: rank === 0 ? meta.hex : "var(--tt-fg-faint)",
-                        }}
-                      >
-                        {rank + 1}
-                      </span>
-
-                      {/* Model name + agent */}
-                      <div className="min-w-0 w-44 shrink-0">
-                        <div className="font-mono text-[12px] text-[var(--tt-fg)] truncate" title={m.model}>
-                          {m.model}
-                        </div>
-                        <div
-                          className="text-[10px] uppercase tracking-[0.14em] mt-0.5"
-                          style={{ color: meta.hex }}
-                        >
-                          {m.agent}
-                        </div>
-                      </div>
-
-                      {/* Bars */}
-                      <div className="flex-1 min-w-0 space-y-1.5">
-                        {/* Avg bar */}
-                        <div className="flex items-center gap-2">
-                          <span className="text-[9px] uppercase tracking-wider text-[var(--tt-fg-faint)] w-6 shrink-0">avg</span>
-                          <div className="flex-1 h-2 rounded-full tt-tint-1 overflow-hidden">
-                            <div
-                              className="h-full rounded-full transition-[width] duration-700"
-                              style={{ width: `${barPct}%`, backgroundColor: effColor }}
-                            />
-                          </div>
-                          <span
-                            className="text-[11px] font-semibold tabular shrink-0 w-8 text-right"
-                            style={{ color: effColor }}
-                          >
-                            {m.avg_efficiency}
-                          </span>
-                        </div>
-                        {/* P75 bar */}
-                        <div className="flex items-center gap-2">
-                          <span className="text-[9px] uppercase tracking-wider text-[var(--tt-fg-faint)] w-6 shrink-0">p75</span>
-                          <div className="flex-1 h-1 rounded-full tt-tint-1 overflow-hidden">
-                            <div
-                              className="h-full rounded-full transition-[width] duration-700"
-                              style={{ width: `${p75Pct}%`, backgroundColor: `${effColor}88` }}
-                            />
-                          </div>
-                          <span className="text-[10px] tabular text-[var(--tt-fg-faint)] shrink-0 w-8 text-right">
-                            {m.p75_efficiency}
-                          </span>
-                        </div>
-                      </div>
-
-                      {/* Stats */}
-                      <div className="flex items-center gap-4 shrink-0 ml-2">
-                        <div className="text-center hidden sm:block">
-                          <div className="text-[11px] font-semibold tabular text-[var(--tt-fg)]">
-                            {m.best_efficiency}
-                          </div>
-                          <div className="text-[9px] uppercase tracking-wider text-[var(--tt-fg-faint)]">best</div>
-                        </div>
-                        <div className="text-center">
-                          <div className="text-[11px] tabular text-[var(--tt-fg-muted)]">
-                            {m.session_count}
-                          </div>
-                          <div className="text-[9px] uppercase tracking-wider text-[var(--tt-fg-faint)]">sess</div>
-                        </div>
-                        <div className="text-center hidden md:block">
-                          <div className="text-[11px] tabular text-[var(--tt-fg-muted)]">
-                            {(m.avg_tokens / 1_000).toFixed(0)}k
-                          </div>
-                          <div className="text-[9px] uppercase tracking-wider text-[var(--tt-fg-faint)]">avg tok</div>
-                        </div>
-                        {/* Task breakdown pills */}
-                        <div className="hidden lg:flex items-center gap-1 flex-wrap max-w-[180px]">
-                          {Object.entries(m.task_breakdown)
-                            .sort((a, b) => b[1].count - a[1].count)
-                            .slice(0, 3)
-                            .map(([tt, { count, avg_efficiency: te }]) => {
-                              const tc = te >= 70 ? "#22c55e" : te >= 40 ? "#f59e0b" : "#ef4444";
-                              return (
-                                <span
-                                  key={tt}
-                                  title={`${tt}: ${te} avg efficiency (${count} sessions)`}
-                                  className="inline-flex items-center gap-0.5 rounded px-1.5 py-0.5 text-[9px] font-medium capitalize"
-                                  style={{
-                                    backgroundColor: `${tc}12`,
-                                    color: tc,
-                                    border: `1px solid ${tc}30`,
-                                  }}
-                                >
-                                  {tt}
-                                  <span className="opacity-70">{count}</span>
-                                </span>
-                              );
-                            })}
-                        </div>
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            )}
-          </Card>
-        </Section>
-      )}
-      {/* ── Session Trends ────────────────────────────────────── */}
-      {(trendsRes.data?.days_with_data ?? 0) >= 2 && (() => {
-        const td = trendsRes.data!;
-        const trendColor = td.trend === "improving" ? "#4ade80" : td.trend === "declining" ? "#f87171" : "#facc15";
-        const trendIcon = td.trend === "improving" ? "↑" : td.trend === "declining" ? "↓" : "→";
-        const formatDate = (d: string) => {
-          const dt = new Date(d + "T12:00:00Z");
-          return dt.toLocaleDateString("en-US", { month: "short", day: "numeric" });
-        };
-        const barColor = (val: number) =>
-          val >= 70 ? "#4ade80" : val >= 40 ? "#facc15" : "#f87171";
-
-        return (
-          <Section
-            title="Session trends"
-            description={`Efficiency over the last ${trendsDays} days · ${td.days_with_data} active days · ${td.total_sessions} sessions`}
-          >
-            <Card className="space-y-4">
-              {/* Header row: trend badge + stats chips + day toggle */}
-              <div className="flex flex-wrap items-center gap-3">
-                {/* Trend badge */}
-                <div
-                  className="flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-semibold"
-                  style={{ background: trendColor + "22", color: trendColor, border: `1px solid ${trendColor}44` }}
-                >
-                  <span className="text-sm leading-none">{trendIcon}</span>
-                  <span className="capitalize">{td.trend}</span>
-                  {Math.abs(td.trend_delta) >= 1 && (
-                    <span className="opacity-80 font-mono">
-                      {td.trend_delta > 0 ? "+" : ""}{td.trend_delta.toFixed(1)} pts WoW
-                    </span>
-                  )}
-                </div>
-
-                {/* Overall avg chip */}
-                {td.overall_avg !== null && (
-                  <div className="text-xs text-[var(--tt-fg-muted)] px-2 py-1 rounded bg-[var(--tt-surface-raised)]">
-                    Avg <span className="font-semibold text-[var(--tt-fg)]">{td.overall_avg.toFixed(1)}</span>
-                  </div>
-                )}
-
-                {/* Streak chip */}
-                {td.current_streak >= 2 && (
-                  <div className="flex items-center gap-1 text-xs px-2 py-1 rounded bg-[var(--tt-surface-raised)] text-amber-400">
-                    <Flame size={11} />
-                    <span className="font-semibold">{td.current_streak}d</span>
-                    <span className="text-[var(--tt-fg-faint)]">streak</span>
-                  </div>
-                )}
-
-                {/* Best day chip */}
-                {td.best_day && (
-                  <div className="text-xs text-[var(--tt-fg-muted)] px-2 py-1 rounded bg-[var(--tt-surface-raised)]">
-                    Best <span className="font-semibold text-emerald-400">{td.best_day.avg_efficiency.toFixed(1)}</span>
-                    <span className="ml-1 text-[var(--tt-fg-faint)]">on {formatDate(td.best_day.date)}</span>
-                  </div>
-                )}
-
-                {/* Day range toggle */}
-                <div className="ml-auto flex items-center gap-1 text-xs">
-                  {([30, 60] as const).map((n) => (
-                    <button
-                      key={n}
-                      onClick={() => setTrendsDays(n)}
-                      className="px-2.5 py-1 rounded transition-colors"
-                      style={{
-                        background: trendsDays === n ? "var(--tt-brand)" : "var(--tt-surface-raised)",
-                        color: trendsDays === n ? "var(--tt-bg)" : "var(--tt-fg-muted)",
-                        fontWeight: trendsDays === n ? 600 : 400,
-                      }}
-                    >
-                      {n}d
-                    </button>
-                  ))}
-                </div>
-              </div>
-
-              {/* Chart */}
-              <div style={{ height: 200 }}>
-                <ResponsiveContainer width="100%" height="100%">
-                  <ComposedChart data={td.days} margin={{ top: 4, right: 8, bottom: 0, left: -16 }}>
-                    <CartesianGrid strokeDasharray="3 3" stroke="var(--tt-border)" vertical={false} />
-                    <XAxis
-                      dataKey="date"
-                      tickFormatter={formatDate}
-                      tick={{ fill: "var(--tt-fg-faint)", fontSize: 10 }}
-                      tickLine={false}
-                      axisLine={false}
-                      interval="preserveStartEnd"
-                    />
-                    <YAxis
-                      domain={[0, 100]}
-                      tick={{ fill: "var(--tt-fg-faint)", fontSize: 10 }}
-                      tickLine={false}
-                      axisLine={false}
-                      tickCount={5}
-                    />
-                    <ReTooltip
-                      contentStyle={{
-                        background: "var(--tt-surface)",
-                        border: "1px solid var(--tt-border)",
-                        borderRadius: 8,
-                        fontSize: 12,
-                        color: "var(--tt-fg)",
-                      }}
-                      labelFormatter={(l) => formatDate(String(l))}
-                      formatter={(value, name) => {
-                        const v = typeof value === "number" ? value.toFixed(1) : String(value);
-                        if (name === "avg_efficiency") return [v, "Avg efficiency"];
-                        if (name === "rolling_7d") return [v, "7d rolling avg"];
-                        return [v, String(name)];
-                      }}
-                    />
-                    {/* 60pt "good" threshold line */}
-                    <ReferenceLine y={60} stroke="var(--tt-fg-faint)" strokeDasharray="4 4" strokeOpacity={0.5} />
-                    <Bar dataKey="avg_efficiency" radius={[3, 3, 0, 0]} maxBarSize={32}>
-                      {td.days.map((day) => (
-                        <Cell key={day.date} fill={barColor(day.avg_efficiency)} fillOpacity={0.85} />
-                      ))}
-                    </Bar>
-                    <Line
-                      type="monotone"
-                      dataKey="rolling_7d"
-                      stroke="var(--tt-brand)"
-                      strokeWidth={2}
-                      dot={false}
-                      connectNulls
-                    />
-                  </ComposedChart>
-                </ResponsiveContainer>
-              </div>
-
-              {/* Legend */}
-              <div className="flex items-center gap-4 text-[10px] text-[var(--tt-fg-faint)]">
-                <div className="flex items-center gap-1.5">
-                  <div className="w-3 h-3 rounded-sm bg-emerald-400 opacity-85" />
-                  Good (≥70)
-                </div>
-                <div className="flex items-center gap-1.5">
-                  <div className="w-3 h-3 rounded-sm bg-yellow-400 opacity-85" />
-                  Fair (40–69)
-                </div>
-                <div className="flex items-center gap-1.5">
-                  <div className="w-3 h-3 rounded-sm bg-red-400 opacity-85" />
-                  Poor (&lt;40)
-                </div>
-                <div className="flex items-center gap-1.5 ml-2">
-                  <div className="w-6 h-0.5 rounded" style={{ background: "var(--tt-brand)" }} />
-                  7d rolling avg
-                </div>
-              </div>
-            </Card>
-          </Section>
-        );
-      })()}
-
-      {/* ── Git Activity ──────────────────────────────────────── */}
-      {(gitRes.data?.git_sessions ?? 0) > 0 && (
-        <Section
-          title="Repository activity"
-          description={`${gitRes.data!.git_sessions} git-tracked sessions · +${gitRes.data!.total_lines_added.toLocaleString()} / −${gitRes.data!.total_lines_deleted.toLocaleString()} lines across ${gitRes.data!.projects.length} repos`}
-        >
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-            {gitRes.data!.projects.filter(p => p.session_count > 0).map((p) => {
-              const projName = p.project.split(/[/\\]/).pop() || p.project;
-              const hasStats = p.total_lines_added > 0 || p.total_lines_deleted > 0;
-              const netColor = p.net_lines > 0 ? "#4ade80" : p.net_lines < 0 ? "#f87171" : "var(--tt-fg-faint)";
-              return (
-                <Card key={p.project} className="space-y-3">
-                  {/* Header */}
-                  <div className="flex items-start justify-between gap-2">
-                    <div className="min-w-0">
-                      <div className="font-mono text-[12px] font-semibold text-[var(--tt-fg)] truncate" title={p.project}>
-                        {projName}
-                      </div>
-                      {p.branch && (
-                        <div className="flex items-center gap-1 mt-0.5 text-[10px] text-[var(--tt-fg-faint)]">
-                          <GitBranch size={9} />
-                          <span className="truncate">{p.branch}</span>
-                        </div>
-                      )}
-                    </div>
-                    <span className="text-[10px] tabular text-[var(--tt-fg-dim)] whitespace-nowrap shrink-0">
-                      {p.session_count} sess
-                    </span>
-                  </div>
-
-                  {/* Latest commit */}
-                  {p.latest_commit_sha && (
-                    <div className="flex items-start gap-1.5">
-                      <GitCommit size={10} className="text-[var(--tt-fg-faint)] mt-0.5 shrink-0" />
-                      <div className="min-w-0">
-                        <span className="font-mono text-[10px] text-[var(--tt-brand)]">{p.latest_commit_sha}</span>
-                        <span className="ml-1.5 text-[10px] text-[var(--tt-fg-muted)] truncate block" title={p.latest_commit_msg ?? ""}>
-                          {p.latest_commit_msg}
-                        </span>
-                      </div>
-                    </div>
-                  )}
-
-                  {/* Line stats */}
-                  {hasStats && (
-                    <div className="flex items-center gap-3 pt-1 border-t border-[var(--tt-border)]">
-                      <div className="flex items-center gap-1 text-[10px] text-emerald-400">
-                        <Plus size={9} />
-                        <span className="tabular">{p.total_lines_added.toLocaleString()}</span>
-                      </div>
-                      <div className="flex items-center gap-1 text-[10px] text-red-400">
-                        <Minus size={9} />
-                        <span className="tabular">{p.total_lines_deleted.toLocaleString()}</span>
-                      </div>
-                      <div className="flex items-center gap-1 text-[10px]" style={{ color: netColor }}>
-                        <span className="tabular font-medium">
-                          {p.net_lines > 0 ? "+" : ""}{p.net_lines.toLocaleString()} net
-                        </span>
-                      </div>
-                      <div className="ml-auto text-[10px] text-[var(--tt-fg-faint)] tabular">
-                        {p.total_files_changed} files
-                      </div>
-                    </div>
-                  )}
-                </Card>
-              );
-            })}
-          </div>
-        </Section>
-      )}
-      {/* ── Time Intelligence ─────────────────────────────────── */}
-      {(timeRes.data?.sessions_analysed ?? 0) >= 3 && (() => {
-        const ti = timeRes.data!;
-        const barColor = (v: number) => v >= 70 ? "#4ade80" : v >= 40 ? "#facc15" : "#f87171";
-        const periodEmoji: Record<string, string> = {
-          morning: "🌅", afternoon: "☀️", evening: "🌆", night: "🌙",
-        };
-
-        return (
-          <Section
-            title="Time intelligence"
-            description={`When you code best · ${ti.sessions_analysed} sessions analysed`}
-          >
-            {/* Stats strip */}
-            <div className="flex flex-wrap gap-3 mb-4">
-              {ti.peak_hour && (
-                <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-[var(--tt-surface-raised)] text-xs">
-                  <span className="text-emerald-400 font-semibold">Peak hour</span>
-                  <span className="text-[var(--tt-fg)] font-mono">{ti.peak_hour.label}</span>
-                  <span className="text-[var(--tt-fg-faint)]">{ti.peak_hour.avg_efficiency.toFixed(1)} avg</span>
-                </div>
-              )}
-              {ti.peak_dow && (
-                <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-[var(--tt-surface-raised)] text-xs">
-                  <span className="text-emerald-400 font-semibold">Peak day</span>
-                  <span className="text-[var(--tt-fg)] font-mono">{ti.peak_dow.label}</span>
-                  <span className="text-[var(--tt-fg-faint)]">{ti.peak_dow.avg_efficiency.toFixed(1)} avg</span>
-                </div>
-              )}
-              <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-[var(--tt-surface-raised)] text-xs">
-                <span className="text-[var(--tt-fg-muted)]">Best period</span>
-                <span className="text-[var(--tt-fg)] font-semibold capitalize">
-                  {periodEmoji[ti.peak_period] ?? ""} {ti.peak_period}
-                </span>
-              </div>
-              {ti.worst_hour && (
-                <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-[var(--tt-surface-raised)] text-xs">
-                  <span className="text-red-400 font-semibold">Avoid</span>
-                  <span className="text-[var(--tt-fg)] font-mono">{ti.worst_hour.label}</span>
-                  <span className="text-[var(--tt-fg-faint)]">{ti.worst_hour.avg_efficiency.toFixed(1)} avg</span>
-                </div>
-              )}
-            </div>
-
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-              {/* By hour of day */}
-              <Card className="space-y-2">
-                <div className="text-xs font-semibold text-[var(--tt-fg-dim)] uppercase tracking-wide">By hour of day</div>
-                <div style={{ height: 180 }}>
-                  <ResponsiveContainer width="100%" height="100%">
-                    <ComposedChart data={ti.by_hour} margin={{ top: 4, right: 4, bottom: 0, left: -20 }}>
-                      <CartesianGrid strokeDasharray="3 3" stroke="var(--tt-border)" vertical={false} />
-                      <XAxis
-                        dataKey="label"
-                        tick={{ fill: "var(--tt-fg-faint)", fontSize: 9 }}
-                        tickLine={false}
-                        axisLine={false}
-                        interval={0}
-                        angle={-45}
-                        textAnchor="end"
-                        height={36}
-                      />
-                      <YAxis domain={[0, 100]} tick={{ fill: "var(--tt-fg-faint)", fontSize: 9 }} tickLine={false} axisLine={false} tickCount={4} />
-                      <ReTooltip
-                        contentStyle={{ background: "var(--tt-surface)", border: "1px solid var(--tt-border)", borderRadius: 8, fontSize: 11, color: "var(--tt-fg)" }}
-                        formatter={(v, n) => [typeof v === "number" ? v.toFixed(1) : v, n === "avg_efficiency" ? "Avg efficiency" : String(n)]}
-                      />
-                      <ReferenceLine y={60} stroke="var(--tt-fg-faint)" strokeDasharray="4 4" strokeOpacity={0.4} />
-                      <Bar dataKey="avg_efficiency" radius={[3, 3, 0, 0]} maxBarSize={28}>
-                        {ti.by_hour.map((row) => (
-                          <Cell key={row.hour} fill={barColor(row.avg_efficiency)} fillOpacity={0.85} />
-                        ))}
-                      </Bar>
-                    </ComposedChart>
-                  </ResponsiveContainer>
-                </div>
-              </Card>
-
-              {/* By day of week */}
-              <Card className="space-y-2">
-                <div className="text-xs font-semibold text-[var(--tt-fg-dim)] uppercase tracking-wide">By day of week</div>
-                <div style={{ height: 180 }}>
-                  <ResponsiveContainer width="100%" height="100%">
-                    <ComposedChart data={ti.by_dow} margin={{ top: 4, right: 4, bottom: 0, left: -20 }}>
-                      <CartesianGrid strokeDasharray="3 3" stroke="var(--tt-border)" vertical={false} />
-                      <XAxis dataKey="label" tick={{ fill: "var(--tt-fg-faint)", fontSize: 10 }} tickLine={false} axisLine={false} />
-                      <YAxis domain={[0, 100]} tick={{ fill: "var(--tt-fg-faint)", fontSize: 9 }} tickLine={false} axisLine={false} tickCount={4} />
-                      <ReTooltip
-                        contentStyle={{ background: "var(--tt-surface)", border: "1px solid var(--tt-border)", borderRadius: 8, fontSize: 11, color: "var(--tt-fg)" }}
-                        formatter={(v, n) => [typeof v === "number" ? v.toFixed(1) : v, n === "avg_efficiency" ? "Avg efficiency" : String(n)]}
-                      />
-                      <ReferenceLine y={60} stroke="var(--tt-fg-faint)" strokeDasharray="4 4" strokeOpacity={0.4} />
-                      <Bar dataKey="avg_efficiency" radius={[3, 3, 0, 0]} maxBarSize={40}>
-                        {ti.by_dow.map((row) => (
-                          <Cell key={row.dow} fill={barColor(row.avg_efficiency)} fillOpacity={0.85} />
-                        ))}
-                      </Bar>
-                    </ComposedChart>
-                  </ResponsiveContainer>
-                </div>
-              </Card>
-            </div>
-          </Section>
-        );
-      })()}
-
-      {/* ── Tool Footprint ────────────────────────────────────── */}
-      {(toolRes.data?.sessions_analysed ?? 0) >= 3 && (() => {
-        const tf = toolRes.data!;
-        const sizeColor: Record<string, string> = {
-          lean: "#4ade80", standard: "#60a5fa", heavy: "#facc15", bloated: "#f87171",
-        };
-        const catColor: Record<string, string> = {
-          core: "#4ade80", agent: "#a78bfa", browser: "#60a5fa", mcp: "#fb923c", meta: "#94a3b8",
-        };
-        const shortTool = (t: string) => {
-          if (t.startsWith("mcp__")) {
-            const parts = t.split("__");
-            return parts[parts.length - 1].replace(/_/g, " ");
-          }
-          return t;
-        };
-
-        return (
-          <Section
-            title="Tool footprint"
-            description={`How toolset size and composition affect efficiency · ${tf.sessions_analysed} sessions`}
-          >
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-              {/* By toolset size */}
-              <Card className="space-y-3">
-                <div className="text-xs font-semibold text-[var(--tt-fg-dim)] uppercase tracking-wide">
-                  Efficiency by toolset size
-                  {tf.optimal_range && (
-                    <span className="ml-2 normal-case font-normal text-[var(--tt-fg-faint)]">
-                      · optimal: <span className="font-semibold text-[var(--tt-fg)]">{tf.optimal_range} tools</span>
-                    </span>
-                  )}
-                </div>
-                <div className="space-y-2">
-                  {tf.by_size.map((b) => (
-                    <div key={b.bucket} className="flex items-center gap-2">
-                      <div className="w-16 text-[11px] text-[var(--tt-fg-muted)] tabular shrink-0">{b.bucket}</div>
-                      <div className="flex-1 h-5 bg-[var(--tt-surface-raised)] rounded overflow-hidden">
-                        <div
-                          className="h-full rounded transition-all"
-                          style={{
-                            width: `${b.avg_efficiency}%`,
-                            background: sizeColor[b.label] ?? "#60a5fa",
-                            opacity: 0.8,
-                          }}
-                        />
-                      </div>
-                      <div className="w-10 text-right text-[11px] font-mono text-[var(--tt-fg)] tabular shrink-0">
-                        {b.avg_efficiency.toFixed(1)}
-                      </div>
-                      <div className="w-8 text-right text-[10px] text-[var(--tt-fg-faint)] tabular shrink-0">
-                        {b.session_count}s
-                      </div>
-                      <span
-                        className="text-[10px] px-1.5 py-0.5 rounded-full capitalize shrink-0"
-                        style={{ background: (sizeColor[b.label] ?? "#60a5fa") + "22", color: sizeColor[b.label] ?? "#60a5fa" }}
-                      >
-                        {b.label}
-                      </span>
-                    </div>
-                  ))}
-                </div>
-              </Card>
-
-              {/* Top tools */}
-              <Card className="space-y-3">
-                <div className="text-xs font-semibold text-[var(--tt-fg-dim)] uppercase tracking-wide">Top tools by frequency</div>
-                <div className="space-y-1 overflow-y-auto" style={{ maxHeight: 220 }}>
-                  {tf.top_tools.map((t, i) => (
-                    <div key={t.tool} className="flex items-center gap-2 py-1 border-b border-[var(--tt-border)] last:border-0">
-                      <span className="text-[10px] text-[var(--tt-fg-faint)] w-4 tabular shrink-0">{i + 1}</span>
-                      <span
-                        className="text-[10px] px-1 py-0.5 rounded shrink-0 capitalize"
-                        style={{ background: (catColor[t.category] ?? "#94a3b8") + "22", color: catColor[t.category] ?? "#94a3b8" }}
-                      >
-                        {t.category}
-                      </span>
-                      <span className="text-[11px] text-[var(--tt-fg)] truncate flex-1 font-mono" title={t.tool}>
-                        {shortTool(t.tool)}
-                      </span>
-                      <span className="text-[10px] text-[var(--tt-fg-faint)] tabular shrink-0">{t.session_count}s</span>
-                      <span
-                        className="text-[10px] font-mono tabular shrink-0 w-10 text-right"
-                        style={{ color: t.avg_efficiency >= 70 ? "#4ade80" : t.avg_efficiency >= 40 ? "#facc15" : "#f87171" }}
-                      >
-                        {t.avg_efficiency.toFixed(1)}
-                      </span>
-                    </div>
-                  ))}
-                </div>
-              </Card>
-            </div>
-          </Section>
-        );
-      })()}
-
-      {/* ── Cost Intelligence ─────────────────────────────────── */}
-      {(costRes.data?.sessions_analysed ?? 0) >= 2 && (() => {
-        const ci = costRes.data!;
-
-        const fmtCost = (v: number) =>
-          v >= 1 ? `$${v.toFixed(2)}` : `$${v.toFixed(4)}`;
-
-        const fmtCpp = (v: number | null) => {
-          if (v === null) return "—";
-          if (v < 0.01) return `$${v.toFixed(5)}/pt`;
-          return `$${v.toFixed(3)}/pt`;
-        };
-
-        const effColor = (v: number) =>
-          v >= 70 ? "#4ade80" : v >= 40 ? "#facc15" : "#f87171";
-
-        // max cpp for bar scaling
-        const maxCpp = Math.max(
-          ...ci.by_model.filter(r => r.cost_per_eff_pt !== null).map(r => r.cost_per_eff_pt as number),
-          0.001,
-        );
-
-        return (
-          <Section
-            title="Cost intelligence"
-            description={`${fmtCost(ci.total_cost)} total spend · ${ci.sessions_analysed} sessions · ${ci.avg_cache_hit_pct?.toFixed(0) ?? "—"}% avg cache hit`}
-          >
-            {/* Stats strip */}
-            <div className="flex flex-wrap gap-3 mb-4">
-              <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-[var(--tt-surface-raised)] text-xs">
-                <DollarSign size={12} className="text-emerald-400" />
-                <span className="text-[var(--tt-fg-muted)]">Total spend</span>
-                <span className="font-semibold text-[var(--tt-fg)]">{fmtCost(ci.total_cost)}</span>
-              </div>
-              <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-[var(--tt-surface-raised)] text-xs">
-                <span className="text-[var(--tt-fg-muted)]">Avg / session</span>
-                <span className="font-semibold text-[var(--tt-fg)]">{fmtCost(ci.avg_cost_per_session)}</span>
-              </div>
-              {ci.best_value_model && (
-                <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-[var(--tt-surface-raised)] text-xs">
-                  <span className="text-emerald-400 font-semibold">Best value</span>
-                  <span className="font-mono text-[var(--tt-fg)]">{ci.best_value_model}</span>
-                </div>
-              )}
-              {ci.avg_cache_hit_pct !== null && (
-                <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-[var(--tt-surface-raised)] text-xs">
-                  <span className="text-[var(--tt-fg-muted)]">Cache hit</span>
-                  <span className="font-semibold text-[var(--tt-fg)]">{ci.avg_cache_hit_pct.toFixed(0)}%</span>
-                </div>
-              )}
-            </div>
-
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-              {/* By model — cost per efficiency point */}
-              <Card className="space-y-3">
-                <div className="text-xs font-semibold text-[var(--tt-fg-dim)] uppercase tracking-wide">
-                  Cost per efficiency point <span className="normal-case font-normal text-[var(--tt-fg-faint)]">(lower = better value)</span>
-                </div>
-                <div className="space-y-2.5">
-                  {ci.by_model.map((m) => (
-                    <div key={m.model} className="space-y-1">
-                      <div className="flex items-center justify-between">
-                        <div className="flex items-center gap-1.5 min-w-0">
-                          <span className="font-mono text-[11px] text-[var(--tt-fg)] truncate">{m.model}</span>
-                          <span className="text-[10px] text-[var(--tt-fg-faint)]">×{m.session_count}</span>
-                        </div>
-                        <div className="flex items-center gap-3 shrink-0 ml-2">
-                          <span className="text-[10px]" style={{ color: effColor(m.avg_efficiency) }}>
-                            {m.avg_efficiency.toFixed(1)} eff
-                          </span>
-                          <span className="text-[11px] font-mono text-[var(--tt-fg-muted)] tabular">
-                            {fmtCpp(m.cost_per_eff_pt)}
-                          </span>
-                        </div>
-                      </div>
-                      {m.cost_per_eff_pt !== null && (
-                        <div className="h-1.5 bg-[var(--tt-surface-raised)] rounded overflow-hidden">
-                          <div
-                            className="h-full rounded"
-                            style={{
-                              width: `${Math.min((m.cost_per_eff_pt / maxCpp) * 100, 100)}%`,
-                              background: m.cost_per_eff_pt / maxCpp < 0.3
-                                ? "#4ade80"
-                                : m.cost_per_eff_pt / maxCpp < 0.7
-                                ? "#facc15"
-                                : "#f87171",
-                              opacity: 0.8,
-                            }}
-                          />
-                        </div>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              </Card>
-
-              {/* Right column: cache tiers + wasteful */}
-              <div className="space-y-4">
-                {/* Cache tier analysis */}
-                {ci.cache_tiers.length >= 2 && (
-                  <Card className="space-y-3">
-                    <div className="text-xs font-semibold text-[var(--tt-fg-dim)] uppercase tracking-wide">
-                      Cache hit rate vs efficiency
-                    </div>
-                    <div className="space-y-1.5">
-                      {ci.cache_tiers.map((t) => (
-                        <div key={t.tier} className="flex items-center gap-2">
-                          <div className="w-16 text-[10px] text-[var(--tt-fg-faint)] tabular shrink-0">{t.tier}</div>
-                          <div className="flex-1 h-4 bg-[var(--tt-surface-raised)] rounded overflow-hidden">
-                            <div
-                              className="h-full rounded"
-                              style={{
-                                width: `${t.avg_efficiency}%`,
-                                background: effColor(t.avg_efficiency),
-                                opacity: 0.75,
-                              }}
-                            />
-                          </div>
-                          <span className="text-[11px] font-mono w-8 text-right tabular" style={{ color: effColor(t.avg_efficiency) }}>
-                            {t.avg_efficiency.toFixed(0)}
-                          </span>
-                          <span className="text-[10px] text-[var(--tt-fg-faint)] w-14 text-right tabular shrink-0">
-                            {fmtCost(t.avg_cost)}
-                          </span>
-                          <span className="text-[10px] text-[var(--tt-fg-faint)] shrink-0">×{t.session_count}</span>
-                        </div>
-                      ))}
-                    </div>
-                  </Card>
-                )}
-
-                {/* Wasteful sessions */}
-                {ci.wasteful.length > 0 && (
-                  <Card className="space-y-3">
-                    <div className="text-xs font-semibold text-[var(--tt-fg-dim)] uppercase tracking-wide flex items-center gap-1.5">
-                      <AlertTriangle size={11} className="text-red-400" />
-                      Expensive flops
-                      <span className="normal-case font-normal text-[var(--tt-fg-faint)]">high cost, low efficiency</span>
-                    </div>
-                    <div className="space-y-2">
-                      {ci.wasteful.map((w) => (
-                        <div key={w.session_id} className="flex items-center gap-2 py-1 border-b border-[var(--tt-border)] last:border-0">
-                          <span className="font-mono text-[10px] text-[var(--tt-fg-faint)] shrink-0">{w.session_id.slice(0, 8)}</span>
-                          <span className="font-mono text-[10px] text-[var(--tt-fg)] truncate flex-1">{w.model}</span>
-                          <span className="text-[11px] font-mono text-red-400 tabular shrink-0">{fmtCost(w.cost)}</span>
-                          <span className="text-[10px] tabular shrink-0" style={{ color: effColor(w.efficiency) }}>
-                            {w.efficiency.toFixed(1)}
-                          </span>
-                        </div>
-                      ))}
-                    </div>
-                  </Card>
-                )}
-              </div>
-            </div>
-          </Section>
-        );
-      })()}
+      {/* ── Intelligence Snapshot ────────────────────────────────── */}
+      <IntelligenceSnapshot />
     </div>
   );
 }
@@ -1668,6 +897,75 @@ function ActivityLoading() {
         </div>
       ))}
     </div>
+  );
+}
+
+// ── Intelligence Snapshot ─────────────────────────────────────────────────────
+
+interface SnapRec { total: number; high_count: number; }
+interface SnapHealth { healthy_projects: number; at_risk_projects: number; total_projects: number; }
+interface SnapAnomaly { total_anomalies: number; }
+
+function IntelligenceSnapshot() {
+  const recRes    = useResource<SnapRec>("/insights/recommendations", { pollMs: 120_000 });
+  const healthRes = useResource<SnapHealth>("/insights/project-health", { pollMs: 120_000 });
+  const anomalyRes = useResource<SnapAnomaly>("/insights/anomalies", { pollMs: 60_000 });
+
+  const recs    = recRes.data;
+  const health  = healthRes.data;
+  const anomaly = anomalyRes.data;
+
+  if (!recs && !health && !anomaly) return null;
+
+  return (
+    <Section title="Intelligence" description="Cross-session analytics and recommendations">
+      <div className="flex flex-col sm:flex-row items-start sm:items-center gap-4 p-5 rounded-xl border border-[var(--tt-border)] bg-[var(--tt-surface-raised)]">
+        <div className="flex flex-wrap gap-6 flex-1">
+          {recs && recs.total > 0 && (
+            <div className="flex items-center gap-2">
+              <div className="w-8 h-8 rounded-lg bg-[var(--tt-brand)]/10 flex items-center justify-center">
+                <Brain size={15} className="text-[var(--tt-brand)]" />
+              </div>
+              <div>
+                <div className="text-sm font-semibold text-[var(--tt-fg)]">{recs.total} recommendations</div>
+                {recs.high_count > 0 && (
+                  <div className="text-[11px] text-red-400">{recs.high_count} high priority</div>
+                )}
+              </div>
+            </div>
+          )}
+          {health && health.total_projects > 0 && (
+            <div className="flex items-center gap-2">
+              <div className="w-8 h-8 rounded-lg bg-emerald-400/10 flex items-center justify-center">
+                <Activity size={15} className="text-emerald-400" />
+              </div>
+              <div>
+                <div className="text-sm font-semibold text-[var(--tt-fg)]">{health.healthy_projects}/{health.total_projects} projects healthy</div>
+                {health.at_risk_projects > 0 && (
+                  <div className="text-[11px] text-red-400">{health.at_risk_projects} at risk</div>
+                )}
+              </div>
+            </div>
+          )}
+          {anomaly && anomaly.total_anomalies > 0 && (
+            <div className="flex items-center gap-2">
+              <div className="w-8 h-8 rounded-lg bg-yellow-400/10 flex items-center justify-center">
+                <AlertTriangle size={15} className="text-yellow-400" />
+              </div>
+              <div>
+                <div className="text-sm font-semibold text-[var(--tt-fg)]">{anomaly.total_anomalies} anomalies</div>
+                <div className="text-[11px] text-[var(--tt-fg-faint)]">detected this cycle</div>
+              </div>
+            </div>
+          )}
+        </div>
+        <Link href="/intelligence">
+          <Button variant="secondary" size="md">
+            View Intelligence <ArrowUpRight size={14} />
+          </Button>
+        </Link>
+      </div>
+    </Section>
   );
 }
 

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import {
   LayoutDashboard, Folder, BarChart3, Activity, Settings2,
-  PanelLeftOpen, PanelLeftClose, Zap,
+  PanelLeftOpen, PanelLeftClose, Zap, Brain,
 } from "lucide-react";
 import { useResource } from "@/lib/api";
 import { ALL_AGENT_KEYS, getAgent } from "@/lib/agents";
@@ -18,9 +18,10 @@ interface NavigationProps {
 }
 
 const LINKS = [
-  { name: "Dashboard", href: "/",         icon: LayoutDashboard },
-  { name: "Projects",  href: "/projects", icon: Folder },
-  { name: "Analytics", href: "/analytics", icon: BarChart3 },
+  { name: "Dashboard",    href: "/",             icon: LayoutDashboard },
+  { name: "Projects",     href: "/projects",     icon: Folder },
+  { name: "Analytics",    href: "/analytics",    icon: BarChart3 },
+  { name: "Intelligence", href: "/intelligence", icon: Brain },
   { name: "Local Models", href: "/local-models", icon: Zap },
 ];
 


### PR DESCRIPTION
## Summary

Three new analytical capabilities built on top of the existing session data — all pure computation, no new required dependencies.

### 1. Agent Efficiency Score (`backend/scoring.py`)
A 0–100 score per session measuring how productively tokens were used:

```
score = output_ratio × error_penalty × turn_penalty × 100
```

- `output_ratio` = output tokens / total tokens (more output = more productive)
- `error_penalty` = 1 / (1 + errors × 0.15) — penalises tool failures
- `turn_penalty` = 1 / (1 + log(turns) × 0.18) — rewards concise prompts

Every session in `/sessions` now includes `efficiency: 73.2` and `efficiency_label: good | fair | poor`.

### 2. AI Smell Detection (`backend/smells.py`)
Rule-based detection of 5 anti-patterns:

| Smell | Threshold | Severity |
|-------|-----------|----------|
| `context_rot` | > 200 turns | warning → critical at 400 |
| `loop_trap` | ≥ 8 consecutive identical tool calls | critical |
| `tool_thrash` | ≥ 25 reads of the same file | warning |
| `high_error_rate` | errors > 20% of turns | warning → critical at 40% |
| `massive_session` | > 2M total tokens | warning → critical at 5M |

Every session includes `smells: [{type, title, detail, severity}]`. New endpoint `GET /smells?project=<path>` returns only sessions with warnings.

### 3. Burn Rate Forecasting (`backend/forecast.py`)
Linear projection of token usage toward monthly subscription limits:

- Daily token buckets over 60 days
- 7-day average vs prior-7-day average → trend detection (accelerating / steady / slowing)
- Projects tokens to end of month at current pace
- Calculates days-until-limit for Claude Pro (500M), Claude Max (2B), Codex Plus (200M), Copilot (100M)
- Exposed via `GET /forecast?plan=claude_pro`

### Frontend (`frontend/src/app/page.tsx`)
- **Efficiency badge**: new `⚡ Score` column in the Recent Activity table — colour-coded pill (green ≥70, amber ≥40, red <40)
- **Smell indicator**: `⚠` icon on session rows with smell count and critical/warning colour
- **Burn Rate card** in the dashboard sidebar:
  - Daily token rate (7d avg) + projected monthly total
  - Progress bar vs plan limit with urgency colouring
  - Alert when limit is ≤7 days away at current pace
  - Trend label with week-over-week percentage

## No new required dependencies
All Python modules use stdlib only (`math`, `datetime`, `collections`). Lucide icons used are already in the project's icon set.

## Test plan
- [ ] Start backend — confirm `/sessions` response includes `efficiency` and `smells` fields
- [ ] Hit `GET /forecast` — confirm JSON with `daily_avg_7d`, `trend`, `days_until_limit`
- [ ] Hit `GET /smells` — confirm only sessions with warnings are returned
- [ ] Hit `GET /efficiency` — confirm sessions sorted by efficiency score descending
- [ ] Open dashboard — confirm Score column appears with coloured badges
- [ ] Open dashboard — confirm ⚠ icon appears on sessions with high error rate or many turns
- [ ] Open dashboard — confirm Burn Rate card renders in right sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)