### PR TITLE
Delegation & ecosystem telemetry: subagent costs, skills & MCP usage across agents

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,160 @@
+# Delegation & Ecosystem Telemetry — design notes
+
+Goal: show the TRUE cost of a session including everything it spawned (subagents),
+and which skills / MCP servers / subagent types actually earn their keep — without
+eroding trust: no silent historical changes, no fake zeros, model-correct pricing,
+explicit "n/a" where an agent's logs don't record the signal.
+
+All shapes below were verified against real data on this machine (2026-06-10).
+
+## 1. Verified data shapes
+
+### Claude Code (full support — token rollup possible)
+
+```
+~/.claude/projects/<encoded-proj>/<sessionId>/subagents/agent-<agentId>.jsonl
+~/.claude/projects/<encoded-proj>/<sessionId>/subagents/agent-<agentId>.meta.json
+```
+
+- `meta.json` (present on all 55 local files, but code defensively):
+  `{"agentType": "Explore", "description": "...", "toolUseId": "toolu_01RB3..."}`
+- The parent transcript contains a matching `tool_use` block: `name: "Agent"`
+  (older Claude Code versions used `"Task"` — match both), `id == meta.toolUseId`,
+  `input: {description, subagent_type, prompt}`.
+- Subagent JSONL lines mirror the main-session schema. Assistant lines carry:
+  `isSidechain: true`, `agentId`, `attributionAgent` (agent type),
+  `sessionId` (= PARENT session id — fallback linkage if dir name is lost),
+  `message.model`, `message.usage` with full cache fields
+  (`cache_read_input_tokens`, `cache_creation_input_tokens`,
+  `cache_creation.ephemeral_1h_input_tokens`).
+- Empirical facts (don't rely on them, but don't over-engineer either):
+  one model per file today (but cost per-line by that line's model anyway;
+  skip `<synthetic>`); no nested `subagents/` dirs; `usage.iterations` always
+  length ≤ 1 (ignore it; read top-level usage only).
+- Models seen in subagent files differ from parents: haiku-4-5, sonnet-4-6,
+  opus-4-7, opus-4-8. **Costing with the parent's model would be wrong.**
+- The session dir also contains `tool-results/` — ignore it.
+- Local hidden volume (why this is Phase 1): 55 subagent files / 14 sessions =
+  521k in + 402k out + 6.7M cache-write + 87.8M cache-read tokens, currently 0
+  in the dashboard.
+
+### Cursor (spawn detection ONLY — no token data)
+
+```
+~/.cursor/projects/<slug>/agent-transcripts/<sessionId>/subagents/<uuid>.jsonl
+```
+
+- **Subagent files contain NO usage fields at all** (verified: plain
+  `{role, message}` lines, no token counts, no model, no meta.json).
+- Therefore: report spawn count + transcripts existence; tokens/cost = "not
+  recorded by Cursor". Do NOT estimate.
+
+### OpenCode / Hermes (hierarchy via parent id — children are already sessions)
+
+- OpenCode sqlite `session.parent_id`: 5 of 12 local sessions are children.
+- Hermes sqlite `sessions.parent_session_id`: 12 of 21 local sessions are children.
+- Child usage is ALREADY counted (each child appears as its own session today).
+  So: annotate hierarchy (`parent_session_id` on child, `child_session_ids` +
+  display-only delegated sums on parent). NEVER add child sums into aggregate
+  totals — that would double-count.
+
+### No subagent signal (render explicit "not recorded by <agent>")
+
+codex, gemini, qwen, grok, copilot, vibe, antigravity.
+
+## 2. Token semantics — the count-once invariant
+
+Every token is counted in project/analytics aggregates exactly once.
+
+- **Claude Code**: subagent files are NOT sessions; their usage is counted
+  nowhere today. Add as a separate `delegated` bucket on the parent and DO
+  include it in aggregates (this is the fix — totals will visibly increase;
+  announce in UPDATE.json, don't let users discover it).
+- **OpenCode/Hermes**: children ARE sessions; their usage is already in
+  aggregates. Parent-side delegated sums are display-only annotations.
+- Parent `tokens.{input,output,cached,...}` stay EXACTLY as today. New fields
+  only; headline UI shows "X + Y delegated", never a silently merged number.
+- Cache semantics match the existing scanner: `cached` = high-water-mark of
+  `cache_read_input_tokens` per transcript file; cache_creation cumulative.
+  Apply per subagent file, cost via `calculate_cost(model_of_that_file, ...)`.
+
+## 3. Shapes (Phase 1 — IMPLEMENTED on branch worktree-delegation-telemetry)
+
+Every session in `/sessions` carries a `delegation` marker. Capability is
+per-agent (`_DELEGATION_CAPABLE_AGENTS = {claude, cursor, opencode, hermes}`);
+everything else gets `{"supported": false}` — frontend renders
+"not recorded by <agent>", never 0.
+
+```json
+claude:           {"supported": true,  "tokens_recorded": true,  "spawn_count": 2, "delegated_total": 82340}
+cursor:           {"supported": true,  "tokens_recorded": false, "spawn_count": 4}
+opencode/hermes parent: {"supported": true, "tokens_recorded": false, "linked_children": 1}
+```
+
+Claude sessions with spawns additionally get `tokens.delegated_input/_output/
+_cached/_cache_creation` + top-level `delegated_cost` (existing token fields
+untouched). OpenCode/Hermes: `parent_session_id` on children,
+`child_session_ids` on parents.
+
+The RICH breakdown lives on a per-session overlay endpoint (the claude detail
+endpoint returns a raw event list, so it follows the `/sessions/{id}/hermes-
+overlay` precedent): `GET /sessions/{session_id}/delegation?agent=...` →
+
+```json
+{
+  "supported": true, "tokens_recorded": true, "spawn_count": 2, "cost": 0.245,
+  "totals": {"input": 0, "output": 0, "cached": 0, "cache_creation": 0, "cache_creation_1h": 0, "total": 0},
+  "subagents": [
+    {"agent_id": "aaef9765c0454d680", "agent_type": "Explore",
+     "description": "Explore backend request/auth surface",
+     "tool_use_id": "toolu_01RB3...", "model": "claude-haiku-4-5-20251001",
+     "tokens": {"...": 0}, "cost": 0.12}
+  ]
+}
+```
+
+cursor returns spawn entries with `tokens: null` (never invented); opencode/
+hermes return `parent_session_id` + `child_session_ids`; unsupported agents
+`{"supported": false}`. Implementation: `_claude_subagent_usage()` +
+`session_delegation()` in `backend/main.py`; tests in
+`backend/test_delegation.py`.
+
+Phase 2 (per session): `skills_used: [{name, count}]` (from `Skill` tool_use
+`input.skill` + `<command-name>` tags in user lines — filter out built-in CLI
+commands like /model, /usage which also emit the tag), and
+`mcp_usage: {server: {tool: count}}` parsed from `mcp__<server>__<tool>` names
+(Grok: `signals.json.toolsUsed[]`; Copilot/Vibe/Antigravity: unsupported).
+`/analytics`: `by_skill`, `by_mcp_server`, `by_subagent_type`.
+
+## 4. Edge cases
+
+- meta.json missing/corrupt → agent_type "unknown", still sum usage.
+- Subagent file still being written (background agent) → per-line tolerant JSON
+  parse (same as existing scanner), partial last line skipped.
+- `<synthetic>` model lines and usage-less lines → skip for cost, don't crash.
+- Possible future nesting (subagent spawning subagents) → at minimum don't
+  recurse infinitely; either one level (today's reality) or bounded recursion.
+- Session resumed/compacted: subagent dir name == original sessionId; the
+  `sessionId` field inside subagent lines is the authoritative parent link.
+- Scanner perf: the per-session subdir check is one `is_dir()` stat for the
+  top-100 sessions; full subagent read happens in the list scan only as a cheap
+  sum (55 small files locally — fine), detail endpoint does the rich version.
+  Respect the existing sessions cache (`get_sessions_cached`) and 100-cap.
+- Tests: scanner paths are module-level constants (`CLAUDE_DIR = HOME/".claude"`)
+  — fixtures must monkeypatch the constant (see existing test files for the
+  pattern) and build a tmp tree with parent jsonl + subagents/.
+
+## 5. Order of work
+
+1. **Phase 1 backend** — Claude Code subagent scan (rollup + detail), Cursor
+   spawn-count only, OpenCode/Hermes parent/child markers. Fixture tests.
+   Primary token fields untouched.
+2. **Phase 2 backend** — skills + MCP usage extraction, analytics `by_*`,
+   count-once enforcement in aggregates.
+3. **Phase 3 frontend** — Delegated-work card on session detail (linked to the
+   spawning Agent/Task tool call in the trace), Tools panel split (direct vs
+   MCP grouped by server), analytics charts, usage overlays on the /config
+   inventory ("installed but never used" is an insight), honest n/a states.
+4. **UPDATE.json + browser verification** — feat: commits require an
+   UPDATE.json entry (pre-push hook); the entry should explicitly say totals
+   now include previously hidden subagent usage.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -58,9 +58,38 @@ All shapes below were verified against real data on this machine (2026-06-10).
   display-only delegated sums on parent). NEVER add child sums into aggregate
   totals — that would double-count.
 
+### Grok Build / Codex / Antigravity CLI (probe findings, 2026-06-10)
+
+Verified by actually RUNNING the CLIs headlessly with a delegation prompt
+(grok 0.2.39, codex 0.136.0, agy 1.0.7) — all three support subagents:
+
+- **Grok Build** (subagents ON by default; `--no-subagents` to disable):
+  parent writes `<session>/subagents/<spawn-id>/meta.json` with
+  `{subagent_type, description, prompt, status, duration_ms, tool_calls,
+  turns, effective_model_id, parent_session_id, child_session_id}`. The child
+  is a full sibling session dir with its own `signals.json`
+  (`contextTokensUsed`) — already counted as a session, annotation only.
+  `spawn_subagent` / `get_command_or_subagent_output` appear in events.jsonl.
+- **Codex** (`multi_agent` feature flag stable+enabled): each subagent thread
+  is its own rollout file whose `session_meta.payload` carries
+  `thread_source: "subagent"`, `forked_from_id`, and
+  `source.subagent.thread_spawn {parent_thread_id, depth, agent_nickname,
+  agent_role}`. NOTE: plain `forked_from_id` also fires for user `codex fork`
+  — require the subagent markers. **Discovery bug found**: codex stopped
+  maintaining `session_index.jsonl` (frozen 2026-04-23 on this machine), so
+  index-seeded discovery missed every newer session (10 indexed vs 36 actual)
+  — scanner now globs rollouts and uses the index only for legacy thread
+  names.
+- **Antigravity CLI** (`agy`): spawns create full sibling conversations; the
+  parent's brain transcript
+  (`brain/<id>/.system_generated/logs/transcript.jsonl`) records an
+  `INVOKE_SUBAGENT` step whose content embeds the child `conversationId`
+  (JSON-escaped). Children link back via `send_message` to the parent id.
+  Retroactive linkage over existing local data found 7 parents / 10 children.
+
 ### No subagent signal (render explicit "not recorded by <agent>")
 
-codex, gemini, qwen, grok, copilot, vibe, antigravity.
+gemini, qwen, copilot, vibe.
 
 ## 2. Token semantics — the count-once invariant
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -119,12 +119,16 @@ hermes return `parent_session_id` + `child_session_ids`; unsupported agents
 `session_delegation()` in `backend/main.py`; tests in
 `backend/test_delegation.py`.
 
-Phase 2 (per session): `skills_used: [{name, count}]` (from `Skill` tool_use
-`input.skill` + `<command-name>` tags in user lines — filter out built-in CLI
-commands like /model, /usage which also emit the tag), and
-`mcp_usage: {server: {tool: count}}` parsed from `mcp__<server>__<tool>` names
-(Grok: `signals.json.toolsUsed[]`; Copilot/Vibe/Antigravity: unsupported).
-`/analytics`: `by_skill`, `by_mcp_server`, `by_subagent_type`.
+Phase 2 (IMPLEMENTED): per session, `skills_used: [{name, count}]` (claude:
+`Skill` tool_use `input.skill` + `<command-name>` tags in user lines, built-in
+CLI commands like /model and /plan filtered via `_BUILTIN_CLI_COMMANDS`),
+`tool_counts: {name: n}` (claude/codex/gemini/qwen/cursor/opencode/hermes) and
+`mcp_usage: {server: {tool: n}}` derived from `mcp__<server>__<tool>` names.
+Claude's `delegation` gains `by_type: {agent_type: {count, total, cost}}`.
+`/analytics` adds `by_skill`, `by_mcp_server`, `by_subagent_type`, and a
+`delegation` totals bucket — all NEW keys; existing aggregates byte-identical
+(delegated usage exposed separately, never folded in). Copilot/Vibe/
+Antigravity/Grok carry no per-call tool signal → keys simply absent.
 
 ## 4. Edge cases
 

--- a/UPDATE.json
+++ b/UPDATE.json
@@ -1,6 +1,31 @@
 {
   "releases": [
     {
+      "tag": "2026-06-10",
+      "title": "See what your subagents, skills & MCPs cost",
+      "highlights": [
+        {
+          "title": "Subagent spend, finally visible",
+          "description": "When a Claude Code session spawns subagents (Explore, general-purpose, custom agents), their tokens were invisible until now — on a typical machine that's millions of tokens. Session pages show a \"Delegated work\" card with each subagent's task, model, tokens and cost, priced by the model the subagent actually ran (an Explore on Haiku no longer hides inside an Opus session).",
+          "href": "/"
+        },
+        {
+          "title": "Which subagent types earn their keep",
+          "description": "Analytics gains a Delegation & ecosystem section: total delegated tokens and cost, plus a per-type ranking. If general-purpose agents cost you 5× what Explore agents do for similar work, you'll see it — and can change how you delegate.",
+          "href": "/analytics"
+        },
+        {
+          "title": "Skill & MCP usage, cross-linked to your inventory",
+          "description": "Sessions now record which skills you invoked and how often each MCP server was actually called. Your project's Config page overlays that usage on every installed skill, command, subagent and MCP server — anything marked \"no recorded use\" is a candidate to clean up.",
+          "href": "/analytics"
+        },
+        {
+          "title": "Honest gaps, not fake zeros",
+          "description": "Cursor records subagent runs but not their tokens; OpenCode and Hermes link parent and child sessions; other agents don't log spawns at all. The dashboard says exactly which of these applies instead of showing a misleading 0 — and existing session totals are unchanged, delegated usage is always a separate bucket."
+        }
+      ]
+    },
+    {
       "tag": "2026-06-08",
       "title": "View the dashboard from another device",
       "highlights": [

--- a/UPDATE.json
+++ b/UPDATE.json
@@ -20,8 +20,12 @@
           "href": "/analytics"
         },
         {
-          "title": "Honest gaps, not fake zeros",
-          "description": "Cursor records subagent runs but not their tokens; OpenCode and Hermes link parent and child sessions; other agents don't log spawns at all. The dashboard says exactly which of these applies instead of showing a misleading 0 — and existing session totals are unchanged, delegated usage is always a separate bucket."
+          "title": "Delegation across Grok Build, Codex & Antigravity too",
+          "description": "Grok Build, Codex and Antigravity CLI all spawn subagents as separate sessions — those are now linked: the parent session shows each spawn (task, duration, role) with a jump to the child session, and children link back to their parent. Cursor shows spawn counts; agents that don't log spawns say so honestly instead of showing a misleading 0."
+        },
+        {
+          "title": "Recent Codex sessions were missing — now found",
+          "description": "Newer Codex versions stopped updating the session index TokenTelemetry relied on, so sessions from the last weeks never appeared. Sessions are now discovered from the session files themselves — expect your Codex session count (and totals) to jump to reality."
         }
       ]
     },

--- a/backend/main.py
+++ b/backend/main.py
@@ -4195,6 +4195,56 @@ async def get_session_detail(session_id: str, agent: str):
     return {"error": "Invalid agent"}
 
 
+def _jsonl_events(path: Path) -> List[Dict[str, Any]]:
+    """Parse a transcript JSONL into the event list shape the trace UI expects
+    (same normalization as the claude branch of get_session_detail)."""
+    events: List[Dict[str, Any]] = []
+    with open(path, "r", encoding="utf-8", errors="replace") as f:
+        for line in f:
+            try:
+                data = json.loads(line)
+            except Exception:
+                continue
+            if data.get("timestamp"):
+                try:
+                    ts = _aware(datetime.fromisoformat(data["timestamp"].replace('Z', '+00:00')))
+                    data["normalized_timestamp"] = ts.timestamp() * 1000
+                except Exception:
+                    pass
+            events.append(data)
+    return events
+
+
+_SUBAGENT_ID_RE = re.compile(r"^[\w.-]+$")
+
+
+@app.get("/sessions/{session_id}/subagents/{agent_id}/trace")
+async def session_subagent_trace(session_id: str, agent_id: str, agent: str):
+    """Raw trace of ONE subagent transcript, for the in-place drill-in viewer.
+
+    Only claude and cursor need this: their subagent transcripts are files
+    inside the parent's session dir, NOT sessions of their own (grok/codex/
+    opencode/hermes children are real sessions — fetch the normal detail
+    endpoint for those instead)."""
+    if not _SUBAGENT_ID_RE.match(agent_id or ""):
+        return {"error": "Invalid subagent id"}
+    if agent == "claude":
+        files = list(CLAUDE_DIR.glob(f"projects/**/{session_id}.jsonl"))
+        if not files:
+            return {"error": "Not found"}
+        t = files[0].parent / session_id / "subagents" / f"agent-{agent_id}.jsonl"
+        if not t.exists():
+            return {"error": "Not found"}
+        return _jsonl_events(t)
+    if agent == "cursor":
+        for pd in (CURSOR_DIR / "projects").glob("*"):
+            t = pd / "agent-transcripts" / session_id / "subagents" / f"{agent_id}.jsonl"
+            if t.exists():
+                return _jsonl_events(t)
+        return {"error": "Not found"}
+    return {"error": "Invalid agent"}
+
+
 @app.get("/sessions/{session_id}/delegation")
 async def session_delegation(session_id: str, agent: str):
     """Per-session subagent/delegation breakdown (overlay, like hermes-overlay).

--- a/backend/main.py
+++ b/backend/main.py
@@ -1886,8 +1886,13 @@ def _scan_grok_sessions() -> List[Dict[str, Any]]:
             if grok_spawns:
                 by_type: Dict[str, Dict[str, Any]] = {}
                 for sp in grok_spawns:
-                    bt = by_type.setdefault(sp.get("agent_type") or "unknown", {"count": 0})
+                    bt = by_type.setdefault(sp.get("agent_type") or "unknown",
+                                            {"count": 0, "child_session_ids": []})
                     bt["count"] += 1
+                    # Child ids let /analytics attribute each child session's
+                    # (already-counted) tokens to its subagent type.
+                    if sp.get("child_session_id"):
+                        bt["child_session_ids"].append(sp["child_session_id"])
                 sess["delegation"] = {"supported": True, "tokens_recorded": False,
                                       "spawn_count": len(grok_spawns),
                                       "by_type": by_type}
@@ -4628,9 +4633,33 @@ async def get_analytics():
     by_skill: Dict[str, Dict[str, Any]] = {}
     by_mcp_server: Dict[str, Dict[str, Any]] = {}
     by_subagent_type: Dict[str, Dict[str, Any]] = {}
-    delegation_totals = {"delegated_tokens": 0, "delegated_cost": 0.0,
-                         "sessions_with_spawns": 0}
+    # delegated_*: usage that exists NOWHERE else (claude subagent transcripts).
+    # linked_child_*: child sessions spawned by a parent — their tokens are
+    # already in by_agent/by_day/total above; surfaced here as an attribution
+    # view, never added on top.
+    delegation_totals: Dict[str, Any] = {
+        "delegated_tokens": 0, "delegated_cost": 0.0,
+        "sessions_with_spawns": 0,
+        "linked_children": 0, "linked_child_tokens": 0, "linked_child_cost": 0.0,
+        "by_agent": {},
+    }
+    # Child sessions are looked up per (agent, id) so grok by_type rows can
+    # attribute each child's tokens to its subagent type.
+    sess_by_key = {(s.get("agent"), s.get("id")): s for s in sessions}
+
+    def _subagent_row(t: str) -> Dict[str, Any]:
+        return by_subagent_type.setdefault(t, {
+            "spawns": 0, "tokens": 0, "cost": 0.0, "session_count": 0,
+            "tokens_recorded": False, "agents": []})
+
+    def _deleg_agent_row(agent: str) -> Dict[str, Any]:
+        return delegation_totals["by_agent"].setdefault(agent, {
+            "parents": 0, "spawns": 0, "children": 0,
+            "child_tokens": 0, "child_cost": 0.0,
+            "delegated_tokens": 0, "delegated_cost": 0.0})
+
     for s in sessions:
+        agent = s.get("agent")
         for sk in s.get("skills_used") or []:
             row = by_skill.setdefault(sk["name"], {"invocations": 0, "session_count": 0})
             row["invocations"] += sk["count"]
@@ -4641,18 +4670,60 @@ async def get_analytics():
             for tool, n in tools.items():
                 row["calls"] += n
                 row["tools"][tool] = row["tools"].get(tool, 0) + n
+
         deleg = s.get("delegation") or {}
+        spawns_here = deleg.get("spawn_count") or deleg.get("linked_children") or 0
+        if spawns_here:
+            delegation_totals["sessions_with_spawns"] += 1
+            arow = _deleg_agent_row(agent)
+            arow["parents"] += 1
+            arow["spawns"] += spawns_here
         for t, d in (deleg.get("by_type") or {}).items():
-            row = by_subagent_type.setdefault(t, {"spawns": 0, "tokens": 0, "cost": 0.0, "session_count": 0})
+            row = _subagent_row(t)
             row["spawns"] += d.get("count", 0)
-            row["tokens"] += d.get("total", 0)
-            row["cost"] = round(row["cost"] + (d.get("cost") or 0), 6)
             row["session_count"] += 1
+            if agent not in row["agents"]:
+                row["agents"].append(agent)
+            # claude: per-type totals come straight from subagent transcripts.
+            if d.get("total") or d.get("cost"):
+                row["tokens"] += d.get("total", 0)
+                row["cost"] = round(row["cost"] + (d.get("cost") or 0), 6)
+                row["tokens_recorded"] = True
+            # grok: attribute each child SESSION's tokens to the spawning type.
+            for cid in d.get("child_session_ids") or []:
+                child = sess_by_key.get((agent, cid))
+                if child is None:
+                    continue
+                row["tokens"] += (child.get("tokens") or {}).get("total", 0)
+                row["cost"] = round(row["cost"] + (child.get("cost") or 0), 6)
+                row["tokens_recorded"] = True
+        # codex children carry their role; attribute the child session directly.
+        si = s.get("subagent_info")
+        if s.get("parent_session_id") and isinstance(si, dict) and si.get("role"):
+            row = _subagent_row(si["role"])
+            row["spawns"] += 1
+            if agent not in row["agents"]:
+                row["agents"].append(agent)
+            row["tokens"] += (s.get("tokens") or {}).get("total", 0)
+            row["cost"] = round(row["cost"] + (s.get("cost") or 0), 6)
+            row["tokens_recorded"] = True
+
         if deleg.get("tokens_recorded") and deleg.get("delegated_total"):
             delegation_totals["delegated_tokens"] += deleg["delegated_total"]
             delegation_totals["delegated_cost"] = round(
                 delegation_totals["delegated_cost"] + (s.get("delegated_cost") or 0), 6)
-            delegation_totals["sessions_with_spawns"] += 1
+            arow = _deleg_agent_row(agent)
+            arow["delegated_tokens"] += deleg["delegated_total"]
+            arow["delegated_cost"] = round(arow["delegated_cost"] + (s.get("delegated_cost") or 0), 6)
+        if s.get("parent_session_id"):
+            delegation_totals["linked_children"] += 1
+            delegation_totals["linked_child_tokens"] += (s.get("tokens") or {}).get("total", 0)
+            delegation_totals["linked_child_cost"] = round(
+                delegation_totals["linked_child_cost"] + (s.get("cost") or 0), 6)
+            arow = _deleg_agent_row(agent)
+            arow["children"] += 1
+            arow["child_tokens"] += (s.get("tokens") or {}).get("total", 0)
+            arow["child_cost"] = round(arow["child_cost"] + (s.get("cost") or 0), 6)
 
     return {
         "by_agent": by_agent,

--- a/backend/main.py
+++ b/backend/main.py
@@ -2130,6 +2130,13 @@ _BUILTIN_CLI_COMMANDS = {
 }
 
 
+# Codex records no structured skill event (verified on 0.136 by invoking a
+# sample skill): activation shows up only as the agent READING the skill's
+# SKILL.md through a tool call. The path inside function_call arguments is the
+# one reliable breadcrumb — match ".../skills/<name>/SKILL.md" (either slash).
+_CODEX_SKILL_RE = re.compile(r'skills[/\\]+([\w.-]+)[/\\]+SKILL\.md')
+
+
 def _count_tool(tool_counts: Dict[str, int], name) -> None:
     if name:
         tool_counts[name] = tool_counts.get(name, 0) + 1
@@ -2624,6 +2631,11 @@ def _scan_sessions_sync():
                                     tool = data["payload"].get("name")
                                     if tool not in sess["mcp_tools"]: sess["mcp_tools"].append(tool)
                                     _count_tool(sess.setdefault("tool_counts", {}), tool)
+                                    # Skill activation breadcrumb: the agent reads
+                                    # <skills-dir>/<name>/SKILL.md (no structured event).
+                                    for _skm in _CODEX_SKILL_RE.finditer(data["payload"].get("arguments") or ""):
+                                        _sc = sess.setdefault("_skill_counts", {})
+                                        _sc[_skm.group(1)] = _sc.get(_skm.group(1), 0) + 1
                                     if tool == "update_plan":
                                         try:
                                             args = json.loads(data["payload"].get("arguments") or "{}")
@@ -2661,6 +2673,10 @@ def _scan_sessions_sync():
             mcp = _mcp_usage_from_counts(s.get("tool_counts") or {})
             if mcp:
                 s["mcp_usage"] = mcp
+            _sc = s.pop("_skill_counts", None)
+            if _sc:
+                s["skills_used"] = [{"name": k, "count": v}
+                                    for k, v in sorted(_sc.items(), key=lambda kv: (-kv[1], kv[0]))]
         # Annotate parents of subagent threads (children are full sessions with
         # their own usage — linkage only, never re-summed).
         for s in codex_sessions.values():

--- a/backend/main.py
+++ b/backend/main.py
@@ -1970,6 +1970,112 @@ def _opencode_resolve_model(val):
     return None
 
 
+# Agents whose local logs record subagent/child-session spawns at all.
+# claude: full token rollup; cursor: spawn count only (transcripts carry no
+# usage fields); opencode/hermes: parent/child linkage between real sessions.
+_DELEGATION_CAPABLE_AGENTS = {"claude", "cursor", "opencode", "hermes"}
+
+
+def _claude_subagent_usage(session_file: Path, sid: str) -> Optional[Dict[str, Any]]:
+    """Roll up subagent (Task/Agent tool) usage for one Claude Code session.
+
+    Claude Code writes each spawned subagent's full transcript to
+      <project-dir>/<sessionId>/subagents/agent-<agentId>.jsonl
+    with a sibling agent-<agentId>.meta.json {agentType, description, toolUseId}.
+    These files are NOT sessions — their usage is counted nowhere else, so this
+    rollup is the only place it surfaces (count-once invariant: the parent's own
+    token fields stay untouched; delegated usage is a separate bucket).
+
+    Each subagent runs its own context and often a DIFFERENT model than the
+    parent (e.g. Explore on Haiku under an Opus session), so cost is computed
+    per file with that file's model. Cache semantics match the main scanner:
+    cached = high-water-mark of cache_read per transcript, cache writes are
+    billed per event and accumulate.
+
+    Returns None when the session has no subagents/ dir; otherwise
+    {spawn_count, subagents: [...], totals: {...}, cost}.
+    """
+    sub_dir = session_file.parent / sid / "subagents"
+    try:
+        if not sub_dir.is_dir():
+            return None
+    except Exception:
+        return None
+    entries: List[Dict[str, Any]] = []
+    for f in sorted(sub_dir.glob("agent-*.jsonl")):
+        agent_id = f.stem[len("agent-"):]
+        agent_type = None
+        description = None
+        tool_use_id = None
+        try:
+            with open(f.with_name(f.stem + ".meta.json"), "r", encoding="utf-8") as mf:
+                meta = json.load(mf)
+            if isinstance(meta, dict):
+                agent_type = meta.get("agentType")
+                description = meta.get("description")
+                tool_use_id = meta.get("toolUseId")
+        except Exception:
+            pass
+        tokens = {"input": 0, "output": 0, "cached": 0, "cache_creation": 0,
+                  "cache_creation_1h": 0, "total": 0}
+        model = None
+        try:
+            with open(f, "r", encoding="utf-8", errors="replace") as fh:
+                for line in fh:
+                    try:
+                        data = json.loads(line)
+                    except Exception:
+                        continue
+                    if data.get("type") != "assistant":
+                        continue
+                    msg = data.get("message", {}) if isinstance(data.get("message"), dict) else {}
+                    m = msg.get("model")
+                    if m and m != "<synthetic>" and not model:
+                        model = m
+                    # Fallback identity when meta.json is missing/corrupt.
+                    if not agent_type and data.get("attributionAgent"):
+                        agent_type = data.get("attributionAgent")
+                    usage = msg.get("usage", {}) if isinstance(msg.get("usage"), dict) else {}
+                    if not usage:
+                        continue
+                    cr = usage.get("cache_read_input_tokens", 0) or 0
+                    cc = usage.get("cache_creation_input_tokens", 0) or 0
+                    cc_1h = (usage.get("cache_creation", {}) or {}).get("ephemeral_1h_input_tokens", 0) or 0
+                    tokens["input"] += usage.get("input_tokens", 0) or 0
+                    tokens["output"] += usage.get("output_tokens", 0) or 0
+                    tokens["cached"] = max(tokens["cached"], cr)
+                    tokens["cache_creation"] += cc
+                    tokens["cache_creation_1h"] += cc_1h
+        except Exception:
+            continue
+        tokens["total"] = tokens["input"] + tokens["output"] + tokens["cached"]
+        cost = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"],
+                              cache_creation_tokens=tokens["cache_creation"],
+                              cache_creation_1h_tokens=tokens["cache_creation_1h"])
+        entries.append({
+            "agent_id": agent_id,
+            "agent_type": agent_type or "unknown",
+            "description": description,
+            "tool_use_id": tool_use_id,
+            "model": model,
+            "tokens": tokens,
+            "cost": cost,
+        })
+    if not entries:
+        return None
+    totals = {"input": 0, "output": 0, "cached": 0, "cache_creation": 0,
+              "cache_creation_1h": 0, "total": 0}
+    for e in entries:
+        for k in totals:
+            totals[k] += e["tokens"][k]
+    return {
+        "spawn_count": len(entries),
+        "subagents": entries,
+        "totals": totals,
+        "cost": round(sum(e["cost"] or 0 for e in entries), 6),
+    }
+
+
 def _scan_sessions_sync():
     sessions = []
     aliases = _load_project_aliases()
@@ -2145,6 +2251,23 @@ def _scan_sessions_sync():
                                 #     prior_edit_failed = False
                                 #     pending_edit_tool_ids = set()
                 except Exception: continue
+                # Subagent (Task/Agent) rollup — separate "delegated" bucket so the
+                # parent's own token fields stay exactly as before. Full per-subagent
+                # breakdown is served by /sessions/{id}/delegation, the list carries
+                # only the summary.
+                deleg = _claude_subagent_usage(session_file, sid)
+                sess["delegation"] = {
+                    "supported": True,
+                    "tokens_recorded": True,
+                    "spawn_count": deleg["spawn_count"] if deleg else 0,
+                    "delegated_total": deleg["totals"]["total"] if deleg else 0,
+                }
+                if deleg:
+                    sess["tokens"]["delegated_input"] = deleg["totals"]["input"]
+                    sess["tokens"]["delegated_output"] = deleg["totals"]["output"]
+                    sess["tokens"]["delegated_cached"] = deleg["totals"]["cached"]
+                    sess["tokens"]["delegated_cache_creation"] = deleg["totals"]["cache_creation"]
+                    sess["delegated_cost"] = deleg["cost"]
         sessions.extend(claude_sessions.values())
     # 2. Codex
     codex_index = CODEX_DIR / "session_index.jsonl"
@@ -2689,7 +2812,16 @@ def _scan_sessions_sync():
                                                         plans.append({"session_id": sid, "agent": "cursor", "timestamp": mtime, "content": t_text})
                                 tokens["total"] = tokens["input"] + tokens["output"] + tokens["cached"]
                                 tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"], cache_creation_tokens=tokens.get("cache_creation", 0), cache_creation_1h_tokens=tokens.get("cache_creation_1h", 0))
-                                sessions.append({"id": sid, "agent": "cursor", "project": project_path, "timestamp": mtime, "display": first_msg[:100], "tokens": tokens, "mcp_tools": mcp_tools, "subagents": subagents, "has_plan": has_plan, "plans": plans, "model": model, "artifacts": artifacts, "cost": tokens["cost"]})
+                                # Cursor writes subagent transcripts to <sid>/subagents/
+                                # but they carry NO usage fields (verified), so we can
+                                # only count spawns — never estimate their tokens.
+                                spawn_count = 0
+                                try:
+                                    spawn_count = sum(1 for _ in (trans_dir / "subagents").glob("*.jsonl"))
+                                except Exception: pass
+                                delegation = {"supported": True, "tokens_recorded": False,
+                                              "spawn_count": max(spawn_count, len(subagents))}
+                                sessions.append({"id": sid, "agent": "cursor", "project": project_path, "timestamp": mtime, "display": first_msg[:100], "tokens": tokens, "mcp_tools": mcp_tools, "subagents": subagents, "has_plan": has_plan, "plans": plans, "model": model, "artifacts": artifacts, "cost": tokens["cost"], "delegation": delegation})
                             except Exception: continue
 
     # 7. Copilot
@@ -2830,7 +2962,14 @@ def _scan_sessions_sync():
                 except Exception:
                     _sess_cols = set()
                 _has_sess_model = "model" in _sess_cols
-                rows = conn.execute("SELECT id, directory, title, time_created, time_updated FROM session").fetchall()
+                # parent_id links child (delegated) sessions to their parent. Children
+                # are full sessions already counted in aggregates, so hierarchy here is
+                # annotation-only — never re-summed (count-once invariant).
+                _has_parent = "parent_id" in _sess_cols
+                _parent_sel = ", parent_id" if _has_parent else ""
+                oc_by_id: Dict[str, Dict[str, Any]] = {}
+                oc_parent_of: Dict[str, str] = {}
+                rows = conn.execute(f"SELECT id, directory, title, time_created, time_updated{_parent_sel} FROM session").fetchall()
                 for srow in rows:
                     sid = srow["id"]
                     ts = datetime.fromtimestamp((srow["time_updated"] or srow["time_created"] or 0) / 1000, tz=timezone.utc)
@@ -2922,14 +3061,31 @@ def _scan_sessions_sync():
                         has_plan = True
                         plan_text = "\n".join(f"- [{r['status']}] {r['content']}" for r in todo_rows)
                         plans.append({"session_id": sid, "agent": "opencode", "timestamp": ts, "content": plan_text})
-                    sessions.append({
+                    oc_sess = {
                         "id": sid, "agent": "opencode", "project": apply_alias(srow["directory"] or "unknown"), "timestamp": ts,
                         "display": display, "tokens": tokens, "mcp_tools": mcp_tools,
                         "has_plan": has_plan, "plans": plans, "model": model,
                         "models_used": models_used, "artifacts": [],
                         "provider": provider_id,  # expose runtime (e.g. "ollama") so analytics can detect local sessions
                         "cost": tokens["cost"],
-                    })
+                    }
+                    if _has_parent and srow["parent_id"]:
+                        oc_sess["parent_session_id"] = srow["parent_id"]
+                        oc_parent_of[sid] = srow["parent_id"]
+                    oc_by_id[sid] = oc_sess
+                    sessions.append(oc_sess)
+                # Annotate parents with their children (display-only; child tokens
+                # are already counted as their own sessions).
+                for child_id, parent_id in oc_parent_of.items():
+                    parent = oc_by_id.get(parent_id)
+                    if parent is None:
+                        continue
+                    parent.setdefault("child_session_ids", []).append(child_id)
+                for oc_sess in oc_by_id.values():
+                    kids = oc_sess.get("child_session_ids") or []
+                    if kids:
+                        oc_sess["delegation"] = {"supported": True, "tokens_recorded": False,
+                                                 "linked_children": len(kids)}
             finally:
                 conn.close()
         except Exception:
@@ -2940,6 +3096,7 @@ def _scan_sessions_sync():
 
     # 9. Hermes Agent (SQLite: sessions / messages, pre-aggregated tokens)
     hermes_cwd_map = _hermes_cwd_by_session() if _hermes_dbs() else {}
+    hermes_by_id: Dict[str, Dict[str, Any]] = {}
     for db_path in _hermes_dbs():
         try:
             uri = f"file:{db_path}?mode=ro"
@@ -3021,7 +3178,7 @@ def _scan_sessions_sync():
                         "WHERE session_id=? AND tool_name IS NOT NULL AND tool_name != ''",
                         (sid,)).fetchall()]
                     cwd = hermes_cwd_map.get(sid)
-                    sessions.append({
+                    hermes_by_id[sid] = {
                         "id": sid, "agent": "hermes",
                         "project": apply_alias(cwd or "unknown"),
                         "project_inferred": cwd is not None,
@@ -3035,11 +3192,30 @@ def _scan_sessions_sync():
                         "provider": srow["billing_provider"],
                         "endpoint": srow["billing_base_url"],
                         "tok_per_sec": _measured_tps,
-                    })
+                    }
+                    sessions.append(hermes_by_id[sid])
             finally:
                 conn.close()
         except Exception:
             pass
+    # Hermes hierarchy: children carry parent_session_id (pre-aggregated tokens
+    # of their own, already in totals) — annotate parents, never re-sum.
+    for h_sess in hermes_by_id.values():
+        pid = h_sess.get("parent_session_id")
+        if pid and pid in hermes_by_id:
+            hermes_by_id[pid].setdefault("child_session_ids", []).append(h_sess["id"])
+    for h_sess in hermes_by_id.values():
+        kids = h_sess.get("child_session_ids") or []
+        if kids:
+            h_sess["delegation"] = {"supported": True, "tokens_recorded": False,
+                                    "linked_children": len(kids)}
+
+    # Every session gets an explicit delegation marker: agents whose logs carry
+    # no spawn signal report supported=False (an honest "n/a", never a fake 0).
+    # Capability is per-agent — a claude session outside the parsed top-100 is
+    # still "supported", just not scanned yet.
+    for s in sessions:
+        s.setdefault("delegation", {"supported": s.get("agent") in _DELEGATION_CAPABLE_AGENTS})
 
     # Global sort by timestamp descending
     sessions.sort(key=lambda x: x["timestamp"], reverse=True)
@@ -3689,6 +3865,83 @@ async def get_session_detail(session_id: str, agent: str):
     #                 })
     #             return events
     return {"error": "Invalid agent"}
+
+
+@app.get("/sessions/{session_id}/delegation")
+async def session_delegation(session_id: str, agent: str):
+    """Per-session subagent/delegation breakdown (overlay, like hermes-overlay).
+
+    claude: full per-subagent usage + cost from <sid>/subagents/agent-*.jsonl.
+    cursor: spawn count only — its subagent transcripts carry no usage fields.
+    opencode/hermes: parent/child session linkage from their SQLite hierarchies.
+    Everything else: {"supported": False} — the agent's logs don't record spawns.
+    """
+    if agent == "claude":
+        files = list(CLAUDE_DIR.glob(f"projects/**/{session_id}.jsonl"))
+        if not files:
+            return {"error": "Not found"}
+        deleg = _claude_subagent_usage(files[0], session_id)
+        if not deleg:
+            return {"supported": True, "tokens_recorded": True, "spawn_count": 0,
+                    "subagents": [], "totals": None, "cost": 0.0}
+        return {"supported": True, "tokens_recorded": True, **deleg}
+
+    if agent == "cursor":
+        for pd in (CURSOR_DIR / "projects").glob("*"):
+            trans_dir = pd / "agent-transcripts" / session_id
+            if trans_dir.is_dir():
+                sub_files = sorted((trans_dir / "subagents").glob("*.jsonl")) if (trans_dir / "subagents").is_dir() else []
+                return {"supported": True, "tokens_recorded": False,
+                        "spawn_count": len(sub_files),
+                        "subagents": [{"agent_id": f.stem, "agent_type": "unknown",
+                                       "tokens": None, "cost": None} for f in sub_files]}
+        return {"error": "Not found"}
+
+    if agent == "opencode":
+        if not OPENCODE_DB.exists():
+            return {"error": "Not found"}
+        try:
+            conn = sqlite3.connect(f"file:{OPENCODE_DB}?mode=ro", uri=True, timeout=1.0)
+            try:
+                cols = {r[1] for r in conn.execute("PRAGMA table_info(session)")}
+                if "parent_id" not in cols:
+                    return {"supported": False}
+                row = conn.execute("SELECT parent_id FROM session WHERE id=?", (session_id,)).fetchone()
+                if row is None:
+                    return {"error": "Not found"}
+                children = [r[0] for r in conn.execute(
+                    "SELECT id FROM session WHERE parent_id=?", (session_id,))]
+                return {"supported": True, "tokens_recorded": False,
+                        "parent_session_id": row[0],
+                        "child_session_ids": children,
+                        "linked_children": len(children)}
+            finally:
+                conn.close()
+        except Exception:
+            return {"error": "Not found"}
+
+    if agent == "hermes":
+        for db_path in _hermes_dbs():
+            try:
+                conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=1.0)
+                try:
+                    row = conn.execute("SELECT parent_session_id FROM sessions WHERE id=?", (session_id,)).fetchone()
+                    if row is None:
+                        continue
+                    children = [r[0] for r in conn.execute(
+                        "SELECT id FROM sessions WHERE parent_session_id=?", (session_id,))]
+                    return {"supported": True, "tokens_recorded": False,
+                            "parent_session_id": row[0],
+                            "child_session_ids": children,
+                            "linked_children": len(children)}
+                finally:
+                    conn.close()
+            except Exception:
+                continue
+        return {"error": "Not found"}
+
+    return {"supported": False}
+
 
 @app.get("/projects")
 async def get_projects(include_hidden: bool = False):

--- a/backend/main.py
+++ b/backend/main.py
@@ -302,6 +302,21 @@ ANTIGRAVITY_BRAIN_DIRS = [d for d, _ in ANTIGRAVITY_BRAIN_SOURCES]
 ANTIGRAVITY_CLI_DIR = GEMINI_DIR / "antigravity-cli"
 PROJECT_ALIASES_FILE = data_dir() / "aliases.json"
 
+
+def _sqlite_ro_uri(db_path) -> str:
+    """Read-only sqlite URI that works on every OS.
+
+    f"file:{path}" breaks on Windows — backslashes are not URI path
+    separators, so sqlite fails to resolve the file and the scanner silently
+    skips the agent. Forward-slash the path (no-op on POSIX) and
+    percent-encode URI-special characters (spaces, '?', '#'); the drive
+    colon stays literal, which sqlite's Windows URI parser expects.
+    """
+    from urllib.parse import quote
+    p = db_path if hasattr(db_path, "as_posix") else Path(db_path)
+    return "file:" + quote(p.as_posix(), safe="/:") + "?mode=ro"
+
+
 def _load_project_aliases() -> Dict[str, str]:
     # Ensure directory exists
     PROJECT_ALIASES_FILE.parent.mkdir(parents=True, exist_ok=True)
@@ -432,7 +447,7 @@ def _antigravity_db_meta(db_path: Path) -> Dict[str, Optional[str]]:
     files: "Counter[str]" = Counter()
     gemini_home = str(GEMINI_DIR)
     try:
-        con = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        con = sqlite3.connect(_sqlite_ro_uri(db_path), uri=True)
         try:
             for (blob,) in con.execute("SELECT data FROM gen_metadata WHERE data IS NOT NULL"):
                 if blob:
@@ -523,7 +538,7 @@ def _antigravity_cli_trace(db_path: Path, session_id: str) -> List[Dict[str, Any
     Returns events the existing viewer renders (user / reasoning / tool / tool
     output), or [] when nothing usable is found (caller falls back to brain)."""
     try:
-        con = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        con = sqlite3.connect(_sqlite_ro_uri(db_path), uri=True)
     except sqlite3.Error:
         return []
     try:
@@ -803,7 +818,7 @@ def _hermes_memory_io(session_id: str) -> Dict[str, Any]:
     }
     for db_path in _hermes_dbs():
         try:
-            uri = f"file:{db_path}?mode=ro"
+            uri = _sqlite_ro_uri(db_path)
             conn = sqlite3.connect(uri, uri=True, timeout=1.0)
             try:
                 rows = conn.execute(
@@ -2663,7 +2678,7 @@ def _scan_sessions_sync():
     gemini_projects_file = GEMINI_DIR / "projects.json"
     if gemini_projects_file.exists():
         try:
-            with open(gemini_projects_file, "r") as f:
+            with open(gemini_projects_file, "r", encoding="utf-8", errors="replace") as f:
                 pj_data = json.load(f).get("projects", {})
                 gemini_slugs = set(pj_data.values())
                 gemini_slug_to_path = {v: k for k, v in pj_data.items()}
@@ -3011,7 +3026,7 @@ def _scan_sessions_sync():
         if CURSOR_STORAGE.exists():
             for ws in CURSOR_STORAGE.glob("*/workspace.json"):
                 try:
-                    with open(ws, "r") as f:
+                    with open(ws, "r", encoding="utf-8", errors="replace") as f:
                         data = json.load(f)
                         folder = data.get("folder")
                         if folder:
@@ -3119,7 +3134,7 @@ def _scan_sessions_sync():
                 workspace_json = ws_folder.parent / "workspace.json"
                 project_path = "unknown"
                 if workspace_json.exists():
-                    with open(workspace_json, "r") as f:
+                    with open(workspace_json, "r", encoding="utf-8", errors="replace") as f:
                         wj = json.load(f); folder_url = wj.get("folder")
                         if folder_url: project_path = unquote(folder_url.replace("file://", ""))
                 # VS Code ~1.100+ switched session files from <id>.json (single
@@ -3237,7 +3252,7 @@ def _scan_sessions_sync():
     if OPENCODE_DB.exists():
         try:
             # immutable=1 so we don't block the live TUI process's write lock
-            uri = f"file:{OPENCODE_DB}?mode=ro"
+            uri = _sqlite_ro_uri(OPENCODE_DB)
             conn = sqlite3.connect(uri, uri=True, timeout=1.0)
             conn.row_factory = sqlite3.Row
             try:
@@ -3390,7 +3405,7 @@ def _scan_sessions_sync():
     hermes_by_id: Dict[str, Dict[str, Any]] = {}
     for db_path in _hermes_dbs():
         try:
-            uri = f"file:{db_path}?mode=ro"
+            uri = _sqlite_ro_uri(db_path)
             conn = sqlite3.connect(uri, uri=True, timeout=1.0)
             conn.row_factory = sqlite3.Row
             try:
@@ -4042,7 +4057,7 @@ async def get_session_detail(session_id: str, agent: str):
         return events
     elif agent == "opencode":
         if not OPENCODE_DB.exists(): return {"error": "Not found"}
-        uri = f"file:{OPENCODE_DB}?mode=ro"
+        uri = _sqlite_ro_uri(OPENCODE_DB)
         conn = sqlite3.connect(uri, uri=True, timeout=1.0)
         conn.row_factory = sqlite3.Row
         try:
@@ -4084,7 +4099,7 @@ async def get_session_detail(session_id: str, agent: str):
     elif agent == "hermes":
         for db_path in _hermes_dbs():
             try:
-                uri = f"file:{db_path}?mode=ro"
+                uri = _sqlite_ro_uri(db_path)
                 conn = sqlite3.connect(uri, uri=True, timeout=1.0)
                 conn.row_factory = sqlite3.Row
                 try:
@@ -4198,7 +4213,7 @@ async def session_delegation(session_id: str, agent: str):
         if not OPENCODE_DB.exists():
             return {"error": "Not found"}
         try:
-            conn = sqlite3.connect(f"file:{OPENCODE_DB}?mode=ro", uri=True, timeout=1.0)
+            conn = sqlite3.connect(_sqlite_ro_uri(OPENCODE_DB), uri=True, timeout=1.0)
             try:
                 cols = {r[1] for r in conn.execute("PRAGMA table_info(session)")}
                 if "parent_id" not in cols:
@@ -4220,7 +4235,7 @@ async def session_delegation(session_id: str, agent: str):
     if agent == "hermes":
         for db_path in _hermes_dbs():
             try:
-                conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=1.0)
+                conn = sqlite3.connect(_sqlite_ro_uri(db_path), uri=True, timeout=1.0)
                 try:
                     row = conn.execute("SELECT parent_session_id FROM sessions WHERE id=?", (session_id,)).fetchone()
                     if row is None:

--- a/backend/main.py
+++ b/backend/main.py
@@ -2121,16 +2121,34 @@ def _count_tool(tool_counts: Dict[str, int], name) -> None:
 
 
 def _mcp_usage_from_counts(tool_counts: Dict[str, int]) -> Dict[str, Dict[str, int]]:
-    """Group mcp__<server>__<tool> call counts by server. Non-MCP names skipped."""
+    """Group MCP tool-call counts by server. Non-MCP names skipped.
+
+    Naming conventions differ per agent (both verified in real logs):
+      - claude/cursor/qwen-style: mcp__<server>__<tool>  (double underscore)
+      - gemini-style: mcp_<server>_<tool>, sometimes wrapped as
+        default_api:mcp_<server>_<tool>; servers may contain dashes
+        (local-server) so only the FIRST underscore after the server splits.
+    """
     out: Dict[str, Dict[str, int]] = {}
     for name, n in tool_counts.items():
-        if not isinstance(name, str) or not name.startswith("mcp__"):
+        if not isinstance(name, str):
             continue
-        parts = name.split("__", 2)
-        if len(parts) < 3 or not parts[1] or not parts[2]:
+        raw = name
+        if raw.startswith("default_api:"):
+            raw = raw[len("default_api:"):]
+        server_name = tool = None
+        if raw.startswith("mcp__"):
+            parts = raw.split("__", 2)
+            if len(parts) == 3 and parts[1] and parts[2]:
+                server_name, tool = parts[1], parts[2]
+        elif raw.startswith("mcp_"):
+            rest = raw[len("mcp_"):]
+            if "_" in rest:
+                server_name, tool = rest.split("_", 1)
+        if not server_name or not tool:
             continue
-        server = out.setdefault(parts[1], {})
-        server[parts[2]] = server.get(parts[2], 0) + n
+        server = out.setdefault(server_name, {})
+        server[tool] = server.get(tool, 0) + n
     return out
 
 
@@ -2704,6 +2722,7 @@ def _scan_sessions_sync():
                                 tokens = {"input": 0, "output": 0, "cached": 0, "total": 0}
                                 mcp_tools = []; has_plan = False; first_msg = ""; plans = []
                                 tool_counts: Dict[str, int] = {}
+                                skill_counts: Dict[str, int] = {}
                                 has_user = False
                                 for msg in data.get("messages", []):
                                     if msg.get("type") == "user":
@@ -2719,6 +2738,11 @@ def _scan_sessions_sync():
                                         for tc in msg["toolCalls"]:
                                             if tc.get("name") not in mcp_tools: mcp_tools.append(tc.get("name"))
                                             _count_tool(tool_counts, tc.get("name"))
+                                            # Gemini's structured skill signal.
+                                            if tc.get("name") == "activate_skill":
+                                                _sk = (tc.get("args") or {}).get("name")
+                                                if _sk:
+                                                    skill_counts[_sk] = skill_counts.get(_sk, 0) + 1
                                             if tc.get("name") == "exit_plan_mode":
                                                 plan_text = ""
                                                 pp = (tc.get("args") or {}).get("plan_path")
@@ -2757,7 +2781,7 @@ def _scan_sessions_sync():
                                 if sid in _seen_antigravity: continue
                                 _seen_antigravity.add(sid)
                                 _g_sess = {"id": sid, "agent": effective_agent, "project": project_path, "timestamp": ts, "display": first_msg[:100], "tokens": tokens, "mcp_tools": mcp_tools, "has_plan": has_plan, "plans": plans, "model": model, "artifacts": artifacts, "antigravity_source": _ag_surface.get(sid), "cost": tokens["cost"]}
-                                _attach_tool_usage(_g_sess, tool_counts)
+                                _attach_tool_usage(_g_sess, tool_counts, skill_counts)
                                 sessions.append(_g_sess)
                         except Exception: continue
                 # Scan logs.json for Antigravity sessions that have no chat JSON file
@@ -2917,7 +2941,7 @@ def _scan_sessions_sync():
                         sid = cf.stem; mcp_tools = []; has_plan = False; first_msg = ""; plans = []
                         tokens = {"input": 0, "output": 0, "cached": 0, "total": 0}
                         project_path = "unknown"; last_ts = _file_mtime_utc(cf); model = None
-                        artifacts = []; tool_counts = {}
+                        artifacts = []; tool_counts = {}; q_skill_counts = {}
                         with open(cf, "r", encoding="utf-8", errors="replace") as f:
                             for line in f:
                                 try:
@@ -2945,6 +2969,11 @@ def _scan_sessions_sync():
                                             if item.get("type") == "tool_use":
                                                 if item.get("name") not in mcp_tools: mcp_tools.append(item.get("name"))
                                                 _count_tool(tool_counts, item.get("name"))
+                                                # qwen is a gemini fork; same structured skill signal.
+                                                if item.get("name") == "activate_skill":
+                                                    _sk = (item.get("input") or {}).get("name")
+                                                    if _sk:
+                                                        q_skill_counts[_sk] = q_skill_counts.get(_sk, 0) + 1
                                             if item.get("type") == "thinking":
                                                 t_text = item.get("thinking", "")
                                                 if "plan" in t_text.lower() and len(t_text) > 100:
@@ -2954,7 +2983,7 @@ def _scan_sessions_sync():
                         tokens["total"] = tokens["input"] + tokens["output"] + tokens["cached"]
                         tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"], cache_creation_tokens=tokens.get("cache_creation", 0), cache_creation_1h_tokens=tokens.get("cache_creation_1h", 0))
                         _q_sess = {"id": sid, "agent": "qwen", "project": project_path, "timestamp": last_ts, "display": first_msg[:100], "tokens": tokens, "mcp_tools": mcp_tools, "has_plan": has_plan, "plans": plans, "model": model, "artifacts": artifacts, "cost": tokens["cost"]}
-                        _attach_tool_usage(_q_sess, tool_counts)
+                        _attach_tool_usage(_q_sess, tool_counts, q_skill_counts)
                         sessions.append(_q_sess)
                     except Exception: continue
 
@@ -4661,12 +4690,16 @@ async def get_analytics():
     for s in sessions:
         agent = s.get("agent")
         for sk in s.get("skills_used") or []:
-            row = by_skill.setdefault(sk["name"], {"invocations": 0, "session_count": 0})
+            row = by_skill.setdefault(sk["name"], {"invocations": 0, "session_count": 0, "agents": []})
             row["invocations"] += sk["count"]
             row["session_count"] += 1
+            if agent not in row["agents"]:
+                row["agents"].append(agent)
         for server, tools in (s.get("mcp_usage") or {}).items():
-            row = by_mcp_server.setdefault(server, {"calls": 0, "tools": {}, "session_count": 0})
+            row = by_mcp_server.setdefault(server, {"calls": 0, "tools": {}, "session_count": 0, "agents": []})
             row["session_count"] += 1
+            if agent not in row["agents"]:
+                row["agents"].append(agent)
             for tool, n in tools.items():
                 row["calls"] += n
                 row["tools"][tool] = row["tools"].get(tool, 0) + n

--- a/backend/main.py
+++ b/backend/main.py
@@ -1975,6 +1975,56 @@ def _opencode_resolve_model(val):
 # usage fields); opencode/hermes: parent/child linkage between real sessions.
 _DELEGATION_CAPABLE_AGENTS = {"claude", "cursor", "opencode", "hermes"}
 
+# Skill / slash-command invocations (Claude Code). Two structured signals:
+#   - assistant tool_use named "Skill" with input.skill = "<name>";
+#   - <command-name>/<name></command-name> tags echoed into user lines.
+# The tag also fires for built-in CLI commands (/model, /usage, ...) which are
+# NOT skills — counting those would drown real skill usage in noise.
+_COMMAND_NAME_RE = re.compile(r"<command-name>/?([\w.:-]+)</command-name>")
+_BUILTIN_CLI_COMMANDS = {
+    "add-dir", "agents", "bashes", "bug", "clear", "compact", "config",
+    "context", "cost", "doctor", "exit", "export", "fast", "help", "hooks",
+    "ide", "install-github-app", "login", "logout", "mcp", "memory",
+    "migrate-installer", "model", "output-style", "permissions", "plan", "plugin",
+    "privacy-settings", "quit", "release-notes", "resume", "rewind", "status",
+    "statusline", "terminal-setup", "theme", "todos", "upgrade", "usage", "vim",
+}
+
+
+def _count_tool(tool_counts: Dict[str, int], name) -> None:
+    if name:
+        tool_counts[name] = tool_counts.get(name, 0) + 1
+
+
+def _mcp_usage_from_counts(tool_counts: Dict[str, int]) -> Dict[str, Dict[str, int]]:
+    """Group mcp__<server>__<tool> call counts by server. Non-MCP names skipped."""
+    out: Dict[str, Dict[str, int]] = {}
+    for name, n in tool_counts.items():
+        if not isinstance(name, str) or not name.startswith("mcp__"):
+            continue
+        parts = name.split("__", 2)
+        if len(parts) < 3 or not parts[1] or not parts[2]:
+            continue
+        server = out.setdefault(parts[1], {})
+        server[parts[2]] = server.get(parts[2], 0) + n
+    return out
+
+
+def _attach_tool_usage(sess: Dict[str, Any], tool_counts: Dict[str, int],
+                       skill_counts: Optional[Dict[str, int]] = None) -> None:
+    """Attach tool_counts / mcp_usage / skills_used to a session dict (only when
+    non-empty, so agents without the signal simply lack the keys)."""
+    if tool_counts:
+        sess["tool_counts"] = tool_counts
+        mcp = _mcp_usage_from_counts(tool_counts)
+        if mcp:
+            sess["mcp_usage"] = mcp
+    if skill_counts:
+        sess["skills_used"] = [
+            {"name": k, "count": v}
+            for k, v in sorted(skill_counts.items(), key=lambda kv: (-kv[1], kv[0]))
+        ]
+
 
 def _claude_subagent_usage(session_file: Path, sid: str) -> Optional[Dict[str, Any]]:
     """Roll up subagent (Task/Agent tool) usage for one Claude Code session.
@@ -2065,13 +2115,19 @@ def _claude_subagent_usage(session_file: Path, sid: str) -> Optional[Dict[str, A
         return None
     totals = {"input": 0, "output": 0, "cached": 0, "cache_creation": 0,
               "cache_creation_1h": 0, "total": 0}
+    by_type: Dict[str, Dict[str, Any]] = {}
     for e in entries:
         for k in totals:
             totals[k] += e["tokens"][k]
+        bt = by_type.setdefault(e["agent_type"], {"count": 0, "total": 0, "cost": 0.0})
+        bt["count"] += 1
+        bt["total"] += e["tokens"]["total"]
+        bt["cost"] = round(bt["cost"] + (e["cost"] or 0), 6)
     return {
         "spawn_count": len(entries),
         "subagents": entries,
         "totals": totals,
+        "by_type": by_type,
         "cost": round(sum(e["cost"] or 0 for e in entries), 6),
     }
 
@@ -2189,6 +2245,8 @@ def _scan_sessions_sync():
 
                 # pending_edit_tool_ids: Set[str] = set()  # quality signals (commented out)
                 # prior_edit_failed = False
+                tool_counts: Dict[str, int] = {}
+                skill_counts: Dict[str, int] = {}
                 try:
                     with open(session_file, "r", encoding="utf-8", errors="replace") as f:
                         for line in f:
@@ -2219,6 +2277,11 @@ def _scan_sessions_sync():
                                     if item.get("type") == "tool_use":
                                         tool = item.get("name")
                                         if tool not in sess["mcp_tools"]: sess["mcp_tools"].append(tool)
+                                        _count_tool(tool_counts, tool)
+                                        if tool == "Skill":
+                                            skill = (item.get("input") or {}).get("skill")
+                                            if skill:
+                                                skill_counts[skill] = skill_counts.get(skill, 0) + 1
                                         if tool == "ExitPlanMode":
                                             plan_text = (item.get("input") or {}).get("plan") or ""
                                             if plan_text:
@@ -2241,6 +2304,11 @@ def _scan_sessions_sync():
                                 u_content = u_msg.get("content", "")
                                 if "/plan" in str(u_content):
                                     sess["has_plan"] = True
+                                # Slash-command echoes: count skill invocations,
+                                # skip built-in CLI commands (/model, /usage, ...).
+                                for cmd in _COMMAND_NAME_RE.findall(str(u_content)):
+                                    if cmd not in _BUILTIN_CLI_COMMANDS:
+                                        skill_counts[cmd] = skill_counts.get(cmd, 0) + 1
                                 # Quality signals (retry chain tracking) commented out:
                                 # if isinstance(u_content, list):
                                 #     for it in u_content:
@@ -2251,6 +2319,7 @@ def _scan_sessions_sync():
                                 #     prior_edit_failed = False
                                 #     pending_edit_tool_ids = set()
                 except Exception: continue
+                _attach_tool_usage(sess, tool_counts, skill_counts)
                 # Subagent (Task/Agent) rollup — separate "delegated" bucket so the
                 # parent's own token fields stay exactly as before. Full per-subagent
                 # breakdown is served by /sessions/{id}/delegation, the list carries
@@ -2263,6 +2332,7 @@ def _scan_sessions_sync():
                     "delegated_total": deleg["totals"]["total"] if deleg else 0,
                 }
                 if deleg:
+                    sess["delegation"]["by_type"] = deleg["by_type"]
                     sess["tokens"]["delegated_input"] = deleg["totals"]["input"]
                     sess["tokens"]["delegated_output"] = deleg["totals"]["output"]
                     sess["tokens"]["delegated_cached"] = deleg["totals"]["cached"]
@@ -2357,6 +2427,7 @@ def _scan_sessions_sync():
                                 if data.get("payload", {}).get("type") == "function_call":
                                     tool = data["payload"].get("name")
                                     if tool not in sess["mcp_tools"]: sess["mcp_tools"].append(tool)
+                                    _count_tool(sess.setdefault("tool_counts", {}), tool)
                                     if tool == "update_plan":
                                         try:
                                             args = json.loads(data["payload"].get("arguments") or "{}")
@@ -2391,6 +2462,9 @@ def _scan_sessions_sync():
             if not s.get("model") and s.get("_provider"):
                 s["model"] = s["_provider"]
             s.pop("_provider", None)
+            mcp = _mcp_usage_from_counts(s.get("tool_counts") or {})
+            if mcp:
+                s["mcp_usage"] = mcp
         sessions.extend(codex_sessions.values())
 
     # 3 & 7. Gemini & Antigravity
@@ -2455,6 +2529,7 @@ def _scan_sessions_sync():
                                 ts = _aware(datetime.fromisoformat(data.get("lastUpdated").replace('Z', '+00:00'))) if data.get("lastUpdated") else _file_mtime_utc(cf)
                                 tokens = {"input": 0, "output": 0, "cached": 0, "total": 0}
                                 mcp_tools = []; has_plan = False; first_msg = ""; plans = []
+                                tool_counts: Dict[str, int] = {}
                                 has_user = False
                                 for msg in data.get("messages", []):
                                     if msg.get("type") == "user":
@@ -2469,6 +2544,7 @@ def _scan_sessions_sync():
                                     if "toolCalls" in msg:
                                         for tc in msg["toolCalls"]:
                                             if tc.get("name") not in mcp_tools: mcp_tools.append(tc.get("name"))
+                                            _count_tool(tool_counts, tc.get("name"))
                                             if tc.get("name") == "exit_plan_mode":
                                                 plan_text = ""
                                                 pp = (tc.get("args") or {}).get("plan_path")
@@ -2506,7 +2582,9 @@ def _scan_sessions_sync():
                                 tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"])
                                 if sid in _seen_antigravity: continue
                                 _seen_antigravity.add(sid)
-                                sessions.append({"id": sid, "agent": effective_agent, "project": project_path, "timestamp": ts, "display": first_msg[:100], "tokens": tokens, "mcp_tools": mcp_tools, "has_plan": has_plan, "plans": plans, "model": model, "artifacts": artifacts, "antigravity_source": _ag_surface.get(sid), "cost": tokens["cost"]})
+                                _g_sess = {"id": sid, "agent": effective_agent, "project": project_path, "timestamp": ts, "display": first_msg[:100], "tokens": tokens, "mcp_tools": mcp_tools, "has_plan": has_plan, "plans": plans, "model": model, "artifacts": artifacts, "antigravity_source": _ag_surface.get(sid), "cost": tokens["cost"]}
+                                _attach_tool_usage(_g_sess, tool_counts)
+                                sessions.append(_g_sess)
                         except Exception: continue
                 # Scan logs.json for Antigravity sessions that have no chat JSON file
                 _logs_file = tmp_dir / "logs.json"
@@ -2665,7 +2743,7 @@ def _scan_sessions_sync():
                         sid = cf.stem; mcp_tools = []; has_plan = False; first_msg = ""; plans = []
                         tokens = {"input": 0, "output": 0, "cached": 0, "total": 0}
                         project_path = "unknown"; last_ts = _file_mtime_utc(cf); model = None
-                        artifacts = []
+                        artifacts = []; tool_counts = {}
                         with open(cf, "r", encoding="utf-8", errors="replace") as f:
                             for line in f:
                                 try:
@@ -2692,6 +2770,7 @@ def _scan_sessions_sync():
                                         for item in data.get("message", {}).get("content", []):
                                             if item.get("type") == "tool_use":
                                                 if item.get("name") not in mcp_tools: mcp_tools.append(item.get("name"))
+                                                _count_tool(tool_counts, item.get("name"))
                                             if item.get("type") == "thinking":
                                                 t_text = item.get("thinking", "")
                                                 if "plan" in t_text.lower() and len(t_text) > 100:
@@ -2700,7 +2779,9 @@ def _scan_sessions_sync():
                                 except Exception: continue
                         tokens["total"] = tokens["input"] + tokens["output"] + tokens["cached"]
                         tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"], cache_creation_tokens=tokens.get("cache_creation", 0), cache_creation_1h_tokens=tokens.get("cache_creation_1h", 0))
-                        sessions.append({"id": sid, "agent": "qwen", "project": project_path, "timestamp": last_ts, "display": first_msg[:100], "tokens": tokens, "mcp_tools": mcp_tools, "has_plan": has_plan, "plans": plans, "model": model, "artifacts": artifacts, "cost": tokens["cost"]})
+                        _q_sess = {"id": sid, "agent": "qwen", "project": project_path, "timestamp": last_ts, "display": first_msg[:100], "tokens": tokens, "mcp_tools": mcp_tools, "has_plan": has_plan, "plans": plans, "model": model, "artifacts": artifacts, "cost": tokens["cost"]}
+                        _attach_tool_usage(_q_sess, tool_counts)
+                        sessions.append(_q_sess)
                     except Exception: continue
 
     # 5. Vibe
@@ -2767,6 +2848,7 @@ def _scan_sessions_sync():
                                 first_msg = ""
                                 tokens = {"input": 0, "output": 0, "cached": 0, "total": 0}
                                 mcp_tools = []
+                                tool_counts = {}
                                 subagents = []
                                 has_plan = False
                                 plans = []
@@ -2800,6 +2882,7 @@ def _scan_sessions_sync():
                                                 if item.get("type") == "tool_use":
                                                     name = item.get("name")
                                                     if name not in mcp_tools: mcp_tools.append(name)
+                                                    _count_tool(tool_counts, name)
                                                     if name == "Subagent":
                                                         sub_input = item.get("input") or {}
                                                         sub_name = sub_input.get("name") or sub_input.get("subagent_type")
@@ -2821,7 +2904,9 @@ def _scan_sessions_sync():
                                 except Exception: pass
                                 delegation = {"supported": True, "tokens_recorded": False,
                                               "spawn_count": max(spawn_count, len(subagents))}
-                                sessions.append({"id": sid, "agent": "cursor", "project": project_path, "timestamp": mtime, "display": first_msg[:100], "tokens": tokens, "mcp_tools": mcp_tools, "subagents": subagents, "has_plan": has_plan, "plans": plans, "model": model, "artifacts": artifacts, "cost": tokens["cost"], "delegation": delegation})
+                                _c_sess = {"id": sid, "agent": "cursor", "project": project_path, "timestamp": mtime, "display": first_msg[:100], "tokens": tokens, "mcp_tools": mcp_tools, "subagents": subagents, "has_plan": has_plan, "plans": plans, "model": model, "artifacts": artifacts, "cost": tokens["cost"], "delegation": delegation}
+                                _attach_tool_usage(_c_sess, tool_counts)
+                                sessions.append(_c_sess)
                             except Exception: continue
 
     # 7. Copilot
@@ -2979,6 +3064,7 @@ def _scan_sessions_sync():
                     models_used: List[str] = []   # distinct models, in first-seen order (#39)
                     first_user = ""
                     mcp_tools: List[str] = []
+                    oc_tool_counts: Dict[str, int] = {}
                     has_plan = False
                     plans: List[Dict[str, Any]] = []
                     # Model + tokens from assistant messages
@@ -3041,6 +3127,7 @@ def _scan_sessions_sync():
                         if ptype == "tool":
                             tname = pdata.get("tool")
                             if tname and tname not in mcp_tools: mcp_tools.append(tname)
+                            _count_tool(oc_tool_counts, tname)
                         if ptype == "step-finish":
                             tk = pdata.get("tokens") or {}
                             cache = tk.get("cache") or {}
@@ -3072,6 +3159,7 @@ def _scan_sessions_sync():
                     if _has_parent and srow["parent_id"]:
                         oc_sess["parent_session_id"] = srow["parent_id"]
                         oc_parent_of[sid] = srow["parent_id"]
+                    _attach_tool_usage(oc_sess, oc_tool_counts)
                     oc_by_id[sid] = oc_sess
                     sessions.append(oc_sess)
                 # Annotate parents with their children (display-only; child tokens
@@ -3172,11 +3260,13 @@ def _scan_sessions_sync():
                     if fu:
                         first_user = fu["content"] or ""
                     display = (srow["title"] or first_user)[:100]
-                    # Distinct tool names used in this session
-                    mcp_tools = [r[0] for r in conn.execute(
-                        "SELECT DISTINCT tool_name FROM messages "
-                        "WHERE session_id=? AND tool_name IS NOT NULL AND tool_name != ''",
-                        (sid,)).fetchall()]
+                    # Tool names + call counts used in this session
+                    h_tool_counts = {r[0]: r[1] for r in conn.execute(
+                        "SELECT tool_name, COUNT(*) FROM messages "
+                        "WHERE session_id=? AND tool_name IS NOT NULL AND tool_name != '' "
+                        "GROUP BY tool_name",
+                        (sid,)).fetchall()}
+                    mcp_tools = list(h_tool_counts.keys())
                     cwd = hermes_cwd_map.get(sid)
                     hermes_by_id[sid] = {
                         "id": sid, "agent": "hermes",
@@ -3193,6 +3283,7 @@ def _scan_sessions_sync():
                         "endpoint": srow["billing_base_url"],
                         "tok_per_sec": _measured_tps,
                     }
+                    _attach_tool_usage(hermes_by_id[sid], h_tool_counts)
                     sessions.append(hermes_by_id[sid])
             finally:
                 conn.close()
@@ -4271,10 +4362,50 @@ async def get_analytics():
     total_input = sum(a["input"] for a in by_agent.values())
     total_output = sum(a["output"] for a in by_agent.values())
     total_cached = sum(a["cached"] for a in by_agent.values())
+
+    # Ecosystem usage: skills, MCP servers, subagent types. New keys only — the
+    # existing by_agent/by_day/by_model/total stay byte-identical (no silent
+    # historical changes). Delegated usage is exposed as its OWN bucket, never
+    # folded into the per-agent sums: claude subagent transcripts aren't
+    # sessions (counted nowhere else), while opencode/hermes children already
+    # appear as sessions above — adding parent-side sums would double-count.
+    by_skill: Dict[str, Dict[str, Any]] = {}
+    by_mcp_server: Dict[str, Dict[str, Any]] = {}
+    by_subagent_type: Dict[str, Dict[str, Any]] = {}
+    delegation_totals = {"delegated_tokens": 0, "delegated_cost": 0.0,
+                         "sessions_with_spawns": 0}
+    for s in sessions:
+        for sk in s.get("skills_used") or []:
+            row = by_skill.setdefault(sk["name"], {"invocations": 0, "session_count": 0})
+            row["invocations"] += sk["count"]
+            row["session_count"] += 1
+        for server, tools in (s.get("mcp_usage") or {}).items():
+            row = by_mcp_server.setdefault(server, {"calls": 0, "tools": {}, "session_count": 0})
+            row["session_count"] += 1
+            for tool, n in tools.items():
+                row["calls"] += n
+                row["tools"][tool] = row["tools"].get(tool, 0) + n
+        deleg = s.get("delegation") or {}
+        for t, d in (deleg.get("by_type") or {}).items():
+            row = by_subagent_type.setdefault(t, {"spawns": 0, "tokens": 0, "cost": 0.0, "session_count": 0})
+            row["spawns"] += d.get("count", 0)
+            row["tokens"] += d.get("total", 0)
+            row["cost"] = round(row["cost"] + (d.get("cost") or 0), 6)
+            row["session_count"] += 1
+        if deleg.get("tokens_recorded") and deleg.get("delegated_total"):
+            delegation_totals["delegated_tokens"] += deleg["delegated_total"]
+            delegation_totals["delegated_cost"] = round(
+                delegation_totals["delegated_cost"] + (s.get("delegated_cost") or 0), 6)
+            delegation_totals["sessions_with_spawns"] += 1
+
     return {
         "by_agent": by_agent,
         "by_day": sorted_days,
         "by_model": by_model,
+        "by_skill": by_skill,
+        "by_mcp_server": by_mcp_server,
+        "by_subagent_type": by_subagent_type,
+        "delegation": delegation_totals,
         "total": {
             "input": total_input,
             "output": total_output,

--- a/backend/main.py
+++ b/backend/main.py
@@ -1854,6 +1854,12 @@ def _scan_grok_sessions() -> List[Dict[str, Any]]:
                 "commit": summary.get("head_commit"),
             }
 
+            # Subagent spawns: Grok writes <session>/subagents/<id>/meta.json with
+            # {subagent_type, description, status, duration_ms, tool_calls, turns,
+            #  parent_session_id, child_session_id}. The child runs as its OWN
+            # session dir (already counted above/below) — annotation only.
+            grok_spawns = _grok_subagent_meta(sess_id_dir)
+
             sess = {
                 "id": sid,
                 "agent": "grok",
@@ -1877,9 +1883,64 @@ def _scan_grok_sessions() -> List[Dict[str, Any]]:
                     "last_active_at": summary.get("last_active_at"),
                 },
             }
+            if grok_spawns:
+                by_type: Dict[str, Dict[str, Any]] = {}
+                for sp in grok_spawns:
+                    bt = by_type.setdefault(sp.get("agent_type") or "unknown", {"count": 0})
+                    bt["count"] += 1
+                sess["delegation"] = {"supported": True, "tokens_recorded": False,
+                                      "spawn_count": len(grok_spawns),
+                                      "by_type": by_type}
+                sess["child_session_ids"] = [sp["child_session_id"] for sp in grok_spawns
+                                             if sp.get("child_session_id")]
             out.append(sess)
 
+    # Children are full sessions in the same bucket — annotate them with their
+    # parent (count-once: their tokens already stand on their own).
+    grok_by_id = {s["id"]: s for s in out}
+    for s in out:
+        for cid in s.get("child_session_ids") or []:
+            child = grok_by_id.get(cid)
+            if child is not None:
+                child["parent_session_id"] = s["id"]
     return out
+
+
+def _grok_subagent_meta(sess_dir: Path) -> List[Dict[str, Any]]:
+    """Read Grok Build subagent spawn records for one session.
+
+    Verified shape (grok 0.2.39): <session>/subagents/<spawn-id>/meta.json with
+    subagent_type, description, prompt, status, started_at/completed_at,
+    duration_ms, tool_calls, turns, effective_model_id, parent_session_id and
+    child_session_id — the child is a full sibling session directory.
+    """
+    sub_dir = sess_dir / "subagents"
+    entries: List[Dict[str, Any]] = []
+    try:
+        if not sub_dir.is_dir():
+            return entries
+        for meta_path in sorted(sub_dir.glob("*/meta.json")):
+            try:
+                with open(meta_path, "r", encoding="utf-8") as f:
+                    m = json.load(f)
+            except Exception:
+                continue
+            if not isinstance(m, dict):
+                continue
+            entries.append({
+                "agent_id": m.get("subagent_id") or meta_path.parent.name,
+                "agent_type": m.get("subagent_type") or "unknown",
+                "description": m.get("description"),
+                "status": m.get("status"),
+                "duration_ms": m.get("duration_ms"),
+                "tool_calls": m.get("tool_calls"),
+                "turns": m.get("turns"),
+                "model": m.get("effective_model_id"),
+                "child_session_id": m.get("child_session_id"),
+            })
+    except Exception:
+        pass
+    return entries
 
 
 def _reconstruct_vscode_chat_jsonl(path) -> Dict[str, Any]:
@@ -1972,8 +2033,66 @@ def _opencode_resolve_model(val):
 
 # Agents whose local logs record subagent/child-session spawns at all.
 # claude: full token rollup; cursor: spawn count only (transcripts carry no
-# usage fields); opencode/hermes: parent/child linkage between real sessions.
-_DELEGATION_CAPABLE_AGENTS = {"claude", "cursor", "opencode", "hermes"}
+# usage fields); opencode/hermes: parent/child linkage between real sessions;
+# grok: subagents/<id>/meta.json spawn records, children are sibling sessions;
+# codex: child rollouts carry thread_source="subagent" + parent thread id;
+# antigravity: parent brain transcript INVOKE_SUBAGENT steps name the child
+# conversation ids. (All verified empirically by running the CLIs — see
+# DESIGN.md "probe findings".)
+_DELEGATION_CAPABLE_AGENTS = {"claude", "cursor", "opencode", "hermes",
+                              "grok", "codex", "antigravity"}
+
+
+# content is JSON-escaped inside the INVOKE_SUBAGENT step record, so the quote
+# before the uuid may appear as \" in the raw line.
+_AG_CONVERSATION_ID_RE = re.compile(
+    r'conversationId\\?["\']?\s*:\s*\\?["\']'
+    r'([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})')
+
+
+def _antigravity_subagent_children(sid: str) -> List[str]:
+    """Child conversation ids spawned by an Antigravity session, from the
+    INVOKE_SUBAGENT steps in its brain transcript. Empty when none/no transcript."""
+    kids: List[str] = []
+    for brain_dir in ANTIGRAVITY_BRAIN_DIRS:
+        tpath = brain_dir / sid / ".system_generated" / "logs" / "transcript.jsonl"
+        try:
+            if not tpath.exists():
+                continue
+            with open(tpath, "r", encoding="utf-8", errors="replace") as f:
+                for line in f:
+                    if "INVOKE_SUBAGENT" not in line:
+                        continue
+                    for cid in _AG_CONVERSATION_ID_RE.findall(line):
+                        if cid != sid and cid not in kids:
+                            kids.append(cid)
+        except Exception:
+            continue
+    return kids
+
+
+def _antigravity_link_subagents(sessions: List[Dict[str, Any]]) -> None:
+    """Link Antigravity parent conversations to their spawned subagents.
+
+    `agy` supports parallel subagents; each spawn creates a full sibling
+    conversation. The parent's brain transcript
+    (brain/<id>/.system_generated/logs/transcript.jsonl) records an
+    INVOKE_SUBAGENT step whose content embeds the child's conversationId.
+    Children are already counted as their own sessions — annotation only.
+    """
+    ag = {s["id"]: s for s in sessions if s.get("agent") == "antigravity"}
+    if not ag:
+        return
+    for sid, sess in ag.items():
+        kids = _antigravity_subagent_children(sid)
+        if kids:
+            sess["child_session_ids"] = kids
+            sess["delegation"] = {"supported": True, "tokens_recorded": False,
+                                  "linked_children": len(kids)}
+            for cid in kids:
+                child = ag.get(cid)
+                if child is not None:
+                    child["parent_session_id"] = sid
 
 # Skill / slash-command invocations (Claude Code). Two structured signals:
 #   - assistant tool_use named "Skill" with input.skill = "<name>";
@@ -2341,7 +2460,7 @@ def _scan_sessions_sync():
         sessions.extend(claude_sessions.values())
     # 2. Codex
     codex_index = CODEX_DIR / "session_index.jsonl"
-    if codex_index.exists():
+    if codex_index.exists() or (CODEX_DIR / "sessions").is_dir():
         codex_sessions = {}
         # Pre-index Codex rollout files
         codex_file_map = {}
@@ -2366,6 +2485,20 @@ def _scan_sessions_sync():
                             codex_sessions[sid] = {"id": sid, "agent": "codex", "project": "unknown", "timestamp": ts, "text": data.get("thread_name"), "tokens": {"input": 0, "output": 0, "cached": 0, "total": 0}, "mcp_tools": [], "has_plan": False, "plans": [], "model": None, "artifacts": []}
                     except Exception: continue
         except Exception: pass
+
+        # The index is no longer maintained by recent Codex versions (observed
+        # frozen since codex 0.13x): exec runs and subagent threads never get
+        # an entry, and neither do new interactive sessions. Discover every
+        # session from the rollout files themselves; the index above only
+        # contributes nicer thread names for legacy entries.
+        for sid, files in codex_file_map.items():
+            if sid in codex_sessions:
+                continue
+            try:
+                ts = max(_file_mtime_utc(f) for f in files)
+            except Exception:
+                ts = _now()
+            codex_sessions[sid] = {"id": sid, "agent": "codex", "project": "unknown", "timestamp": ts, "text": None, "tokens": {"input": 0, "output": 0, "cached": 0, "total": 0}, "mcp_tools": [], "has_plan": False, "plans": [], "model": None, "artifacts": []}
         
         # Process the 100 most recent sessions
         for sid, sess in sorted(codex_sessions.items(), key=lambda kv: kv[1]["timestamp"], reverse=True)[:100]:
@@ -2385,6 +2518,24 @@ def _scan_sessions_sync():
                                     sess["model"] = data["payload"].get("model")
                                 if not sess.get("_provider"):
                                     sess["_provider"] = data["payload"].get("model_provider")
+                                # Subagent threads (multi_agent feature): the child
+                                # rollout's session_meta carries thread_source ==
+                                # "subagent" plus source.subagent.thread_spawn with
+                                # the parent thread id, depth, role and nickname.
+                                # forked_from_id alone is NOT enough — user-initiated
+                                # `codex fork` sets it too with thread_source "user".
+                                _src = data["payload"].get("source")
+                                _spawn = (_src.get("subagent") or {}).get("thread_spawn") if isinstance(_src, dict) else None
+                                if data["payload"].get("thread_source") == "subagent" or _spawn:
+                                    _spawn = _spawn or {}
+                                    _pid = _spawn.get("parent_thread_id") or data["payload"].get("forked_from_id")
+                                    if _pid:
+                                        sess["parent_session_id"] = _pid
+                                    sess["subagent_info"] = {
+                                        "role": _spawn.get("agent_role") or data["payload"].get("agent_role"),
+                                        "nickname": _spawn.get("agent_nickname") or data["payload"].get("agent_nickname"),
+                                        "depth": _spawn.get("depth"),
+                                    }
                             if data.get("type") == "turn_context" and not sess.get("model"):
                                 sess["model"] = data.get("payload", {}).get("model")
                             if data.get("type") == "event_msg":
@@ -2396,6 +2547,13 @@ def _scan_sessions_sync():
                                         event_day = _aware(event_dt).strftime("%Y-%m-%d")
                                     except Exception: pass
 
+                                # Sessions discovered from rollouts (not the stale
+                                # index) have no thread_name; first user prompt is
+                                # the natural display.
+                                if not sess.get("text") and (data.get("payload") or {}).get("type") == "user_message":
+                                    _um = data["payload"].get("message")
+                                    if isinstance(_um, str) and _um.strip():
+                                        sess["text"] = _um.strip()[:120]
                                 usage = ((data.get("payload") or {}).get("info") or {}).get("total_token_usage") or {}
                                 if usage:
                                     # OpenAI/Codex semantics differ from Anthropic:
@@ -2465,6 +2623,17 @@ def _scan_sessions_sync():
             mcp = _mcp_usage_from_counts(s.get("tool_counts") or {})
             if mcp:
                 s["mcp_usage"] = mcp
+        # Annotate parents of subagent threads (children are full sessions with
+        # their own usage — linkage only, never re-summed).
+        for s in codex_sessions.values():
+            pid = s.get("parent_session_id")
+            if pid and pid in codex_sessions:
+                codex_sessions[pid].setdefault("child_session_ids", []).append(s["id"])
+        for s in codex_sessions.values():
+            kids = s.get("child_session_ids") or []
+            if kids:
+                s["delegation"] = {"supported": True, "tokens_recorded": False,
+                                   "linked_children": len(kids)}
         sessions.extend(codex_sessions.values())
 
     # 3 & 7. Gemini & Antigravity
@@ -3301,6 +3470,9 @@ def _scan_sessions_sync():
             h_sess["delegation"] = {"supported": True, "tokens_recorded": False,
                                     "linked_children": len(kids)}
 
+    # Antigravity subagent linkage (needs the full session list to pair ids).
+    _antigravity_link_subagents(sessions)
+
     # Every session gets an explicit delegation marker: agents whose logs carry
     # no spawn signal report supported=False (an honest "n/a", never a fake 0).
     # Capability is per-agent — a claude session outside the parsed top-100 is
@@ -4030,6 +4202,90 @@ async def session_delegation(session_id: str, agent: str):
             except Exception:
                 continue
         return {"error": "Not found"}
+
+    if agent == "grok":
+        for bucket in GROK_SESSIONS_DIR.glob("*"):
+            sess_dir = bucket / session_id
+            if not (sess_dir.is_dir() and (sess_dir / GROK_SUMMARY).exists()):
+                continue
+            spawns = _grok_subagent_meta(sess_dir)
+            # Parent linkage: the parent's spawn meta names this session as child.
+            parent_id = None
+            try:
+                for other in bucket.iterdir():
+                    if not other.is_dir() or other.name == session_id:
+                        continue
+                    for m in _grok_subagent_meta(other):
+                        if m.get("child_session_id") == session_id:
+                            parent_id = other.name
+                            break
+                    if parent_id:
+                        break
+            except Exception:
+                pass
+            return {"supported": True, "tokens_recorded": False,
+                    "spawn_count": len(spawns), "subagents": spawns,
+                    "parent_session_id": parent_id,
+                    "child_session_ids": [m["child_session_id"] for m in spawns
+                                          if m.get("child_session_id")],
+                    "linked_children": len(spawns)}
+        return {"error": "Not found"}
+
+    if agent == "codex":
+        def _spawn_meta(path):
+            """(payload, thread_spawn) from a rollout's session_meta first line."""
+            try:
+                with open(path, "r", encoding="utf-8", errors="replace") as f:
+                    first = json.loads(f.readline())
+            except Exception:
+                return None, None
+            p = first.get("payload") or {}
+            src = p.get("source")
+            spawn = (src.get("subagent") or {}).get("thread_spawn") if isinstance(src, dict) else None
+            if spawn is None and p.get("thread_source") == "subagent":
+                spawn = {}
+            return p, spawn
+
+        own = list(CODEX_DIR.glob(f"sessions/**/rollout-*{session_id}*.jsonl"))
+        if not own:
+            return {"error": "Not found"}
+        payload, spawn = _spawn_meta(own[0])
+        parent_id = None
+        info = None
+        if spawn is not None:
+            parent_id = spawn.get("parent_thread_id") or (payload or {}).get("forked_from_id")
+            info = {"role": spawn.get("agent_role") or (payload or {}).get("agent_role"),
+                    "nickname": spawn.get("agent_nickname") or (payload or {}).get("agent_nickname"),
+                    "depth": spawn.get("depth")}
+        children = []
+        try:
+            for f in (CODEX_DIR / "sessions").rglob("rollout-*.jsonl"):
+                if session_id in f.name:
+                    continue
+                p, sp = _spawn_meta(f)
+                if sp is None:
+                    continue
+                pid = sp.get("parent_thread_id") or (p or {}).get("forked_from_id")
+                if pid != session_id:
+                    continue
+                parts = f.stem.split("-")
+                children.append({
+                    "child_session_id": "-".join(parts[-5:]) if len(parts) >= 6 else f.stem,
+                    "agent_role": sp.get("agent_role") or (p or {}).get("agent_role"),
+                    "nickname": sp.get("agent_nickname") or (p or {}).get("agent_nickname"),
+                })
+        except Exception:
+            pass
+        return {"supported": True, "tokens_recorded": False,
+                "parent_session_id": parent_id, "subagent_info": info,
+                "subagents": children,
+                "child_session_ids": [c["child_session_id"] for c in children],
+                "linked_children": len(children)}
+
+    if agent == "antigravity":
+        kids = _antigravity_subagent_children(session_id)
+        return {"supported": True, "tokens_recorded": False,
+                "child_session_ids": kids, "linked_children": len(kids)}
 
     return {"supported": False}
 

--- a/backend/test_delegation.py
+++ b/backend/test_delegation.py
@@ -361,7 +361,20 @@ def test_analytics_ecosystem_aggregates(monkeypatch):
          "mcp_usage": {"chrome": {"navigate": 1, "find": 2}},
          "delegation": {"supported": True, "tokens_recorded": True, "spawn_count": 0,
                         "delegated_total": 0}},
