### PR TITLE
ci: bump actions/checkout and setup-node to v5

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -24,8 +24,8 @@ jobs:
       run:
         working-directory: website
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
       

--- a/.github/workflows/pricing-sync.yml
+++ b/.github/workflows/pricing-sync.yml
@@ -18,7 +18,7 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -37,9 +37,9 @@ jobs:
           - "frontend"   # dashboard (exposed in remote mode)
           - "website"    # public marketing site (GitHub Pages)
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "20"
 

--- a/.github/workflows/sync-traffic.yml
+++ b/.github/workflows/sync-traffic.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Why
GitHub is force-migrating Node 20 actions to Node 24 **starting 2026-06-16**, and `actions/checkout@v4` / `actions/setup-node@v4` emit a deprecation warning on every run (surfaced by the new security-audit workflow logs).

## Change
Bump both to `@v5` (Node 24) across every workflow that used them:
- `security-audit.yml` — checkout + setup-node
- `deploy-website.yml` — checkout + setup-node
- `sync-traffic.yml` — checkout
- `pricing-sync.yml` — checkout

`actions/setup-python@v5` is already current and left as-is. No logic changes — version bumps only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)