### PR TITLE
fix: reinstall frontend deps when package.json changes (#92)

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -258,10 +258,25 @@ function ensureBackend() {
 
 function ensureFrontend() {
   if (!which('npm')) die('npm is required but was not found in PATH.');
-  if (!fs.existsSync(path.join(frontendDir, 'node_modules'))) {
-    console.log('→ installing frontend dependencies (first run can take a minute)…');
-    run('npm', ['install'], { cwd: frontendDir });
-  }
+  // Reinstall when package.json changed since the last install — not just when
+  // node_modules is missing. A bare existence check let stale installs linger:
+  // users who installed before a new dependency was declared (e.g. qrcode.react,
+  // issue #92) kept an old node_modules and hit "Module not found" at runtime.
+  // Mirrors ensureBackend()'s requirements.txt SHA stamp. A missing stamp (old
+  // install predating this check) hashes to a mismatch, so affected users
+  // self-heal on their next launch.
+  const nmDir = path.join(frontendDir, 'node_modules');
+  const pkgPath = path.join(frontendDir, 'package.json');
+  const stampPath = path.join(nmDir, '.package-json.sha');
+  const currentSha = require('crypto').createHash('sha1').update(fs.readFileSync(pkgPath)).digest('hex');
+  let cachedSha = null;
+  try { cachedSha = fs.readFileSync(stampPath, 'utf8').trim(); } catch {}
+  if (fs.existsSync(nmDir) && cachedSha === currentSha) return;
+  console.log(fs.existsSync(nmDir)
+    ? '→ frontend dependencies changed; updating…'
+    : '→ installing frontend dependencies (first run can take a minute)…');
+  run('npm', ['install'], { cwd: frontendDir });
+  try { fs.writeFileSync(stampPath, currentSha); } catch {}
 }
 
 async function start() {


### PR DESCRIPTION
## Problem
Opening **Settings** crashes the app with `Module not found: Can't resolve 'qrcode.react'` (issue #92).

`ConnectDevice.tsx` imports `qrcode.react`, which **is** correctly declared in `frontend/package.json`. The real bug is in `bin/cli.js`: `ensureFrontend()` only ran `npm install` when `node_modules` was **entirely absent**. Anyone who installed *before* `qrcode.react` was added (commit `6aab12a`) kept a stale `node_modules`, the existence check passed, install was skipped, and the new dependency never landed.

## Fix
Gate the install on a `package.json` SHA stamp instead of a bare existence check — mirroring how `ensureBackend()` already handles `requirements.txt`. A missing stamp (every pre-fix install) hashes to a mismatch, so **affected users self-heal on their next `./start.sh`**. Unchanged manifests still skip install for fast restarts.

One function changed in `bin/cli.js`.

## Testing
- ✅ **Reproduced** the exact failure: stale `node_modules` + `next build` → `Module not found: Can't resolve 'qrcode.react'`.
- ✅ **Gate logic, 4 states**: pre-fix user (no stamp) → install; unchanged → skip; manifest changed → install; fresh clone → install.
- ✅ **End-to-end**: after the triggered reinstall, `next build` → `✓ Compiled successfully` and the `/settings` route generates.
- ✅ `node --check bin/cli.js` passes.

Fixes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)