-        {**base, "id": "c", "agent": "codex", "delegation": {"supported": False}},
+        # grok: parent's by_type points at the child SESSION, whose tokens are
+        # already in totals — attribution only.
+        {**base, "id": "gp", "agent": "grok",
+         "delegation": {"supported": True, "tokens_recorded": False, "spawn_count": 1,
+                        "by_type": {"general-purpose": {"count": 1, "child_session_ids": ["gc"]}}},
+         "child_session_ids": ["gc"]},
+        {**base, "id": "gc", "agent": "grok", "parent_session_id": "gp",
+         "tokens": {"input": 100, "output": 0, "cached": 0, "total": 100}, "cost": 0.05},
+        # codex: the child carries its own role.
+        {**base, "id": "cp", "agent": "codex",
+         "delegation": {"supported": True, "tokens_recorded": False, "linked_children": 1}},
+        {**base, "id": "cc", "agent": "codex", "parent_session_id": "cp",
+         "subagent_info": {"role": "explorer", "nickname": "Dewey", "depth": 1},
+         "tokens": {"input": 60, "output": 10, "cached": 0, "total": 70}, "cost": 0.01},
     ]
 
     async def fake_sessions(fresh: bool = False):
@@ -372,13 +385,26 @@ def test_analytics_ecosystem_aggregates(monkeypatch):
     assert a["by_skill"] == {"graphify": {"invocations": 3, "session_count": 2}}
     assert a["by_mcp_server"] == {"chrome": {"calls": 6, "session_count": 2,
                                              "tools": {"navigate": 4, "find": 2}}}
