### PR TITLE
fix(summarizers): launch CLIs by resolved path and feed claude prompt via stdin

### DIFF
--- a/backend/summarizers/base.py
+++ b/backend/summarizers/base.py
@@ -39,6 +39,25 @@ def _ensure_cwd() -> str:
     return str(SUMMARIZER_CWD)
 
 
+def _resolve_executable(name: str) -> str:
+    """Resolve a bare CLI name to its full path on PATH, honouring PATHEXT.
+
+    On Windows the coding CLIs are installed by npm as batch shims
+    (``claude.cmd``, ``codex.cmd``, …) — there is no ``.exe``. ``shutil.which``
+    finds them because it consults ``PATHEXT``, but a bare-name
+    ``subprocess.run(["claude", …])`` with ``shell=False`` goes straight to
+    Win32 ``CreateProcess``, which only appends ``.exe`` and so raises
+    ``FileNotFoundError`` / ``[WinError 2]`` even though the CLI works in the
+    shell. Handing subprocess the fully-resolved ``…\\claude.cmd`` path launches
+    correctly (CreateProcess runs the batch shim by full path). On macOS/Linux
+    ``which`` just returns the plain executable path, so this is a no-op there.
+
+    Falls back to the original name when nothing is found, so the existing
+    "failed to launch" error still surfaces with the same wording.
+    """
+    return shutil.which(name) or name
+
+
 def run_cli(
     cmd: list[str],
     *,
@@ -51,6 +70,10 @@ def run_cli(
     stdout is returned even on a non-zero exit when it is non-empty — some CLIs
     print a usable result and then exit non-zero on a teardown warning.
     """
+    # Keep the friendly name for error messages; launch with the resolved path.
+    name = cmd[0] if cmd else ""
+    if cmd:
+        cmd = [_resolve_executable(cmd[0]), *cmd[1:]]
     try:
         proc = subprocess.run(
             cmd,
@@ -61,9 +84,9 @@ def run_cli(
             cwd=cwd,
         )
     except subprocess.TimeoutExpired as e:
-        raise SummarizerError(f"{cmd[0]} timed out after {timeout}s") from e
+        raise SummarizerError(f"{name} timed out after {timeout}s") from e
     except (OSError, ValueError) as e:
-        raise SummarizerError(f"failed to launch {cmd[0]}: {e}") from e
+        raise SummarizerError(f"failed to launch {name}: {e}") from e
 
     out = (proc.stdout or "").strip()
     if proc.returncode != 0 and not out:
@@ -77,9 +100,9 @@ def run_cli(
             err = "\n".join(err_lines[-5:])[:2000]
         else:
             err = stderr[-2000:] if len(stderr) > 2000 else stderr
-        raise SummarizerError(f"{cmd[0]} exited {proc.returncode}: {err}")
+        raise SummarizerError(f"{name} exited {proc.returncode}: {err}")
     if not out:
-        raise SummarizerError(f"{cmd[0]} produced no output")
+        raise SummarizerError(f"{name} produced no output")
     return out
 
 

--- a/backend/summarizers/claude.py
+++ b/backend/summarizers/claude.py
@@ -17,15 +17,20 @@ class ClaudeSummarizer(BaseSummarizer):
     binary = "claude"
 
     def summarize(self, prompt: str, *, timeout: int = 120) -> str:
+        # Feed the prompt via stdin, not as a `-p <prompt>` argv. Trace briefs
+        # are routinely tens-to-hundreds of KB, which blows past the OS command
+        # line limit — most acutely on Windows, where the npm `claude.cmd` shim
+        # runs under cmd.exe and caps the line at ~8 KB ("The command line is too
+        # long."). `claude -p` with no positional reads the prompt from stdin.
         out = run_cli(
             [
                 self.binary,
                 "-p",
-                prompt,
                 "--output-format",
                 "json",
                 "--no-session-persistence",
             ],
+            stdin=prompt,
             timeout=timeout,
         )
         # `--output-format json` yields a single result object:


### PR DESCRIPTION
## Summary

Fixes two Windows-only failures in the CLI summarizer launch path, surfaced when generating a trace summary with the Claude Code backend (#98).

### 1). `failed to launch claude: [WinError 2]`
On Windows the npm-installed coding CLIs are batch shims (`claude.cmd`, no `claude.exe`). `BaseSummarizer.is_available()` uses `shutil.which`, which honours `PATHEXT` and finds the shim — but `run_cli` launched a bare `subprocess.run([claude, …])`, which goes through Win32 `CreateProcess` and only resolves `.exe`. So the picker showed Claude as available while the actual launch raised `[WinError 2]`, even though `claude` works in the shell.

**Fix:** resolve `cmd[0]` to its full path via `shutil.which` before launching (`_resolve_executable` in `base.py`). On macOS/Linux `which` returns the plain executable path, so it's a no-op. Benefits all four CLI adapters (claude/codex/gemini/qwen), since they all route through `run_cli`.

### 2). `claude exited 1: The command line is too long.`
With 1) fixed, the next failure appeared: the claude adapter passed the prompt as a `-p <prompt>` argv, and trace briefs are routinely tens-to-hundreds of KB — well past cmd.exe's ~8 KB command-line limit (the `claude.cmd` shim runs under cmd.exe).

**Fix:** feed the prompt over **stdin** (`claude -p` with no positional), matching what the codex/gemini/qwen/antigravity adapters already do. The prompt no longer appears on the command line at all, so the limit can't be hit regardless of brief size.

## Testing
- Verified `run_cli([claude, --version])` now resolves to `…\claude.CMD` and returns `2.1.173` (previously `[WinError 2]`).
- Verified `claude -p` with the prompt on stdin returns the expected JSON `result` envelope.
- Confirmed the other CLI adapters were already stdin-based, so Claude was the lone outlier.
- Confirmed the trace summary now works:
	<img width="992" height="804" alt="image" src="https://github.com/user-attachments/assets/fd0c437d-d5db-43d0-84bc-b135a67a0caf" />


Fixes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)