### PR TITLE
feat: chip-aware local power default + drain-priority billing routes

### DIFF
--- a/UPDATE.json
+++ b/UPDATE.json
@@ -1,6 +1,22 @@
 {
   "releases": [
     {
+      "tag": "2026-06-13",
+      "title": "Truer costs: local power + which credit pool pays",
+      "highlights": [
+        {
+          "title": "Local-model power cost now reads your actual chip",
+          "description": "Self-hosted models are priced by electricity, and the default wattage now comes from your detected chip (e.g. an Apple M-series part) instead of a one-size-fits-all 80 W. On machines we can't auto-detect, the field stops pretending and asks you to enter your draw under load (or click Measure) — so the estimate is honest rather than a silent placeholder.",
+          "href": "/local-models"
+        },
+        {
+          "title": "See which credit pool each agent actually drains",
+          "description": "Providers no longer bill an agent through one bucket. Expand any agent under Settings to see its drain order, split by interactive vs programmatic use — including Claude's separate Agent-SDK credit pool (claude -p, SDK, CI) that has no auto-fallback, plus pool sizes and stops-at-$0 warnings. Pick your plan tier to size the pools. It explains the cost framing; it doesn't change the math.",
+          "href": "/settings"
+        }
+      ]
+    },
+    {
       "tag": "2026-06-10",
       "title": "See what your subagents, skills & MCPs cost",
       "highlights": [

--- a/backend/billing_route.py
+++ b/backend/billing_route.py
@@ -1,0 +1,484 @@
+"""Drain-priority billing routes: which credit *bucket* pays for a session.
+
+``billing_mode.py`` answers a coarse question — "how should we *frame* this
+agent's cost?" (subscription / api / local / unknown). That single label is no
+longer enough, because as of mid-2026 every major provider bills a single agent
+through **multiple buckets with a drain order**, and *which* bucket pays depends
+on the **task type** (interactive vs programmatic). The flat label literally
+can't represent this — it would call all Claude usage "subscription" → $0, while
+a ``claude -p`` loop silently drains a separate, capped, no-fallback credit pool.
+
+This module encodes, per agent, an ordered list of buckets and resolves the
+**active bucket** for a given task type. It changes no cost math by itself; it
+tells the caller (and the UI) *which* bucket is being drained, what the user's
+marginal cost is while it's active, and when a capped pool is about to run dry.
+
+Provider facts baked in below are a **snapshot** (see ``SNAPSHOT_AS_OF``) and
+are wrong the moment a provider changes terms — re-verify against current
+provider docs before trusting the numbers. Policies with a future effective
+date are date-gated (e.g. Anthropic's June 15 2026 Agent-SDK split): resolution
+takes ``today`` and only routes through a bucket once its policy is in force.
+
+Key concepts
+------------
+``charges`` — what the *user* pays at the margin while this bucket is active:
+  - ``included``     — already paid via the subscription/credit pool → marginal $0.
+  - ``api_rate``     — billed at API list price (paygo, or pool-overflow).
+  - ``electricity``  — local hardware; priced by ``power_config`` (not here).
+
+``pool_usd`` — size of a prepaid pool *measured at API rates* (e.g. Anthropic's
+  Agent-SDK credit: $20 Pro / $100 Max-5x / $200 Max-20x). Even when ``charges``
+  is ``included`` (marginal $0), API-rate value still accrues against this cap so
+  the UI can warn before it empties. ``None`` = no metered dollar cap.
+
+``pool_requests`` — request-count cap for pools metered in calls, not dollars
+  (Gemini CLI's 1,000 requests/day free tier). ``pool_period`` says how often it
+  resets (``"day"`` / ``"month"``).
+
+``no_spillover`` — when a pool is exhausted, requests **stop**; there is no
+  automatic fall-through to the next bucket unless the user opts into overflow.
+  (Anthropic's June-15 split is the canonical case: no rollover, no auto-paygo.)
+
+``task_types`` — which task types route to this bucket: ``("interactive",)``,
+  ``("programmatic",)``, or both.
+
+Bucket resolution itself is pure (no I/O). The only I/O here is the explicit
+per-agent *plan* persistence (``load_plans`` / ``save_plan`` →
+``~/.tokentelemetry/billing_plans.json``), which mirrors billing_mode's
+override file and never raises on missing/malformed data.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from tt_paths import data_dir
+
+# When the provider facts below were last verified against live sources.
+# Surfaced in API payloads so the UI can disclaim staleness.
+SNAPSHOT_AS_OF = "2026-06-11"
+
+# Task types a session can be. "interactive" = a human at a terminal/editor;
+# "programmatic" = headless/automated (claude -p, Agent SDK, GitHub Actions,
+# codex app-server, CI). Default to interactive when unknown — it's the
+# conservative, common case and never over-reports a separate metered pool.
+TASK_TYPES = ("interactive", "programmatic")
+DEFAULT_TASK_TYPE = "interactive"
+
+CHARGES = ("included", "api_rate", "electricity")
+
+DEFAULT_PLAN = "default"
+
+# Anthropic's Agent-SDK billing split: announced May 13 2026, in force from
+# June 15 2026. Before this date programmatic usage still draws subscription
+# limits; from this date it draws the separate SDK credit pool.
+ANTHROPIC_SDK_SPLIT_DATE = _dt.date(2026, 6, 15)
+
+# Plan vocabularies are PER-PROVIDER — "max5x" means nothing to Cursor and
+# "ultra" nothing to Anthropic. Used to validate persisted plan choices.
+AGENT_PLANS: Dict[str, Tuple[str, ...]] = {
+    "claude": ("pro", "max5x", "max20x"),
+    "copilot": ("pro_plus", "business", "enterprise"),
+    "cursor": ("pro", "pro_plus", "ultra"),
+}
+
+
+def _bucket(
+    id: str,
+    label: str,
+    charges: str,
+    task_types: Tuple[str, ...],
+    *,
+    pool_usd: Optional[float] = None,
+    pool_requests: Optional[int] = None,
+    pool_period: Optional[str] = None,
+    no_spillover: bool = False,
+    note: str = "",
+) -> Dict[str, Any]:
+    return {
+        "id": id,
+        "label": label,
+        "charges": charges,
+        "task_types": list(task_types),
+        "pool_usd": pool_usd,
+        "pool_requests": pool_requests,
+        "pool_period": pool_period,
+        "no_spillover": no_spillover,
+        "note": note,
+    }
+
+
+# Per-plan Agent-SDK credit pool for Anthropic (USD/month, measured at API
+# rates). Pro $20 / Max-5x $100 / Max-20x $200.
+# https://thenewstack.io/anthropic-agent-sdk-credits/
+_ANTHROPIC_SDK_POOL = {"default": 20.0, "pro": 20.0, "max5x": 100.0, "max20x": 200.0}
+
+# GitHub Copilot moved to usage-based AI Credits on June 1 2026 (1 credit =
+# $0.01). Monthly included credit ≈ plan price for Pro+/Business/Enterprise.
+# https://github.blog/news-insights/company-news/github-copilot-is-moving-to-usage-based-billing/
+_COPILOT_POOL = {"default": 39.0, "pro_plus": 39.0, "business": 19.0, "enterprise": 39.0}
+
+# Cursor's included credit pool equals the subscription value
+# ($20 Pro / $60 Pro+ / $200 Ultra). https://www.vantage.sh/blog/cursor-pricing-explained
+_CURSOR_POOL = {"default": 20.0, "pro": 20.0, "pro_plus": 60.0, "ultra": 200.0}
+
+
+def _today(today: Optional[_dt.date]) -> _dt.date:
+    return today or _dt.date.today()
+
+
+# ---------------------------------------------------------------------------
+# Per-agent bucket definitions (drain order, top = drains first).
+#
+# Each builder takes (plan, today) so pool sizes can vary by tier and policies
+# with a future effective date only kick in once in force. Order is the
+# *priority* order; resolution filters by task type, then takes the first match.
+# ---------------------------------------------------------------------------
+def _anthropic_buckets(plan: str, today: _dt.date) -> List[Dict[str, Any]]:
+    sdk_pool = _ANTHROPIC_SDK_POOL.get(plan, _ANTHROPIC_SDK_POOL["default"])
+
+    if today < ANTHROPIC_SDK_SPLIT_DATE:
+        # Pre-split: one subscription pool covers interactive AND programmatic.
+        # The note pre-warns about the upcoming change so users aren't surprised.
+        return [
+            _bucket(
+                "subscription", "Subscription limits", "included",
+                ("interactive", "programmatic"),
+                no_spillover=True,
+                note=(f"Until {ANTHROPIC_SDK_SPLIT_DATE.isoformat()} all Claude "
+                      "usage draws your plan's limits. From that date, claude -p "
+                      "/ Agent SDK / GitHub Actions move to a separate "
+                      f"${sdk_pool:.0f}/mo SDK credit pool with no auto-fallback."),
+            ),
+        ]
+
+    return [
+        # Programmatic drains the separate Agent-SDK credit pool FIRST and only.
+        _bucket(
+            "sdk_credit", "Agent SDK credit", "included", ("programmatic",),
+            pool_usd=sdk_pool, pool_period="month", no_spillover=True,
+            note=("claude -p / Agent SDK / GitHub Actions draw a separate "
+                  f"${sdk_pool:.0f}/mo pool, billed at API rates. No rollover, "
+                  "no auto-fallback — automation stops at $0 unless overflow "
+                  "billing is enabled."),
+        ),
+        # Overflow paygo for programmatic, only reached if the user opted in.
+        _bucket(
+            "api_overflow", "Usage credits / API key", "api_rate", ("programmatic",),
+            note="Pay-as-you-go overflow once the SDK credit pool is empty (opt-in).",
+        ),
+        # Interactive use draws normal subscription limits — separate, no spillover.
+        _bucket(
+            "subscription", "Subscription limits", "included", ("interactive",),
+            no_spillover=True,
+            note=("Interactive Claude Code / chat / Cowork draw your plan's "
+                  "usage limits — unaffected by the Agent-SDK split."),
+        ),
+    ]
+
+
+def _codex_buckets(plan: str, today: _dt.date) -> List[Dict[str, Any]]:
+    # One ChatGPT subscription OAuth bucket covers BOTH interactive Codex CLI and
+    # programmatic codex app-server. Bills against plan-included usage, then
+    # purchased credits. https://developers.openai.com/codex/pricing
+    return [
+        _bucket(
+            "subscription", "ChatGPT subscription", "included",
+            ("interactive", "programmatic"),
+            note=("One ChatGPT plan covers both interactive Codex CLI and the "
+                  "programmatic app-server — no separate SDK credit."),
+        ),
+        _bucket(
+            "api_paygo", "Purchased credits / API", "api_rate",
+            ("interactive", "programmatic"),
+            note="Per-token API rates once plan-included usage is spent.",
+        ),
+    ]
+
+
+def _gemini_buckets(plan: str, today: _dt.date) -> List[Dict[str, Any]]:
+    # Gemini CLI: generous free tier capped by REQUEST COUNT (not dollars),
+    # then API paygo. https://www.termdock.com/en/blog/free-ai-cli-tools-ranked
+    return [
+        _bucket(
+            "free_tier", "Free tier", "included", ("interactive", "programmatic"),
+            pool_requests=1000, pool_period="day",
+            note="1,000 free model requests per day; Google absorbs the compute.",
+        ),
+        _bucket(
+            "api_paygo", "API key", "api_rate", ("interactive", "programmatic"),
+            note="Per-token API rates beyond the free quota.",
+        ),
+    ]
+
+
+def _copilot_buckets(plan: str, today: _dt.date) -> List[Dict[str, Any]]:
+    pool = _COPILOT_POOL.get(plan, _COPILOT_POOL["default"])
+    return [
+        # Completions are unlimited/free and never touch credits — model that as
+        # an always-on included bucket for interactive completion-style use.
+        _bucket(
+            "completions", "Code completions", "included", ("interactive",),
+            note="Inline completions & next-edit suggestions stay free/unlimited.",
+        ),
+        _bucket(
+            "ai_credits", "Monthly AI credits", "included",
+            ("interactive", "programmatic"),
+            pool_usd=pool, pool_period="month",
+            note=(f"Chat / agents / Copilot CLI consume a ${pool:.0f}/mo AI-credit "
+                  "pool (1 credit = $0.01)."),
+        ),
+        _bucket(
+            "usage_overage", "Usage-based overage", "api_rate",
+            ("interactive", "programmatic"),
+            note="Metered overage once monthly AI credits are spent.",
+        ),
+    ]
+
+
+def _cursor_buckets(plan: str, today: _dt.date) -> List[Dict[str, Any]]:
+    pool = _CURSOR_POOL.get(plan, _CURSOR_POOL["default"])
+    return [
+        # Auto / Composer agentic mode is unlimited on paid plans → included, no cap.
+        _bucket(
+            "auto_mode", "Auto / Composer (unlimited)", "included",
+            ("interactive", "programmatic"),
+            note="Auto and Composer agentic coding are unlimited on paid plans.",
+        ),
+        _bucket(
+            "included_credits", "Included model credits", "included",
+            ("interactive", "programmatic"),
+            pool_usd=pool, pool_period="month",
+            note=(f"Premium models burn a ${pool:.0f}/mo credit pool (equal to your "
+                  "subscription), priced by model + context."),
+        ),
+        _bucket(
+            "usage_overage", "Usage-based overage", "api_rate",
+            ("interactive", "programmatic"),
+            note="Metered overage once included model credits are spent.",
+        ),
+    ]
+
+
+def _api_only_buckets(plan: str, today: _dt.date) -> List[Dict[str, Any]]:
+    # Grok (xAI key), Hermes (provider keys), OpenCode (BYO key): pure paygo.
+    return [
+        _bucket(
+            "api_paygo", "API key", "api_rate", ("interactive", "programmatic"),
+            note="Pay-per-token on your own API key — the estimate approximates "
+                 "your bill.",
+        ),
+    ]
+
+
+def _local_buckets(plan: str, today: _dt.date) -> List[Dict[str, Any]]:
+    return [
+        _bucket(
+            "electricity", "Local electricity", "electricity",
+            ("interactive", "programmatic"),
+            note="Self-hosted; priced by power_config (watts × time × tariff), "
+                 "not an API charge.",
+        ),
+    ]
+
+
+# agent → builder. Agents absent here fall back by billing-mode (see resolve).
+_AGENT_BUILDERS = {
+    "claude": _anthropic_buckets,
+    "codex": _codex_buckets,
+    "gemini": _gemini_buckets,
+    "copilot": _copilot_buckets,
+    "cursor": _cursor_buckets,
+    "grok": _api_only_buckets,
+    "hermes": _api_only_buckets,
+    "opencode": _api_only_buckets,
+}
+
+# Fallback builders keyed by coarse billing-mode for agents without a bespoke
+# bucket table (keeps the engine total — every agent resolves to *something*).
+_MODE_FALLBACK = {
+    "subscription": lambda plan, today: [
+        _bucket("subscription", "Subscription", "included",
+                ("interactive", "programmatic"),
+                note="Flat monthly plan — marginal per-call cost is $0."),
+    ],
+    "api": _api_only_buckets,
+    "local": _local_buckets,
+    "unknown": lambda plan, today: [
+        _bucket("unknown", "Unknown", "api_rate", ("interactive", "programmatic"),
+                note="Billing not determined; figure shown at API list price."),
+    ],
+}
+
+
+def buckets_for(
+    agent: str,
+    plan: str = DEFAULT_PLAN,
+    mode: Optional[str] = None,
+    today: Optional[_dt.date] = None,
+) -> List[Dict[str, Any]]:
+    """Full ordered bucket list for an agent (all task types), drain order.
+
+    ``mode`` (a billing_mode value) is used only as a fallback for agents that
+    have no bespoke table — it never overrides a bespoke one, *except* that a
+    user who marks any agent ``local`` gets the electricity bucket (local
+    re-pricing always wins, mirroring billing_mode's contract). ``today``
+    date-gates policies that aren't in force yet (tests pass it explicitly;
+    callers default to the real date so behavior flips automatically).
+    """
+    t = _today(today)
+    if mode == "local":
+        return _local_buckets(plan, t)
+    builder = _AGENT_BUILDERS.get(agent)
+    if builder is not None:
+        return builder(plan, t)
+    return _MODE_FALLBACK.get(mode or "unknown", _MODE_FALLBACK["unknown"])(plan, t)
+
+
+def resolve_billing_route(
+    agent: str,
+    task_type: str = DEFAULT_TASK_TYPE,
+    plan: str = DEFAULT_PLAN,
+    mode: Optional[str] = None,
+    today: Optional[_dt.date] = None,
+) -> Dict[str, Any]:
+    """Resolve the drain route for one (agent, task_type).
+
+    Returns::
+
+        {
+          "agent": str,
+          "task_type": "interactive" | "programmatic",
+          "buckets": [ <bucket>, ... ],   # drain order, filtered to this task type
+          "active": <bucket> | None,      # first bucket = what pays right now
+          "charges": "included"|"api_rate"|"electricity"|None,  # active bucket's basis
+          "marginal_cost_zero": bool,     # True iff the active bucket is `included`
+                                          # (already paid; `electricity` is its own
+                                          # non-API estimate and stays False)
+          "capped": bool,                 # active bucket has a metered pool to warn on
+        }
+
+    Never raises; an unknown task type collapses to the default.
+    """
+    if task_type not in TASK_TYPES:
+        task_type = DEFAULT_TASK_TYPE
+
+    ordered = [b for b in buckets_for(agent, plan, mode, today)
+               if task_type in b["task_types"]]
+    active = ordered[0] if ordered else None
+    charges = active["charges"] if active else None
+
+    return {
+        "agent": agent,
+        "task_type": task_type,
+        "plan": plan,
+        "buckets": ordered,
+        "active": active,
+        "charges": charges,
+        "marginal_cost_zero": charges == "included",
+        "capped": bool(active and (active.get("pool_usd") is not None
+                                   or active.get("pool_requests") is not None)),
+    }
+
+
+# Word-boundary patterns for programmatic entrypoints. Matched as whole tokens
+# (split on space / slash / underscore / hyphen), NOT substrings — "interactions"
+# must not match "actions", "claude-pro" must not match "-p", "pencil" not "ci".
+_PROGRAMMATIC_TOKEN_RE = re.compile(
+    r"(?:^|[\s/_-])"
+    r"(p|print|headless|sdk|app-?server|github-?actions?|actions?|ci|cron|automation)"
+    r"(?=$|[\s/_-])"
+)
+
+
+def classify_task_type(
+    *,
+    headless: Optional[bool] = None,
+    source: Optional[str] = None,
+) -> str:
+    """Best-effort, conservative task-type classifier.
+
+    Returns ``"programmatic"`` only on a clear signal (an explicit headless flag,
+    or a source string containing a known automation entrypoint as a whole
+    token); otherwise ``"interactive"``. Mirrors billing_mode's detectors:
+    prefer the safe, common default over an over-eager guess that would surface
+    a scary metered pool.
+    """
+    if headless is True:
+        return "programmatic"
+    s = (source or "").lower()
+    if s and _PROGRAMMATIC_TOKEN_RE.search(s):
+        return "programmatic"
+    return "interactive"
+
+
+# ---------------------------------------------------------------------------
+# Per-agent plan persistence (~/.tokentelemetry/billing_plans.json:
+# {"<agent>": "<plan>"}). Separate file from billing.json so the flat
+# {agent: mode} schema there stays untouched/back-compatible.
+# ---------------------------------------------------------------------------
+def _plans_path() -> Path:
+    return data_dir() / "billing_plans.json"
+
+
+def load_plans() -> Dict[str, str]:
+    """User-chosen plan per agent, validated against AGENT_PLANS.
+    Missing/garbage file → empty dict (everyone on DEFAULT_PLAN)."""
+    try:
+        with open(_plans_path(), "r", encoding="utf-8") as f:
+            raw = json.load(f)
+    except Exception:
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+    return {
+        str(a): p
+        for a, p in raw.items()
+        if isinstance(a, str) and p in AGENT_PLANS.get(a, ())
+    }
+
+
+def save_plan(agent: str, plan: Optional[str]) -> Dict[str, str]:
+    """Set (or, with plan=None, clear) one agent's plan. Returns the full map.
+
+    Invalid plans for that agent are rejected by the caller (endpoint) against
+    AGENT_PLANS — here we trust ``plan`` is validated or None.
+    """
+    plans = load_plans()
+    if plan is None:
+        plans.pop(agent, None)
+    else:
+        plans[agent] = plan
+
+    path = _plans_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(plans, f, indent=2)
+    os.replace(tmp, path)
+    return plans
+
+
+def get_route_overview(
+    agent: str,
+    plan: str = DEFAULT_PLAN,
+    mode: Optional[str] = None,
+    today: Optional[_dt.date] = None,
+) -> Dict[str, Any]:
+    """Both task-type routes for an agent plus the full bucket list — the shape
+    the Settings UI consumes to render the drain order and pool warnings."""
+    return {
+        "agent": agent,
+        "plan": plan,
+        "plans": list(AGENT_PLANS.get(agent, ())),
+        "buckets": buckets_for(agent, plan, mode, today),
+        "routes": {
+            tt: resolve_billing_route(agent, tt, plan, mode, today)
+            for tt in TASK_TYPES
+        },
+    }

--- a/backend/main.py
+++ b/backend/main.py
@@ -4527,11 +4527,14 @@ async def get_power_config():
 
     `configured` tells the UI whether a power.json exists yet — when false the
     returned values are the shipped defaults and the local-model electricity
-    branch is inactive until the user saves.
+    branch is inactive until the user saves. `deviceDefault` is the chip-aware
+    wattage detected for this machine (e.g. Apple M5 → 22 W); it's the baseline
+    `loadWatts` falls back to when the user hasn't set one, so the UI can show
+    "default for your machine" instead of a generic number.
     """
-    from power_config import load_power_config, has_user_config
+    from power_config import load_power_config, has_user_config, device_default
     cfg = load_power_config()
-    return {**cfg, "configured": has_user_config()}
+    return {**cfg, "configured": has_user_config(), "deviceDefault": device_default()}
 
 
 @app.put("/config/power")
@@ -4570,14 +4573,23 @@ async def get_power_meter():
 async def calibrate_power():
     """Sample real power for a few seconds and return it as a SUGGESTION.
 
-    Does NOT persist — the UI fills the loadWatts field with the measured value
-    for the user to review and Save. When no root-free source is available (e.g.
-    Apple Silicon on AC), returns `{measured: null, reason: …}`.
+    Does NOT persist — the UI fills the loadWatts field with the value for the
+    user to review and Save. When no root-free *measurement* is available (e.g.
+    Apple Silicon on AC) we fall back to a chip-aware *estimate* so the field
+    still gets a sensible starting value: `{measured: null, estimated: <watts>,
+    source, detail, reason}`. When nothing is derivable, `estimated` is null too.
     """
-    from power_meter import sample_average_watts, capability
+    from power_meter import sample_average_watts, capability, estimated_watts
     sample = sample_average_watts(duration_s=4.0, interval_s=1.0)
     if not sample:
-        return {"measured": None, "reason": capability().get("reason")}
+        est = estimated_watts()
+        return {
+            "measured": None,
+            "estimated": est["watts"] if est else None,
+            "source": est["source"] if est else None,
+            "detail": est.get("detail") if est else None,
+            "reason": capability().get("reason"),
+        }
     return {
         "measured": sample["watts"], "source": sample["source"],
         "samples": sample.get("samples"),
@@ -4623,6 +4635,77 @@ async def put_billing_config(payload: dict = Body(...)):
         raise HTTPException(status_code=500, detail="Could not save billing config to disk.")
     _invalidate_sessions_cache()
     return {"agents": get_all(_list_available_agents()), "modes": list(MODES)}
+
+
+@app.get("/config/billing-route")
+async def get_billing_route_config():
+    """Drain-priority billing routes per agent: which credit *bucket* pays, and
+    in what order, split by task type (interactive vs programmatic).
+
+    For each detected agent this returns the full ordered bucket list plus the
+    resolved `routes.{interactive,programmatic}` (active bucket, marginal-cost
+    flag, and whether the active bucket is a capped pool to warn on). The agent's
+    resolved billing `mode` is threaded in so a user-marked `local` agent routes
+    to the electricity bucket, and each agent's persisted *plan* (set via PUT)
+    sizes its pools — plan vocabularies are per-provider, so there is no global
+    plan knob. Date-gated policies (Anthropic's June-15 SDK split) flip on the
+    real clock. This drives the Settings drain-order view; it does not change
+    cost math on its own. `as_of` is when the provider snapshot was last
+    verified — the UI shows it as a staleness disclaimer.
+    """
+    from billing_mode import get_all
+    from billing_route import (
+        get_route_overview, load_plans, TASK_TYPES, CHARGES,
+        DEFAULT_PLAN, SNAPSHOT_AS_OF,
+    )
+    agents = _list_available_agents()
+    modes = get_all(agents)
+    plans = load_plans()
+    overview = {
+        a: get_route_overview(
+            a,
+            plan=plans.get(a, DEFAULT_PLAN),
+            mode=modes.get(a, {}).get("mode"),
+        )
+        for a in agents
+    }
+    return {
+        "agents": overview,
+        "task_types": list(TASK_TYPES),
+        "charges": list(CHARGES),
+        "as_of": SNAPSHOT_AS_OF,
+    }
+
+
+@app.put("/config/billing-route")
+async def put_billing_route_config(payload: dict = Body(...)):
+    """Set or clear one agent's plan tier (sizes its credit pools).
+
+    Body: {"agent": "<agent>", "plan": "<plan>" | null}. A null/absent plan
+    clears the choice and reverts the agent to its provider's default tier.
+    Plans are validated against that agent's own vocabulary (e.g. "max5x" is
+    Anthropic-only). Invalid input is rejected with a plain message.
+    """
+    from fastapi import HTTPException
+    from billing_route import save_plan, AGENT_PLANS
+    if not isinstance(payload, dict):
+        raise HTTPException(status_code=400, detail="body must be a JSON object")
+    agent = payload.get("agent")
+    if not isinstance(agent, str) or not agent.strip():
+        raise HTTPException(status_code=400, detail="'agent' is required")
+    agent = agent.strip()
+    plan = payload.get("plan")
+    valid = AGENT_PLANS.get(agent, ())
+    if plan is not None and plan not in valid:
+        raise HTTPException(
+            status_code=400,
+            detail=f"'plan' for {agent} must be one of {list(valid)} or null",
+        )
+    try:
+        save_plan(agent, plan)
+    except OSError:
+        raise HTTPException(status_code=500, detail="Could not save plan to disk.")
+    return await get_billing_route_config()
 
 
 @app.get("/config/aliases")

--- a/backend/power_config.py
+++ b/backend/power_config.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import json
 import os
 import re
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -82,6 +83,41 @@ LOCAL_PROVIDERS = {
 DEFAULT_TOK_PER_SEC = 30.0
 
 
+@lru_cache(maxsize=1)
+def device_default() -> Dict[str, Any]:
+    """The default load wattage for THIS machine, detected once per process.
+
+    Prefers a chip-aware estimate (``power_meter.estimated_watts`` — e.g. Apple
+    Silicon tier) over the flat ``DEFAULT_LOAD_WATTS``, so the electricity cost
+    uses a realistic per-device baseline instead of a generic 80 W when the user
+    hasn't set a wattage. Returns ``{watts, source, detail}`` — ``source`` is
+    ``"apple-silicon-default"`` (etc.) when device-derived, else ``"default"``.
+
+    Cached because the underlying detection shells out to ``sysctl``; this is
+    called on the hot cost path. Call ``device_default.cache_clear()`` in tests.
+    """
+    watts, source, detail = DEFAULT_LOAD_WATTS, "default", None
+    try:
+        from power_meter import estimated_watts
+        est = estimated_watts(with_detail=False)
+        if est and est.get("watts"):
+            watts = int(round(est["watts"]))
+            source = est.get("source", "device")
+            detail = est.get("detail")
+    except Exception:
+        pass
+    # `detected` is False on environments we can't auto-detect (Intel Macs, AMD,
+    # Linux/Windows CPU boxes) — the UI uses this to prompt the user to enter
+    # their own wattage instead of presenting the flat fallback as if detected.
+    return {"watts": watts, "source": source, "detail": detail,
+            "detected": source != "default"}
+
+
+def device_default_watts() -> int:
+    """Device-aware default load wattage (chip estimate or flat fallback)."""
+    return device_default()["watts"]
+
+
 def _config_path() -> Path:
     return data_dir() / "power.json"
 
@@ -129,6 +165,9 @@ def load_power_config() -> Dict[str, Any]:
     """
     config = dict(DEFAULTS)
     config["subscriptionEndpoints"] = list(DEFAULT_SUBSCRIPTION_ENDPOINTS)
+    # Baseline wattage is device-aware (chip estimate) — an explicit value in
+    # power.json below still overrides it.
+    config["loadWatts"] = device_default_watts()
 
     path = _config_path()
     if not path.exists():
@@ -336,7 +375,7 @@ def electricity_cost(
         config = load_power_config()
     if output_tokens <= 0 or not tok_per_sec or tok_per_sec <= 0:
         return 0.0
-    watts = config.get("loadWatts", DEFAULT_LOAD_WATTS)
+    watts = config.get("loadWatts", device_default_watts())
     cost_per_kwh = config.get("costPerKwh", DEFAULT_COST_PER_KWH)
     gen_seconds = output_tokens / tok_per_sec
     # watts * seconds = watt-seconds (joules); /3_600_000 converts Wh->kWh and
@@ -362,7 +401,7 @@ def co2_for_session(
         config = load_power_config()
     if output_tokens <= 0 or not tok_per_sec or tok_per_sec <= 0:
         return 0.0
-    watts = config.get("loadWatts", DEFAULT_LOAD_WATTS)
+    watts = config.get("loadWatts", device_default_watts())
     gen_seconds = output_tokens / tok_per_sec
     kwh = (watts * gen_seconds) / 3_600_000
     intensity = config.get("gridCarbonIntensity", DEFAULT_CARBON_INTENSITY)

--- a/backend/power_meter.py
+++ b/backend/power_meter.py
@@ -100,6 +100,88 @@ def _macos_battery_watts() -> Optional[float]:
     return watts if watts > 0 else None
 
 
+# ---------------------------------------------------------------------------
+# Apple Silicon estimated default (userspace, no root)
+# ---------------------------------------------------------------------------
+# There is no root-free way to MEASURE watts on Apple Silicon (powermetrics is
+# root-only; on AC the battery current is ~0). But the chip itself is readable in
+# userspace via sysctl + system_profiler. We use that to seed a far better
+# DEFAULT than the generic 80 W: a laptop M-series package under sustained
+# inference draws ~20-45 W, so 80 W overestimates electricity cost by ~2x on the
+# machines most likely to run local models. This is an ESTIMATE
+# (confidence="estimated"), never a measurement — the user overrides it if they
+# know their real draw. Cf. llama-swap discussion #814.
+
+# Typical whole-package draw (watts) under sustained inference load by chip tier.
+# Deliberately mid-range, conservative ballpark figures — they exist so the
+# default isn't wildly wrong for Apple Silicon, not to claim precision.
+_APPLE_TIER_WATTS = {
+    "ultra": 120.0,
+    "max": 65.0,
+    "pro": 35.0,
+    "base": 22.0,
+}
+
+_APPLE_BRAND_RE = re.compile(r"\bApple\s+M(\d+)\s*(Pro|Max|Ultra)?\b", re.IGNORECASE)
+
+
+def _apple_silicon_chip(with_gpu_cores: bool = True) -> Optional[Dict[str, Any]]:
+    """Identify the Apple Silicon chip from userspace (no root). None if not AS.
+
+    Returns ``{chip, generation, tier, gpu_cores}`` where ``tier`` is one of
+    base/pro/max/ultra and ``gpu_cores`` may be None if unreadable. The wattage
+    only needs ``tier`` (from the fast sysctl call); ``with_gpu_cores=False``
+    skips the slower ``system_profiler`` call used purely for the human label.
+    """
+    if platform.system() != "Darwin" or platform.machine() != "arm64":
+        return None
+    brand = _run(["sysctl", "-n", "machdep.cpu.brand_string"])
+    if not brand:
+        return None
+    m = _APPLE_BRAND_RE.search(brand.strip())
+    if not m:
+        return None
+    tier = (m.group(2) or "base").lower()
+    chip = " ".join(m.group(0).split())  # normalise internal whitespace
+    # GPU core count (userspace) — refines the human label only, not the wattage.
+    gpu_cores: Optional[int] = None
+    if with_gpu_cores:
+        sp = _run(["system_profiler", "SPDisplaysDataType"], timeout=5.0)
+        if sp:
+            cm = re.search(r"Total Number of Cores:\s*(\d+)", sp)
+            if cm:
+                gpu_cores = int(cm.group(1))
+    return {
+        "chip": chip,
+        "generation": int(m.group(1)),
+        "tier": tier,
+        "gpu_cores": gpu_cores,
+    }
+
+
+def estimated_watts(with_detail: bool = True) -> Optional[Dict[str, Any]]:
+    """A best-effort DEFAULT wattage when no real reading is possible.
+
+    On Apple Silicon, derived from the (userspace-readable) chip tier; elsewhere
+    None. Always ``confidence="estimated"`` — a starting point the user reviews
+    and overrides, not a measurement. Returns
+    ``{watts, source, confidence, detail}`` or None. ``with_detail=False`` skips
+    the slower GPU-core lookup when only the wattage is needed (hot path).
+    """
+    chip = _apple_silicon_chip(with_gpu_cores=with_detail)
+    if not chip:
+        return None
+    watts = _APPLE_TIER_WATTS.get(chip["tier"], _APPLE_TIER_WATTS["base"])
+    cores = chip.get("gpu_cores")
+    label = chip["chip"] + (f" ({cores}-core GPU)" if cores else "")
+    return {
+        "watts": watts,
+        "source": "apple-silicon-default",
+        "confidence": "estimated",
+        "detail": label,
+    }
+
+
 # A personal machine's draw under inference load realistically sits well under
 # this. Anything outside (0, MAX] is treated as a bad reading and discarded — a
 # guard against parsing glitches (e.g. unsigned battery counters) reaching cost.
@@ -171,7 +253,9 @@ def capability() -> Dict[str, Any]:
         if out:
             m = re.search(r'(?<![A-Za-z0-9])"?ExternalConnected"?\s*=\s*(Yes|No)', out)
             on_ac = not (m and m.group(1) == "No")
-        return {
+        # No measurement on AC, but we can still suggest a chip-aware default.
+        est = estimated_watts() if on_ac else None
+        cap = {
             "available": not on_ac,
             "method": "macos-battery" if not on_ac else None,
             "system": system,
@@ -179,10 +263,17 @@ def capability() -> Dict[str, Any]:
                 "On battery: whole-system power is read from the battery."
                 if not on_ac else
                 "On Apple Silicon, accurate GPU power needs admin (powermetrics). "
-                "Unplug to read battery-based power, or set/calibrate a wattage manually."
+                "Unplug to read battery-based power, or use the chip-based estimate below."
             ),
         }
-    return {
+        if est:
+            cap["estimated"] = est
+        return cap
+    est = estimated_watts()
+    cap = {
         "available": False, "method": None, "system": system,
         "reason": "No root-free power source detected; set a wattage manually.",
     }
+    if est:
+        cap["estimated"] = est
+    return cap

--- a/backend/test_billing_route.py
+++ b/backend/test_billing_route.py
@@ -1,0 +1,216 @@
+"""Tests for the drain-priority billing-route engine (billing_route.py).
+
+Snapshot-of-June-2026 provider rules — these assert the *structure* of the drain
+order (which bucket pays first, marginal cost, capped pools, no-spillover,
+effective dates), not exact dollar amounts beyond the documented pool sizes.
+"""
+
+import datetime as dt
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import billing_route as br
+
+# Anthropic's split is date-gated; pin both sides of the boundary explicitly so
+# these tests don't change meaning as the wall clock crosses June 15 2026.
+PRE_SPLIT = dt.date(2026, 6, 14)
+POST_SPLIT = dt.date(2026, 6, 15)
+
+
+# ---------------------------------------------------------------------------
+# Anthropic: the canonical June-15 split — interactive vs programmatic diverge,
+# but ONLY once the policy is in force.
+# ---------------------------------------------------------------------------
+def test_anthropic_pre_split_programmatic_still_draws_subscription():
+    r = br.resolve_billing_route("claude", "programmatic", today=PRE_SPLIT)
+    assert r["active"]["id"] == "subscription"
+    assert r["marginal_cost_zero"] is True
+    assert r["capped"] is False
+    # The pre-warning about the upcoming split is in the note.
+    assert "2026-06-15" in r["active"]["note"]
+
+
+def test_anthropic_interactive_draws_subscription_no_pool():
+    r = br.resolve_billing_route("claude", "interactive", today=POST_SPLIT)
+    assert r["active"]["id"] == "subscription"
+    assert r["charges"] == "included"
+    assert r["marginal_cost_zero"] is True
+    assert r["capped"] is False
+    assert r["active"]["no_spillover"] is True
+
+
+def test_anthropic_programmatic_drains_sdk_credit_first_post_split():
+    r = br.resolve_billing_route("claude", "programmatic", today=POST_SPLIT)
+    assert r["active"]["id"] == "sdk_credit"
+    # Marginal $0 while the prepaid pool lasts, but it's a *capped* pool we warn on.
+    assert r["marginal_cost_zero"] is True
+    assert r["capped"] is True
+    assert r["active"]["pool_usd"] == 20.0          # Pro default
+    assert r["active"]["pool_period"] == "month"
+    assert r["active"]["no_spillover"] is True
+    # Overflow paygo is the next bucket in drain order for programmatic.
+    ids = [b["id"] for b in r["buckets"]]
+    assert ids == ["sdk_credit", "api_overflow"]
+
+
+def test_anthropic_plan_changes_sdk_pool_size():
+    assert br.resolve_billing_route(
+        "claude", "programmatic", plan="max5x", today=POST_SPLIT
+    )["active"]["pool_usd"] == 100.0
+    assert br.resolve_billing_route(
+        "claude", "programmatic", plan="max20x", today=POST_SPLIT
+    )["active"]["pool_usd"] == 200.0
+
+
+def test_anthropic_interactive_never_sees_sdk_credit():
+    r = br.resolve_billing_route("claude", "interactive", today=POST_SPLIT)
+    assert all(b["id"] != "sdk_credit" for b in r["buckets"])
+
+
+# ---------------------------------------------------------------------------
+# Codex: ONE subscription bucket covers both task types (no SDK split).
+# ---------------------------------------------------------------------------
+def test_codex_single_bucket_both_task_types():
+    interactive = br.resolve_billing_route("codex", "interactive")
+    programmatic = br.resolve_billing_route("codex", "programmatic")
+    assert interactive["active"]["id"] == "subscription"
+    assert programmatic["active"]["id"] == "subscription"
+    assert interactive["marginal_cost_zero"] and programmatic["marginal_cost_zero"]
+
+
+# ---------------------------------------------------------------------------
+# Gemini free tier (request-count cap), Copilot credits, Cursor pools.
+# ---------------------------------------------------------------------------
+def test_gemini_free_tier_is_request_capped():
+    r = br.resolve_billing_route("gemini", "interactive")
+    assert r["active"]["id"] == "free_tier"
+    # The cap is requests/day, not dollars — and it still counts as capped.
+    assert r["active"]["pool_usd"] is None
+    assert r["active"]["pool_requests"] == 1000
+    assert r["active"]["pool_period"] == "day"
+    assert r["capped"] is True
+    ids = [b["id"] for b in br.buckets_for("gemini")]
+    assert ids == ["free_tier", "api_paygo"]
+
+
+def test_copilot_completions_free_and_credits_capped():
+    r = br.resolve_billing_route("copilot", "interactive")
+    # Completions are the first interactive bucket and are free/unlimited.
+    assert r["active"]["id"] == "completions"
+    # The AI-credit bucket carries a metered pool.
+    credits = next(b for b in r["buckets"] if b["id"] == "ai_credits")
+    assert credits["pool_usd"] == 39.0
+
+
+def test_cursor_pool_scales_with_plan():
+    assert next(b for b in br.buckets_for("cursor", plan="ultra")
+                if b["id"] == "included_credits")["pool_usd"] == 200.0
+
+
+# ---------------------------------------------------------------------------
+# API-only + local + fallbacks.
+# ---------------------------------------------------------------------------
+def test_api_only_agents_are_paygo():
+    for agent in ("grok", "hermes", "opencode"):
+        r = br.resolve_billing_route(agent)
+        assert r["active"]["id"] == "api_paygo"
+        assert r["charges"] == "api_rate"
+        assert r["marginal_cost_zero"] is False
+
+
+def test_local_mode_overrides_to_electricity():
+    r = br.resolve_billing_route("claude", "programmatic", mode="local")
+    assert r["active"]["id"] == "electricity"
+    assert r["charges"] == "electricity"
+    # Electricity is not an API charge, so marginal_cost_zero stays False.
+    assert r["marginal_cost_zero"] is False
+
+
+def test_unknown_agent_falls_back_by_mode():
+    assert br.resolve_billing_route("weirdtool", mode="subscription")["active"]["id"] == "subscription"
+    assert br.resolve_billing_route("weirdtool", mode="api")["active"]["id"] == "api_paygo"
+    assert br.resolve_billing_route("weirdtool")["active"]["id"] == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Robustness + helpers.
+# ---------------------------------------------------------------------------
+def test_bad_task_type_collapses_to_default():
+    r = br.resolve_billing_route("claude", "garbage", today=POST_SPLIT)
+    assert r["task_type"] == "interactive"
+    assert r["active"]["id"] == "subscription"
+
+
+def test_classify_task_type_positive_signals():
+    assert br.classify_task_type(headless=True) == "programmatic"
+    assert br.classify_task_type(source="claude -p") == "programmatic"
+    assert br.classify_task_type(source="codex app-server") == "programmatic"
+    assert br.classify_task_type(source="github-actions") == "programmatic"
+    assert br.classify_task_type(source="agent sdk") == "programmatic"
+    assert br.classify_task_type(source="nightly cron job") == "programmatic"
+
+
+def test_classify_task_type_no_substring_false_positives():
+    # Whole-token matching: none of these contain a programmatic token as a word.
+    assert br.classify_task_type(source="interactive terminal") == "interactive"
+    assert br.classify_task_type(source="interactions panel") == "interactive"  # not "actions"
+    assert br.classify_task_type(source="claude-pro session") == "interactive"  # not "-p"
+    assert br.classify_task_type(source="pencil sketcher") == "interactive"     # not "ci"
+    assert br.classify_task_type(source="printer-friendly view") == "interactive"  # not "print"
+    assert br.classify_task_type() == "interactive"
+
+
+def test_overview_has_both_routes_plans_and_all_buckets():
+    ov = br.get_route_overview("claude", today=POST_SPLIT)
+    assert set(ov["routes"]) == {"interactive", "programmatic"}
+    assert ov["plans"] == ["pro", "max5x", "max20x"]
+    # Full bucket list (all task types) is a superset of either single route.
+    assert len(ov["buckets"]) >= len(ov["routes"]["programmatic"]["buckets"])
+
+
+def test_every_known_agent_resolves():
+    for agent in ("claude", "codex", "gemini", "copilot", "cursor",
+                  "grok", "hermes", "opencode"):
+        for tt in br.TASK_TYPES:
+            for day in (PRE_SPLIT, POST_SPLIT):
+                r = br.resolve_billing_route(agent, tt, today=day)
+                assert r["active"] is not None, f"{agent}/{tt}/{day} had no active bucket"
+                assert r["charges"] in br.CHARGES
+
+
+# ---------------------------------------------------------------------------
+# Per-agent plan persistence (billing_plans.json).
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def plans_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("TOKENTELEMETRY_HOME", str(tmp_path))
+    return tmp_path
+
+
+def test_plans_roundtrip(plans_home):
+    assert br.load_plans() == {}
+    assert br.save_plan("claude", "max5x") == {"claude": "max5x"}
+    assert br.load_plans() == {"claude": "max5x"}
+    # Clearing reverts the agent to the default plan.
+    assert br.save_plan("claude", None) == {}
+    assert br.load_plans() == {}
+
+
+def test_plans_invalid_values_dropped_on_load(plans_home):
+    # A plan valid for one provider isn't valid for another ("ultra" is Cursor's).
+    p = br._plans_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps({"claude": "ultra", "cursor": "ultra", "x": 3}))
+    assert br.load_plans() == {"cursor": "ultra"}
+
+
+def test_plans_garbage_file_is_empty(plans_home):
+    p = br._plans_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("{not json")
+    assert br.load_plans() == {}

--- a/backend/test_power_config.py
+++ b/backend/test_power_config.py
@@ -42,10 +42,50 @@ def test_defaults_when_no_file():
     with tempfile.TemporaryDirectory() as home:
         pc, _ = _fresh_modules(home)
         cfg = pc.load_power_config()
-        assert cfg["loadWatts"] == pc.DEFAULT_LOAD_WATTS
+        # Default wattage is now device-aware (chip estimate where available,
+        # else the flat DEFAULT_LOAD_WATTS) — assert against that source of truth.
+        assert cfg["loadWatts"] == pc.device_default_watts()
         assert cfg["costPerKwh"] == pc.DEFAULT_COST_PER_KWH
         assert cfg["subscriptionEndpoints"] == []
         assert pc.has_user_config() is False
+
+
+def test_device_default_drives_loadwatts_when_unset(monkeypatch):
+    """A chip-aware estimate becomes the default loadWatts (not the flat 80)."""
+    with tempfile.TemporaryDirectory() as home:
+        pc, pr = _fresh_modules(home)
+        import power_meter
+        # Pretend we're on an Apple M-series box → 22 W estimate.
+        monkeypatch.setattr(
+            power_meter, "estimated_watts",
+            lambda with_detail=True: {
+                "watts": 22.0, "source": "apple-silicon-default",
+                "confidence": "estimated", "detail": "Apple M5 (10-core GPU)",
+            },
+        )
+        pc.device_default.cache_clear()
+        assert pc.device_default_watts() == 22
+        assert pc.device_default()["detected"] is True
+        # No power.json → electricity cost uses the 22 W device default, not 80.
+        cfg = pc.load_power_config()
+        assert cfg["loadWatts"] == 22
+        cost = pc.electricity_cost(900, cfg, tok_per_sec=90.0)  # 10 s of gen
+        assert abs(cost - (10 * 22 / 3_600_000 * pc.DEFAULT_COST_PER_KWH)) < 1e-12
+        # An explicit power.json value still wins over the device default.
+        _write_power_json(home, {"loadWatts": 150})
+        pc.device_default.cache_clear()
+        assert pc.load_power_config()["loadWatts"] == 150
+
+
+def test_device_default_falls_back_to_flat_when_no_estimate(monkeypatch):
+    with tempfile.TemporaryDirectory() as home:
+        pc, _ = _fresh_modules(home)
+        import power_meter
+        monkeypatch.setattr(power_meter, "estimated_watts", lambda with_detail=True: None)
+        pc.device_default.cache_clear()
+        assert pc.device_default_watts() == pc.DEFAULT_LOAD_WATTS
+        assert pc.device_default()["source"] == "default"
+        assert pc.device_default()["detected"] is False
 
 
 def test_malformed_file_falls_back_to_defaults():
@@ -55,7 +95,7 @@ def test_malformed_file_falls_back_to_defaults():
         (d / "power.json").write_text("{not valid json", encoding="utf-8")
         pc, _ = _fresh_modules(home)
         cfg = pc.load_power_config()  # must not raise
-        assert cfg["loadWatts"] == pc.DEFAULT_LOAD_WATTS
+        assert cfg["loadWatts"] == pc.device_default_watts()
         # File exists, so it counts as user-configured even though it's garbage.
         assert pc.has_user_config() is True
 

--- a/backend/test_power_meter.py
+++ b/backend/test_power_meter.py
@@ -1,0 +1,105 @@
+"""Tests for the userspace Apple-Silicon power estimate in power_meter.
+
+These cover the pure parsing + tier→watts logic deterministically by mocking the
+subprocess calls, so they pass on any platform (CI is usually Linux).
+"""
+
+import power_meter as pm
+
+
+def _patch_apple(monkeypatch, brand, gpu_cores=None, arm=True):
+    """Make power_meter look like an Apple Silicon box returning `brand`."""
+    monkeypatch.setattr(pm.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(pm.platform, "machine", lambda: "arm64" if arm else "x86_64")
+
+    def fake_run(cmd, timeout=3.0):
+        if cmd[:2] == ["sysctl", "-n"]:
+            return brand
+        if cmd[0] == "system_profiler":
+            return f"  Total Number of Cores: {gpu_cores}\n" if gpu_cores else ""
+        return None
+
+    monkeypatch.setattr(pm, "_run", fake_run)
+
+
+def test_chip_base(monkeypatch):
+    _patch_apple(monkeypatch, "Apple M5", gpu_cores=10)
+    chip = pm._apple_silicon_chip()
+    assert chip == {"chip": "Apple M5", "generation": 5, "tier": "base", "gpu_cores": 10}
+
+
+def test_chip_tiers(monkeypatch):
+    for brand, tier in [
+        ("Apple M3 Pro", "pro"),
+        ("Apple M3 Max", "max"),
+        ("Apple M2 Ultra", "ultra"),
+        ("Apple M1", "base"),
+    ]:
+        _patch_apple(monkeypatch, brand)
+        assert pm._apple_silicon_chip()["tier"] == tier
+
+
+def test_estimated_watts_by_tier(monkeypatch):
+    cases = [
+        ("Apple M5", 22.0),
+        ("Apple M4 Pro", 35.0),
+        ("Apple M3 Max", 65.0),
+        ("Apple M2 Ultra", 120.0),
+    ]
+    for brand, watts in cases:
+        _patch_apple(monkeypatch, brand)
+        est = pm.estimated_watts()
+        assert est["watts"] == watts
+        assert est["source"] == "apple-silicon-default"
+        assert est["confidence"] == "estimated"
+
+
+def test_estimated_watts_label_includes_cores(monkeypatch):
+    _patch_apple(monkeypatch, "Apple M5", gpu_cores=10)
+    assert pm.estimated_watts()["detail"] == "Apple M5 (10-core GPU)"
+
+
+def test_estimated_watts_label_without_cores(monkeypatch):
+    _patch_apple(monkeypatch, "Apple M5", gpu_cores=None)
+    assert pm.estimated_watts()["detail"] == "Apple M5"
+
+
+def test_not_apple_silicon_returns_none(monkeypatch):
+    # Intel mac → not arm64 → no chip estimate.
+    _patch_apple(monkeypatch, "Apple M5", arm=True, gpu_cores=8)
+    monkeypatch.setattr(pm.platform, "machine", lambda: "x86_64")
+    assert pm._apple_silicon_chip() is None
+    assert pm.estimated_watts() is None
+
+
+def test_linux_returns_none(monkeypatch):
+    monkeypatch.setattr(pm.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(pm.platform, "machine", lambda: "x86_64")
+    assert pm.estimated_watts() is None
+
+
+def test_unparseable_brand_returns_none(monkeypatch):
+    _patch_apple(monkeypatch, "Some Unknown CPU")
+    assert pm._apple_silicon_chip() is None
+
+
+def test_capability_includes_estimate_on_ac(monkeypatch):
+    """Apple Silicon on AC: no measurement, but a chip estimate is offered."""
+    monkeypatch.setattr(pm.shutil, "which", lambda _: None)  # no nvidia-smi
+    monkeypatch.setattr(pm.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(pm.platform, "machine", lambda: "arm64")
+
+    def fake_run(cmd, timeout=3.0):
+        if cmd[:2] == ["ioreg", "-r"]:
+            return 'ExternalConnected = Yes\n'  # on AC
+        if cmd[:2] == ["sysctl", "-n"]:
+            return "Apple M5"
+        if cmd[0] == "system_profiler":
+            return "Total Number of Cores: 10\n"
+        return None
+
+    monkeypatch.setattr(pm, "_run", fake_run)
+    cap = pm.capability()
+    assert cap["available"] is False
+    assert cap["estimated"]["watts"] == 22.0
+    assert cap["estimated"]["detail"] == "Apple M5 (10-core GPU)"

--- a/frontend/src/components/settings/BillingSettings.tsx
+++ b/frontend/src/components/settings/BillingSettings.tsx
@@ -1,13 +1,16 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Wallet, Check, Loader2 } from "lucide-react";
+import { Wallet, Check, Loader2, ChevronDown, ChevronRight } from "lucide-react";
 import { getAgent } from "@/lib/agents";
 import { Card, CardHeader, CardTitle, Badge, Skeleton } from "@/components/ui";
 import {
   getBillingConfig, setBillingMode, MODE_LABEL,
+  getBillingRouteConfig, setBillingPlan,
   type BillingConfig, type AgentBilling, type BillingMode,
+  type BillingRouteConfig,
 } from "@/lib/billing";
+import { DrainOrder } from "./DrainOrder";
 
 // Modes a user can pick explicitly (plus the implicit "auto" = clear override).
 const SELECTABLE: BillingMode[] = ["subscription", "api", "local"];
@@ -20,6 +23,8 @@ function sourceNote(b: AgentBilling): string {
 
 export function BillingSettings() {
   const [config, setConfig] = useState<BillingConfig | null>(null);
+  const [routes, setRoutes] = useState<BillingRouteConfig | null>(null);
+  const [expanded, setExpanded] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [savingAgent, setSavingAgent] = useState<string | null>(null);
   const [savedAgent, setSavedAgent] = useState<string | null>(null);
@@ -34,8 +39,27 @@ export function BillingSettings() {
         setError(e instanceof Error ? e.message : "Failed to load billing config.");
         setLoading(false);
       });
+    // Drain-order routes load separately and degrade gracefully — an older
+    // backend without /config/billing-route just hides the expandable section.
+    getBillingRouteConfig()
+      .then((r) => { if (!cancelled) setRoutes(r); })
+      .catch(() => {});
     return () => { cancelled = true; };
   }, []);
+
+  const onPlanChange = async (agent: string, plan: string | null) => {
+    setSavingAgent(agent);
+    setError(null);
+    try {
+      setRoutes(await setBillingPlan(agent, plan));
+      setSavedAgent(agent);
+      setTimeout(() => setSavedAgent((a) => (a === agent ? null : a)), 2000);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to save plan.");
+    } finally {
+      setSavingAgent((a) => (a === agent ? null : a));
+    }
+  };
 
   const onChange = async (agent: string, raw: string) => {
     // "auto" clears the override → revert to auto-detection.
@@ -45,6 +69,8 @@ export function BillingSettings() {
     try {
       const next = await setBillingMode(agent, mode);
       setConfig(next);
+      // Mode changes can reroute buckets (e.g. "local" → electricity) — refresh.
+      getBillingRouteConfig().then(setRoutes).catch(() => {});
       setSavedAgent(agent);
       setTimeout(() => setSavedAgent((a) => (a === agent ? null : a)), 2000);
     } catch (e) {
@@ -78,42 +104,66 @@ export function BillingSettings() {
             const meta = getAgent(agent);
             const Icon = meta.icon;
             const value = b.source === "user" ? b.mode : "auto";
+            const overview = routes?.agents[agent];
+            const isExpanded = expanded === agent;
             return (
-              <div key={agent} className="flex items-center justify-between gap-4 py-3">
-                <div className="flex items-center gap-2.5 min-w-0">
-                  <span
-                    className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md"
-                    style={{ background: `${meta.hex}1a`, color: meta.hex }}
-                  >
-                    <Icon size={15} />
-                  </span>
-                  <div className="min-w-0">
-                    <div className="text-[13px] font-medium text-[var(--tt-fg)]">{meta.label}</div>
-                    <div className="text-[11px] text-[var(--tt-fg-muted)] truncate">{sourceNote(b)}</div>
+              <div key={agent} className="py-3">
+                <div className="flex items-center justify-between gap-4">
+                  <div className="flex items-center gap-2.5 min-w-0">
+                    <span
+                      className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md"
+                      style={{ background: `${meta.hex}1a`, color: meta.hex }}
+                    >
+                      <Icon size={15} />
+                    </span>
+                    <div className="min-w-0">
+                      <div className="text-[13px] font-medium text-[var(--tt-fg)]">{meta.label}</div>
+                      <div className="text-[11px] text-[var(--tt-fg-muted)] truncate">{sourceNote(b)}</div>
+                    </div>
+                  </div>
+
+                  <div className="flex items-center gap-2 shrink-0">
+                    {savedAgent === agent && (
+                      <span className="flex items-center gap-1 text-[11px] text-[var(--tt-success-fg)]">
+                        <Check size={12} /> Saved
+                      </span>
+                    )}
+                    {savingAgent === agent && <Loader2 size={13} className="animate-spin text-[var(--tt-fg-muted)]" />}
+                    <select
+                      value={value}
+                      disabled={savingAgent === agent}
+                      onChange={(e) => onChange(agent, e.target.value)}
+                      className="rounded-md border border-[var(--tt-border)] bg-[var(--tt-bg-elev)] px-2.5 py-1.5 text-[12px] text-[var(--tt-fg)] outline-none focus:border-[var(--tt-brand)] cursor-pointer"
+                    >
+                      <option value="auto">
+                        Auto{b.detected ? ` · ${MODE_LABEL[b.detected]}` : b.source === "default" ? ` · ${MODE_LABEL[b.default]}` : ""}
+                      </option>
+                      {SELECTABLE.map((m) => (
+                        <option key={m} value={m}>{MODE_LABEL[m]}</option>
+                      ))}
+                    </select>
+                    {overview && (
+                      <button
+                        type="button"
+                        onClick={() => setExpanded(isExpanded ? null : agent)}
+                        aria-expanded={isExpanded}
+                        aria-label={`${isExpanded ? "Hide" : "Show"} ${meta.label} drain order`}
+                        className="flex h-7 w-7 items-center justify-center rounded-md border border-[var(--tt-border)] bg-[var(--tt-bg-elev)] text-[var(--tt-fg-muted)] hover:text-[var(--tt-fg)] cursor-pointer"
+                      >
+                        {isExpanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+                      </button>
+                    )}
                   </div>
                 </div>
 
-                <div className="flex items-center gap-2 shrink-0">
-                  {savedAgent === agent && (
-                    <span className="flex items-center gap-1 text-[11px] text-[var(--tt-success-fg)]">
-                      <Check size={12} /> Saved
-                    </span>
-                  )}
-                  {savingAgent === agent && <Loader2 size={13} className="animate-spin text-[var(--tt-fg-muted)]" />}
-                  <select
-                    value={value}
-                    disabled={savingAgent === agent}
-                    onChange={(e) => onChange(agent, e.target.value)}
-                    className="rounded-md border border-[var(--tt-border)] bg-[var(--tt-bg-elev)] px-2.5 py-1.5 text-[12px] text-[var(--tt-fg)] outline-none focus:border-[var(--tt-brand)] cursor-pointer"
-                  >
-                    <option value="auto">
-                      Auto{b.detected ? ` · ${MODE_LABEL[b.detected]}` : b.source === "default" ? ` · ${MODE_LABEL[b.default]}` : ""}
-                    </option>
-                    {SELECTABLE.map((m) => (
-                      <option key={m} value={m}>{MODE_LABEL[m]}</option>
-                    ))}
-                  </select>
-                </div>
+                {isExpanded && overview && routes && (
+                  <DrainOrder
+                    overview={overview}
+                    asOf={routes.as_of}
+                    saving={savingAgent === agent}
+                    onPlanChange={(plan) => onPlanChange(agent, plan)}
+                  />
+                )}
               </div>
             );
           })}

--- a/frontend/src/components/settings/DrainOrder.tsx
+++ b/frontend/src/components/settings/DrainOrder.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { AlertTriangle } from "lucide-react";
+import {
+  PLAN_LABEL, TASK_TYPE_LABEL, CHARGES_LABEL,
+  type AgentRouteOverview, type RouteBucket, type TaskType, type BucketCharges,
+} from "@/lib/billing";
+
+// Stage 1: structure only. Renders the per-task-type drain ORDER (which bucket
+// pays first), charge badges, pool sizes and the no-fallback warning. Live pool
+// *fill* meters need per-session task-type attribution and come in stage 2.
+
+const CHARGE_STYLE: Record<BucketCharges, string> = {
+  included: "text-[var(--tt-success-fg)] bg-[var(--tt-success-fg)]/10",
+  api_rate: "text-[var(--tt-warning-fg,#b45309)] bg-[var(--tt-warning-fg,#b45309)]/10",
+  electricity: "text-[var(--tt-fg-dim)] bg-[var(--tt-fg-dim)]/10",
+};
+
+function poolText(b: RouteBucket): string | null {
+  if (b.pool_usd != null) return `$${b.pool_usd.toFixed(0)}/${b.pool_period ?? "month"} pool`;
+  if (b.pool_requests != null)
+    return `${b.pool_requests.toLocaleString()} requests/${b.pool_period ?? "day"}`;
+  return null;
+}
+
+function BucketRow({ bucket, index }: { bucket: RouteBucket; index: number }) {
+  const pool = poolText(bucket);
+  return (
+    <div className="flex items-start gap-2 py-1.5">
+      <span className="mt-0.5 flex h-4.5 w-4.5 shrink-0 items-center justify-center rounded-full bg-[var(--tt-bg-elev)] text-[10px] font-semibold text-[var(--tt-fg-muted)]">
+        {index + 1}
+      </span>
+      <div className="min-w-0">
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="text-[12px] font-medium text-[var(--tt-fg)]">{bucket.label}</span>
+          <span className={`rounded px-1.5 py-px text-[10px] font-medium ${CHARGE_STYLE[bucket.charges]}`}>
+            {CHARGES_LABEL[bucket.charges]}
+          </span>
+          {pool && (
+            <span className="rounded px-1.5 py-px text-[10px] font-medium text-[var(--tt-fg-muted)] bg-[var(--tt-bg-elev)]">
+              {pool}
+            </span>
+          )}
+          {bucket.no_spillover && (
+            <span className="flex items-center gap-0.5 text-[10px] text-[var(--tt-danger-fg)]">
+              <AlertTriangle size={10} /> no fallback
+            </span>
+          )}
+        </div>
+        {bucket.note && (
+          <p className="mt-0.5 text-[11px] leading-snug text-[var(--tt-fg-muted)]">{bucket.note}</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function DrainOrder({
+  overview,
+  asOf,
+  saving,
+  onPlanChange,
+}: {
+  overview: AgentRouteOverview;
+  asOf: string;
+  saving: boolean;
+  onPlanChange: (plan: string | null) => void;
+}) {
+  const taskTypes = Object.keys(overview.routes) as TaskType[];
+
+  // When both task types resolve through an identical bucket sequence (Codex,
+  // Gemini, all paygo agents), collapse to a single list — the split is only
+  // worth screen space where it changes the answer (Claude post-June-15).
+  const sameRoute =
+    taskTypes.length === 2 &&
+    JSON.stringify(overview.routes[taskTypes[0]].buckets.map((b) => b.id)) ===
+      JSON.stringify(overview.routes[taskTypes[1]].buckets.map((b) => b.id));
+
+  return (
+    <div className="mt-1 mb-2 rounded-md border border-[var(--tt-border)] bg-[var(--tt-bg)]/50 px-3 py-2">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[11px] font-semibold uppercase tracking-wide text-[var(--tt-fg-muted)]">
+          Drain order
+        </span>
+        {overview.plans.length > 0 && (
+          <select
+            value={overview.plans.includes(overview.plan) ? overview.plan : "default"}
+            disabled={saving}
+            onChange={(e) => onPlanChange(e.target.value === "default" ? null : e.target.value)}
+            className="rounded-md border border-[var(--tt-border)] bg-[var(--tt-bg-elev)] px-2 py-1 text-[11px] text-[var(--tt-fg)] outline-none focus:border-[var(--tt-brand)] cursor-pointer"
+          >
+            <option value="default">Plan: default</option>
+            {overview.plans.map((p) => (
+              <option key={p} value={p}>Plan: {PLAN_LABEL[p] ?? p}</option>
+            ))}
+          </select>
+        )}
+      </div>
+
+      {sameRoute ? (
+        <div className="mt-1">
+          {overview.routes[taskTypes[0]].buckets.map((b, i) => (
+            <BucketRow key={b.id} bucket={b} index={i} />
+          ))}
+        </div>
+      ) : (
+        taskTypes.map((tt) => (
+          <div key={tt} className="mt-1.5">
+            <div className="text-[11px] font-medium text-[var(--tt-fg-dim)]">
+              {TASK_TYPE_LABEL[tt]}
+            </div>
+            {overview.routes[tt].buckets.map((b, i) => (
+              <BucketRow key={`${tt}-${b.id}`} bucket={b} index={i} />
+            ))}
+          </div>
+        ))
+      )}
+
+      <p className="mt-1.5 text-[10px] text-[var(--tt-fg-muted)]">
+        Provider billing rules verified {asOf}. Plans change often — treat pools as approximate.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/settings/PowerSettings.tsx
+++ b/frontend/src/components/settings/PowerSettings.tsx
@@ -73,6 +73,12 @@ export function PowerSettings() {
       if (r.measured != null) {
         setWatts(String(Math.round(r.measured)));
         setCalibMsg(`✓ Measured ${r.measured} W via ${r.source} — review and click Save.`);
+      } else if (r.estimated != null) {
+        // No root-free measurement (e.g. Apple Silicon on AC), but we derived a
+        // chip-aware estimate. Prefill it as a starting point to override.
+        setWatts(String(Math.round(r.estimated)));
+        const from = r.detail ? ` from ${r.detail}` : "";
+        setCalibMsg(`≈ Estimated ${r.estimated} W${from} — this is a rough default; override with your real draw if you know it, then Save.`);
       } else {
         const why = r.reason ? ` (${r.reason})` : "";
         setCalibMsg(`Couldn't read power automatically on this machine — type your watts in “Load watts” above and Save.${why}`);
@@ -114,6 +120,23 @@ export function PowerSettings() {
                 type="number" inputMode="decimal" value={watts} onChange={(e) => setWatts(e.target.value)}
                 className="mt-1 w-full rounded-md border border-[var(--tt-border)] bg-[var(--tt-bg-elev)] px-2.5 py-1.5 text-[13px] text-[var(--tt-fg)] outline-none focus:border-[var(--tt-brand)]"
               />
+              {cfg?.deviceDefault && (
+                cfg.deviceDefault.detected ? (
+                  <button
+                    type="button"
+                    onClick={() => setWatts(String(cfg.deviceDefault!.watts))}
+                    className="mt-1 text-[11px] text-[var(--tt-fg-muted)] hover:text-[var(--tt-brand)] transition-colors"
+                    title="Use the detected default for this machine"
+                  >
+                    Default for {cfg.deviceDefault.detail ?? "this machine"}: {cfg.deviceDefault.watts} W (estimated)
+                  </button>
+                ) : (
+                  <span className="mt-1 block text-[11px] text-[var(--tt-fg-muted)]">
+                    Couldn&apos;t auto-detect your hardware — enter your machine&apos;s draw under load
+                    (or click Measure). Using a generic {cfg.deviceDefault.watts} W until you do.
+                  </span>
+                )
+              )}
             </label>
             <label className="block">
               <span className="text-[11px] uppercase tracking-wide text-[var(--tt-fg-muted)]">Cost per kWh ($)</span>

--- a/frontend/src/lib/billing.ts
+++ b/frontend/src/lib/billing.ts
@@ -35,6 +35,93 @@ export const setBillingMode = (agent: string, mode: BillingMode | null) =>
     body: JSON.stringify({ agent, mode }),
   });
 
+// ---------------------------------------------------------------------------
+// Drain-priority routes (/config/billing-route): which credit *bucket* pays,
+// in what order, split by task type. Structure only (Stage 1) — pool fill
+// meters need per-session task-type data and come later.
+// ---------------------------------------------------------------------------
+
+export type TaskType = "interactive" | "programmatic";
+
+/** What the user pays at the margin while a bucket is active. */
+export type BucketCharges = "included" | "api_rate" | "electricity";
+
+export interface RouteBucket {
+  id: string;
+  label: string;
+  charges: BucketCharges;
+  task_types: TaskType[];
+  /** Prepaid pool size in USD/month at API rates, or null = no dollar cap. */
+  pool_usd: number | null;
+  /** Request-count cap (e.g. Gemini's 1,000/day free tier), or null. */
+  pool_requests: number | null;
+  pool_period: "day" | "month" | null;
+  /** Pool exhaustion STOPS requests — no automatic fall-through. */
+  no_spillover: boolean;
+  note: string;
+}
+
+export interface BillingRoute {
+  agent: string;
+  task_type: TaskType;
+  plan: string;
+  buckets: RouteBucket[];
+  active: RouteBucket | null;
+  charges: BucketCharges | null;
+  marginal_cost_zero: boolean;
+  capped: boolean;
+}
+
+export interface AgentRouteOverview {
+  agent: string;
+  plan: string;
+  /** Plan tiers this agent's provider offers ([] = no plan knob). */
+  plans: string[];
+  buckets: RouteBucket[];
+  routes: Record<TaskType, BillingRoute>;
+}
+
+export interface BillingRouteConfig {
+  agents: Record<string, AgentRouteOverview>;
+  task_types: TaskType[];
+  charges: BucketCharges[];
+  /** When the provider billing snapshot was last verified (staleness note). */
+  as_of: string;
+}
+
+export const getBillingRouteConfig = () =>
+  api<BillingRouteConfig>("/config/billing-route");
+
+/** Set an agent's plan tier, or `null` to revert to the provider default. */
+export const setBillingPlan = (agent: string, plan: string | null) =>
+  api<BillingRouteConfig>("/config/billing-route", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ agent, plan }),
+  });
+
+export const PLAN_LABEL: Record<string, string> = {
+  default: "Default",
+  pro: "Pro",
+  max5x: "Max 5x",
+  max20x: "Max 20x",
+  pro_plus: "Pro+",
+  business: "Business",
+  enterprise: "Enterprise",
+  ultra: "Ultra",
+};
+
+export const TASK_TYPE_LABEL: Record<TaskType, string> = {
+  interactive: "Interactive — you, in the terminal/editor",
+  programmatic: "Programmatic — headless: scripts, SDK, CI",
+};
+
+export const CHARGES_LABEL: Record<BucketCharges, string> = {
+  included: "$0 marginal",
+  api_rate: "API rate",
+  electricity: "power estimate",
+};
+
 export const MODE_LABEL: Record<BillingMode, string> = {
   subscription: "Subscription (flat fee)",
   api: "API (pay-per-token)",

--- a/frontend/src/lib/power.ts
+++ b/frontend/src/lib/power.ts
@@ -10,6 +10,22 @@ export interface PowerConfig {
   localEndpoints: string[];
   /** True once the user has saved a power.json (else values are shipped defaults). */
   configured: boolean;
+  /** Chip-aware default wattage for this machine, the baseline loadWatts falls back to. */
+  deviceDefault?: {
+    watts: number;
+    source: string;
+    detail?: string;
+    /** True only when the hardware was auto-detected (e.g. Apple Silicon); false = generic fallback. */
+    detected?: boolean;
+  };
+}
+
+export interface PowerEstimate {
+  watts: number;
+  source: string;
+  confidence: string;
+  /** Human label for what the estimate is based on, e.g. "Apple M5 (10-core GPU)". */
+  detail?: string;
 }
 
 export interface PowerMeter {
@@ -18,6 +34,8 @@ export interface PowerMeter {
     method: string | null;
     system: string;
     reason: string;
+    /** Chip-aware fallback default when no real measurement is possible. */
+    estimated?: PowerEstimate;
   };
   /** Live real reading, or null when no root-free source is available. */
   reading: { watts: number; source: string; confidence: string } | null;
@@ -26,7 +44,11 @@ export interface PowerMeter {
 export interface CalibrateResult {
   /** Measured watts, or null when no real source was available (config unchanged). */
   measured: number | null;
-  source?: string;
+  /** Chip-aware estimated watts when measurement wasn't possible, else null. */
+  estimated?: number | null;
+  source?: string | null;
+  /** What the estimate is based on, e.g. "Apple M5 (10-core GPU)". */
+  detail?: string | null;
   samples?: number;
   reason?: string;
   config?: PowerConfig;


### PR DESCRIPTION
Two cost-accuracy features that share the **Settings** surface. Closes the implementation tracked in #45 (drain-priority engine) and finishes the Apple-Silicon power default.

## 1. Local-model power: read the actual chip
- `device_default()` now returns a `detected` flag (`source != "default"`), surfaced via `GET /config/power`.
- **Auto-detected (Apple Silicon):** the chip estimate (e.g. M-series wattage) becomes the default that drives cost.
- **Not detected (Intel/AMD/Win/Linux CPU):** the field stops presenting a generic 80 W as if real and prompts the user to enter their draw under load (or click **Measure**, which still works via `nvidia-smi` etc. where the static table can't).

## 2. Drain-priority billing routes (#45)
The flat `billing_mode` label (subscription/api/local) can't represent how providers now bill a single agent — multiple credit **buckets** with a drain order that depends on **task type** (interactive vs programmatic).

- **`backend/billing_route.py`** — per-agent ordered bucket model + `resolve_billing_route(agent, task_type, plan, mode)`. Encodes a **June-2026 snapshot** (`as_of` surfaced to the UI):
  - **Anthropic** June-15 Agent-SDK credit split — **date-gated**, so it flips automatically on the effective date (today it still shows the pre-split single bucket with a pre-warning note).
  - **Codex** single ChatGPT-OAuth bucket (both task types), **Gemini** request-capped free tier, **Copilot** AI-credit pool, **Cursor** pools, paygo agents.
  - Conservative **whole-token** task classifier (no "interactions"→"actions" false positives).
- **`GET`/`PUT /config/billing-route`** — routes + per-agent **plan tier**, persisted to `~/.tokentelemetry/billing_plans.json`, validated against each provider's own vocabulary.
- **Settings UI** — expandable per-agent **Drain order** panel (`DrainOrder.tsx`): bucket order, charge badges ($0 marginal / API rate / power), pool sizes, "no fallback" warnings, plan selector, staleness disclaimer. Degrades gracefully on an older backend.

**Stage 1 (structure) only** — live pool-fill meters need per-session task-type attribution (`classify_task_type` is ready for that Stage 2). This explains the cost framing; it does **not** change the cost math.

## Tests
- **161 backend pass** (20 new in `test_billing_route.py` — both sides of the June-15 boundary, plan persistence round-trip, garbage-file tolerance, classifier false-positives).
- Frontend `tsc --noEmit` clean.
- Endpoint pair exercised end-to-end (GET shape, PUT persist + 400 on wrong-provider plan); verified live in browser.

## Notes / follow-ups
- Pool dollar amounts are hard-coded from provider sources for now; a future `billing_routes_data.json` synced like `pricing_data.json` is the right home (the `as_of` disclaimer mitigates staleness meanwhile).
- Branch was 3 commits behind `origin/main` at PR time; no conflicts expected (changes are in distinct regions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)