-    assert a["by_subagent_type"] == {"Explore": {"spawns": 2, "tokens": 500,
-                                                 "cost": 0.2, "session_count": 1}}
-    assert a["delegation"] == {"delegated_tokens": 500, "delegated_cost": 0.2,
-                               "sessions_with_spawns": 1}
-    # Existing aggregates unchanged in shape: delegated usage NOT folded in.
+    assert a["by_subagent_type"]["Explore"] == {
+        "spawns": 2, "tokens": 500, "cost": 0.2, "session_count": 1,
+        "tokens_recorded": True, "agents": ["claude"]}
+    # grok type rows attribute the child session's tokens.
+    assert a["by_subagent_type"]["general-purpose"]["tokens"] == 100
+    assert a["by_subagent_type"]["general-purpose"]["agents"] == ["grok"]
+    # codex children aggregate by role with their own session tokens.
+    assert a["by_subagent_type"]["explorer"]["spawns"] == 1
+    assert a["by_subagent_type"]["explorer"]["tokens"] == 70
+    d = a["delegation"]
+    assert d["delegated_tokens"] == 500 and d["delegated_cost"] == 0.2
+    assert d["sessions_with_spawns"] == 3          # claude a + grok gp + codex cp
+    assert d["linked_children"] == 2 and d["linked_child_tokens"] == 170
+    assert d["by_agent"]["grok"] == {"parents": 1, "spawns": 1, "children": 1,
+                                     "child_tokens": 100, "child_cost": 0.05,
+                                     "delegated_tokens": 0, "delegated_cost": 0.0}
+    # Existing aggregates unchanged in shape: delegated usage NOT folded in,
+    # children counted once as their own sessions.
     assert a["by_agent"]["claude"]["total"] == 30
