### PR TITLE
fix: remove vulnerable/unused deps so npm audit is clean (#91)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -78,6 +78,30 @@ The hook is intentionally narrow. Cases:
 5. **Repo without `origin/main`**: hook allows through (assumes you know your setup).
 6. **Last resort**: `claude --no-hooks` for that session — but if you find yourself reaching for this often, the rule is mis-tuned and worth revisiting.
 
+## Pre-push merge validation (two gates)
+
+After issue #91 (vulnerable + unused deps merged un-reviewed during the
+fast remote-access ship), every change destined for `main` passes two gates:
+
+1. **`.claude/hooks/prepush-claude-review.py`** (local, PreToolUse on `Bash`).
+   On a `git push` / `gh pr create` from a non-main branch, it diffs
+   `origin/main..HEAD`, sends the diff to your local `claude` CLI for a focused
+   review (dependency hygiene, remote-exposure / auth-bypass regressions,
+   committed secrets, injection-class bugs), and **denies the push only on an
+   explicit high-confidence `block` verdict**. It **fails open**: missing
+   `claude` CLI, empty/huge diff, timeout, or unparseable output all ALLOW the
+   push — a flaky reviewer never blocks legit work. Reuses the push-detection
+   helpers from `enforce-update-json.py` (imported, not duplicated). Skips
+   docs/asset-only pushes. Bypass with `--no-hooks`.
+2. **`.github/workflows/security-audit.yml`** (CI, deterministic). Runs
+   `npm audit --omit=dev --audit-level=high` across root / `frontend` / `website`
+   on every PR touching a `package.json`, failing on high/critical *runtime*
+   vulns (dev-only advisories are reported but non-blocking). This catches
+   contributor PRs (which the local hook can't see) and is the exact gate that
+   would have stopped #91. Lockfiles are gitignored, so CI uses
+   `npm install --package-lock-only` — fixes ride on the committed `package.json`
+   pins + `overrides`, not a lockfile.
+
 ## Other project conventions
 
 - **Schedules page is read-only.** The CRUD UI was built but is commented out under `# DISABLED-MUTATIONS:` markers in `backend/main.py`. Re-enable by uncommenting; don't reimplement.

--- a/.claude/hooks/prepush-claude-review.py
+++ b/.claude/hooks/prepush-claude-review.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: run a local Claude review of `origin/main..HEAD` before a
+`git push` / `gh pr create`, and block the push if the review flags a
+high-severity regression.
+
+Why this exists (issue #91): the remote-access feature shipped fast, without a
+maintainer review pass, and merged vulnerable/unused dependencies plus a real
+exposure question (the auth token never guarded the Next.js dev server). A
+deterministic `npm audit` CI gate catches *known* CVEs, but not "this looks like
+an auth bypass" / "this dep is unused" / "this widens the remote surface". That
+judgement is what a reviewer provides — so this hook spends ~30s of local Claude
+time on every push to a main-bound branch and surfaces the same kind of findings
+*before* the code leaves the machine.
+
+Design choices:
+- **Fail OPEN.** If the `claude` CLI is missing, the diff is empty/huge, the
+  review times out, or its output can't be parsed, the push is ALLOWED. A flaky
+  reviewer must never become a hard blocker on legit work. Only an explicit
+  `"verdict": "block"` denies.
+- **Local only.** Uses the maintainer's own `claude` CLI — no CI secret, no
+  per-PR cloud cost. Catches *your* pushes (which is exactly the gap #91 came
+  from); contributor PRs are covered by the separate `security-audit.yml` gate.
+- **Reuses** the push-detection + git helpers from `enforce-update-json.py`
+  (imported, not duplicated) so both hooks agree on what "a push" is.
+- Exits 0 always; block decisions travel via the JSON payload, matching the
+  sibling hook's contract.
+
+Bypass with `--no-hooks` for that session (e.g. an urgent hotfix).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from typing import List, Optional
+
+
+# --- Reuse the sibling hook's battle-tested push detection / git helpers ------
+# Importing is side-effect free: enforce-update-json.py only defines functions
+# under an `if __name__ == "__main__"` guard.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def _load_sibling():
+    path = os.path.join(_HERE, "enforce-update-json.py")
+    spec = importlib.util.spec_from_file_location("enforce_update_json", path)
+    if spec is None or spec.loader is None:
+        return None
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(mod)
+    except Exception:
+        return None
+    return mod
+
+
+_SIB = _load_sibling()
+
+
+# File extensions whose changes are worth a review. Pure docs/markdown/asset
+# churn is skipped so the hook stays quiet on non-code pushes.
+_CODE_SUFFIXES = (
+    ".py", ".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs",
+    ".json", ".sh", ".bash", ".zsh", ".yml", ".yaml", ".toml",
+)
+# Manifests are always interesting (this is how #91's vuln deps slipped in).
+_ALWAYS_REVIEW = ("package.json", "requirements.txt", "pyproject.toml")
+
+_MAX_DIFF_CHARS = 60_000   # cap prompt size → bounded latency/cost
+_REVIEW_TIMEOUT = 150      # seconds; on timeout we fail open
+
+
+def _allow() -> None:
+    sys.exit(0)
+
+
+def _deny(reason: str) -> None:
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }))
+    sys.exit(0)
+
+
+def _git(*args: str, cwd: Optional[str] = None, timeout: int = 10) -> Optional[str]:
+    if _SIB is not None:
+        return _SIB._git(*args, cwd=cwd, timeout=timeout)
+    try:
+        out = subprocess.check_output(
+            ["git", *args], stderr=subprocess.DEVNULL, cwd=cwd, timeout=timeout
+        )
+        return out.decode("utf-8", errors="replace").strip()
+    except Exception:
+        return None
+
+
+def _is_push(command: str) -> bool:
+    if _SIB is not None:
+        return _SIB._command_contains_push(command)
+    # Conservative fallback if the sibling failed to load.
+    return "push" in command.split()
+
+
+REVIEW_PROMPT = """\
+You are a strict pre-push reviewer for the TokenTelemetry repo. A unified git \
+diff of `origin/main..HEAD` is below. Review ONLY this diff. Look specifically \
+for regressions that a fast-moving maintainer would miss:
+
+1. Dependency hygiene: newly added npm/python deps that are unused, unnecessary, \
+   or carry known vulnerabilities (e.g. a left-over runtime dep, an unpinned or \
+   downgraded version). Issue #91 was exactly this.
+2. Remote-exposure / auth regressions: anything that widens what is reachable \
+   when the app runs with `--host`/remote access, weakens `RemoteAuthMiddleware` \
+   or the loopback exemption, or exposes the Next.js dev server / an endpoint \
+   without the token gate.
+3. Secrets or credentials committed in the diff.
+4. Obvious security bugs: command/shell injection, path traversal, SSRF, unsafe \
+   deserialization.
+
+Be conservative about blocking — only block on a HIGH-confidence, genuinely \
+risky finding, not style or nits. Respond with ONE line of strict minified JSON \
+and nothing else:
+{"verdict":"pass"|"block","summary":"<=200 chars","findings":["<short finding>", ...]}
+
+DIFF:
+"""
+
+
+def _run_review(diff: str) -> Optional[dict]:
+    """Invoke the local claude CLI in headless print mode. Returns the parsed
+    verdict dict, or None on any failure (→ caller fails open)."""
+    claude = shutil.which("claude")
+    if not claude:
+        return None
+    prompt = REVIEW_PROMPT + diff
+    try:
+        proc = subprocess.run(
+            [claude, "-p", prompt],
+            capture_output=True, text=True, timeout=_REVIEW_TIMEOUT,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if proc.returncode != 0:
+        return None
+    out = (proc.stdout or "").strip()
+    # The model may wrap the JSON in prose/fences; extract the first {...} blob.
+    m = re.search(r"\{.*\}", out, re.DOTALL)
+    if not m:
+        return None
+    try:
+        data = json.loads(m.group(0))
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict) or "verdict" not in data:
+        return None
+    return data
+
+
+def main() -> None:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        _allow()
+
+    command = (payload.get("tool_input") or {}).get("command") or ""
+    if not command or not _is_push(command):
+        _allow()
+
+    # Avoid recursion: never review from inside a nested headless review.
+    if os.environ.get("TT_PREPUSH_REVIEW_RUNNING"):
+        _allow()
+
+    repo_root = _git("rev-parse", "--show-toplevel")
+    if not repo_root:
+        _allow()
+
+    branch = _git("rev-parse", "--abbrev-ref", "HEAD", cwd=repo_root)
+    if branch in (None, "main", "master", "HEAD"):
+        _allow()
+
+    subprocess.run(
+        ["git", "fetch", "origin", "main", "--quiet"],
+        cwd=repo_root, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        timeout=15,
+    )
+
+    base_ref = None
+    for candidate in ("origin/main", "main"):
+        if subprocess.run(
+            ["git", "rev-parse", "--verify", candidate],
+            cwd=repo_root, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        ).returncode == 0:
+            base_ref = candidate
+            break
+    if not base_ref:
+        _allow()
+
+    changed = (_git("diff", "--name-only", f"{base_ref}...HEAD", cwd=repo_root) or "").splitlines()
+    relevant = [
+        f for f in changed
+        if f.endswith(_CODE_SUFFIXES) or os.path.basename(f) in _ALWAYS_REVIEW
+    ]
+    if not relevant:
+        _allow()  # docs/asset-only push — nothing for the reviewer to weigh in on
+
+    diff = _git("diff", f"{base_ref}...HEAD", "--", *relevant, cwd=repo_root, timeout=20) or ""
+    if not diff.strip():
+        _allow()
+    truncated = len(diff) > _MAX_DIFF_CHARS
+    if truncated:
+        diff = diff[:_MAX_DIFF_CHARS] + "\n…[diff truncated for review]…\n"
+
+    os.environ["TT_PREPUSH_REVIEW_RUNNING"] = "1"
+    verdict = _run_review(diff)
+    if not verdict:
+        _allow()  # reviewer unavailable / unparseable → fail open
+
+    if str(verdict.get("verdict", "")).lower() == "block":
+        findings = verdict.get("findings") or []
+        summary = str(verdict.get("summary") or "review flagged a high-risk change")
+        bullets = "\n".join(f"  • {str(f)[:200]}" for f in findings[:6]) or "  • (no detail)"
+        _deny(
+            "Pre-push Claude review flagged this change:\n"
+            f"{summary}\n{bullets}\n\n"
+            "Address the findings, or re-run with `--no-hooks` to bypass "
+            "(e.g. urgent hotfix / false positive)."
+        )
+
+    _allow()
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,6 +8,10 @@
           {
             "type": "command",
             "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/enforce-update-json.py"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/prepush-claude-review.py"
           }
         ]
       }

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,58 @@
+name: Dependency security audit
+
+# Why this exists: issue #91 — vulnerable runtime deps (concurrently→shell-quote,
+# next 16.2.4) were merged because nobody ran `npm audit` before shipping the
+# remote-access feature. This gate runs that check automatically on every PR and
+# push, so audit regressions in any of the three npm packages fail CI instead of
+# reaching main. Lockfiles are gitignored here, so we `npm install` (not `npm ci`)
+# to resolve a fresh tree exactly like a new contributor would.
+
+on:
+  pull_request:
+    paths:
+      - "package.json"
+      - "frontend/package.json"
+      - "website/package.json"
+      - ".github/workflows/security-audit.yml"
+  push:
+    branches: [main]
+    paths:
+      - "package.json"
+      - "frontend/package.json"
+      - "website/package.json"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - "."          # root CLI package
+          - "frontend"   # dashboard (exposed in remote mode)
+          - "website"    # public marketing site (GitHub Pages)
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Resolve dependency tree (no lockfile committed)
+        working-directory: ${{ matrix.package }}
+        run: npm install --package-lock-only
+
+      # Runtime deps are the real exposed surface — fail the build on any
+      # high/critical there. Dev-only advisories are reported but non-blocking.
+      - name: Audit runtime dependencies (blocking)
+        working-directory: ${{ matrix.package }}
+        run: npm audit --omit=dev --audit-level=high
+
+      - name: Audit full tree incl. devDependencies (advisory only)
+        working-directory: ${{ matrix.package }}
+        run: npm audit --audit-level=high || true

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "lucide-react": "^1.8.0",
-    "next": "16.2.4",
+    "next": "16.2.9",
     "qrcode.react": "^4.2.0",
     "react": "19.2.4",
     "react-dom": "19.2.4",
