### PR TITLE
ci: bump Node-20 actions to Node-24 runtimes before June 16 cutoff

### DIFF
--- a/.github/workflows/pricing-sync.yml
+++ b/.github/workflows/pricing-sync.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -28,7 +28,7 @@ jobs:
         run: python backend/pricing_sync.py
 
       - name: Open PR with refreshed pricing
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: "chore(pricing): refresh pricing_data.json from models.dev"
           title: "chore(pricing): weekly models.dev pricing refresh"

--- a/.github/workflows/sync-traffic.yml
+++ b/.github/workflows/sync-traffic.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 


### PR DESCRIPTION
GitHub forces **Node 24** on Actions runners starting **June 16, 2026** (3 days out). PR #95 bumped most workflows but missed two Node-20 action pins, flagged by the deprecation annotation on the last `pricing-sync` run.

## Changes (runtime verified per major before bumping)
| Action | Before | After | Why |
|---|---|---|---|
| `actions/setup-python` | `@v5` (node20) | `@v6` (node24) | `pricing-sync.yml`, `sync-traffic.yml` |
| `peter-evans/create-pull-request` | `@v6` (node20) | `@v8` (node24) | `pricing-sync.yml` |

⚠️ **`create-pull-request@v7` is still Node 20** — `v8` is the first Node-24 major, so v6→v8 was required (verified via each tag's `action.yml` `runs.using`). The inputs this workflow uses (`commit-message`, `title`, `body`, `branch`, `delete-branch`, `add-paths`) are unchanged in v8.

`actions/checkout@v5` and `actions/setup-node@v5` were already on Node 24 — untouched. A repo-wide grep confirms no Node-20-era action majors remain.

Docs/CI-only; no UPDATE.json entry needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)