-    assert a["total"]["total"] == 45
+    assert a["total"]["total"] == 30 + 15 + 100 + 15 + 70
 
 
 # --- grok / codex / antigravity (probe-verified shapes) ----------------------
@@ -417,7 +443,7 @@ def test_scan_grok_delegation(scan_env, monkeypatch):
     by_id = {s["id"]: s for s in main._scan_sessions_sync() if s["agent"] == "grok"}
     assert by_id[GROK_PARENT]["delegation"] == {
         "supported": True, "tokens_recorded": False, "spawn_count": 1,
-        "by_type": {"general-purpose": {"count": 1}}}
+        "by_type": {"general-purpose": {"count": 1, "child_session_ids": [GROK_CHILD]}}}
     assert by_id[GROK_PARENT]["child_session_ids"] == [GROK_CHILD]
     assert by_id[GROK_CHILD]["parent_session_id"] == GROK_PARENT
     # Children stand alone token-wise (count-once).

--- a/backend/test_delegation.py
+++ b/backend/test_delegation.py
@@ -646,5 +646,17 @@ def test_endpoint_unsupported_agent():
     assert _run(main.session_delegation("anything", "gemini")) == {"supported": False}
 
 
+def test_subagent_trace_endpoint(scan_env):
+    make_claude_tree(scan_env / ".claude")
+    events = _run(main.session_subagent_trace(SID, "one", "claude"))
+    assert isinstance(events, list)
+    # Both real assistant lines come through; truncated/mid-write line skipped.
+    assert sum(1 for e in events if e.get("type") == "assistant") == 3  # 2 + synthetic
+    assert _run(main.session_subagent_trace(SID, "nope", "claude")) == {"error": "Not found"}
+    # Path traversal is rejected before any filesystem access.
+    assert _run(main.session_subagent_trace(SID, "../../../etc/passwd", "claude")) == {"error": "Invalid subagent id"}
+    assert _run(main.session_subagent_trace(SID, "one", "gemini")) == {"error": "Invalid agent"}
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))

--- a/backend/test_delegation.py
+++ b/backend/test_delegation.py
@@ -1,0 +1,342 @@
+"""Tests for delegation telemetry (subagent attribution) — see DESIGN.md.
+
+Covers:
+  - _claude_subagent_usage(): rollup of <sid>/subagents/agent-*.jsonl with
+    model-correct per-file costing, meta.json fallbacks, tolerant parsing.
+  - _scan_sessions_sync() wiring: delegation summary on claude/cursor sessions,
+    parent/child markers for opencode/hermes, count-once invariant (parent
+    token fields never absorb delegated usage).
+  - /sessions/{id}/delegation overlay endpoint.
+
+Run: pytest backend/test_delegation.py
+"""
+import asyncio
+import json
+import os
+import sqlite3
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+import main  # noqa: E402
+
+SID = "11111111-2222-3333-4444-555555555555"
+PROJ = "-tmp-proj"
+
+
+def _jl(**kw) -> str:
+    return json.dumps(kw) + "\n"
+
+
+def _assistant_line(model="claude-opus-4-8", inp=0, out=0, cache_read=0,
+                    cache_creation=0, cache_creation_1h=0, attribution=None):
+    usage = {
+        "input_tokens": inp, "output_tokens": out,
+        "cache_read_input_tokens": cache_read,
+        "cache_creation_input_tokens": cache_creation,
+        "cache_creation": {"ephemeral_1h_input_tokens": cache_creation_1h},
+    }
+    line = {"type": "assistant", "message": {"model": model, "usage": usage, "content": []}}
+    if attribution:
+        line["attributionAgent"] = attribution
+    return json.dumps(line) + "\n"
+
+
+def make_claude_tree(claude_dir: Path, sid: str = SID, with_subagents: bool = True) -> Path:
+    """Parent session + (optionally) three subagents exercising the edge cases."""
+    proj = claude_dir / "projects" / PROJ
+    proj.mkdir(parents=True, exist_ok=True)
+    session_file = proj / f"{sid}.jsonl"
+    session_file.write_text(
+        _jl(type="user", cwd="/tmp/proj", message={"role": "user", "content": "hi"})
+        + _assistant_line(inp=100, out=50, cache_read=1000, cache_creation=200),
+        encoding="utf-8",
+    )
+    if not with_subagents:
+        return session_file
+    sub = proj / sid / "subagents"
+    sub.mkdir(parents=True)
+    # 1) Happy path: meta.json present, Haiku model, cache hwm across two calls,
+    #    a <synthetic> line and a truncated trailing line (agent still running).
+    (sub / "agent-one.meta.json").write_text(json.dumps(
+        {"agentType": "Explore", "description": "look around", "toolUseId": "toolu_1"}))
+    (sub / "agent-one.jsonl").write_text(
+        _assistant_line(model="claude-haiku-4-5-20251001", inp=10, out=5,
+                        cache_read=100, cache_creation=50)
+        + _assistant_line(model="claude-haiku-4-5-20251001", inp=20, out=5,
+                          cache_read=300, cache_creation=50)
+        + _jl(type="assistant", message={"model": "<synthetic>", "content": []})
+        + '{"type": "assistant", "message": {"usage": {"input_tok',  # mid-write
+        encoding="utf-8",
+    )
+    # 2) meta.json MISSING → agent_type from attributionAgent on the lines.
+    (sub / "agent-two.jsonl").write_text(
+        _assistant_line(model="claude-sonnet-4-6", inp=7, out=3, cache_read=40,
+                        attribution="general-purpose"),
+        encoding="utf-8",
+    )
+    # 3) meta.json corrupt, no attributionAgent → "unknown".
+    (sub / "agent-three.meta.json").write_text("not json at all {")
+    (sub / "agent-three.jsonl").write_text(
+        _assistant_line(model="claude-opus-4-8", inp=1, out=2),
+        encoding="utf-8",
+    )
+    return session_file
+
+
+# --- helper unit tests ------------------------------------------------------
+
+def test_helper_none_without_subagents(tmp_path):
+    sf = make_claude_tree(tmp_path / ".claude", with_subagents=False)
+    assert main._claude_subagent_usage(sf, SID) is None
+
+
+def test_helper_none_with_empty_dir(tmp_path):
+    sf = make_claude_tree(tmp_path / ".claude", with_subagents=False)
+    (sf.parent / SID / "subagents").mkdir(parents=True)
+    assert main._claude_subagent_usage(sf, SID) is None
+
+
+def test_helper_rollup(tmp_path):
+    sf = make_claude_tree(tmp_path / ".claude")
+    deleg = main._claude_subagent_usage(sf, SID)
+    assert deleg["spawn_count"] == 3
+    by_id = {e["agent_id"]: e for e in deleg["subagents"]}
+    one = by_id["one"]
+    assert one["agent_type"] == "Explore"
+    assert one["description"] == "look around"
+    assert one["tool_use_id"] == "toolu_1"
+    assert one["model"] == "claude-haiku-4-5-20251001"
+    # input/output cumulative; cached = high-water-mark (NOT 100+300);
+    # cache_creation cumulative. Synthetic + truncated lines ignored.
+    assert one["tokens"]["input"] == 30
+    assert one["tokens"]["output"] == 10
+    assert one["tokens"]["cached"] == 300
+    assert one["tokens"]["cache_creation"] == 100
+    assert one["tokens"]["total"] == 30 + 10 + 300
+    # meta fallbacks
+    assert by_id["two"]["agent_type"] == "general-purpose"
+    assert by_id["three"]["agent_type"] == "unknown"
+    # totals sum across entries
+    assert deleg["totals"]["input"] == 30 + 7 + 1
+    assert deleg["totals"]["output"] == 10 + 3 + 2
+    assert deleg["totals"]["cached"] == 300 + 40 + 0
+    assert deleg["cost"] >= 0
+
+
+def test_helper_costs_with_each_files_own_model(tmp_path, monkeypatch):
+    sf = make_claude_tree(tmp_path / ".claude")
+    seen = []
+
+    def fake_cost(model, inp, out, cached, **kw):
+        seen.append(model)
+        return 1.0
+
+    monkeypatch.setattr(main, "calculate_cost", fake_cost)
+    deleg = main._claude_subagent_usage(sf, SID)
+    assert sorted(seen) == ["claude-haiku-4-5-20251001", "claude-opus-4-8",
+                            "claude-sonnet-4-6"]
+    assert deleg["cost"] == pytest.approx(3.0)
+
+
+# --- scanner integration ----------------------------------------------------
+
+@pytest.fixture
+def scan_env(tmp_path, monkeypatch):
+    """Point every agent store at tmp_path so the scan is hermetic."""
+    missing = tmp_path / "missing"
+    for attr in ("CODEX_DIR", "GEMINI_DIR", "QWEN_DIR", "VIBE_DIR", "OLLAMA_DIR",
+                 "GROK_SESSIONS_DIR", "VSCODE_STORAGE", "CURSOR_STORAGE",
+                 "COPILOT_CLI_DIR", "ANTIGRAVITY_BRAIN_DIR", "ANTIGRAVITY_CLI_DIR",
+                 "HERMES_DIR"):
+        monkeypatch.setattr(main, attr, missing / attr.lower())
+    monkeypatch.setattr(main, "ANTIGRAVITY_BRAIN_SOURCES", [])
+    monkeypatch.setattr(main, "ANTIGRAVITY_BRAIN_DIRS", [])
+    monkeypatch.setattr(main, "_antigravity_cli_meta", lambda *a, **k: {})
+    monkeypatch.setattr(main, "CLAUDE_DIR", tmp_path / ".claude")
+    monkeypatch.setattr(main, "CURSOR_DIR", tmp_path / ".cursor")
+    monkeypatch.setattr(main, "OPENCODE_DB", tmp_path / "opencode.db")
+    monkeypatch.setattr(main, "HERMES_DB", tmp_path / "hermes-state.db")
+    monkeypatch.setattr(main, "HERMES_PROFILES_DIR", missing / "hermes-profiles")
+    monkeypatch.setattr(main, "PROJECT_ALIASES_FILE", tmp_path / "aliases.json")
+    return tmp_path
+
+
+def test_scan_claude_delegation_summary(scan_env):
+    make_claude_tree(scan_env / ".claude")
+    sessions = [s for s in main._scan_sessions_sync() if s["agent"] == "claude"]
+    assert len(sessions) == 1
+    s = sessions[0]
+    assert s["delegation"] == {"supported": True, "tokens_recorded": True,
+                               "spawn_count": 3,
+                               "delegated_total": (30 + 7 + 1) + (10 + 3 + 2) + (300 + 40)}
+    assert s["tokens"]["delegated_input"] == 38
+    assert s["tokens"]["delegated_output"] == 15
+    assert s["tokens"]["delegated_cached"] == 340
+    assert s["tokens"]["delegated_cache_creation"] == 100
+    assert s["delegated_cost"] >= 0
+    # Count-once invariant: the parent's own buckets reflect ONLY the parent file.
+    assert s["tokens"]["input"] == 100
+    assert s["tokens"]["output"] == 50
+    assert s["tokens"]["cached"] == 1000
+    assert s["tokens"]["total"] == 100 + 50 + 1000
+
+
+def test_scan_claude_without_spawns(scan_env):
+    make_claude_tree(scan_env / ".claude", with_subagents=False)
+    s = [s for s in main._scan_sessions_sync() if s["agent"] == "claude"][0]
+    assert s["delegation"]["supported"] is True
+    assert s["delegation"]["spawn_count"] == 0
+    assert "delegated_input" not in s["tokens"]
+    assert "delegated_cost" not in s
+
+
+def test_scan_cursor_spawn_count_only(scan_env):
+    sid = str(uuid.uuid4())
+    trans = scan_env / ".cursor" / "projects" / "tmp-proj" / "agent-transcripts" / sid
+    trans.mkdir(parents=True)
+    (trans / f"{sid}.jsonl").write_text(
+        json.dumps({"role": "user", "message": {"content": "do things"}}) + "\n"
+        + json.dumps({"role": "assistant", "message": {
+            "model": "claude-opus-4-8",
+            "usage": {"input_tokens": 9, "output_tokens": 4},
+            "content": []}}) + "\n",
+        encoding="utf-8",
+    )
+    subs = trans / "subagents"
+    subs.mkdir()
+    for _ in range(2):
+        # Cursor subagent transcripts carry NO usage fields — count only.
+        (subs / f"{uuid.uuid4()}.jsonl").write_text(
+            json.dumps({"role": "assistant", "message": {"content": "text"}}) + "\n")
+    s = [s for s in main._scan_sessions_sync() if s["agent"] == "cursor"][0]
+    assert s["delegation"] == {"supported": True, "tokens_recorded": False,
+                               "spawn_count": 2}
+    # No invented tokens for cursor spawns.
+    assert s["tokens"]["input"] == 9
+    assert "delegated_input" not in s["tokens"]
+
+
+def _make_opencode_db(path: Path):
+    con = sqlite3.connect(path)
+    con.execute("CREATE TABLE session (id TEXT, project_id TEXT, parent_id TEXT, "
+                "directory TEXT, title TEXT, time_created INT, time_updated INT)")
+    con.execute("CREATE TABLE message (session_id TEXT, time_created INT, data TEXT)")
+    con.execute("CREATE TABLE part (session_id TEXT, time_created INT, data TEXT)")
+    con.execute("CREATE TABLE todo (session_id TEXT, position INT, content TEXT, status TEXT)")
+    now = 1750000000000
+    con.execute("INSERT INTO session VALUES ('ses_parent', 'p', NULL, '/tmp/x', 'parent', ?, ?)", (now, now))
+    con.execute("INSERT INTO session VALUES ('ses_child', 'p', 'ses_parent', '/tmp/x', 'child', ?, ?)", (now, now))
+    for sid in ("ses_parent", "ses_child"):
+        con.execute("INSERT INTO message VALUES (?, ?, ?)", (sid, now, json.dumps(
+            {"role": "assistant", "modelID": "gpt-5.2-codex", "providerID": "openai"})))
+        con.execute("INSERT INTO part VALUES (?, ?, ?)", (sid, now, json.dumps(
+            {"type": "step-finish", "tokens": {"input": 11, "output": 6, "cache": {"read": 0, "write": 0}}})))
+    con.commit()
+    con.close()
+
+
+def test_scan_opencode_hierarchy(scan_env):
+    _make_opencode_db(scan_env / "opencode.db")
+    by_id = {s["id"]: s for s in main._scan_sessions_sync() if s["agent"] == "opencode"}
+    assert by_id["ses_child"]["parent_session_id"] == "ses_parent"
+    assert by_id["ses_parent"]["child_session_ids"] == ["ses_child"]
+    assert by_id["ses_parent"]["delegation"] == {"supported": True,
+                                                 "tokens_recorded": False,
+                                                 "linked_children": 1}
+    # Children are full sessions (already counted) — child keeps its own tokens,
+    # parent's buckets are NOT inflated.
+    assert by_id["ses_child"]["tokens"]["input"] == 11
+    assert by_id["ses_parent"]["tokens"]["input"] == 11
+    # Child without children of its own: capability marker, no linked_children.
+    assert by_id["ses_child"]["delegation"] == {"supported": True}
+
+
+def _make_hermes_db(path: Path):
+    con = sqlite3.connect(path)
+    con.execute("CREATE TABLE sessions (id TEXT, source TEXT, model TEXT, "
+                "parent_session_id TEXT, started_at INT, ended_at INT, "
+                "input_tokens INT, output_tokens INT, cache_read_tokens INT, "
+                "cache_write_tokens INT, reasoning_tokens INT, "
+                "estimated_cost_usd REAL, actual_cost_usd REAL, title TEXT, "
+                "billing_provider TEXT, billing_base_url TEXT, end_reason TEXT)")
+    con.execute("CREATE TABLE messages (session_id TEXT, role TEXT, content TEXT, "
+                "timestamp INT, tool_name TEXT)")
+    con.execute("INSERT INTO sessions VALUES ('h_parent', 'cli', 'claude-sonnet-4-6', NULL, "
+                "1750000000, 1750000100, 100, 40, 0, 0, 0, 0.01, 0.01, 'parent', "
+                "'anthropic', NULL, 'done')")
+    con.execute("INSERT INTO sessions VALUES ('h_child', 'cli', 'claude-sonnet-4-6', 'h_parent', "
+                "1750000010, 1750000090, 50, 20, 0, 0, 0, 0.005, 0.005, 'child', "
+                "'anthropic', NULL, 'done')")
+    con.commit()
+    con.close()
+
+
+def test_scan_hermes_hierarchy(scan_env):
+    _make_hermes_db(scan_env / "hermes-state.db")
+    by_id = {s["id"]: s for s in main._scan_sessions_sync() if s["agent"] == "hermes"}
+    assert by_id["h_child"]["parent_session_id"] == "h_parent"
+    assert by_id["h_parent"]["child_session_ids"] == ["h_child"]
+    assert by_id["h_parent"]["delegation"]["linked_children"] == 1
+    assert by_id["h_child"]["delegation"] == {"supported": True}
+
+
+# --- /sessions/{id}/delegation endpoint -------------------------------------
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_endpoint_claude_breakdown(scan_env):
+    make_claude_tree(scan_env / ".claude")
+    r = _run(main.session_delegation(SID, "claude"))
+    assert r["supported"] is True and r["tokens_recorded"] is True
+    assert r["spawn_count"] == 3
+    assert {e["agent_type"] for e in r["subagents"]} == {"Explore", "general-purpose", "unknown"}
+
+
+def test_endpoint_claude_no_spawns(scan_env):
+    make_claude_tree(scan_env / ".claude", with_subagents=False)
+    r = _run(main.session_delegation(SID, "claude"))
+    assert r == {"supported": True, "tokens_recorded": True, "spawn_count": 0,
+                 "subagents": [], "totals": None, "cost": 0.0}
+
+
+def test_endpoint_claude_missing_session(scan_env):
+    assert _run(main.session_delegation("nope", "claude")) == {"error": "Not found"}
+
+
+def test_endpoint_cursor(scan_env):
+    sid = str(uuid.uuid4())
+    trans = scan_env / ".cursor" / "projects" / "tmp-proj" / "agent-transcripts" / sid
+    (trans / "subagents").mkdir(parents=True)
+    (trans / "subagents" / "abc.jsonl").write_text("{}\n")
+    r = _run(main.session_delegation(sid, "cursor"))
+    assert r["supported"] is True and r["tokens_recorded"] is False
+    assert r["spawn_count"] == 1
+    assert r["subagents"][0]["tokens"] is None  # never invented
+
+
+def test_endpoint_opencode(scan_env):
+    _make_opencode_db(scan_env / "opencode.db")
+    r = _run(main.session_delegation("ses_parent", "opencode"))
+    assert r["child_session_ids"] == ["ses_child"] and r["linked_children"] == 1
+    r = _run(main.session_delegation("ses_child", "opencode"))
+    assert r["parent_session_id"] == "ses_parent" and r["linked_children"] == 0
+
+
+def test_endpoint_hermes(scan_env):
+    _make_hermes_db(scan_env / "hermes-state.db")
+    r = _run(main.session_delegation("h_parent", "hermes"))
+    assert r["child_session_ids"] == ["h_child"]
+
+
+def test_endpoint_unsupported_agent():
+    assert _run(main.session_delegation("anything", "gemini")) == {"supported": False}
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/backend/test_delegation.py
+++ b/backend/test_delegation.py
@@ -521,8 +521,14 @@ def _make_codex_tree(codex_dir: Path):
                                              "total_tokens": 70}}}}) + "\n"
     prompt = json.dumps({"timestamp": "2026-06-10T07:01:47.000Z", "type": "event_msg",
                          "payload": {"type": "user_message", "message": "probe prompt"}}) + "\n"