@@ -21,13 +21,16 @@
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.5.0"
   },
+  "overrides": {
+    "postcss": "^8.5.10"
+  },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
-    "eslint-config-next": "16.2.4",
+    "eslint-config-next": "16.2.9",
     "tailwindcss": "^4",
     "typescript": "^5"
   }

--- a/package.json
+++ b/package.json
@@ -28,11 +28,7 @@
   "bugs": {
     "url": "https://github.com/VasiHemanth/tokentelemetry/issues"
   },
-  "dependencies": {
-    "concurrently": "^9.1.0",
-    "chalk": "^5.3.0",
-    "open": "^10.1.0"
-  },
+  "dependencies": {},
   "engines": {
     "node": ">=18"
   }

--- a/website/package.json
+++ b/website/package.json
@@ -11,9 +11,12 @@
   "dependencies": {
     "framer-motion": "^11.11.0",
     "lucide-react": "^1.8.0",
-    "next": "16.2.4",
+    "next": "16.2.9",
     "react": "19.2.4",
     "react-dom": "19.2.4"
+  },
+  "overrides": {
+    "postcss": "^8.5.10"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
## Problem
A fresh `npm audit --omit=dev` reports runtime vulnerabilities (issue #91):
- **Root:** `concurrently` pulls in vulnerable `shell-quote` — `GHSA-w7jw-789q-3m8p`, 2 criticals. `concurrently` is also **unused** (cli.js spawns processes directly).
- **Frontend:** `next@16.2.4` → 1 high + 1 moderate.

## Fix
- **Drop unused `concurrently`** from root — eliminates the `shell-quote` criticals. Also drop unused **`chalk`** and **`open`** (cli.js uses Node built-ins and spawns the OS opener directly); root `dependencies` is now empty and nothing breaks.
- **Bump `next` 16.2.4 → 16.2.9** in `frontend` **and** `website` (the public site shipped the same vulnerable version), plus a **`postcss ^8.5.10` override** to clear a moderate nested inside next's own tree.

Result: all three packages report **0 vulns** at `npm audit --omit=dev --audit-level=high`. Lockfiles are gitignored, so the fix rides on the committed `package.json` pins + overrides.

## Note on remote exposure
The reporter correctly flagged that remote mode matters here. Worth recording: the auth token (`RemoteAuthMiddleware`) only guards the **backend on :8000** — the **Next.js dev server on :3000 is a separate process with no token in front of it**, so a vulnerable Next.js was genuinely part of the exposed surface in remote mode. The version bump closes that.

## Prevention (so a fast feature ship can't reintroduce this)
- **`.github/workflows/security-audit.yml`** — fails any PR that touches a `package.json` if `npm audit --omit=dev --audit-level=high` flags root / frontend / website. This is the exact gate that would have caught #91.
- **`.claude/hooks/prepush-claude-review.py`** — local pre-push Claude review of `origin/main..HEAD` (dependency hygiene, remote-exposure/auth regressions, secrets). Fails open; blocks only on a high-confidence verdict.

Both documented in `.claude/CLAUDE.md`.

Fixes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)