+    # Skill activation breadcrumb: codex reads the SKILL.md via a tool call
+    # (it records no structured skill event — verified on 0.136).
+    skill_read = json.dumps({"timestamp": "2026-06-10T07:01:48.000Z", "type": "response_item",
+                             "payload": {"type": "function_call", "name": "exec_command",
+                                         "arguments": json.dumps({"cmd": [
+                                             "cat", "/Users/u/.codex/skills/tt-probe-skill/SKILL.md"]})}}) + "\n"
     (day / f"rollout-2026-06-10T12-31-46-{CODEX_PARENT}.jsonl").write_text(
-        meta(CODEX_PARENT, {"thread_source": "user", "source": "exec"}) + prompt + usage)
+        meta(CODEX_PARENT, {"thread_source": "user", "source": "exec"}) + prompt + skill_read + usage)
     (day / f"rollout-2026-06-10T12-32-00-{CODEX_CHILD}.jsonl").write_text(
         meta(CODEX_CHILD, {"thread_source": "subagent",
                            "forked_from_id": CODEX_PARENT,
@@ -546,6 +552,8 @@ def test_scan_codex_discovery_and_linkage(scan_env, monkeypatch):
     assert by_id[CODEX_PARENT]["delegation"] == {"supported": True,
                                                  "tokens_recorded": False,
                                                  "linked_children": 1}
+    # Skill use recovered from the SKILL.md read breadcrumb.
+    assert by_id[CODEX_PARENT]["skills_used"] == [{"name": "tt-probe-skill", "count": 1}]
     # Each thread keeps its own tokens (count-once).
     assert by_id[CODEX_PARENT]["tokens"]["total"] == 70
     assert by_id[CODEX_CHILD]["tokens"]["total"] == 70

--- a/backend/test_delegation.py
+++ b/backend/test_delegation.py
@@ -381,6 +381,148 @@ def test_analytics_ecosystem_aggregates(monkeypatch):
     assert a["total"]["total"] == 45
 
 
+# --- grok / codex / antigravity (probe-verified shapes) ----------------------
+
+GROK_PARENT = "019eb056-455f-7442-bf79-000000000001"
+GROK_CHILD = "019eb056-646a-7a03-b3f7-000000000002"
+
+
+def _make_grok_tree(root: Path):
+    """Bucket with a parent session that spawned one subagent (child is a full
+    sibling session dir) — mirrors grok 0.2.39 on-disk layout."""
+    bucket = root / "%2Ftmp%2Fx"
+    for sid, ctx in ((GROK_PARENT, 200), (GROK_CHILD, 100)):
+        d = bucket / sid
+        d.mkdir(parents=True)
+        (d / "summary.json").write_text(json.dumps({
+            "created_at": "2026-06-10T07:00:00Z", "updated_at": "2026-06-10T07:01:00Z",
+            "generated_title": f"sess {sid[:6]}", "current_model_id": "grok-build",
+            "info": {"cwd": "/tmp/x"}}))
+        (d / "signals.json").write_text(json.dumps({
+            "contextTokensUsed": ctx, "toolsUsed": ["read_file"],
+            "modelsUsed": ["grok-build"]}))
+    sub = bucket / GROK_PARENT / "subagents" / GROK_CHILD
+    sub.mkdir(parents=True)
+    (sub / "meta.json").write_text(json.dumps({
+        "subagent_id": GROK_CHILD, "parent_session_id": GROK_PARENT,
+        "child_session_id": GROK_CHILD, "subagent_type": "general-purpose",
+        "description": "Summarize README", "status": "completed",
+        "duration_ms": 5898, "tool_calls": 1, "turns": 1,
+        "effective_model_id": "grok-build"}))
+
+
+def test_scan_grok_delegation(scan_env, monkeypatch):
+    monkeypatch.setattr(main, "GROK_SESSIONS_DIR", scan_env / "grok-sessions")
+    _make_grok_tree(scan_env / "grok-sessions")
+    by_id = {s["id"]: s for s in main._scan_sessions_sync() if s["agent"] == "grok"}
+    assert by_id[GROK_PARENT]["delegation"] == {
+        "supported": True, "tokens_recorded": False, "spawn_count": 1,
+        "by_type": {"general-purpose": {"count": 1}}}
+    assert by_id[GROK_PARENT]["child_session_ids"] == [GROK_CHILD]
+    assert by_id[GROK_CHILD]["parent_session_id"] == GROK_PARENT
+    # Children stand alone token-wise (count-once).
+    assert by_id[GROK_CHILD]["tokens"]["total"] == 100
+    assert by_id[GROK_PARENT]["tokens"]["total"] == 200
+
+
+def test_endpoint_grok(scan_env, monkeypatch):
+    monkeypatch.setattr(main, "GROK_SESSIONS_DIR", scan_env / "grok-sessions")
+    _make_grok_tree(scan_env / "grok-sessions")
+    r = _run(main.session_delegation(GROK_PARENT, "grok"))
+    assert r["spawn_count"] == 1
+    assert r["subagents"][0]["description"] == "Summarize README"
+    assert r["subagents"][0]["child_session_id"] == GROK_CHILD
+    # Child resolves its parent via the parent's spawn meta.
+    r = _run(main.session_delegation(GROK_CHILD, "grok"))
+    assert r["parent_session_id"] == GROK_PARENT and r["spawn_count"] == 0
+
+
+CODEX_PARENT = "019eb056-4eae-7280-8617-000000000001"
+CODEX_CHILD = "019eb056-83a6-7fe0-99ce-000000000002"
+
+
+def _make_codex_tree(codex_dir: Path):
+    """Two rollouts, NO session_index.jsonl (codex stopped maintaining it):
+    parent (thread_source user) + subagent child with thread_spawn meta."""
+    day = codex_dir / "sessions" / "2026" / "06" / "10"
+    day.mkdir(parents=True)
+
+    def meta(sid, extra):
+        return json.dumps({"timestamp": "2026-06-10T07:01:46.921Z", "type": "session_meta",
+                           "payload": {"id": sid, "timestamp": "2026-06-10T07:01:46.798Z",
+                                       "cwd": "/tmp/x", "model_provider": "openai",
+                                       "cli_version": "0.136.0", **extra}}) + "\n"
+
+    usage = json.dumps({"timestamp": "2026-06-10T07:01:50.000Z", "type": "event_msg",
+                        "payload": {"type": "token_count",
+                                    "info": {"total_token_usage": {"input_tokens": 50,
+                                             "cached_input_tokens": 0, "output_tokens": 20,
+                                             "total_tokens": 70}}}}) + "\n"
+    prompt = json.dumps({"timestamp": "2026-06-10T07:01:47.000Z", "type": "event_msg",
+                         "payload": {"type": "user_message", "message": "probe prompt"}}) + "\n"
+    (day / f"rollout-2026-06-10T12-31-46-{CODEX_PARENT}.jsonl").write_text(
+        meta(CODEX_PARENT, {"thread_source": "user", "source": "exec"}) + prompt + usage)
+    (day / f"rollout-2026-06-10T12-32-00-{CODEX_CHILD}.jsonl").write_text(
+        meta(CODEX_CHILD, {"thread_source": "subagent",
+                           "forked_from_id": CODEX_PARENT,
+                           "source": {"subagent": {"thread_spawn": {
+                               "parent_thread_id": CODEX_PARENT, "depth": 1,
+                               "agent_nickname": "Dewey", "agent_role": "explorer"}}}})
+        + usage)
+
+
+def test_scan_codex_discovery_and_linkage(scan_env, monkeypatch):
+    codex_dir = scan_env / ".codex"
+    monkeypatch.setattr(main, "CODEX_DIR", codex_dir)
+    _make_codex_tree(codex_dir)
+    by_id = {s["id"]: s for s in main._scan_sessions_sync() if s["agent"] == "codex"}
+    # Discovered from rollout files alone — no session_index.jsonl exists.
+    assert set(by_id) == {CODEX_PARENT, CODEX_CHILD}
+    assert by_id[CODEX_PARENT]["text"] == "probe prompt"
+    assert by_id[CODEX_CHILD]["parent_session_id"] == CODEX_PARENT
+    assert by_id[CODEX_CHILD]["subagent_info"] == {"role": "explorer",
+                                                   "nickname": "Dewey", "depth": 1}
+    assert by_id[CODEX_PARENT]["delegation"] == {"supported": True,
+                                                 "tokens_recorded": False,
+                                                 "linked_children": 1}
+    # Each thread keeps its own tokens (count-once).
+    assert by_id[CODEX_PARENT]["tokens"]["total"] == 70
+    assert by_id[CODEX_CHILD]["tokens"]["total"] == 70
+
+
+def test_endpoint_codex(scan_env, monkeypatch):
+    codex_dir = scan_env / ".codex"
+    monkeypatch.setattr(main, "CODEX_DIR", codex_dir)
+    _make_codex_tree(codex_dir)
+    r = _run(main.session_delegation(CODEX_PARENT, "codex"))
+    assert r["child_session_ids"] == [CODEX_CHILD]
+    assert r["subagents"][0]["agent_role"] == "explorer"
+    r = _run(main.session_delegation(CODEX_CHILD, "codex"))
+    assert r["parent_session_id"] == CODEX_PARENT
+    assert r["subagent_info"]["nickname"] == "Dewey"
+
+
+def test_antigravity_subagent_children(scan_env, monkeypatch):
+    brain = scan_env / "brain"
+    parent = "6fd942ec-d61d-4d38-a5d4-a3054d58835f"
+    child = "d5361c61-c969-4f95-89b8-942bc99a4c24"
+    logs = brain / parent / ".system_generated" / "logs"
+    logs.mkdir(parents=True)
+    # INVOKE_SUBAGENT content embeds the child id as escaped JSON (verified shape).
+    (logs / "transcript.jsonl").write_text(json.dumps({
+        "step_index": 6, "source": "MODEL", "type": "INVOKE_SUBAGENT",
+        "content": 'Created the following subagents:\n{\n  "conversationId": "%s",\n}' % child,
+    }) + "\n")
+    monkeypatch.setattr(main, "ANTIGRAVITY_BRAIN_DIRS", [brain])
+    assert main._antigravity_subagent_children(parent) == [child]
+    # Linkage pass annotates both sides of a synthetic session list.
+    sessions = [{"id": parent, "agent": "antigravity"},
+                {"id": child, "agent": "antigravity"}]
+    main._antigravity_link_subagents(sessions)
+    assert sessions[0]["delegation"]["linked_children"] == 1
+    assert sessions[1]["parent_session_id"] == parent
+
+
 # --- /sessions/{id}/delegation endpoint -------------------------------------
 
 def _run(coro):

--- a/backend/test_delegation.py
+++ b/backend/test_delegation.py
@@ -105,6 +105,19 @@ def make_claude_tree(claude_dir: Path, sid: str = SID, with_subagents: bool = Tr
 
 # --- helper unit tests ------------------------------------------------------
 
+def test_sqlite_ro_uri_cross_platform():
+    from pathlib import PurePosixPath, PureWindowsPath
+    # POSIX: byte-identical to the old f"file:{path}?mode=ro" for plain paths.
+    assert main._sqlite_ro_uri(PurePosixPath("/home/u/.hermes/state.db")) == \
+        "file:/home/u/.hermes/state.db?mode=ro"
+    # Windows: backslashes are NOT URI separators — must be forward-slashed,
+    # drive colon kept literal (sqlite's Windows URI parser expects C:/...).
+    assert main._sqlite_ro_uri(PureWindowsPath(r"C:\Users\u\state.db")) == \
+        "file:C:/Users/u/state.db?mode=ro"
+    # URI-special characters get percent-encoded (spaces, '?', '#').
+    assert main._sqlite_ro_uri(PurePosixPath("/data/My Files/a?b.db")) == \
+        "file:/data/My%20Files/a%3Fb.db?mode=ro"
+
 def test_helper_none_without_subagents(tmp_path):
     sf = make_claude_tree(tmp_path / ".claude", with_subagents=False)
     assert main._claude_subagent_usage(sf, SID) is None

--- a/backend/test_delegation.py
+++ b/backend/test_delegation.py
@@ -320,6 +320,26 @@ def test_mcp_usage_from_counts_parses_and_skips_malformed():
                    "jira": {"search": 2}}
 
 
+def test_mcp_usage_gemini_single_underscore_convention():
+    # Real names observed in ~/.gemini chats: servers may contain dashes,
+    # tools contain underscores, and some calls carry a default_api: wrapper.
+    out = main._mcp_usage_from_counts({
+        "mcp_computerUse_execute_action": 10,
+        "mcp_local-server_take_snapshot": 9,
+        "default_api:mcp_local-server_fill": 36,
+        "mcp_blender_execute_blender_code": 8,
+        "mcp_github_get_file_contents": 7,
+        "run_shell_command": 500,  # not MCP
+        "mcp_orphan": 1,           # malformed (no tool part)
+    })
+    assert out == {
+        "computerUse": {"execute_action": 10},
+        "local-server": {"take_snapshot": 9, "fill": 36},
+        "blender": {"execute_blender_code": 8},
+        "github": {"get_file_contents": 7},
+    }
+
+
 def test_scan_claude_skills_and_mcp(scan_env):
     make_claude_tree(scan_env / ".claude")
     s = [s for s in main._scan_sessions_sync() if s["agent"] == "claude"][0]
@@ -382,9 +402,11 @@ def test_analytics_ecosystem_aggregates(monkeypatch):
 
     monkeypatch.setattr(main, "get_sessions_cached", fake_sessions)
     a = _run(main.get_analytics())
-    assert a["by_skill"] == {"graphify": {"invocations": 3, "session_count": 2}}
+    assert a["by_skill"] == {"graphify": {"invocations": 3, "session_count": 2,
+                                          "agents": ["claude"]}}
     assert a["by_mcp_server"] == {"chrome": {"calls": 6, "session_count": 2,
-                                             "tools": {"navigate": 4, "find": 2}}}
+                                             "tools": {"navigate": 4, "find": 2},
+                                             "agents": ["claude"]}}
     assert a["by_subagent_type"]["Explore"] == {
         "spawns": 2, "tokens": 500, "cost": 0.2, "session_count": 1,
         "tokens_recorded": True, "agents": ["claude"]}

--- a/backend/test_delegation.py
+++ b/backend/test_delegation.py
@@ -32,17 +32,22 @@ def _jl(**kw) -> str:
 
 
 def _assistant_line(model="claude-opus-4-8", inp=0, out=0, cache_read=0,
-                    cache_creation=0, cache_creation_1h=0, attribution=None):
+                    cache_creation=0, cache_creation_1h=0, attribution=None,
+                    content=None):
     usage = {
         "input_tokens": inp, "output_tokens": out,
         "cache_read_input_tokens": cache_read,
         "cache_creation_input_tokens": cache_creation,
         "cache_creation": {"ephemeral_1h_input_tokens": cache_creation_1h},
     }
-    line = {"type": "assistant", "message": {"model": model, "usage": usage, "content": []}}
+    line = {"type": "assistant", "message": {"model": model, "usage": usage, "content": content or []}}
     if attribution:
         line["attributionAgent"] = attribution
     return json.dumps(line) + "\n"
+
+
+def _tool_use(name, **input_kw):
+    return {"type": "tool_use", "name": name, "id": "toolu_x", "input": input_kw}
 
 
 def make_claude_tree(claude_dir: Path, sid: str = SID, with_subagents: bool = True) -> Path:
@@ -52,7 +57,18 @@ def make_claude_tree(claude_dir: Path, sid: str = SID, with_subagents: bool = Tr
     session_file = proj / f"{sid}.jsonl"
     session_file.write_text(
         _jl(type="user", cwd="/tmp/proj", message={"role": "user", "content": "hi"})
-        + _assistant_line(inp=100, out=50, cache_read=1000, cache_creation=200),
+        + _assistant_line(inp=100, out=50, cache_read=1000, cache_creation=200,
+                          content=[_tool_use("Bash"), _tool_use("Bash"),
+                                   _tool_use("mcp__chrome__navigate"),
+                                   _tool_use("mcp__chrome__navigate"),
+                                   _tool_use("mcp__chrome__navigate"),
+                                   _tool_use("Skill", skill="graphify"),
+                                   _tool_use("Skill", skill="graphify")])
+        # Slash-command echoes: a real skill (counted) and a built-in (filtered).
+        + _jl(type="user", message={"role": "user", "content":
+              "<command-name>/code-review</command-name><command-args>high</command-args>"})
+        + _jl(type="user", message={"role": "user", "content":
+              "<command-name>/model</command-name>"}),
         encoding="utf-8",
     )
     if not with_subagents:
@@ -170,9 +186,14 @@ def test_scan_claude_delegation_summary(scan_env):
     sessions = [s for s in main._scan_sessions_sync() if s["agent"] == "claude"]
     assert len(sessions) == 1
     s = sessions[0]
-    assert s["delegation"] == {"supported": True, "tokens_recorded": True,
-                               "spawn_count": 3,
-                               "delegated_total": (30 + 7 + 1) + (10 + 3 + 2) + (300 + 40)}
+    d = s["delegation"]
+    assert d["supported"] is True and d["tokens_recorded"] is True
+    assert d["spawn_count"] == 3
+    assert d["delegated_total"] == (30 + 7 + 1) + (10 + 3 + 2) + (300 + 40)
+    # Per-type rollup for analytics: Explore file = 30+10+300 tokens.
+    assert d["by_type"]["Explore"] == {"count": 1, "total": 340,
+                                       "cost": d["by_type"]["Explore"]["cost"]}
+    assert set(d["by_type"]) == {"Explore", "general-purpose", "unknown"}
     assert s["tokens"]["delegated_input"] == 38
     assert s["tokens"]["delegated_output"] == 15
     assert s["tokens"]["delegated_cached"] == 340
@@ -282,6 +303,82 @@ def test_scan_hermes_hierarchy(scan_env):
     assert by_id["h_parent"]["child_session_ids"] == ["h_child"]
     assert by_id["h_parent"]["delegation"]["linked_children"] == 1
     assert by_id["h_child"]["delegation"] == {"supported": True}
+
+
+# --- skills + MCP usage (Phase 2) -------------------------------------------
+
+def test_mcp_usage_from_counts_parses_and_skips_malformed():
+    out = main._mcp_usage_from_counts({
+        "mcp__chrome__navigate": 3,
+        "mcp__chrome__read_page": 1,
+        "mcp__jira__search": 2,
+        "Bash": 9,             # not MCP
+        "mcp__": 1,            # malformed
+        "mcp__only-server": 1, # malformed (no tool)
+    })
+    assert out == {"chrome": {"navigate": 3, "read_page": 1},
+                   "jira": {"search": 2}}
+
+
+def test_scan_claude_skills_and_mcp(scan_env):
+    make_claude_tree(scan_env / ".claude")
+    s = [s for s in main._scan_sessions_sync() if s["agent"] == "claude"][0]
+    # Skill tool ×2 + /code-review echo; /model is a built-in CLI command → filtered.
+    assert s["skills_used"] == [{"name": "graphify", "count": 2},
+                                {"name": "code-review", "count": 1}]
+    assert s["tool_counts"]["Bash"] == 2
+    assert s["tool_counts"]["mcp__chrome__navigate"] == 3
+    assert s["tool_counts"]["Skill"] == 2
+    assert s["mcp_usage"] == {"chrome": {"navigate": 3}}
+
+
+def test_scan_agents_without_signal_lack_keys(scan_env):
+    make_claude_tree(scan_env / ".claude", with_subagents=False)
+    _make_hermes_db(scan_env / "hermes-state.db")
+    for s in main._scan_sessions_sync():
+        if s["agent"] == "hermes":
+            # fixture has no tool messages → no invented usage keys
+            assert "mcp_usage" not in s and "tool_counts" not in s
+
+
+# --- /analytics ecosystem aggregates -----------------------------------------
+
+def test_analytics_ecosystem_aggregates(monkeypatch):
+    from datetime import datetime, timezone
+    base = {"project": "/tmp/x", "timestamp": datetime.now(timezone.utc),
+            "tokens": {"input": 10, "output": 5, "cached": 0, "total": 15},
+            "cost": 0.01, "model": "claude-opus-4-8", "mcp_tools": []}
+    sessions = [
+        {**base, "id": "a", "agent": "claude",
+         "skills_used": [{"name": "graphify", "count": 2}],
+         "mcp_usage": {"chrome": {"navigate": 3}},
+         "delegation": {"supported": True, "tokens_recorded": True, "spawn_count": 2,
+                        "delegated_total": 500,
+                        "by_type": {"Explore": {"count": 2, "total": 500, "cost": 0.2}}},
+         "delegated_cost": 0.2},
+        {**base, "id": "b", "agent": "claude",
+         "skills_used": [{"name": "graphify", "count": 1}],
+         "mcp_usage": {"chrome": {"navigate": 1, "find": 2}},
+         "delegation": {"supported": True, "tokens_recorded": True, "spawn_count": 0,
+                        "delegated_total": 0}},
+        {**base, "id": "c", "agent": "codex", "delegation": {"supported": False}},
+    ]
+
+    async def fake_sessions(fresh: bool = False):
+        return sessions
+
+    monkeypatch.setattr(main, "get_sessions_cached", fake_sessions)
+    a = _run(main.get_analytics())
+    assert a["by_skill"] == {"graphify": {"invocations": 3, "session_count": 2}}
+    assert a["by_mcp_server"] == {"chrome": {"calls": 6, "session_count": 2,
+                                             "tools": {"navigate": 4, "find": 2}}}
+    assert a["by_subagent_type"] == {"Explore": {"spawns": 2, "tokens": 500,
+                                                 "cost": 0.2, "session_count": 1}}
+    assert a["delegation"] == {"delegated_tokens": 500, "delegated_cost": 0.2,
+                               "sessions_with_spawns": 1}
+    # Existing aggregates unchanged in shape: delegated usage NOT folded in.
+    assert a["by_agent"]["claude"]["total"] == 30
+    assert a["total"]["total"] == 45
 
 
 # --- /sessions/{id}/delegation endpoint -------------------------------------

--- a/frontend/src/app/analytics/page.tsx
+++ b/frontend/src/app/analytics/page.tsx
@@ -4,7 +4,7 @@ import { useMemo, useState } from "react";
 import { cn } from "@/lib/cn";
 import {
   BarChart3, TrendingUp, ArrowDownToLine, ArrowUpFromLine,
-  Zap, DollarSign, Cpu,
+  Zap, DollarSign, Cpu, GitBranch,
 } from "lucide-react";
 import {
   AreaChart, Area, BarChart, Bar, PieChart as RePieChart, Pie, Cell,
@@ -24,6 +24,10 @@ interface AnalyticsData {
   by_agent: Record<string, AgentStats>;
   by_day: { date: string; total: number; input: number; output: number; cached: number; cost: number }[];
   by_model?: Record<string, AgentStats & { agent: string }>;
+  by_skill?: Record<string, { invocations: number; session_count: number }>;
+  by_mcp_server?: Record<string, { calls: number; tools: Record<string, number>; session_count: number }>;
+  by_subagent_type?: Record<string, { spawns: number; tokens: number; cost: number; session_count: number }>;
+  delegation?: { delegated_tokens: number; delegated_cost: number; sessions_with_spawns: number };
   total: { input: number; output: number; cached: number; total: number; cost: number };
   pricing_updated?: string;
 }
@@ -410,7 +414,131 @@ export default function AnalyticsPage() {
           </Card>
         </Section>
       )}
+
+      <EcosystemSection data={data} />
     </div>
+  );
+}
+
+/* Delegation + skills + MCP usage — which capabilities actually earn their keep.
+   Only agents whose logs record these signals contribute; the section hides
+   itself entirely when there's nothing to show (no fake zeros). */
+function EcosystemSection({ data }: { data: AnalyticsData }) {
+  const subagentTypes = Object.entries(data.by_subagent_type || {})
+    .map(([name, s]) => ({ name, ...s }))
+    .sort((a, b) => b.cost - a.cost);
+  const skills = Object.entries(data.by_skill || {})
+    .map(([name, s]) => ({ name, ...s }))
+    .sort((a, b) => b.invocations - a.invocations);
+  const mcpServers = Object.entries(data.by_mcp_server || {})
+    .map(([name, s]) => ({ name, ...s }))
+    .sort((a, b) => b.calls - a.calls);
+  const deleg = data.delegation;
+  if (subagentTypes.length === 0 && skills.length === 0 && mcpServers.length === 0) return null;
+
+  return (
+    <Section
+      title="Delegation & ecosystem"
+      description="Subagents your sessions spawned, skills you invoked, and MCP servers you actually used — recorded only where the agent's logs carry the signal (Claude Code is the richest source)."
+    >
+      {deleg && deleg.sessions_with_spawns > 0 && (
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+          <StatTile
+            label="Delegated tokens"
+            value={compact(deleg.delegated_tokens)}
+            hint="Consumed by spawned subagents — on top of session totals"
+            icon={<GitBranch size={16} />}
+            accent="var(--tt-brand)"
+          />
+          <StatTile
+            label="Delegated cost"
+            value={`$${deleg.delegated_cost.toFixed(2)}`}
+            hint="Priced per subagent's own model"
+            icon={<DollarSign size={16} />}
+            accent="var(--tt-warn)"
+          />
+          <StatTile
+            label="Sessions that delegated"
+            value={String(deleg.sessions_with_spawns)}
+            hint="Sessions that spawned at least one subagent"
+            icon={<Cpu size={16} />}
+            accent="var(--tt-success)"
+          />
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {subagentTypes.length > 0 && (
+          <Card padding="lg">
+            <CardHeader>
+              <CardTitle><GitBranch size={14} className="text-[var(--tt-brand)]" /> Subagent types</CardTitle>
+              <CardEyebrow>by cost</CardEyebrow>
+            </CardHeader>
+            <ul className="space-y-2">
+              {subagentTypes.map((t) => (
+                <li key={t.name} className="flex items-center justify-between gap-2 text-[11px]">
+                  <span className="min-w-0 flex flex-col">
+                    <span className="font-mono text-[var(--tt-fg)] truncate" title={t.name}>{t.name}</span>
+                    <span className="text-[var(--tt-fg-dim)]">{t.spawns} spawn{t.spawns === 1 ? "" : "s"} · {t.session_count} session{t.session_count === 1 ? "" : "s"}</span>
+                  </span>
+                  <span className="text-right shrink-0">
+                    <span className="block tabular font-semibold text-amber-300">${t.cost.toFixed(2)}</span>
+                    <span className="block tabular text-[var(--tt-fg-dim)]">{compact(t.tokens)} tok</span>
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </Card>
+        )}
+
+        {skills.length > 0 && (
+          <Card padding="lg">
+            <CardHeader>
+              <CardTitle><Zap size={14} className="text-[var(--tt-success)]" /> Skills used</CardTitle>
+              <CardEyebrow>{skills.length} skills</CardEyebrow>
+            </CardHeader>
+            <ul className="space-y-2">
+              {skills.map((s) => (
+                <li key={s.name} className="flex items-center justify-between gap-2 text-[11px]">
+                  <span className="font-mono text-[var(--tt-fg)] truncate" title={s.name}>/{s.name}</span>
+                  <span className="tabular text-[var(--tt-fg-dim)] whitespace-nowrap">
+                    ×{s.invocations} · {s.session_count} session{s.session_count === 1 ? "" : "s"}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </Card>
+        )}
+
+        {mcpServers.length > 0 && (
+          <Card padding="lg">
+            <CardHeader>
+              <CardTitle><Cpu size={14} className="text-cyan-300" /> MCP servers</CardTitle>
+              <CardEyebrow>by calls</CardEyebrow>
+            </CardHeader>
+            <ul className="space-y-3">
+              {mcpServers.map((m) => {
+                const topTools = Object.entries(m.tools).sort((a, b) => b[1] - a[1]).slice(0, 3);
+                return (
+                  <li key={m.name} className="text-[11px]">
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="font-mono text-[var(--tt-fg)] truncate" title={m.name}>{m.name}</span>
+                      <span className="tabular text-[var(--tt-fg-dim)] whitespace-nowrap">
+                        {m.calls} calls · {m.session_count} session{m.session_count === 1 ? "" : "s"}
+                      </span>
+                    </div>
+                    <div className="mt-0.5 text-[10px] text-[var(--tt-fg-dim)] truncate">
+                      {topTools.map(([tool, n]) => `${tool} ×${n}`).join(" · ")}
+                      {Object.keys(m.tools).length > 3 && ` · +${Object.keys(m.tools).length - 3} more`}
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          </Card>
+        )}
+      </div>
+    </Section>
   );
 }
 

--- a/frontend/src/app/analytics/page.tsx
+++ b/frontend/src/app/analytics/page.tsx
@@ -518,7 +518,7 @@ function EcosystemSection({ data }: { data: AnalyticsData }) {
               <CardTitle><GitBranch size={14} className="text-[var(--tt-brand)]" /> Subagent types</CardTitle>
               <CardEyebrow>by cost</CardEyebrow>
             </CardHeader>
-            <ul className="space-y-2">
+            <ul className="space-y-2 max-h-72 overflow-y-auto pr-1">
               {subagentTypes.map((t) => (
                 <li key={t.name} className="flex items-center justify-between gap-2 text-[11px]">
                   <span className="min-w-0 flex flex-col">
@@ -550,7 +550,7 @@ function EcosystemSection({ data }: { data: AnalyticsData }) {
               <CardTitle><Zap size={14} className="text-[var(--tt-success)]" /> Skills used</CardTitle>
               <CardEyebrow>{skills.length} skills</CardEyebrow>
             </CardHeader>
-            <ul className="space-y-2">
+            <ul className="space-y-2 max-h-72 overflow-y-auto pr-1">
               {skills.map((s) => (
                 <li key={s.name} className="flex items-center justify-between gap-2 text-[11px]">
                   <span className="min-w-0">
@@ -574,7 +574,7 @@ function EcosystemSection({ data }: { data: AnalyticsData }) {
               <CardTitle><Cpu size={14} className="text-cyan-300" /> MCP servers</CardTitle>
               <CardEyebrow>by calls</CardEyebrow>
             </CardHeader>
-            <ul className="space-y-3">
+            <ul className="space-y-3 max-h-72 overflow-y-auto pr-1">
               {mcpServers.map((m) => {
                 const topTools = Object.entries(m.tools).sort((a, b) => b[1] - a[1]).slice(0, 3);
                 return (

--- a/frontend/src/app/analytics/page.tsx
+++ b/frontend/src/app/analytics/page.tsx
@@ -26,8 +26,12 @@ interface AnalyticsData {
   by_model?: Record<string, AgentStats & { agent: string }>;
   by_skill?: Record<string, { invocations: number; session_count: number }>;
   by_mcp_server?: Record<string, { calls: number; tools: Record<string, number>; session_count: number }>;
-  by_subagent_type?: Record<string, { spawns: number; tokens: number; cost: number; session_count: number }>;
-  delegation?: { delegated_tokens: number; delegated_cost: number; sessions_with_spawns: number };
+  by_subagent_type?: Record<string, { spawns: number; tokens: number; cost: number; session_count: number; tokens_recorded?: boolean; agents?: string[] }>;
+  delegation?: {
+    delegated_tokens: number; delegated_cost: number; sessions_with_spawns: number;
+    linked_children?: number; linked_child_tokens?: number; linked_child_cost?: number;
+    by_agent?: Record<string, { parents: number; spawns: number; children: number; child_tokens: number; child_cost: number; delegated_tokens: number; delegated_cost: number }>;
+  };
   total: { input: number; output: number; cached: number; total: number; cost: number };
   pricing_updated?: string;
 }
@@ -442,11 +446,11 @@ function EcosystemSection({ data }: { data: AnalyticsData }) {
       description="Subagents your sessions spawned, skills you invoked, and MCP servers you actually used — recorded only where the agent's logs carry the signal (Claude Code is the richest source)."
     >
       {deleg && deleg.sessions_with_spawns > 0 && (
-        <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
           <StatTile
             label="Delegated tokens"
             value={compact(deleg.delegated_tokens)}
-            hint="Consumed by spawned subagents — on top of session totals"
+            hint="Claude subagent transcripts — on top of session totals"
             icon={<GitBranch size={16} />}
             accent="var(--tt-brand)"
           />
@@ -460,11 +464,51 @@ function EcosystemSection({ data }: { data: AnalyticsData }) {
           <StatTile
             label="Sessions that delegated"
             value={String(deleg.sessions_with_spawns)}
-            hint="Sessions that spawned at least one subagent"
+            hint="Across Claude, Grok, Codex, Antigravity, OpenCode & Hermes"
             icon={<Cpu size={16} />}
             accent="var(--tt-success)"
           />
+          <StatTile
+            label="Spawned child sessions"
+            value={String(deleg.linked_children ?? 0)}
+            hint={`${compact(deleg.linked_child_tokens ?? 0)} tokens · $${(deleg.linked_child_cost ?? 0).toFixed(2)} — already in session totals`}
+            icon={<GitBranch size={16} />}
+            accent="var(--tt-info)"
+          />
         </div>
+      )}
+
+      {/* Per-agent delegation: who spawns, and what their children consume */}
+      {deleg?.by_agent && Object.keys(deleg.by_agent).length > 0 && (
+        <Card padding="lg">
+          <CardHeader>
+            <CardTitle><GitBranch size={14} className="text-[var(--tt-brand)]" /> Delegation by agent</CardTitle>
+            <CardEyebrow>{Object.keys(deleg.by_agent).length} agents</CardEyebrow>
+          </CardHeader>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-x-8 gap-y-2">
+            {Object.entries(deleg.by_agent)
+              .sort((a, b) => (b[1].delegated_cost + b[1].child_cost) - (a[1].delegated_cost + a[1].child_cost))
+              .map(([agent, a]) => (
+                <div key={agent} className="flex items-center justify-between gap-2 text-[11px] py-1">
+                  <span className="flex items-center gap-2 min-w-0">
+                    <AgentBadge agent={agent} />
+                    <span className="text-[var(--tt-fg-dim)] whitespace-nowrap">
+                      {a.parents} session{a.parents === 1 ? "" : "s"} · {a.spawns} spawn{a.spawns === 1 ? "" : "s"}
+                    </span>
+                  </span>
+                  <span className="tabular text-right whitespace-nowrap">
+                    {a.delegated_tokens > 0 ? (
+                      <span className="text-amber-300 font-semibold">+{compact(a.delegated_tokens)} · ${a.delegated_cost.toFixed(2)}</span>
+                    ) : a.children > 0 ? (
+                      <span className="text-[var(--tt-fg-muted)]">{compact(a.child_tokens)} in children · ${a.child_cost.toFixed(2)}</span>
+                    ) : (
+                      <span className="text-[var(--tt-fg-dim)]">tokens n/a</span>
+                    )}
+                  </span>
+                </div>
+              ))}
+          </div>
+        </Card>
       )}
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
@@ -479,11 +523,20 @@ function EcosystemSection({ data }: { data: AnalyticsData }) {
                 <li key={t.name} className="flex items-center justify-between gap-2 text-[11px]">
                   <span className="min-w-0 flex flex-col">
                     <span className="font-mono text-[var(--tt-fg)] truncate" title={t.name}>{t.name}</span>
-                    <span className="text-[var(--tt-fg-dim)]">{t.spawns} spawn{t.spawns === 1 ? "" : "s"} · {t.session_count} session{t.session_count === 1 ? "" : "s"}</span>
+                    <span className="text-[var(--tt-fg-dim)]">
+                      {t.spawns} spawn{t.spawns === 1 ? "" : "s"}
+                      {t.agents && t.agents.length > 0 && <> · {t.agents.join(", ")}</>}
+                    </span>
                   </span>
                   <span className="text-right shrink-0">
-                    <span className="block tabular font-semibold text-amber-300">${t.cost.toFixed(2)}</span>
-                    <span className="block tabular text-[var(--tt-fg-dim)]">{compact(t.tokens)} tok</span>
+                    {t.tokens_recorded !== false && (t.tokens > 0 || t.cost > 0) ? (
+                      <>
+                        <span className="block tabular font-semibold text-amber-300">${t.cost.toFixed(2)}</span>
+                        <span className="block tabular text-[var(--tt-fg-dim)]">{compact(t.tokens)} tok</span>
+                      </>
+                    ) : (
+                      <span className="block tabular text-[var(--tt-fg-dim)]">tokens n/a</span>
+                    )}
                   </span>
                 </li>
               ))}

--- a/frontend/src/app/analytics/page.tsx
+++ b/frontend/src/app/analytics/page.tsx
@@ -24,8 +24,8 @@ interface AnalyticsData {
   by_agent: Record<string, AgentStats>;
   by_day: { date: string; total: number; input: number; output: number; cached: number; cost: number }[];
   by_model?: Record<string, AgentStats & { agent: string }>;
-  by_skill?: Record<string, { invocations: number; session_count: number }>;
-  by_mcp_server?: Record<string, { calls: number; tools: Record<string, number>; session_count: number }>;
+  by_skill?: Record<string, { invocations: number; session_count: number; agents?: string[] }>;
+  by_mcp_server?: Record<string, { calls: number; tools: Record<string, number>; session_count: number; agents?: string[] }>;
   by_subagent_type?: Record<string, { spawns: number; tokens: number; cost: number; session_count: number; tokens_recorded?: boolean; agents?: string[] }>;
   delegation?: {
     delegated_tokens: number; delegated_cost: number; sessions_with_spawns: number;
@@ -553,8 +553,13 @@ function EcosystemSection({ data }: { data: AnalyticsData }) {
             <ul className="space-y-2">
               {skills.map((s) => (
                 <li key={s.name} className="flex items-center justify-between gap-2 text-[11px]">
-                  <span className="font-mono text-[var(--tt-fg)] truncate" title={s.name}>/{s.name}</span>
-                  <span className="tabular text-[var(--tt-fg-dim)] whitespace-nowrap">
+                  <span className="min-w-0">
+                    <span className="font-mono text-[var(--tt-fg)] truncate block" title={s.name}>/{s.name}</span>
+                    {s.agents && s.agents.length > 0 && (
+                      <span className="text-[10px] text-[var(--tt-fg-dim)]">{s.agents.join(", ")}</span>
+                    )}
+                  </span>
+                  <span className="tabular text-[var(--tt-fg-dim)] whitespace-nowrap shrink-0">
                     ×{s.invocations} · {s.session_count} session{s.session_count === 1 ? "" : "s"}
                   </span>
                 </li>
@@ -581,6 +586,7 @@ function EcosystemSection({ data }: { data: AnalyticsData }) {
                       </span>
                     </div>
                     <div className="mt-0.5 text-[10px] text-[var(--tt-fg-dim)] truncate">
+                      {m.agents && m.agents.length > 0 && <span className="text-[var(--tt-fg-muted)]">{m.agents.join(", ")} · </span>}
                       {topTools.map(([tool, n]) => `${tool} ×${n}`).join(" · ")}
                       {Object.keys(m.tools).length > 3 && ` · +${Object.keys(m.tools).length - 3} more`}
                     </div>

--- a/frontend/src/app/projects/[path]/_lib/project-context.tsx
+++ b/frontend/src/app/projects/[path]/_lib/project-context.tsx
@@ -22,6 +22,22 @@ export interface SessionRow {
   copilot_source?: string;
   antigravity_source?: string;
   tokens?: { input: number; output: number; cached: number; total: number };
+  cost?: number;
+  /* Delegation & ecosystem telemetry (see DESIGN.md) */
+  delegation?: {
+    supported: boolean;
+    tokens_recorded?: boolean;
+    spawn_count?: number;
+    delegated_total?: number;
+    linked_children?: number;
+    by_type?: Record<string, { count: number; total?: number; cost?: number; child_session_ids?: string[] }>;
+  };
+  delegated_cost?: number;
+  parent_session_id?: string | null;
+  child_session_ids?: string[];
+  subagent_info?: { role?: string; nickname?: string; depth?: number };
+  skills_used?: { name: string; count: number }[];
+  mcp_usage?: Record<string, Record<string, number>>;
 }
 
 export interface ProjectData {

--- a/frontend/src/app/projects/[path]/config/page.tsx
+++ b/frontend/src/app/projects/[path]/config/page.tsx
@@ -31,9 +31,16 @@ interface ProjectConfig {
   plugins: PluginItem[];
 }
 
+interface UsageData {
+  by_skill?: Record<string, { invocations: number; session_count: number }>;
+  by_mcp_server?: Record<string, { calls: number; tools: Record<string, number>; session_count: number }>;
+  by_subagent_type?: Record<string, { spawns: number; tokens: number; cost: number; session_count: number }>;
+}
+
 export default function ConfigTab() {
   const { decodedPath } = useProject();
   const [config, setConfig] = useState<ProjectConfig | null>(null);
+  const [usage, setUsage] = useState<UsageData | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -44,6 +51,26 @@ export default function ConfigTab() {
       .catch(() => {})
       .finally(() => setLoading(false));
   }, [decodedPath]);
+
+  // Usage overlay: cross-link recorded skill/MCP/subagent invocations from
+  // session telemetry onto the inventory ("installed but never used" is itself
+  // an insight). Signal currently comes from Claude Code session logs.
+  useEffect(() => {
+    apiFetch(`/analytics`)
+      .then((r) => r.json())
+      .then(setUsage)
+      .catch(() => {});
+  }, []);
+
+  const skillUse = (x: ConfigItem) => {
+    const m = usage?.by_skill || {};
+    if (m[x.name]) return m[x.name];
+    // Plugin-namespaced skills are invoked as "<plugin>:<name>".
+    const plugin = x.pluginRef ? String(x.pluginRef).split("@")[0] : null;
+    return plugin ? m[`${plugin}:${x.name}`] : undefined;
+  };
+  const mcpUse = (x: ConfigItem) => usage?.by_mcp_server?.[x.name];
+  const subagentUse = (x: ConfigItem) => usage?.by_subagent_type?.[x.name];
 
   if (loading) {
     return (
@@ -101,10 +128,10 @@ export default function ConfigTab() {
         ) : (
           <div className="space-y-5">
             {pb.project.length  > 0 && <Group label="Plugins"   icon={<Puzzle size={12} className="text-violet-400" />}    items={pb.project}  render={renderPlugin} />}
-            {ag.project.length  > 0 && <Group label="Subagents" icon={<Users size={12} className="text-purple-400" />}     items={ag.project}  render={renderSubagent} />}
-            {sb.project.length  > 0 && <Group label="Skills"    icon={<BookOpen size={12} className="text-cyan-400" />}    items={sb.project}  render={renderSkill} />}
-            {cb.project.length  > 0 && <Group label="Commands"  icon={<Terminal size={12} className="text-emerald-400" />} items={cb.project}  render={renderCommand} />}
-            {mb.project.length  > 0 && <Group label="MCP servers" icon={<Wrench size={12} className="text-emerald-400" />} items={mb.project} render={renderMcp} />}
+            {ag.project.length  > 0 && <Group label="Subagents" icon={<Users size={12} className="text-purple-400" />}     items={ag.project}  render={(x) => renderSubagent(x, subagentUse(x), usage !== null)} />}
+            {sb.project.length  > 0 && <Group label="Skills"    icon={<BookOpen size={12} className="text-cyan-400" />}    items={sb.project}  render={(x) => renderSkill(x, skillUse(x), usage !== null)} />}
+            {cb.project.length  > 0 && <Group label="Commands"  icon={<Terminal size={12} className="text-emerald-400" />} items={cb.project}  render={(x) => renderCommand(x, skillUse(x), usage !== null)} />}
+            {mb.project.length  > 0 && <Group label="MCP servers" icon={<Wrench size={12} className="text-emerald-400" />} items={mb.project} render={(x) => renderMcp(x, mcpUse(x), usage !== null)} />}
             {mem.project.length > 0 && <Group label="Memory files" icon={<FileText size={12} className="text-amber-400" />} items={mem.project} render={renderMemory} cols={1} />}
           </div>
         )}
@@ -133,10 +160,10 @@ export default function ConfigTab() {
           </summary>
           <div className="px-5 py-5 border-t border-[var(--tt-border)] space-y-5">
             {pb.user.length  > 0 && <Group label="Plugins"   icon={<Puzzle size={12} className="text-violet-400" />}    items={pb.user}  render={renderPlugin} />}
-            {ag.user.length  > 0 && <Group label="Subagents" icon={<Users size={12} className="text-purple-400" />}     items={ag.user}  render={renderSubagent} />}
-            {sb.user.length  > 0 && <Group label="Skills"    icon={<BookOpen size={12} className="text-cyan-400" />}    items={sb.user}  render={renderSkill} />}
-            {cb.user.length  > 0 && <Group label="Commands"  icon={<Terminal size={12} className="text-emerald-400" />} items={cb.user}  render={renderCommand} />}
-            {mb.user.length  > 0 && <Group label="MCP servers" icon={<Wrench size={12} className="text-emerald-400" />} items={mb.user}  render={renderMcp} />}
+            {ag.user.length  > 0 && <Group label="Subagents" icon={<Users size={12} className="text-purple-400" />}     items={ag.user}  render={(x) => renderSubagent(x, subagentUse(x), usage !== null)} />}
+            {sb.user.length  > 0 && <Group label="Skills"    icon={<BookOpen size={12} className="text-cyan-400" />}    items={sb.user}  render={(x) => renderSkill(x, skillUse(x), usage !== null)} />}
+            {cb.user.length  > 0 && <Group label="Commands"  icon={<Terminal size={12} className="text-emerald-400" />} items={cb.user}  render={(x) => renderCommand(x, skillUse(x), usage !== null)} />}
+            {mb.user.length  > 0 && <Group label="MCP servers" icon={<Wrench size={12} className="text-emerald-400" />} items={mb.user}  render={(x) => renderMcp(x, mcpUse(x), usage !== null)} />}
             {mem.user.length > 0 && <Group label="Memory files" icon={<FileText size={12} className="text-amber-400" />} items={mem.user} render={renderMemory} cols={1} />}
           </div>
         </details>
@@ -172,7 +199,26 @@ function Group({
   );
 }
 
-const renderSkill = (s: ConfigItem) => (
+/* Usage overlay chip. Counts come from scanned session telemetry — the skill/
+   subagent signal is recorded by Claude Code logs (other agents don't log it),
+   so "no recorded use" means "not seen in recent scanned sessions", not proof
+   of zero use everywhere. */
+function UsageChip({ loaded, text }: { loaded: boolean; text: string | null }) {
+  if (!loaded) return null;
+  if (!text) {
+    return (
+      <div className="mt-2 text-[10px] text-[var(--tt-fg-faint)]"
+           title="Not seen in recently scanned sessions (usage signal currently recorded by Claude Code logs)">
+        no recorded use
+      </div>
+    );
+  }
+  return <div className="mt-2 text-[10px] tabular text-cyan-300/80">{text}</div>;
+}
+
+const sessionsLabel = (n: number) => `${n} session${n === 1 ? "" : "s"}`;
+
+const renderSkill = (s: ConfigItem, use?: { invocations: number; session_count: number }, loaded = false) => (
   <Card padding="sm" className="!p-3.5">
     <div className="flex items-start justify-between gap-2 mb-1.5">
       <span className="text-[13px] font-semibold text-[var(--tt-fg)] truncate">{s.name}</span>
@@ -185,10 +231,11 @@ const renderSkill = (s: ConfigItem) => (
         {String(s.source).replace(/^.*\//, "")}
       </div>
     )}
+    <UsageChip loaded={loaded} text={use ? `used ×${use.invocations} · ${sessionsLabel(use.session_count)}` : null} />
   </Card>
 );
 
-const renderSubagent = (a: ConfigItem) => {
+const renderSubagent = (a: ConfigItem, use?: { spawns: number; cost: number; session_count: number }, loaded = false) => {
   const sa = a as SubagentItem;
   return (
     <Card padding="sm" className="!p-3.5">
@@ -209,11 +256,12 @@ const renderSubagent = (a: ConfigItem) => {
         )}
         {sa.pluginRef && <PluginRef ref_={sa.pluginRef} />}
       </div>
+      <UsageChip loaded={loaded} text={use ? `spawned ×${use.spawns} · ${sessionsLabel(use.session_count)} · $${use.cost.toFixed(2)}` : null} />
     </Card>
   );
 };
 
-const renderCommand = (c: ConfigItem) => (
+const renderCommand = (c: ConfigItem, use?: { invocations: number; session_count: number }, loaded = false) => (
   <Card padding="sm" className="!p-3.5">
     <div className="flex items-start justify-between gap-2 mb-1.5">
       <span className="font-mono text-[13px] font-semibold text-[var(--tt-fg)] truncate">/{c.name}</span>
@@ -221,10 +269,11 @@ const renderCommand = (c: ConfigItem) => (
     </div>
     {c.description && <p className="text-[11px] text-[var(--tt-fg-muted)] leading-relaxed line-clamp-3">{String(c.description)}</p>}
     {c.pluginRef && <PluginRef ref_={String(c.pluginRef)} />}
+    <UsageChip loaded={loaded} text={use ? `used ×${use.invocations} · ${sessionsLabel(use.session_count)}` : null} />
   </Card>
 );
 
-const renderMcp = (m: ConfigItem) => {
+const renderMcp = (m: ConfigItem, use?: { calls: number; tools: Record<string, number>; session_count: number }, loaded = false) => {
   const mm = m as McpItem;
   return (
     <Card padding="sm" className="!p-3.5">
@@ -246,6 +295,7 @@ const renderMcp = (m: ConfigItem) => {
       )}
       {mm.type && <div className="mt-2 text-[10px] font-mono text-[var(--tt-fg-faint)] uppercase tracking-[0.16em]">{mm.type}</div>}
       {mm.pluginRef && <PluginRef ref_={mm.pluginRef} />}
+      <UsageChip loaded={loaded} text={use ? `${use.calls} calls · ${Object.keys(use.tools).length} tools · ${sessionsLabel(use.session_count)}` : null} />
     </Card>
   );
 };

--- a/frontend/src/app/projects/[path]/insights/page.tsx
+++ b/frontend/src/app/projects/[path]/insights/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Fragment, useMemo, useState } from "react";
-import { Sparkles, Activity, Flame, Clock4, Wrench } from "lucide-react";
+import { Sparkles, Activity, Flame, Clock4, Wrench, GitBranch, Zap, Cpu } from "lucide-react";
 
 import { getAgent } from "@/lib/agents";
 import { cn } from "@/lib/cn";
@@ -106,6 +106,74 @@ export default function InsightsTab() {
     };
   }, [sessions]);
 
+  // Delegation & ecosystem, scoped to this project's sessions and broken down
+  // per agent. Same count-once rules as /analytics: claude's delegated bucket
+  // is extra usage; spawned child sessions are attribution over tokens already
+  // counted; agents without the signal simply don't appear.
+  const eco = useMemo(() => {
+    type AgentRow = { parents: number; spawns: number; children: number; childTokens: number; childCost: number; delegatedTokens: number; delegatedCost: number };
+    const byAgent: Record<string, AgentRow> = {};
+    const types: Record<string, { spawns: number; tokens: number; cost: number; recorded: boolean; agents: Set<string> }> = {};
+    const skills: Record<string, { invocations: number; sessions: number }> = {};
+    const mcp: Record<string, { calls: number; sessions: number; tools: Record<string, number> }> = {};
+    const byKey = new Map(sessions.map((s) => [`${s.agent}:${s.id}`, s]));
+    let delegatedTokens = 0, delegatedCost = 0, sessionsWithSpawns = 0, linkedChildren = 0, childTokens = 0;
+
+    const arow = (a: string) => (byAgent[a] ||= { parents: 0, spawns: 0, children: 0, childTokens: 0, childCost: 0, delegatedTokens: 0, delegatedCost: 0 });
+    const trow = (t: string) => (types[t] ||= { spawns: 0, tokens: 0, cost: 0, recorded: false, agents: new Set() });
+
+    for (const s of sessions) {
+      const d = s.delegation;
+      const spawns = d?.spawn_count || d?.linked_children || 0;
+      if (spawns > 0) {
+        sessionsWithSpawns++;
+        const r = arow(s.agent); r.parents++; r.spawns += spawns;
+      }
+      for (const [t, info] of Object.entries(d?.by_type || {})) {
+        const r = trow(t);
+        r.spawns += info.count || 0;
+        r.agents.add(s.agent);
+        if (info.total || info.cost) {
+          r.tokens += info.total || 0; r.cost += info.cost || 0; r.recorded = true;
+        }
+        for (const cid of info.child_session_ids || []) {
+          const c = byKey.get(`${s.agent}:${cid}`);
+          if (c) { r.tokens += c.tokens?.total || 0; r.cost += c.cost || 0; r.recorded = true; }
+        }
+      }
+      if (s.parent_session_id && s.subagent_info?.role) {
+        const r = trow(s.subagent_info.role);
+        r.spawns++; r.agents.add(s.agent);
+        r.tokens += s.tokens?.total || 0; r.cost += s.cost || 0; r.recorded = true;
+      }
+      if (d?.tokens_recorded && d?.delegated_total) {
+        delegatedTokens += d.delegated_total; delegatedCost += s.delegated_cost || 0;
+        const r = arow(s.agent); r.delegatedTokens += d.delegated_total; r.delegatedCost += s.delegated_cost || 0;
+      }
+      if (s.parent_session_id) {
+        linkedChildren++; childTokens += s.tokens?.total || 0;
+        const r = arow(s.agent); r.children++; r.childTokens += s.tokens?.total || 0; r.childCost += s.cost || 0;
+      }
+      for (const sk of s.skills_used || []) {
+        const r = (skills[sk.name] ||= { invocations: 0, sessions: 0 });
+        r.invocations += sk.count; r.sessions++;
+      }
+      for (const [srv, tools] of Object.entries(s.mcp_usage || {})) {
+        const r = (mcp[srv] ||= { calls: 0, sessions: 0, tools: {} });
+        r.sessions++;
+        for (const [tool, n] of Object.entries(tools)) { r.calls += n; r.tools[tool] = (r.tools[tool] || 0) + n; }
+      }
+    }
+    return {
+      byAgent: Object.entries(byAgent).sort((a, b) => (b[1].delegatedCost + b[1].childCost) - (a[1].delegatedCost + a[1].childCost)),
+      types: Object.entries(types).map(([name, t]) => ({ name, ...t, agents: [...t.agents] })).sort((a, b) => b.cost - a.cost),
+      skills: Object.entries(skills).sort((a, b) => b[1].invocations - a[1].invocations),
+      mcp: Object.entries(mcp).sort((a, b) => b[1].calls - a[1].calls),
+      delegatedTokens, delegatedCost, sessionsWithSpawns, linkedChildren, childTokens,
+      any: sessionsWithSpawns > 0 || Object.keys(skills).length > 0 || Object.keys(mcp).length > 0,
+    };
+  }, [sessions]);
+
   const totalTokens = insights.agents.reduce((a, [, x]) => a + x.tokens, 0);
   const totalSessions = insights.agents.reduce((a, [, x]) => a + x.count, 0);
 
@@ -196,6 +264,123 @@ export default function InsightsTab() {
           </div>
         )}
       </Card>
+
+      {/* Delegation & ecosystem — this project's subagent spawns, skills and
+          MCP usage, per agent. Only agents whose logs record the signal appear. */}
+      {eco.any && (
+        <Card padding="lg">
+          <CardHeader>
+            <div>
+              <CardTitle><GitBranch size={14} className="text-[var(--tt-brand)]" /> Delegation & ecosystem</CardTitle>
+              <p className="text-[11px] text-[var(--tt-fg-dim)] mt-0.5">
+                {eco.sessionsWithSpawns > 0
+                  ? <>{eco.sessionsWithSpawns} session{eco.sessionsWithSpawns === 1 ? "" : "s"} delegated work in this project
+                      {eco.delegatedTokens > 0 && <> · +{fmtNum(eco.delegatedTokens)} delegated tokens (${eco.delegatedCost.toFixed(2)})</>}
+                      {eco.linkedChildren > 0 && <> · {eco.linkedChildren} child session{eco.linkedChildren === 1 ? "" : "s"} ({fmtNum(eco.childTokens)} tok, already in totals)</>}</>
+                  : "Skill & MCP usage recorded in this project's sessions."}
+              </p>
+            </div>
+          </CardHeader>
+
+          {eco.byAgent.length > 0 && (
+            <div className="space-y-2 mb-2">
+              {eco.byAgent.map(([a, r]) => {
+                const meta = getAgent(a);
+                return (
+                  <div key={a} className="grid grid-cols-[120px_1fr_auto] items-center gap-3">
+                    <span className="text-[11px] font-semibold uppercase tracking-[0.14em] truncate" style={{ color: meta.hex }}>
+                      {meta.label}
+                    </span>
+                    <span className="text-[11px] text-[var(--tt-fg-dim)]">
+                      {r.parents} session{r.parents === 1 ? "" : "s"} · {r.spawns} spawn{r.spawns === 1 ? "" : "s"}
+                      {r.children > 0 && <> · {r.children} child session{r.children === 1 ? "" : "s"}</>}
+                    </span>
+                    <span className="tabular text-[10px] text-right whitespace-nowrap">
+                      {r.delegatedTokens > 0 ? (
+                        <span className="text-amber-300 font-semibold">+{fmtNum(r.delegatedTokens)} tok · ${r.delegatedCost.toFixed(2)}</span>
+                      ) : r.children > 0 ? (
+                        <span className="text-[var(--tt-fg-muted)]">{fmtNum(r.childTokens)} tok in children · ${r.childCost.toFixed(2)}</span>
+                      ) : (
+                        <span className="text-[var(--tt-fg-dim)]">tokens n/a</span>
+                      )}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {(eco.types.length > 0 || eco.skills.length > 0 || eco.mcp.length > 0) && (
+            <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mt-5 pt-5 border-t border-[var(--tt-border)]">
+              {eco.types.length > 0 && (
+                <div>
+                  <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--tt-fg-dim)] mb-2 flex items-center gap-1.5">
+                    <GitBranch size={11} /> Subagent types
+                  </div>
+                  <ul className="space-y-1.5">
+                    {eco.types.map((t) => (
+                      <li key={t.name} className="flex items-center justify-between gap-2 text-[11px]">
+                        <span className="min-w-0">
+                          <span className="font-mono text-[var(--tt-fg)] truncate block" title={t.name}>{t.name}</span>
+                          <span className="text-[var(--tt-fg-dim)]">{t.spawns} spawn{t.spawns === 1 ? "" : "s"} · {t.agents.join(", ")}</span>
+                        </span>
+                        <span className="tabular text-right text-[10px] shrink-0">
+                          {t.recorded ? (
+                            <>
+                              <span className="block font-semibold text-amber-300">${t.cost.toFixed(2)}</span>
+                              <span className="block text-[var(--tt-fg-dim)]">{fmtNum(t.tokens)} tok</span>
+                            </>
+                          ) : (
+                            <span className="text-[var(--tt-fg-dim)]">tokens n/a</span>
+                          )}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+              {eco.skills.length > 0 && (
+                <div>
+                  <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--tt-fg-dim)] mb-2 flex items-center gap-1.5">
+                    <Zap size={11} /> Skills used
+                  </div>
+                  <ul className="space-y-1.5">
+                    {eco.skills.slice(0, 12).map(([name, r]) => (
+                      <li key={name} className="flex items-center justify-between gap-2 text-[11px]">
+                        <span className="font-mono text-[var(--tt-fg)] truncate" title={name}>/{name}</span>
+                        <span className="tabular text-[10px] text-[var(--tt-fg-dim)] whitespace-nowrap">×{r.invocations} · {r.sessions} sess</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+              {eco.mcp.length > 0 && (
+                <div>
+                  <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--tt-fg-dim)] mb-2 flex items-center gap-1.5">
+                    <Cpu size={11} /> MCP servers
+                  </div>
+                  <ul className="space-y-2">
+                    {eco.mcp.slice(0, 8).map(([name, r]) => {
+                      const top = Object.entries(r.tools).sort((a, b) => b[1] - a[1]).slice(0, 3);
+                      return (
+                        <li key={name} className="text-[11px]">
+                          <div className="flex items-center justify-between gap-2">
+                            <span className="font-mono text-[var(--tt-fg)] truncate" title={name}>{name}</span>
+                            <span className="tabular text-[10px] text-[var(--tt-fg-dim)] whitespace-nowrap">{r.calls} calls · {r.sessions} sess</span>
+                          </div>
+                          <div className="text-[10px] text-[var(--tt-fg-dim)] truncate">
+                            {top.map(([tool, n]) => `${tool} ×${n}`).join(" · ")}
+                          </div>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </div>
+              )}
+            </div>
+          )}
+        </Card>
+      )}
 
       {/* Leaderboard + migration ribbon */}
       <Card padding="lg">

--- a/frontend/src/app/projects/[path]/insights/page.tsx
+++ b/frontend/src/app/projects/[path]/insights/page.tsx
@@ -317,7 +317,7 @@ export default function InsightsTab() {
                   <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--tt-fg-dim)] mb-2 flex items-center gap-1.5">
                     <GitBranch size={11} /> Subagent types
                   </div>
-                  <ul className="space-y-1.5">
+                  <ul className="space-y-1.5 max-h-64 overflow-y-auto pr-1">
                     {eco.types.map((t) => (
                       <li key={t.name} className="flex items-center justify-between gap-2 text-[11px]">
                         <span className="min-w-0">
@@ -344,8 +344,8 @@ export default function InsightsTab() {
                   <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--tt-fg-dim)] mb-2 flex items-center gap-1.5">
                     <Zap size={11} /> Skills used
                   </div>
-                  <ul className="space-y-1.5">
-                    {eco.skills.slice(0, 12).map(([name, r]) => (
+                  <ul className="space-y-1.5 max-h-64 overflow-y-auto pr-1">
+                    {eco.skills.map(([name, r]) => (
                       <li key={name} className="flex items-center justify-between gap-2 text-[11px]">
                         <span className="min-w-0">
                           <span className="font-mono text-[var(--tt-fg)] truncate block" title={name}>/{name}</span>
@@ -362,8 +362,8 @@ export default function InsightsTab() {
                   <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--tt-fg-dim)] mb-2 flex items-center gap-1.5">
                     <Cpu size={11} /> MCP servers
                   </div>
-                  <ul className="space-y-2">
-                    {eco.mcp.slice(0, 8).map(([name, r]) => {
+                  <ul className="space-y-2 max-h-64 overflow-y-auto pr-1">
+                    {eco.mcp.map(([name, r]) => {
                       const top = Object.entries(r.tools).sort((a, b) => b[1] - a[1]).slice(0, 3);
                       return (
                         <li key={name} className="text-[11px]">

--- a/frontend/src/app/projects/[path]/insights/page.tsx
+++ b/frontend/src/app/projects/[path]/insights/page.tsx
@@ -114,8 +114,8 @@ export default function InsightsTab() {
     type AgentRow = { parents: number; spawns: number; children: number; childTokens: number; childCost: number; delegatedTokens: number; delegatedCost: number };
     const byAgent: Record<string, AgentRow> = {};
     const types: Record<string, { spawns: number; tokens: number; cost: number; recorded: boolean; agents: Set<string> }> = {};
-    const skills: Record<string, { invocations: number; sessions: number }> = {};
-    const mcp: Record<string, { calls: number; sessions: number; tools: Record<string, number> }> = {};
+    const skills: Record<string, { invocations: number; sessions: number; agents: Set<string> }> = {};
+    const mcp: Record<string, { calls: number; sessions: number; tools: Record<string, number>; agents: Set<string> }> = {};
     const byKey = new Map(sessions.map((s) => [`${s.agent}:${s.id}`, s]));
     let delegatedTokens = 0, delegatedCost = 0, sessionsWithSpawns = 0, linkedChildren = 0, childTokens = 0;
 
@@ -155,12 +155,12 @@ export default function InsightsTab() {
         const r = arow(s.agent); r.children++; r.childTokens += s.tokens?.total || 0; r.childCost += s.cost || 0;
       }
       for (const sk of s.skills_used || []) {
-        const r = (skills[sk.name] ||= { invocations: 0, sessions: 0 });
-        r.invocations += sk.count; r.sessions++;
+        const r = (skills[sk.name] ||= { invocations: 0, sessions: 0, agents: new Set() });
+        r.invocations += sk.count; r.sessions++; r.agents.add(s.agent);
       }
       for (const [srv, tools] of Object.entries(s.mcp_usage || {})) {
-        const r = (mcp[srv] ||= { calls: 0, sessions: 0, tools: {} });
-        r.sessions++;
+        const r = (mcp[srv] ||= { calls: 0, sessions: 0, tools: {}, agents: new Set() });
+        r.sessions++; r.agents.add(s.agent);
         for (const [tool, n] of Object.entries(tools)) { r.calls += n; r.tools[tool] = (r.tools[tool] || 0) + n; }
       }
     }
@@ -347,8 +347,11 @@ export default function InsightsTab() {
                   <ul className="space-y-1.5">
                     {eco.skills.slice(0, 12).map(([name, r]) => (
                       <li key={name} className="flex items-center justify-between gap-2 text-[11px]">
-                        <span className="font-mono text-[var(--tt-fg)] truncate" title={name}>/{name}</span>
-                        <span className="tabular text-[10px] text-[var(--tt-fg-dim)] whitespace-nowrap">×{r.invocations} · {r.sessions} sess</span>
+                        <span className="min-w-0">
+                          <span className="font-mono text-[var(--tt-fg)] truncate block" title={name}>/{name}</span>
+                          <span className="text-[10px] text-[var(--tt-fg-dim)]">{[...r.agents].join(", ")}</span>
+                        </span>
+                        <span className="tabular text-[10px] text-[var(--tt-fg-dim)] whitespace-nowrap shrink-0">×{r.invocations} · {r.sessions} sess</span>
                       </li>
                     ))}
                   </ul>
@@ -369,6 +372,7 @@ export default function InsightsTab() {
                             <span className="tabular text-[10px] text-[var(--tt-fg-dim)] whitespace-nowrap">{r.calls} calls · {r.sessions} sess</span>
                           </div>
                           <div className="text-[10px] text-[var(--tt-fg-dim)] truncate">
+                            <span className="text-[var(--tt-fg-muted)]">{[...r.agents].join(", ")} · </span>
                             {top.map(([tool, n]) => `${tool} ×${n}`).join(" · ")}
                           </div>
                         </li>

--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -99,6 +99,45 @@ function eventKind(evt: Event): StepKind {
   return "other";
 }
 
+/* Normalize a raw trace payload (session detail or subagent transcript) into
+   renderable events — shared by the main trace fetch and the subagent
+   drill-in viewer so both filter the same noise. */
+function normalizeTraceEvents(agent: string | null, data: any): Event[] {
+  let evts: any[] = [];
+  if (agent === "gemini" || agent === "antigravity") {
+    evts = (data?.messages || []).map((m: any) => ({
+      ...m,
+      type: m.type === "gemini" ? "assistant" : m.type,
+    }));
+  } else {
+    evts = Array.isArray(data) ? data : [];
+  }
+  if (data && typeof data === "object" && !Array.isArray(data) && data.error) {
+    evts = [];
+  }
+  if (agent === "codex") {
+    evts = evts.filter((e: any) => {
+      if (e.type === "turn_context") return false;
+      if (e.type === "event_msg" && e.payload?.type === "token_count") return false;
+      return true;
+    });
+  }
+  if (agent === "claude" || agent === "cursor") {
+    const NOISE_TYPES = new Set([
+      "last-prompt", "permission-mode", "ai-title", "file-history-snapshot",
+      "queue-operation", "attachment", "system",
+    ]);
+    evts = evts.filter((e: any) => {
+      if (NOISE_TYPES.has(e.type)) return false;
+      if (e.type === "user" && e.isMeta) return false;
+      const c = e.message?.content;
+      if (e.type === "user" && typeof c === "string" && c.startsWith("<local-command-")) return false;
+      return true;
+    });
+  }
+  return evts;
+}
+
 function normalizeTs(evt: Event): number | undefined {
   if (typeof evt.normalized_timestamp === "number") return evt.normalized_timestamp;
   if (evt.timestamp) {
@@ -160,6 +199,9 @@ export default function SessionDetailPage() {
   const [allHermesSessions, setAllHermesSessions] = useState<Session[] | null>(null);
   const [grokForensics, setGrokForensics] = useState<any | null>(null);
   const [delegation, setDelegation] = useState<any | null>(null);
+  // Subagent drill-in: holds the spawn entry whose trace is open in the
+  // slide-over viewer. Parent trace state (scrubber, tabs) stays untouched.
+  const [subagentView, setSubagentView] = useState<any | null>(null);
 
   // Trace View States
   const [splitView, setSplitView] = useState(false);
@@ -190,43 +232,7 @@ export default function SessionDetailPage() {
       apiFetch(`/sessions/${id}?agent=${agent}`)
         .then((res) => res.json())
         .then((data) => {
-          let evts: any[] = [];
-          if (agent === 'gemini' || agent === 'antigravity') {
-            evts = (data.messages || []).map((m: any) => ({
-              ...m,
-              type: m.type === 'gemini' ? 'assistant' : m.type
-            }));
-          } else {
-            evts = Array.isArray(data) ? data : [];
-          }
-          // Strip codex noise events that clutter the step index with no UX value
-          if (agent === 'codex') {
-            evts = evts.filter((e: any) => {
-              if (e.type === 'turn_context') return false;
-              if (e.type === 'event_msg' && e.payload?.type === 'token_count') return false;
-              return true;
-            });
-          }
-          // Antigravity log-only sessions return { error: "Not found" } from the detail endpoint —
-          // surface that upstream as an empty trace so the empty-state renders instead of a broken viewer.
-          if (data && typeof data === 'object' && !Array.isArray(data) && data.error) {
-            evts = [];
-          }
-          // Strip Claude / Cursor noise events that don't render meaningful trace UI
-          if (agent === 'claude' || agent === 'cursor') {
-            const NOISE_TYPES = new Set([
-              'last-prompt', 'permission-mode', 'ai-title', 'file-history-snapshot',
-              'queue-operation', 'attachment', 'system',
-            ]);
-            evts = evts.filter((e: any) => {
-              if (NOISE_TYPES.has(e.type)) return false;
-              // Drop synthetic local-command echo pings
-              if (e.type === 'user' && e.isMeta) return false;
-              const c = e.message?.content;
-              if (e.type === 'user' && typeof c === 'string' && c.startsWith('<local-command-')) return false;
-              return true;
-            });
-          }
+          const evts = normalizeTraceEvents(agent, data);
           setEvents(evts);
           setPlaybackIndex(evts.length);
           setLoading(false)
@@ -672,7 +678,7 @@ export default function SessionDetailPage() {
              {/* Grok Build forensics — token growth, permissions, tool lifecycle, plan mode */}
              {agent === "grok" && grokForensics && <GrokForensicsCard forensics={grokForensics} cost={sessionInfo?.tokens?.cost ?? sessionInfo?.cost} />}
              {/* Delegated work — subagent spawns and what they actually cost */}
-             {delegation && agent && <DelegationCard delegation={delegation} agent={agent} />}
+             {delegation && agent && <DelegationCard delegation={delegation} agent={agent} sessionId={id} onOpenSubagent={setSubagentView} />}
              <div className={splitView ? "grid grid-cols-2 gap-8" : "space-y-8"}>
                 <div className="space-y-8">
                    {splitView && <h3 className="text-[10px] font-black text-[var(--tt-fg-dim)] uppercase tracking-[0.2em] ml-2 mb-2 flex items-center gap-2"><User size={14}/> User & Agent Dialogue</h3>}
@@ -750,7 +756,14 @@ export default function SessionDetailPage() {
                 </button>
              </div>
              <div className="p-4 text-[11px]">
-                {sidebarTab === "context" && <ContextPanel ctx={context} />}
+                {sidebarTab === "context" && (
+                  <>
+                    <ContextPanel ctx={context} />
+                    {delegation && agent && ((delegation.subagents?.length ?? 0) > 0 || (delegation.child_session_ids?.length ?? 0) > 0) && (
+                      <SubagentsSidebar delegation={delegation} agent={agent} onOpen={setSubagentView} />
+                    )}
+                  </>
+                )}
                 {sidebarTab === "tools" && <ToolsPanel summary={toolSummary} onJump={(name) => {
                    const idx = events.findIndex((e) => {
                       const mc = Array.isArray(e.message?.content) ? e.message.content : [];
@@ -827,6 +840,152 @@ export default function SessionDetailPage() {
             </div>
          </footer>
       )}
+
+      {/* Subagent drill-in: slide-over trace viewer. Closing returns to the
+          main session exactly where the user left it. */}
+      {subagentView && agent && (
+        <SubagentTraceModal
+          entry={subagentView}
+          agent={agent}
+          sessionId={id}
+          onClose={() => setSubagentView(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+/* Sidebar list of this session's subagents — the at-a-glance "what was
+   delegated" context, one click from each child's full trace. */
+function SubagentsSidebar({ delegation, agent, onOpen }: { delegation: any; agent: string; onOpen: (entry: any) => void }) {
+  const entries: any[] = delegation.subagents?.length
+    ? delegation.subagents
+    : (delegation.child_session_ids || []).map((cid: string) => ({ child_session_id: cid }));
+  if (entries.length === 0) return null;
+  return (
+    <div className="px-4 py-4 border-t border-[var(--tt-border)]">
+      <div className="flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--tt-fg-dim)] mb-3">
+        <GitBranch size={12} /> Subagents
+        <span className="tabular text-[var(--tt-fg-faint)]">{entries.length}</span>
+      </div>
+      <div className="space-y-1.5">
+        {entries.map((s: any, i: number) => (
+          <button
+            key={s.agent_id ?? s.child_session_id ?? i}
+            onClick={() => onOpen(s)}
+            className="w-full text-left rounded-[var(--tt-radius)] border border-[var(--tt-border)] bg-[var(--tt-sunken)] px-2.5 py-2 hover:border-[var(--tt-brand)]/50 transition-colors group"
+          >
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--tt-brand)]">
+                {s.agent_type || s.agent_role || "subagent"}
+              </span>
+              <ChevronRight size={12} className="text-[var(--tt-fg-faint)] group-hover:text-[var(--tt-fg)] shrink-0" />
+            </div>
+            <div className="text-[11px] text-[var(--tt-fg)] truncate mt-0.5">
+              {s.description || s.nickname || s.child_session_id || s.agent_id}
+            </div>
+            <div className="text-[10px] tabular text-[var(--tt-fg-dim)] mt-0.5">
+              {s.model && <span>{String(s.model).replace(/-\d{8}$/, "")} · </span>}
+              {s.tokens != null && <span>{formatTokens(s.tokens.total)} tok · </span>}
+              {s.cost != null && <span>{formatCost(s.cost)} · </span>}
+              {typeof s.duration_ms === "number" && <span>{(s.duration_ms / 1000).toFixed(1)}s</span>}
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* Slide-over trace viewer for one subagent — the LangSmith-style drill-in:
+   inspect the child's full trace without losing your place in the parent.
+   claude/cursor subagent transcripts come from the dedicated trace endpoint
+   (they aren't sessions); everyone else's children are real sessions. */
+function SubagentTraceModal({ entry, agent, sessionId, onClose }: { entry: any; agent: string; sessionId: string; onClose: () => void }) {
+  const [traceEvents, setTraceEvents] = useState<Event[] | null>(null);
+
+  const isTranscript = entry.agent_id && (agent === "claude" || agent === "cursor");
+  const childId: string | null = entry.child_session_id || null;
+
+  useEffect(() => {
+    setTraceEvents(null);
+    const url = isTranscript
+      ? `/sessions/${sessionId}/subagents/${entry.agent_id}/trace?agent=${agent}`
+      : childId
+      ? `/sessions/${childId}?agent=${agent}`
+      : null;
+    if (!url) { setTraceEvents([]); return; }
+    apiFetch(url)
+      .then((r) => r.json())
+      .then((d) => setTraceEvents(normalizeTraceEvents(agent, d)))
+      .catch(() => setTraceEvents([]));
+  }, [entry, agent, sessionId, isTranscript, childId]);
+
+  useEffect(() => {
+    const h = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    window.addEventListener("keydown", h);
+    return () => window.removeEventListener("keydown", h);
+  }, [onClose]);
+
+  const backTo = encodeURIComponent(`/sessions/${sessionId}?agent=${agent}`);
+
+  return (
+    <div className="fixed inset-0 z-50 flex justify-end" role="dialog" aria-modal="true">
+      <div className="absolute inset-0 bg-black/50 backdrop-blur-[2px]" onClick={onClose} />
+      <div className="relative h-full w-full max-w-3xl bg-[var(--tt-canvas)] border-l border-[var(--tt-border)] shadow-2xl flex flex-col">
+        <div className="px-5 py-4 border-b border-[var(--tt-border)] flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <GitBranch size={13} className="text-[var(--tt-brand)] shrink-0" />
+              <span className="text-[10px] font-black uppercase tracking-[0.2em] text-[var(--tt-brand)]">Subagent trace</span>
+              <Badge>{entry.agent_type || entry.agent_role || "subagent"}</Badge>
+            </div>
+            <div className="text-[13px] font-semibold text-[var(--tt-fg)] truncate mt-1">
+              {entry.description || entry.nickname || childId || entry.agent_id}
+            </div>
+            <div className="text-[10px] tabular text-[var(--tt-fg-dim)] mt-0.5">
+              {entry.model && <span>{String(entry.model).replace(/-\d{8}$/, "")} · </span>}
+              {entry.tokens != null && <span>in/out {formatTokens(entry.tokens.input)}/{formatTokens(entry.tokens.output)} · {formatTokens(entry.tokens.cached)} cached · </span>}
+              {entry.cost != null && <span>{formatCost(entry.cost)} · </span>}
+              {typeof entry.duration_ms === "number" && <span>{(entry.duration_ms / 1000).toFixed(1)}s · </span>}
+              {entry.status && <span>{entry.status}</span>}
+            </div>
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
+            {childId && (
+              <Link
+                href={`/sessions/${childId}?agent=${agent}&from=${backTo}`}
+                className="text-[11px] text-[var(--tt-brand)] hover:underline whitespace-nowrap"
+                onClick={onClose}
+              >
+                Open full session →
+              </Link>
+            )}
+            <button
+              onClick={onClose}
+              aria-label="Close subagent trace"
+              className="h-8 w-8 grid place-items-center rounded-md text-[var(--tt-fg-muted)] hover:text-[var(--tt-fg)] hover:tt-tint-1 transition-colors"
+            >
+              ✕
+            </button>
+          </div>
+        </div>
+        <div className="flex-1 overflow-y-auto p-6 space-y-6">
+          {traceEvents === null ? (
+            <div className="space-y-3">
+              <Skeleton className="h-20 w-full" />
+              <Skeleton className="h-20 w-full" />
+              <Skeleton className="h-20 w-full" />
+            </div>
+          ) : traceEvents.length === 0 ? (
+            <div className="text-[12px] text-[var(--tt-fg-dim)] italic py-8 text-center">
+              No per-step trace recorded for this subagent.
+            </div>
+          ) : (
+            traceEvents.map((event, idx) => <EventCard key={idx} event={event} agent={agent} />)
+          )}
+        </div>
+      </div>
     </div>
   );
 }
@@ -1831,7 +1990,7 @@ function ResponseBody({ text, tone = "default" }: { text: string; tone?: "defaul
   );
 }
 
-function DelegationCard({ delegation, agent }: { delegation: any; agent: string }) {
+function DelegationCard({ delegation, agent, sessionId, onOpenSubagent }: { delegation: any; agent: string; sessionId: string; onOpenSubagent?: (entry: any) => void }) {
   const subagents: any[] = delegation?.subagents || [];
   const spawnCount: number = delegation?.spawn_count ?? 0;
   const children: string[] = delegation?.child_session_ids || [];
@@ -1839,6 +1998,9 @@ function DelegationCard({ delegation, agent }: { delegation: any; agent: string 
   // Nothing delegated and not itself a child → no card, no fake zeros.
   if (spawnCount === 0 && children.length === 0 && !parentId) return null;
   const totals = delegation?.totals;
+  // Children listed in subagent entries don't need a duplicate "Child session" row.
+  const inlineChildIds = new Set(subagents.map((s: any) => s.child_session_id).filter(Boolean));
+  const backTo = encodeURIComponent(`/sessions/${sessionId}?agent=${agent}`);
   return (
     <div className="mb-8 bg-[var(--tt-panel)]/60 border border-[var(--tt-brand)]/30 rounded-[var(--tt-radius-lg)] p-5">
       <div className="flex items-center justify-between mb-3">
@@ -1862,7 +2024,13 @@ function DelegationCard({ delegation, agent }: { delegation: any; agent: string 
       {subagents.length > 0 && (
         <div className="space-y-1">
           {subagents.map((s: any, i: number) => (
-            <div key={s.agent_id ?? s.child_session_id ?? i} className="flex items-center justify-between gap-3 text-[11px] font-mono text-[var(--tt-fg-muted)] py-1.5 px-2 hover:bg-[var(--tt-sunken)] rounded">
+            <div
+              key={s.agent_id ?? s.child_session_id ?? i}
+              onClick={() => onOpenSubagent?.(s)}
+              role={onOpenSubagent ? "button" : undefined}
+              title={onOpenSubagent ? "View this subagent's trace" : undefined}
+              className={`flex items-center justify-between gap-3 text-[11px] font-mono text-[var(--tt-fg-muted)] py-1.5 px-2 rounded ${onOpenSubagent ? "cursor-pointer hover:bg-[var(--tt-sunken)] hover:text-[var(--tt-fg)]" : "hover:bg-[var(--tt-sunken)]"}`}
+            >
               <span className="flex items-center gap-2 min-w-0">
                 <Badge>{s.agent_type || s.agent_role || "subagent"}</Badge>
                 <span className="truncate text-[var(--tt-fg)]">{s.description || s.nickname || s.agent_id}</span>
@@ -1877,8 +2045,13 @@ function DelegationCard({ delegation, agent }: { delegation: any; agent: string 
                   </>
                 )}
                 {s.cost != null && <span className="text-[var(--tt-fg)]">{formatCost(s.cost)}</span>}
+                {onOpenSubagent && <span className="text-[var(--tt-brand)]">view ▸</span>}
                 {s.child_session_id && (
-                  <Link href={`/sessions/${s.child_session_id}?agent=${agent}`} className="text-[var(--tt-brand)] hover:underline">open</Link>
+                  <Link
+                    href={`/sessions/${s.child_session_id}?agent=${agent}&from=${backTo}`}
+                    onClick={(e) => e.stopPropagation()}
+                    className="text-[var(--tt-brand)] hover:underline"
+                  >open</Link>
                 )}
               </span>
             </div>
@@ -1894,18 +2067,22 @@ function DelegationCard({ delegation, agent }: { delegation: any; agent: string 
       )}
 
       {/* OpenCode / Hermes: linked child sessions (already counted as sessions) */}
-      {(children.length > 0 || parentId) && (
+      {(children.some((cid) => !inlineChildIds.has(cid)) || parentId) && (
         <div className="space-y-1 text-[11px] font-mono">
           {parentId && (
             <div className="text-[var(--tt-fg-muted)]">
               Spawned by{" "}
-              <Link href={`/sessions/${parentId}?agent=${agent}`} className="text-[var(--tt-brand)] hover:underline">{parentId}</Link>
+              <Link href={`/sessions/${parentId}?agent=${agent}&from=${backTo}`} className="text-[var(--tt-brand)] hover:underline">{parentId}</Link>
             </div>
           )}
-          {children.map((cid) => (
+          {children.filter((cid) => !inlineChildIds.has(cid)).map((cid) => (
             <div key={cid} className="text-[var(--tt-fg-muted)]">
               Child session{" "}
-              <Link href={`/sessions/${cid}?agent=${agent}`} className="text-[var(--tt-brand)] hover:underline">{cid}</Link>
+              {onOpenSubagent ? (
+                <button onClick={() => onOpenSubagent({ child_session_id: cid })} className="text-[var(--tt-brand)] hover:underline font-mono">{cid}</button>
+              ) : (
+                <Link href={`/sessions/${cid}?agent=${agent}&from=${backTo}`} className="text-[var(--tt-brand)] hover:underline">{cid}</Link>
+              )}
               <span className="text-[var(--tt-fg-dim)]"> · tokens counted in its own session</span>
             </div>
           ))}

--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -13,6 +13,7 @@ import CopilotSourceBadge from "@/components/CopilotSourceBadge";
 import AntigravitySourceBadge from "@/components/AntigravitySourceBadge";
 import SummaryPanel from "@/components/summarizer/SummaryPanel";
 import { apiFetch, artifactUrl } from "@/lib/api";
+import { formatTokens, formatCost } from "@/lib/format";
 import { resolveSessionBackTarget } from "@/lib/navigation";
 
 interface Artifact {
@@ -158,6 +159,7 @@ export default function SessionDetailPage() {
   const [hermesOverlay, setHermesOverlay] = useState<any | null>(null);
   const [allHermesSessions, setAllHermesSessions] = useState<Session[] | null>(null);
   const [grokForensics, setGrokForensics] = useState<any | null>(null);
+  const [delegation, setDelegation] = useState<any | null>(null);
 
   // Trace View States
   const [splitView, setSplitView] = useState(false);
@@ -248,6 +250,16 @@ export default function SessionDetailPage() {
           .then(res => res.json())
           .then(data => setGrokForensics(data))
           .catch(() => setGrokForensics(null));
+      }
+
+      // 5. Delegation overlay: subagent spawns + delegated token/cost attribution.
+      // Only agents whose logs record spawns at all (claude full, cursor count-only,
+      // opencode/hermes parent-child links).
+      if (agent === "claude" || agent === "cursor" || agent === "opencode" || agent === "hermes") {
+        apiFetch(`/sessions/${id}/delegation?agent=${agent}`)
+          .then(res => res.json())
+          .then(data => setDelegation(data && data.supported ? data : null))
+          .catch(() => setDelegation(null));
       }
     }
   }, [id, agent]);
@@ -535,6 +547,12 @@ export default function SessionDetailPage() {
                       <TokenStat label="Output" value={sessionInfo.tokens.output.toLocaleString()} />
                       <span className="w-px h-5 bg-[var(--tt-border)]" />
                       <TokenStat label="Cached" value={sessionInfo.tokens.cached.toLocaleString()} accent="text-[var(--tt-cyan-fg)]" />
+                      {delegation?.totals?.total > 0 && (
+                        <>
+                          <span className="w-px h-5 bg-[var(--tt-border)]" />
+                          <TokenStat label="Delegated" value={`+${formatTokens(delegation.totals.total)}`} accent="text-[var(--tt-brand)]" />
+                        </>
+                      )}
                     </>
                   )}
                 </div>
@@ -653,6 +671,8 @@ export default function SessionDetailPage() {
              {agent === "hermes" && hermesOverlay && <HermesOverlayCard overlay={hermesOverlay} />}
              {/* Grok Build forensics — token growth, permissions, tool lifecycle, plan mode */}
              {agent === "grok" && grokForensics && <GrokForensicsCard forensics={grokForensics} cost={sessionInfo?.tokens?.cost ?? sessionInfo?.cost} />}
+             {/* Delegated work — subagent spawns and what they actually cost */}
+             {delegation && agent && <DelegationCard delegation={delegation} agent={agent} />}
              <div className={splitView ? "grid grid-cols-2 gap-8" : "space-y-8"}>
                 <div className="space-y-8">
                    {splitView && <h3 className="text-[10px] font-black text-[var(--tt-fg-dim)] uppercase tracking-[0.2em] ml-2 mb-2 flex items-center gap-2"><User size={14}/> User & Agent Dialogue</h3>}
@@ -1807,6 +1827,82 @@ function ResponseBody({ text, tone = "default" }: { text: string; tone?: "defaul
       >
         {mode === "md" ? "View Raw" : "View MD"}
       </button>
+    </div>
+  );
+}
+
+function DelegationCard({ delegation, agent }: { delegation: any; agent: string }) {
+  const subagents: any[] = delegation?.subagents || [];
+  const spawnCount: number = delegation?.spawn_count ?? 0;
+  const children: string[] = delegation?.child_session_ids || [];
+  const parentId: string | null = delegation?.parent_session_id || null;
+  // Nothing delegated and not itself a child → no card, no fake zeros.
+  if (spawnCount === 0 && children.length === 0 && !parentId) return null;
+  const totals = delegation?.totals;
+  return (
+    <div className="mb-8 bg-[var(--tt-panel)]/60 border border-[var(--tt-brand)]/30 rounded-[var(--tt-radius-lg)] p-5">
+      <div className="flex items-center justify-between mb-3">
+        <div className="text-[10px] font-black uppercase tracking-[0.2em] text-[var(--tt-brand)] flex items-center gap-2">
+          <GitBranch size={12} strokeWidth={3} /> Delegated work
+        </div>
+        {!delegation.tokens_recorded && spawnCount > 0 && (
+          <span className="text-[10px] font-mono text-[var(--tt-fg-dim)]">tokens not recorded by {agent}</span>
+        )}
+      </div>
+
+      {/* Claude: full per-subagent attribution */}
+      {totals && (
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-3">
+          <Stat label="Subagents" value={String(spawnCount)} />
+          <Stat label="Delegated tokens" value={formatTokens(totals.total)} />
+          <Stat label="Cache writes" value={formatTokens(totals.cache_creation)} />
+          <Stat label="Delegated cost" value={formatCost(delegation.cost)} />
+        </div>
+      )}
+      {subagents.length > 0 && delegation.tokens_recorded && (
+        <div className="space-y-1">
+          {subagents.map((s: any, i: number) => (
+            <div key={s.agent_id ?? i} className="flex items-center justify-between gap-3 text-[11px] font-mono text-[var(--tt-fg-muted)] py-1.5 px-2 hover:bg-[var(--tt-sunken)] rounded">
+              <span className="flex items-center gap-2 min-w-0">
+                <Badge>{s.agent_type}</Badge>
+                <span className="truncate text-[var(--tt-fg)]">{s.description || s.agent_id}</span>
+              </span>
+              <span className="flex items-center gap-3 shrink-0">
+                {s.model && <span className="text-[var(--tt-fg-dim)]">{s.model.replace(/-\d{8}$/, "")}</span>}
+                <span>in/out {formatTokens(s.tokens?.input)}/{formatTokens(s.tokens?.output)}</span>
+                <span className="text-[var(--tt-cyan-fg)]">{formatTokens(s.tokens?.cached)} cached</span>
+                <span className="text-[var(--tt-fg)]">{formatCost(s.cost)}</span>
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Cursor: spawn count only — transcripts carry no usage data */}
+      {spawnCount > 0 && !delegation.tokens_recorded && (
+        <div className="text-[11px] text-[var(--tt-fg-muted)]">
+          {spawnCount} subagent run{spawnCount === 1 ? "" : "s"} recorded. {agent === "cursor" ? "Cursor's subagent transcripts contain no token usage, so their cost can't be attributed." : ""}
+        </div>
+      )}
+
+      {/* OpenCode / Hermes: linked child sessions (already counted as sessions) */}
+      {(children.length > 0 || parentId) && (
+        <div className="space-y-1 text-[11px] font-mono">
+          {parentId && (
+            <div className="text-[var(--tt-fg-muted)]">
+              Spawned by{" "}
+              <Link href={`/sessions/${parentId}?agent=${agent}`} className="text-[var(--tt-brand)] hover:underline">{parentId}</Link>
+            </div>
+          )}
+          {children.map((cid) => (
+            <div key={cid} className="text-[var(--tt-fg-muted)]">
+              Child session{" "}
+              <Link href={`/sessions/${cid}?agent=${agent}`} className="text-[var(--tt-brand)] hover:underline">{cid}</Link>
+              <span className="text-[var(--tt-fg-dim)]"> · tokens counted in its own session</span>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -254,8 +254,8 @@ export default function SessionDetailPage() {
 
       // 5. Delegation overlay: subagent spawns + delegated token/cost attribution.
       // Only agents whose logs record spawns at all (claude full, cursor count-only,
-      // opencode/hermes parent-child links).
-      if (agent === "claude" || agent === "cursor" || agent === "opencode" || agent === "hermes") {
+      // grok/codex/antigravity/opencode/hermes parent-child links).
+      if (["claude", "cursor", "opencode", "hermes", "grok", "codex", "antigravity"].includes(agent)) {
         apiFetch(`/sessions/${id}/delegation?agent=${agent}`)
           .then(res => res.json())
           .then(data => setDelegation(data && data.supported ? data : null))
@@ -1859,29 +1859,37 @@ function DelegationCard({ delegation, agent }: { delegation: any; agent: string 
           <Stat label="Delegated cost" value={formatCost(delegation.cost)} />
         </div>
       )}
-      {subagents.length > 0 && delegation.tokens_recorded && (
+      {subagents.length > 0 && (
         <div className="space-y-1">
           {subagents.map((s: any, i: number) => (
-            <div key={s.agent_id ?? i} className="flex items-center justify-between gap-3 text-[11px] font-mono text-[var(--tt-fg-muted)] py-1.5 px-2 hover:bg-[var(--tt-sunken)] rounded">
+            <div key={s.agent_id ?? s.child_session_id ?? i} className="flex items-center justify-between gap-3 text-[11px] font-mono text-[var(--tt-fg-muted)] py-1.5 px-2 hover:bg-[var(--tt-sunken)] rounded">
               <span className="flex items-center gap-2 min-w-0">
-                <Badge>{s.agent_type}</Badge>
-                <span className="truncate text-[var(--tt-fg)]">{s.description || s.agent_id}</span>
+                <Badge>{s.agent_type || s.agent_role || "subagent"}</Badge>
+                <span className="truncate text-[var(--tt-fg)]">{s.description || s.nickname || s.agent_id}</span>
               </span>
               <span className="flex items-center gap-3 shrink-0">
                 {s.model && <span className="text-[var(--tt-fg-dim)]">{s.model.replace(/-\d{8}$/, "")}</span>}
-                <span>in/out {formatTokens(s.tokens?.input)}/{formatTokens(s.tokens?.output)}</span>
-                <span className="text-[var(--tt-cyan-fg)]">{formatTokens(s.tokens?.cached)} cached</span>
-                <span className="text-[var(--tt-fg)]">{formatCost(s.cost)}</span>
+                {typeof s.duration_ms === "number" && <span className="text-[var(--tt-fg-dim)]">{(s.duration_ms / 1000).toFixed(1)}s</span>}
+                {s.tokens != null && (
+                  <>
+                    <span>in/out {formatTokens(s.tokens?.input)}/{formatTokens(s.tokens?.output)}</span>
+                    <span className="text-[var(--tt-cyan-fg)]">{formatTokens(s.tokens?.cached)} cached</span>
+                  </>
+                )}
+                {s.cost != null && <span className="text-[var(--tt-fg)]">{formatCost(s.cost)}</span>}
+                {s.child_session_id && (
+                  <Link href={`/sessions/${s.child_session_id}?agent=${agent}`} className="text-[var(--tt-brand)] hover:underline">open</Link>
+                )}
               </span>
             </div>
           ))}
         </div>
       )}
 
-      {/* Cursor: spawn count only — transcripts carry no usage data */}
-      {spawnCount > 0 && !delegation.tokens_recorded && (
-        <div className="text-[11px] text-[var(--tt-fg-muted)]">
-          {spawnCount} subagent run{spawnCount === 1 ? "" : "s"} recorded. {agent === "cursor" ? "Cursor's subagent transcripts contain no token usage, so their cost can't be attributed." : ""}
+      {/* Cursor: spawn count only — its transcripts carry no usage data and no descriptions */}
+      {spawnCount > 0 && agent === "cursor" && (
+        <div className="mt-2 text-[11px] text-[var(--tt-fg-muted)]">
+          Cursor's subagent transcripts contain no token usage, so their cost can't be attributed.
         </div>
       )}
 


### PR DESCRIPTION
## What this does

Every supported agent can now answer: **what did this session actually cost, including everything it spawned — and which skills, MCP servers and subagent types earn their keep?**

### Subagent / delegation tracking
- **Claude Code**: full token+cost rollup of subagent transcripts (`<sid>/subagents/agent-*.jsonl`), priced per the subagent's **own** model — an Explore on Haiku no longer hides inside an Opus session. On the author's machine this surfaced **3.6M+ tokens / ~$34 of previously invisible spend**.
- **Grok Build / Codex / Antigravity CLI**: verified empirically (by running each CLI headlessly with delegation prompts) that all three spawn subagents as sibling sessions with on-disk linkage — parents and children are now cross-linked, including custom `--agents` names on Grok and agent roles/nicknames on Codex.
- **OpenCode / Hermes**: parent/child session linkage from their SQLite hierarchies.
- **Cursor**: spawn counts (its transcripts carry no token data — reported honestly, never estimated).
- **Count-once invariant** throughout: existing token fields are untouched; Claude's delegated usage is a separate bucket; children that are real sessions are annotated, never re-summed.

### Skills & MCP usage
- Per-session `skills_used` (Claude `Skill` tool + slash-command echoes with built-in commands filtered; Gemini/Qwen `activate_skill`; Codex via its SKILL.md-read breadcrumb — it records no structured event) and `mcp_usage` parsed from both `mcp__server__tool` and Gemini's `mcp_server_tool` conventions.
- `/analytics` gains `by_skill`, `by_mcp_server`, `by_subagent_type` and a `delegation` bucket with per-agent breakdown — all new keys, existing aggregates byte-identical.

### UI
- Session detail: **Delegated work** card + header `Delegated +N` stat; **Subagents** section in the context sidebar; **slide-over nested-trace viewer** (LangSmith-style drill-in — inspect a child's full trace without losing your place; full-page opens carry `from=` for round-trip back navigation).
- Analytics: Delegation & ecosystem section (stat tiles, delegation-by-agent, per-type/skill/server cards with source-agent labels and internal scrollbars).
- Project Insights: the same section scoped per project, per agent.
- Config inventory: live usage chips on every skill/command/subagent/MCP server — "no recorded use" makes shelfware visible.

### Fixes found along the way
- **Codex discovery**: `session_index.jsonl` is no longer maintained by recent Codex versions; sessions are now discovered from rollout files (10 → 36 sessions on the author's machine).
- **Windows**: all sqlite read-only URIs were backslash-broken on Windows (silently dropping OpenCode/Hermes/Antigravity-CLI); now built cross-platform and unit-tested against `PureWindowsPath`. Workspace JSON reads got explicit utf-8.

## Verification
- `backend/test_delegation.py`: 33 hermetic fixture tests (tmp trees + synthetic SQLite; all agent stores monkeypatched); full suite **130 passed**.
- Frontend `tsc --noEmit` clean; every surface manually verified in the running app, including a live probe that created sample `tt-probe-*` skills/subagents in Grok, Gemini and Codex and confirmed they appear end-to-end.
- `UPDATE.json` entry included (pre-push hook satisfied).
- `DESIGN.md` documents the verified log shapes, invariants and probe findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)