### PR TITLE
feat: durable analytics history + date/range filters (#83)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,9 @@ GRAPH_REPORT.md
 .claude/worktrees/
 # Local plan files
 .claude/plans/
+
+# Durable history store (default lives in ~/.tokentelemetry; defensive guard
+# for devs who point TOKENTELEMETRY_DATA_DIR into the tree)
+history.db
+history.db-wal
+history.db-shm

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,43 @@ Want to add support for a new coding agent? The backend reads log files from kno
 4. Write a clear PR description explaining what and why
 5. Submit against the `main` branch
 
+### Documentation — keep it minimal
+
+**For most PRs (fixes, small features, chores, docs): you don't need to write any
+formal docs.** Just explain *what* you changed and *why* in the PR description.
+Maintainers handle the rest — adding it to the [Roadmap board](https://github.com/users/VasiHemanth/projects/1),
+writing any decision record, and the `UPDATE.json` release note.
+
+You also don't need to touch the board or `UPDATE.json` yourself.
+
+### Adding a big feature? Include an ADR + design doc
+
+A change is "big" if it does any of these:
+- introduces a new module, storage layer, or external dependency;
+- changes a data shape, API contract, or how an agent's data is read;
+- has more than one reasonable approach, or is hard to reverse later.
+
+If so, add two short markdown files **in the same PR as the code** so the *why* and
+*how* travel with the change (this is how Kubernetes/Rust/Python-scale projects work):
+
+1. **ADR** — copy [`docs/adr/0000-template.md`](docs/adr/0000-template.md) to
+   `docs/adr/NNNN-short-title.md` (next number) and fill in:
+   > **Context** — what problem/constraint forced this?
+   > **Decision** — what are you doing? ("We will …")
+   > **Alternatives considered** — what else you weighed, and why you rejected it.
+   > **Consequences** — the upsides, the costs/limitations, and what would have to
+   > change to undo it.
+
+   Keep it to ~1 page. See [`docs/adr/README.md`](docs/adr/README.md).
+
+2. **Design doc** — add `docs/design/<feature>.md` (the *what & how*: components,
+   data shapes, key invariants). See [`docs/design/durable-history.md`](docs/design/durable-history.md)
+   for the shape.
+
+Not sure if your change counts as "big"? Open it without the docs and ask in the
+PR — a maintainer will tell you, or write the ADR with you. Better to ship than to
+stall on paperwork.
+
 ## Code Style
 - **Python**: follow PEP8, use type hints where possible
 - **TypeScript/JS**: follow the existing patterns in `frontend/`

--- a/UPDATE.json
+++ b/UPDATE.json
@@ -2,6 +2,22 @@
   "releases": [
     {
       "tag": "2026-06-13",
+      "title": "Analytics by date — and history that survives cleanup",
+      "highlights": [
+        {
+          "title": "Filter analytics by date range, week, or month",
+          "description": "The graph is no longer stuck at the last 7 days. Pick a preset (7d, 30d, this month, this year), set a custom range, or switch the buckets to weekly/monthly — and narrow to specific agents or models. Everything is filtered server-side, so even a full year stays fast.",
+          "href": "/analytics"
+        },
+        {
+          "title": "Your history no longer disappears when agents prune it",
+          "description": "Coding agents quietly delete their own session transcripts on a schedule (Claude Code after 30 days by default), which used to erase your older analytics with them. TokenTelemetry now keeps a tiny durable summary of every session it sees, so long-range trends survive. Under Settings you can see each agent's cleanup window, opt to keep full transcripts past it, and reclaim space anytime without losing your stats.",
+          "href": "/settings"
+        }
+      ]
+    },
+    {
+      "tag": "2026-06-13",
       "title": "Truer costs: local power + which credit pool pays",
       "highlights": [
         {

--- a/backend/agent_retention.py
+++ b/backend/agent_retention.py
@@ -1,0 +1,209 @@
+"""Per-agent transcript-retention metadata + TT archive opt-in flags.
+
+Coding agents prune their own on-disk transcripts on different schedules. The
+Settings page surfaces each agent's default so a user understands *why* old
+sessions vanish from analytics — and can opt into having TokenTelemetry keep a
+durable copy (tier-2 archive in ``history_store``) past that window.
+
+The numbers below are the **published defaults** at time of writing (verified
+2026-06); where an agent has no documented auto-cleanup we say so rather than
+guess. Claude Code and Gemini CLI expose the period in their own settings.json,
+so we read the user's *actual* value when present and fall back to the default.
+
+Sources:
+  - Claude Code  ``cleanupPeriodDays`` default 30 — code.claude.com/docs/en/data-usage
+  - Gemini CLI   chat-history retention default 30d (cleanup enabled) — gemini-cli PR #20853
+  - Codex CLI    indefinite, no auto-cleanup — openai/codex issue #6015
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from tt_paths import data_dir
+
+_log = logging.getLogger("tokentelemetry.retention")
+
+HOME = Path.home()
+RETENTION_FILE = data_dir() / "retention.json"
+
+# Static per-agent retention description. ``default_days``:
+#   int  → auto-deletes after N days (a documented default).
+#   None → no documented auto-cleanup (kept until the user clears it).
+# ``configurable`` flags whether the agent lets users change the window, and
+# ``settings_hint`` tells the UI where. ``note`` carries any caveat.
+_RETENTION: Dict[str, Dict[str, Any]] = {
+    "claude": {
+        "label": "Claude Code",
+        "default_days": 30,
+        "configurable": True,
+        "settings_hint": "~/.claude/settings.json → cleanupPeriodDays",
+        "note": "Purges transcripts older than the window on every startup.",
+    },
+    "gemini": {
+        "label": "Gemini CLI",
+        "default_days": 30,
+        "configurable": True,
+        "settings_hint": "~/.gemini/settings.json → chat history maxAge",
+        "note": "Cleanup enabled by default; also supports a maxCount cap.",
+    },
+    "qwen": {
+        "label": "Qwen Code",
+        "default_days": 30,
+        "configurable": True,
+        "settings_hint": "~/.qwen/settings.json (Gemini-CLI fork)",
+        "note": "Gemini-CLI fork — inherits the same 30-day cleanup default.",
+    },
+    "codex": {
+        "label": "Codex CLI",
+        "default_days": None,
+        "configurable": False,
+        "settings_hint": None,
+        "note": "No auto-cleanup today — sessions accumulate in ~/.codex/sessions.",
+    },
+    "opencode": {
+        "label": "OpenCode",
+        "default_days": None,
+        "configurable": False,
+        "settings_hint": None,
+        "note": "Stored in a local SQLite DB; no automatic pruning.",
+    },
+    "hermes": {
+        "label": "Hermes",
+        "default_days": None,
+        "configurable": False,
+        "settings_hint": None,
+        "note": "Stored in a local SQLite DB; no automatic pruning.",
+    },
+    "grok": {
+        "label": "Grok CLI",
+        "default_days": None,
+        "configurable": False,
+        "settings_hint": None,
+        "note": "Append-only JSONL logs; no automatic pruning.",
+    },
+    "antigravity": {
+        "label": "Antigravity",
+        "default_days": None,
+        "configurable": False,
+        "settings_hint": None,
+        "note": "Retention behaviour not documented — treated as kept until cleared.",
+    },
+    "cursor": {
+        "label": "Cursor",
+        "default_days": None,
+        "configurable": False,
+        "settings_hint": None,
+        "note": "Retention behaviour not documented — treated as kept until cleared.",
+    },
+    "copilot": {
+        "label": "GitHub Copilot",
+        "default_days": None,
+        "configurable": False,
+        "settings_hint": None,
+        "note": "Retention behaviour not documented — treated as kept until cleared.",
+    },
+    "vibe": {
+        "label": "Vibe",
+        "default_days": None,
+        "configurable": False,
+        "settings_hint": None,
+        "note": "Retention behaviour not documented — treated as kept until cleared.",
+    },
+}
+
+# Which agents we can actually archive (single-file resolvable transcript).
+# Must stay in sync with main._resolve_transcript_path.
+_ARCHIVABLE = {"claude", "codex"}
+
+
+def _read_claude_cleanup_days() -> Optional[int]:
+    """The user's real cleanupPeriodDays from ~/.claude/settings.json, else None."""
+    f = HOME / ".claude" / "settings.json"
+    if not f.exists():
+        return None
+    try:
+        with open(f, "r", encoding="utf-8") as fh:
+            raw = json.load(fh)
+        v = raw.get("cleanupPeriodDays")
+        return int(v) if isinstance(v, (int, float)) else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+# ── archive opt-in flags (persisted) ─────────────────────────────────────────
+
+def _load_flags() -> Dict[str, bool]:
+    if not RETENTION_FILE.exists():
+        return {}
+    try:
+        with open(RETENTION_FILE, "r", encoding="utf-8") as fh:
+            raw = json.load(fh)
+    except Exception:  # noqa: BLE001
+        return {}
+    archive = raw.get("archive") if isinstance(raw, dict) else None
+    if not isinstance(archive, dict):
+        return {}
+    return {k: bool(v) for k, v in archive.items() if isinstance(k, str)}
+
+
+def _save_flags(flags: Dict[str, bool]) -> None:
+    import os
+    import tempfile
+    RETENTION_FILE.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(RETENTION_FILE.parent),
+                               prefix="retention.json.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump({"archive": flags}, fh, indent=2)
+        os.replace(tmp, RETENTION_FILE)
+    except Exception:  # noqa: BLE001
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def archive_enabled(agent: str) -> bool:
+    """Has the user opted into archiving this agent's transcripts in TT?"""
+    return bool(_load_flags().get(agent, False)) and agent in _ARCHIVABLE
+
+
+def set_archive(agent: str, enabled: bool) -> Dict[str, bool]:
+    """Toggle the archive opt-in for one agent. Returns the full flag map."""
+    flags = _load_flags()
+    flags[agent] = bool(enabled)
+    _save_flags(flags)
+    return flags
+
+
+def describe_agents(available: Optional[list] = None) -> Dict[str, Any]:
+    """Per-agent retention info + the user's archive opt-in + detected overrides.
+
+    ``available`` (from main._list_available_agents) limits the output to agents
+    actually present on this machine; omitted → describe all known agents."""
+    flags = _load_flags()
+    claude_actual = _read_claude_cleanup_days()
+    out: Dict[str, Any] = {}
+    names = available if available is not None else list(_RETENTION.keys())
+    for agent in names:
+        meta = _RETENTION.get(agent, {
+            "label": agent, "default_days": None, "configurable": False,
+            "settings_hint": None, "note": "Unknown agent.",
+        })
+        effective = meta.get("default_days")
+        detected_override = None
+        if agent == "claude" and claude_actual is not None:
+            detected_override = claude_actual
+            effective = claude_actual
+        out[agent] = {
+            **meta,
+            "effective_days": effective,
+            "detected_override": detected_override,
+            "archivable": agent in _ARCHIVABLE,
+            "archive_enabled": bool(flags.get(agent, False)),
+        }
+    return out

--- a/backend/history_store.py
+++ b/backend/history_store.py
@@ -1,0 +1,485 @@
+"""Durable, local history store for TokenTelemetry.
+
+TokenTelemetry is otherwise a pure live-scanner: every request re-reads the
+coding agents' on-disk transcripts and keeps the result only in a 30s in-RAM
+cache. But agents prune their own transcripts (Claude Code deletes
+``~/.claude/projects`` after ``cleanupPeriodDays``, default 30), so any analytics
+window older than that retention silently loses data.
+
+This module gives TT its own SQLite store under the resolved data dir (see
+``tt_paths``) that it upserts on every scan, so a *summary* of each session
+outlives the agent's own pruning. It is deliberately tiered:
+
+  - ``sessions``     core rollup — tiny, always kept (one row per session).
+  - ``transcripts``  opt-in, compressed full transcript blobs — user-deletable.
+  - ``summaries``    generated summaries — persist even after a transcript is gone.
+
+Design rules (mirroring ``harness_config``):
+  - The DB and its directory are created lazily on first write, never on read.
+  - Reads never raise; a missing/locked DB yields empty results.
+  - One short-lived connection per call — safe to call from the scan worker
+    thread and from request handlers. WAL mode lets reads run during a write.
+  - ``query()`` returns rows shaped *exactly* like live session dicts so the
+    existing ``/analytics`` aggregation loop can consume stored + live uniformly.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import zlib
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple
+
+from tt_paths import data_dir
+
+_log = logging.getLogger("tokentelemetry.history")
+
+SCHEMA_VERSION = 1
+
+# Sub-dicts folded into ``ecosystem_json`` and expanded back out on read. These
+# are the keys the analytics aggregation + delegation views consume beyond the
+# core rollup columns.
+_ECOSYSTEM_KEYS = (
+    "skills_used", "mcp_usage", "delegation", "subagent_info", "parent_session_id",
+)
+
+
+def _db_path() -> Path:
+    # Resolved per call so a process that relocates the data dir (or a test that
+    # monkeypatches TOKENTELEMETRY_DATA_DIR) always hits the right file.
+    return data_dir() / "history.db"
+
+
+def _connect() -> sqlite3.Connection:
+    """Open the DB, creating the dir + schema lazily. Caller closes."""
+    path = _db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    con = sqlite3.connect(str(path), timeout=5.0)
+    con.row_factory = sqlite3.Row
+    con.execute("PRAGMA journal_mode=WAL")
+    con.execute("PRAGMA busy_timeout=5000")
+    _migrate(con)
+    return con
+
+
+def _migrate(con: sqlite3.Connection) -> None:
+    ver = con.execute("PRAGMA user_version").fetchone()[0]
+    if ver < 1:
+        con.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS sessions (
+                agent           TEXT NOT NULL,
+                id              TEXT NOT NULL,
+                project         TEXT,
+                model           TEXT,
+                provider        TEXT,
+                endpoint        TEXT,
+                billing_mode    TEXT,
+                first_ts        TEXT,
+                last_ts         TEXT,
+                input           INTEGER DEFAULT 0,
+                output          INTEGER DEFAULT 0,
+                cached          INTEGER DEFAULT 0,
+                total           INTEGER DEFAULT 0,
+                cost            REAL    DEFAULT 0.0,
+                tok_per_sec     REAL,
+                ecosystem_json  TEXT,
+                first_seen_at   TEXT,
+                last_seen_at    TEXT,
+                source_present  INTEGER DEFAULT 1,
+                transcript_archived INTEGER DEFAULT 0,
+                summary_present INTEGER DEFAULT 0,
+                PRIMARY KEY (agent, id)
+            );
+            CREATE INDEX IF NOT EXISTS idx_sessions_last_ts ON sessions(last_ts);
+            CREATE INDEX IF NOT EXISTS idx_sessions_agent   ON sessions(agent);
+            CREATE INDEX IF NOT EXISTS idx_sessions_model   ON sessions(model);
+
+            CREATE TABLE IF NOT EXISTS transcripts (
+                agent       TEXT NOT NULL,
+                id          TEXT NOT NULL,
+                blob        BLOB,
+                bytes       INTEGER DEFAULT 0,
+                archived_at TEXT,
+                PRIMARY KEY (agent, id)
+            );
+
+            CREATE TABLE IF NOT EXISTS summaries (
+                agent      TEXT NOT NULL,
+                id         TEXT NOT NULL,
+                summary    TEXT,
+                created_at TEXT,
+                PRIMARY KEY (agent, id)
+            );
+            """
+        )
+        con.execute(f"PRAGMA user_version={SCHEMA_VERSION}")
+        con.commit()
+
+
+# ── serialization helpers ────────────────────────────────────────────────────
+
+def _to_utc_iso(ts: Any) -> str:
+    """Normalize a session timestamp to UTC ISO-8601 for lexicographic range
+    filtering. Accepts a datetime or an ISO string; falls back to now()."""
+    if isinstance(ts, datetime):
+        dt = ts
+    elif isinstance(ts, str) and ts:
+        try:
+            dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        except ValueError:
+            dt = datetime.now(timezone.utc)
+    else:
+        dt = datetime.now(timezone.utc)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).isoformat()
+
+
+def _ecosystem_blob(row: Dict[str, Any]) -> Optional[str]:
+    eco = {k: row[k] for k in _ECOSYSTEM_KEYS if row.get(k) is not None}
+    return json.dumps(eco, default=str) if eco else None
+
+
+# ── write path ───────────────────────────────────────────────────────────────
+
+def upsert_sessions(rows: Sequence[Dict[str, Any]]) -> int:
+    """Idempotently persist the core rollup for each live session dict.
+
+    Keyed by (agent, id): a session that grows between scans overwrites its row
+    (never duplicates). ``first_ts`` / ``first_seen_at`` are preserved across
+    upserts; ``last_*`` and the token/cost columns track the freshest scan, and
+    ``source_present`` is (re)set to 1 because we just saw the file on disk.
+    Returns the number of rows written. Never raises — a store failure must not
+    break the scan that called it."""
+    valid = [r for r in rows if r.get("id") and r.get("agent")]
+    if not valid:
+        return 0
+    now = datetime.now(timezone.utc).isoformat()
+    written = 0
+    try:
+        con = _connect()
+        try:
+            for r in valid:
+                tok = r.get("tokens") or {}
+                ts = _to_utc_iso(r.get("timestamp"))
+                con.execute(
+                    """
+                    INSERT INTO sessions (
+                        agent, id, project, model, provider, endpoint, billing_mode,
+                        first_ts, last_ts, input, output, cached, total, cost,
+                        tok_per_sec, ecosystem_json, first_seen_at, last_seen_at,
+                        source_present
+                    ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,1)
+                    ON CONFLICT(agent, id) DO UPDATE SET
+                        project=excluded.project,
+                        model=excluded.model,
+                        provider=excluded.provider,
+                        endpoint=excluded.endpoint,
+                        billing_mode=excluded.billing_mode,
+                        first_ts=MIN(sessions.first_ts, excluded.first_ts),
+                        last_ts=MAX(sessions.last_ts, excluded.last_ts),
+                        input=excluded.input,
+                        output=excluded.output,
+                        cached=excluded.cached,
+                        total=excluded.total,
+                        cost=excluded.cost,
+                        tok_per_sec=excluded.tok_per_sec,
+                        ecosystem_json=excluded.ecosystem_json,
+                        last_seen_at=excluded.last_seen_at,
+                        source_present=1
+                    """,
+                    (
+                        r.get("agent"), r.get("id"), r.get("project"), r.get("model"),
+                        r.get("provider"), r.get("endpoint"), r.get("billing_mode"),
+                        ts, ts,
+                        int(tok.get("input", 0) or 0), int(tok.get("output", 0) or 0),
+                        int(tok.get("cached", 0) or 0), int(tok.get("total", 0) or 0),
+                        float(r.get("cost", 0.0) or 0.0),
+                        r.get("tok_per_sec"),
+                        _ecosystem_blob(r), now, now,
+                    ),
+                )
+                written += 1
+            con.commit()
+        finally:
+            con.close()
+    except Exception as e:  # noqa: BLE001 — store must never break the scan
+        _log.exception("history upsert failed: %s", e)
+    return written
+
+
+def mark_absent(seen_keys: Set[Tuple[str, str]]) -> None:
+    """Flag rows whose (agent, id) was NOT in the latest scan as no longer on
+    disk (``source_present=0``). Never deletes — the rollup is what survives
+    agent pruning, so those rows are exactly the ones we must keep."""
+    try:
+        con = _connect()
+        try:
+            present = con.execute(
+                "SELECT agent, id FROM sessions WHERE source_present=1"
+            ).fetchall()
+            gone = [(a, i) for (a, i) in ((r["agent"], r["id"]) for r in present)
+                    if (a, i) not in seen_keys]
+            if gone:
+                con.executemany(
+                    "UPDATE sessions SET source_present=0 WHERE agent=? AND id=?", gone
+                )
+                con.commit()
+        finally:
+            con.close()
+    except Exception as e:  # noqa: BLE001
+        _log.exception("history mark_absent failed: %s", e)
+
+
+# ── read path ────────────────────────────────────────────────────────────────
+
+def _rehydrate(r: sqlite3.Row) -> Dict[str, Any]:
+    """Turn a stored row back into a live-session-shaped dict."""
+    try:
+        ts = datetime.fromisoformat(r["last_ts"]) if r["last_ts"] else datetime.now(timezone.utc)
+    except (ValueError, TypeError):
+        ts = datetime.now(timezone.utc)
+    out: Dict[str, Any] = {
+        "id": r["id"],
+        "agent": r["agent"],
+        "project": r["project"],
+        "model": r["model"],
+        "provider": r["provider"],
+        "endpoint": r["endpoint"],
+        "billing_mode": r["billing_mode"],
+        "timestamp": ts,
+        "tokens": {
+            "input": r["input"], "output": r["output"],
+            "cached": r["cached"], "total": r["total"],
+        },
+        "cost": r["cost"],
+        "tok_per_sec": r["tok_per_sec"],
+        "source_present": bool(r["source_present"]),
+        "transcript_archived": bool(r["transcript_archived"]),
+        "summary_present": bool(r["summary_present"]),
+        "from_history": True,
+    }
+    if r["ecosystem_json"]:
+        try:
+            eco = json.loads(r["ecosystem_json"])
+            for k in _ECOSYSTEM_KEYS:
+                if k in eco:
+                    out[k] = eco[k]
+        except (ValueError, TypeError):
+            pass
+    return out
+
+
+def query(
+    from_: Optional[str] = None,
+    to: Optional[str] = None,
+    agents: Optional[Iterable[str]] = None,
+    models: Optional[Iterable[str]] = None,
+    projects: Optional[Iterable[str]] = None,
+) -> List[Dict[str, Any]]:
+    """Return stored sessions as live-session-shaped dicts.
+
+    ``from_`` / ``to`` are UTC ISO bounds compared against ``last_ts`` in SQL
+    (indexed), so only in-window rows load — never the whole history. Each of
+    ``agents`` / ``models`` / ``projects`` is an optional allow-list; an empty
+    or omitted list means "no filter" (i.e. All). Never raises."""
+    where: List[str] = []
+    params: List[Any] = []
+    if from_:
+        where.append("last_ts >= ?"); params.append(from_)
+    if to:
+        where.append("last_ts <= ?"); params.append(to)
+    for col, vals in (("agent", agents), ("model", models), ("project", projects)):
+        vals = [v for v in (vals or []) if v]
+        if vals:
+            where.append(f"{col} IN ({','.join('?' * len(vals))})")
+            params.extend(vals)
+    sql = "SELECT * FROM sessions"
+    if where:
+        sql += " WHERE " + " AND ".join(where)
+    try:
+        con = _connect()
+        try:
+            return [_rehydrate(r) for r in con.execute(sql, params).fetchall()]
+        finally:
+            con.close()
+    except Exception as e:  # noqa: BLE001
+        _log.exception("history query failed: %s", e)
+        return []
+
+
+def coverage() -> Dict[str, Any]:
+    """Earliest stored date + per-agent present/pruned counts, for the UI's
+    data-availability notice."""
+    out: Dict[str, Any] = {"earliest": None, "by_agent": {}, "total_sessions": 0}
+    try:
+        con = _connect()
+        try:
+            row = con.execute("SELECT MIN(first_ts) AS e, COUNT(*) AS n FROM sessions").fetchone()
+            out["earliest"] = row["e"]
+            out["total_sessions"] = row["n"] or 0
+            for r in con.execute(
+                """SELECT agent,
+                          SUM(source_present) AS present,
+                          SUM(CASE WHEN source_present=0 THEN 1 ELSE 0 END) AS pruned,
+                          SUM(summary_present) AS summarized
+                   FROM sessions GROUP BY agent"""
+            ).fetchall():
+                out["by_agent"][r["agent"]] = {
+                    "present": r["present"] or 0,
+                    "pruned": r["pruned"] or 0,
+                    "summarized": r["summarized"] or 0,
+                }
+        finally:
+            con.close()
+    except Exception as e:  # noqa: BLE001
+        _log.exception("history coverage failed: %s", e)
+    return out
+
+
+def storage_stats() -> Dict[str, Any]:
+    """Row counts + bytes per tier per agent, for the Settings storage readout."""
+    out: Dict[str, Any] = {"by_agent": {}, "transcript_bytes": 0, "total_sessions": 0}
+
+    def _agent_row(a: str) -> Dict[str, Any]:
+        return out["by_agent"].setdefault(
+            a, {"sessions": 0, "transcripts": 0, "transcript_bytes": 0, "summaries": 0}
+        )
+    try:
+        con = _connect()
+        try:
+            for r in con.execute("SELECT agent, COUNT(*) AS n FROM sessions GROUP BY agent"):
+                _agent_row(r["agent"])["sessions"] = r["n"]
+                out["total_sessions"] += r["n"]
+            for r in con.execute(
+                "SELECT agent, COUNT(*) AS n, COALESCE(SUM(bytes),0) AS b FROM transcripts GROUP BY agent"
+            ):
+                row = _agent_row(r["agent"])
+                row["transcripts"] = r["n"]; row["transcript_bytes"] = r["b"]
+                out["transcript_bytes"] += r["b"]
+            for r in con.execute("SELECT agent, COUNT(*) AS n FROM summaries GROUP BY agent"):
+                _agent_row(r["agent"])["summaries"] = r["n"]
+        finally:
+            con.close()
+    except Exception as e:  # noqa: BLE001
+        _log.exception("history storage_stats failed: %s", e)
+    return out
+
+
+# ── tier 2: transcript archive ───────────────────────────────────────────────
+
+def put_transcript(agent: str, id: str, text: str) -> int:
+    """Archive (or replace) a compressed transcript blob. Returns stored bytes."""
+    blob = zlib.compress(text.encode("utf-8", errors="replace"))
+    now = datetime.now(timezone.utc).isoformat()
+    try:
+        con = _connect()
+        try:
+            con.execute(
+                """INSERT INTO transcripts (agent, id, blob, bytes, archived_at)
+                   VALUES (?,?,?,?,?)
+                   ON CONFLICT(agent, id) DO UPDATE SET
+                       blob=excluded.blob, bytes=excluded.bytes, archived_at=excluded.archived_at""",
+                (agent, id, blob, len(blob), now),
+            )
+            con.execute(
+                "UPDATE sessions SET transcript_archived=1 WHERE agent=? AND id=?", (agent, id)
+            )
+            con.commit()
+        finally:
+            con.close()
+        return len(blob)
+    except Exception as e:  # noqa: BLE001
+        _log.exception("history put_transcript failed: %s", e)
+        return 0
+
+
+def get_transcript(agent: str, id: str) -> Optional[str]:
+    try:
+        con = _connect()
+        try:
+            r = con.execute(
+                "SELECT blob FROM transcripts WHERE agent=? AND id=?", (agent, id)
+            ).fetchone()
+        finally:
+            con.close()
+        if r and r["blob"] is not None:
+            return zlib.decompress(r["blob"]).decode("utf-8", errors="replace")
+    except Exception as e:  # noqa: BLE001
+        _log.exception("history get_transcript failed: %s", e)
+    return None
+
+
+def delete_transcripts(agent: Optional[str] = None, older_than_days: Optional[int] = None) -> int:
+    """Purge tier-2 transcript blobs (freeing space) while leaving the core
+    rollup and any summaries intact. Optionally scoped by agent and/or age.
+    Returns the number of blobs deleted."""
+    where: List[str] = []
+    params: List[Any] = []
+    if agent:
+        where.append("agent=?"); params.append(agent)
+    if older_than_days is not None:
+        from datetime import timedelta
+        cutoff = (datetime.now(timezone.utc) - timedelta(days=older_than_days)).isoformat()
+        where.append("archived_at < ?"); params.append(cutoff)
+    clause = (" WHERE " + " AND ".join(where)) if where else ""
+    try:
+        con = _connect()
+        try:
+            doomed = con.execute(
+                "SELECT agent, id FROM transcripts" + clause, params
+            ).fetchall()
+            con.execute("DELETE FROM transcripts" + clause, params)
+            for r in doomed:
+                con.execute(
+                    "UPDATE sessions SET transcript_archived=0 WHERE agent=? AND id=?",
+                    (r["agent"], r["id"]),
+                )
+            con.commit()
+            return len(doomed)
+        finally:
+            con.close()
+    except Exception as e:  # noqa: BLE001
+        _log.exception("history delete_transcripts failed: %s", e)
+        return 0
+
+
+# ── tier 3: summaries ────────────────────────────────────────────────────────
+
+def put_summary(agent: str, id: str, summary: str) -> None:
+    """Persist a generated summary; survives even after the transcript is gone."""
+    now = datetime.now(timezone.utc).isoformat()
+    try:
+        con = _connect()
+        try:
+            con.execute(
+                """INSERT INTO summaries (agent, id, summary, created_at) VALUES (?,?,?,?)
+                   ON CONFLICT(agent, id) DO UPDATE SET summary=excluded.summary, created_at=excluded.created_at""",
+                (agent, id, summary, now),
+            )
+            con.execute(
+                "UPDATE sessions SET summary_present=1 WHERE agent=? AND id=?", (agent, id)
+            )
+            con.commit()
+        finally:
+            con.close()
+    except Exception as e:  # noqa: BLE001
+        _log.exception("history put_summary failed: %s", e)
+
+
+def get_summary(agent: str, id: str) -> Optional[str]:
+    try:
+        con = _connect()
+        try:
+            r = con.execute(
+                "SELECT summary FROM summaries WHERE agent=? AND id=?", (agent, id)
+            ).fetchone()
+        finally:
+            con.close()
+        return r["summary"] if r else None
+    except Exception as e:  # noqa: BLE001
+        _log.exception("history get_summary failed: %s", e)
+        return None

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, Body, Request
+from fastapi import FastAPI, Body, Request, Query
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 import os
@@ -10,7 +10,7 @@ import sqlite3
 from pathlib import Path
 from typing import List, Optional, Dict, Any, Set
 from pydantic import BaseModel
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta, time as _dtime
 from urllib.parse import unquote
 
 from harness_config import (
@@ -3577,6 +3577,66 @@ def _get_sessions_lock() -> _asyncio.Lock:
     return _sessions_lock
 
 
+def _archive_opted_in_transcripts(data: List[Dict[str, Any]]) -> None:
+    """For agents the user opted into, copy each session's on-disk transcript
+    into the durable store (tier 2) so it survives the agent's own pruning.
+    Best-effort and only for agents whose transcript is a single resolvable
+    file; everything else stays rollup-only. Runs on the scan worker thread."""
+    import history_store
+    from agent_retention import archive_enabled
+
+    for s in data:
+        agent, sid = s.get("agent"), s.get("id")
+        if not agent or not sid or not archive_enabled(agent):
+            continue
+        if s.get("transcript_archived"):
+            continue
+        path = _resolve_transcript_path(agent, sid)
+        if not path:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if text:
+            history_store.put_transcript(agent, sid, text)
+
+
+def _resolve_transcript_path(agent: str, session_id: str) -> Optional[Path]:
+    """Best-effort single-file transcript path for archivable agents."""
+    try:
+        if agent == "claude":
+            hits = list(CLAUDE_DIR.glob(f"projects/**/{session_id}.jsonl"))
+            return hits[0] if hits else None
+        if agent == "codex":
+            hits = list(CODEX_DIR.glob(f"sessions/**/*{session_id}*.jsonl"))
+            return hits[0] if hits else None
+    except OSError:
+        return None
+    return None
+
+
+def _persist_history_async(data: List[Dict[str, Any]]) -> None:
+    """Schedule the durable-history write off the request path. Fire-and-forget:
+    failures are logged inside the store and never surface to the caller."""
+    import history_store
+
+    def _work() -> None:
+        try:
+            history_store.upsert_sessions(data)
+            history_store.mark_absent({(s.get("agent"), s.get("id")) for s in data
+                                       if s.get("agent") and s.get("id")})
+            _archive_opted_in_transcripts(data)
+        except Exception as e:  # noqa: BLE001
+            _log.exception("history persist failed: %s", e)
+
+    try:
+        _asyncio.get_running_loop().run_in_executor(None, _work)
+    except RuntimeError:
+        # No running loop (e.g. called from a sync context) — run inline.
+        _work()
+
+
 async def get_sessions_cached(fresh: bool = False) -> List[Dict[str, Any]]:
     """Cached, non-blocking access to the session list.
 
@@ -3607,6 +3667,11 @@ async def get_sessions_cached(fresh: bool = False) -> List[Dict[str, Any]]:
             _sessions_cache["data"] = data
             _sessions_cache["at"] = _time.monotonic()
             _log.info("sessions scan: %d entries in %.0fms", len(data), (_time.monotonic() - t0) * 1000)
+            # Durable rollup: persist a tiny summary of each session so history
+            # outlives the agents' own transcript pruning. Fire-and-forget on a
+            # worker thread — a store failure must never break a request, and the
+            # write must not add latency to this scan.
+            _persist_history_async(data)
         except Exception as e:
             _log.exception("sessions scan failed: %s", e)
             # If we have a previous value, keep serving it rather than 500-ing.
@@ -4521,6 +4586,51 @@ async def post_update_check(payload: dict = Body(...)):
     return {"enabled": enabled, "env_forced_off": env_off, "effective": enabled and not env_off}
 
 
+@app.get("/config/retention")
+async def get_retention():
+    """Per-agent transcript-retention info + TT archive opt-ins + storage usage.
+
+    Drives the Settings "Agent history & retention" section: shows each present
+    agent's default cleanup window (and the user's real override where we can
+    read it), whether TT can archive it, the opt-in state, and how much space
+    the durable store is using per tier."""
+    import agent_retention
+    import history_store
+    agents = _list_available_agents()
+    return {
+        "agents": agent_retention.describe_agents(agents),
+        "storage": history_store.storage_stats(),
+        "coverage": history_store.coverage(),
+    }
+
+
+@app.post("/config/retention")
+async def post_retention(payload: dict = Body(...)):
+    """Toggle whether TT keeps full transcripts for an agent past its own
+    pruning. Body: {"agent": str, "enabled": bool}."""
+    from fastapi import HTTPException
+    import agent_retention
+    agent = payload.get("agent")
+    enabled = payload.get("enabled")
+    if not isinstance(agent, str) or not agent:
+        raise HTTPException(status_code=400, detail="'agent' is required")
+    if not isinstance(enabled, bool):
+        raise HTTPException(status_code=400, detail="'enabled' must be a boolean")
+    flags = agent_retention.set_archive(agent, enabled)
+    return {"ok": True, "archive": flags}
+
+
+@app.delete("/history/transcripts")
+async def delete_history_transcripts(agent: Optional[str] = None,
+                                     older_than_days: Optional[int] = None):
+    """Purge archived (tier-2) transcript blobs to reclaim space. The core
+    rollup and any generated summaries are left intact, so analytics history is
+    preserved — only the heavy full-transcript copies are removed."""
+    import history_store
+    deleted = history_store.delete_transcripts(agent=agent, older_than_days=older_than_days)
+    return {"ok": True, "deleted": deleted, "storage": history_store.storage_stats()}
+
+
 @app.get("/config/power")
 async def get_power_config():
     """Power & subscription cost config for local/subscription models.
@@ -4750,8 +4860,70 @@ def _cache_hit_pct(input_tokens: int, cached_tokens: int) -> Optional[float]:
     return round((cached_tokens / denom) * 100, 1)
 
 
+def _bucket_key(ts: datetime, granularity: str) -> str:
+    """Local-time bucket label for a session timestamp. ``day`` keeps the
+    existing %Y-%m-%d key; ``week`` collapses to that week's ISO Monday; ``month``
+    to the first of the month. Always local, matching the original day bucket."""
+    d = ts.astimezone()
+    if granularity == "week":
+        monday = d - timedelta(days=d.weekday())
+        return monday.strftime("%Y-%m-%d")
+    if granularity == "month":
+        return d.strftime("%Y-%m-01")
+    return d.strftime("%Y-%m-%d")
+
+
+def _date_bound(value: Optional[str], *, end: bool) -> Optional[str]:
+    """Turn a 'YYYY-MM-DD' (or full ISO) filter value into a UTC-ISO bound that
+    compares correctly against the store's UTC ``last_ts``. A bare date becomes
+    local start-of-day (``end=False``) or end-of-day (``end=True``)."""
+    if not value:
+        return None
+    v = value.strip()
+    try:
+        if "T" in v:
+            dt = datetime.fromisoformat(v.replace("Z", "+00:00"))
+        else:
+            d = datetime.fromisoformat(v).date()
+            t = _dtime(23, 59, 59, 999999) if end else _dtime(0, 0, 0, 0)
+            dt = datetime.combine(d, t)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.astimezone()  # interpret bare value in local time
+    return dt.astimezone(timezone.utc).isoformat()
+
+
+def _session_in_filters(s: Dict[str, Any], from_b: Optional[str], to_b: Optional[str],
+                        agents: List[str], models: List[str], projects: List[str]) -> bool:
+    """Apply the same window + allow-list filters to a live session dict that the
+    store applies in SQL, so merged live rows respect the selected view."""
+    if agents and s.get("agent") not in agents:
+        return False
+    if models and s.get("model") not in models:
+        return False
+    if projects and s.get("project") not in projects:
+        return False
+    ts = s.get("timestamp")
+    if isinstance(ts, datetime) and (from_b or to_b):
+        iso = ts.astimezone(timezone.utc).isoformat()
+        if from_b and iso < from_b:
+            return False
+        if to_b and iso > to_b:
+            return False
+    return True
+
+
 @app.get("/analytics")
-async def get_analytics():
+async def get_analytics(
+    from_: Optional[str] = Query(None, alias="from"),
+    to: Optional[str] = Query(None),
+    granularity: str = Query("day"),
+    agents: List[str] = Query(default=[]),
+    models: List[str] = Query(default=[]),
+    projects: List[str] = Query(default=[]),
+):
+    import history_store
     from power_config import (
         is_local_session, load_power_config, default_tok_per_sec_for_model, co2_for_session,
     )
@@ -4759,7 +4931,25 @@ async def get_analytics():
     pc = load_power_config()
     load_watts = pc.get("loadWatts", 80)
     ref_model = pc.get("referenceCloudModel", "claude-sonnet-4-6")
-    sessions = await get_sessions_cached(); by_agent = {}; by_day = {}; by_model = {}
+    if granularity not in ("day", "week", "month"):
+        granularity = "day"
+
+    # Build the working set from the durable store (full history, filtered in
+    # SQL) merged with the live scan (freshest in-flight sessions). The live
+    # scan only matters for a window that reaches today, so a purely-historical
+    # query is served entirely from SQLite — no file scan.
+    from_b = _date_bound(from_, end=False)
+    to_b = _date_bound(to, end=True)
+    stored = history_store.query(from_b, to_b, agents, models, projects)
+    merged: Dict[tuple, Dict[str, Any]] = {(s["agent"], s["id"]): s for s in stored}
+    today_local = datetime.now().astimezone().strftime("%Y-%m-%d")
+    window_includes_today = (to_b is None) or (to is None) or (to >= today_local)
+    if window_includes_today:
+        for s in await get_sessions_cached():
+            if _session_in_filters(s, from_b, to_b, agents, models, projects):
+                merged[(s.get("agent"), s.get("id"))] = s  # live wins over stored
+    sessions = list(merged.values())
+    by_agent = {}; by_day = {}; by_model = {}
     for s in sessions:
         agent = s["agent"]
         if agent not in by_agent:
@@ -4796,7 +4986,7 @@ async def get_analytics():
         by_model[model_name]["co2_g"] += co2
         by_model[model_name]["session_count"] += 1
         # Bucket by LOCAL day, not UTC.
-        day = s["timestamp"].astimezone().strftime("%Y-%m-%d")
+        day = _bucket_key(s["timestamp"], granularity)
         if day not in by_day:
             by_day[day] = {"total": 0, "input": 0, "output": 0, "cached": 0, "cost": 0.0,
                            "energy_wh": 0.0, "savings_usd": 0.0, "co2_g": 0.0}
@@ -4941,6 +5131,8 @@ async def get_analytics():
             "co2_g": sum(a["co2_g"] for a in by_agent.values()),
             "cache_hit_pct": _cache_hit_pct(total_input, total_cached),
         },
+        "coverage": history_store.coverage(),
+        "granularity": granularity,
         "pricing_updated": PRICING_UPDATED,
     }
 

--- a/backend/test_agent_retention.py
+++ b/backend/test_agent_retention.py
@@ -1,0 +1,84 @@
+"""Tests for per-agent retention metadata + TT archive opt-in flags.
+
+The Settings page surfaces each agent's real cleanup window, so the values must
+be correct: Claude Code's is read from the user's own settings.json and falls
+back to the documented 30-day default. Also pins the archive opt-in roundtrip.
+
+No pytest in the venv — run directly:  python backend/test_agent_retention.py
+"""
+import json
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+_VAR = "TOKENTELEMETRY_DATA_DIR"
+
+
+def _fresh_module():
+    """Reimport agent_retention against a fresh data dir (RETENTION_FILE is
+    resolved at import time)."""
+    os.environ[_VAR] = tempfile.mkdtemp(prefix="tt-ret-")
+    import importlib
+    import agent_retention
+    importlib.reload(agent_retention)
+    return agent_retention
+
+
+def test_claude_default_is_30_when_no_settings():
+    from pathlib import Path
+    ar = _fresh_module()
+    ar.HOME = Path(tempfile.mkdtemp(prefix="tt-home-"))  # no ~/.claude/settings.json here
+    info = ar.describe_agents(["claude"])["claude"]
+    assert info["default_days"] == 30
+    assert info["effective_days"] == 30
+    assert info["detected_override"] is None
+
+
+def test_claude_reads_cleanup_period_days_override():
+    ar = _fresh_module()
+    home = tempfile.mkdtemp(prefix="tt-home-")
+    cdir = os.path.join(home, ".claude")
+    os.makedirs(cdir)
+    with open(os.path.join(cdir, "settings.json"), "w") as f:
+        json.dump({"cleanupPeriodDays": 3650}, f)
+    from pathlib import Path
+    ar.HOME = Path(home)
+    info = ar.describe_agents(["claude"])["claude"]
+    assert info["detected_override"] == 3650
+    assert info["effective_days"] == 3650, "user's real window must win over the default"
+
+
+def test_codex_has_no_auto_cleanup():
+    ar = _fresh_module()
+    info = ar.describe_agents(["codex"])["codex"]
+    assert info["default_days"] is None
+    assert info["effective_days"] is None
+
+
+def test_archive_optin_roundtrips_and_gates_unarchivable():
+    ar = _fresh_module()
+    # claude is archivable -> enabling it sticks.
+    ar.set_archive("claude", True)
+    assert ar.archive_enabled("claude") is True
+    ar.set_archive("claude", False)
+    assert ar.archive_enabled("claude") is False
+    # hermes isn't archivable -> archive_enabled stays False even if flagged.
+    ar.set_archive("hermes", True)
+    assert ar.archive_enabled("hermes") is False
+    assert ar.describe_agents(["hermes"])["hermes"]["archivable"] is False
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS  {t.__name__}")
+        except Exception as e:  # noqa: BLE001
+            failed += 1
+            print(f"FAIL  {t.__name__}: {e!r}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    sys.exit(1 if failed else 0)

--- a/backend/test_history_store.py
+++ b/backend/test_history_store.py
@@ -1,0 +1,145 @@
+"""Tests for the durable history store (issue #83 / discussion #27).
+
+The store is what lets analytics outlive the agents' own transcript pruning, so
+these pin the behaviours the feature depends on: idempotent upserts (a growing
+session updates one row, never duplicates), absent-marking that flags pruned
+sessions without deleting them, tiered deletes that free transcript space while
+keeping the core rollup, and SQL-side date/allow-list filtering.
+
+No pytest in the venv — run directly:  python backend/test_history_store.py
+"""
+import os
+import sys
+import tempfile
+from datetime import datetime, timezone, timedelta
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+_VAR = "TOKENTELEMETRY_DATA_DIR"
+
+
+def _fresh_store():
+    """Point the store at a brand-new tmp dir and return the (reimported) module."""
+    d = tempfile.mkdtemp(prefix="tt-hist-")
+    os.environ[_VAR] = d
+    import importlib
+    import history_store
+    importlib.reload(history_store)
+    return history_store
+
+
+def _session(sid="s1", agent="claude", ts=None, total=17, **kw):
+    ts = ts or datetime.now(timezone.utc)
+    s = {
+        "id": sid, "agent": agent, "project": "/p", "model": "claude-opus-4-8",
+        "provider": None, "endpoint": None, "billing_mode": None, "timestamp": ts,
+        "tokens": {"input": 10, "output": 5, "cached": 2, "total": total},
+        "cost": 0.01, "tok_per_sec": 40,
+    }
+    s.update(kw)
+    return s
+
+
+def test_upsert_is_idempotent_and_updates_growing_session():
+    h = _fresh_store()
+    h.upsert_sessions([_session(total=17)])
+    h.upsert_sessions([_session(total=31, tokens={"input": 20, "output": 9, "cached": 2, "total": 31})])
+    rows = h.query()
+    assert len(rows) == 1, f"expected 1 row, got {len(rows)}"
+    assert rows[0]["tokens"]["total"] == 31, "row should reflect the latest scan"
+
+
+def test_mark_absent_flags_without_deleting():
+    h = _fresh_store()
+    h.upsert_sessions([_session()])
+    h.mark_absent(set())  # nothing seen this scan -> the row is now off-disk
+    rows = h.query()
+    assert len(rows) == 1, "mark_absent must never delete the rollup"
+    assert rows[0]["source_present"] is False
+
+
+def test_ecosystem_roundtrips():
+    h = _fresh_store()
+    h.upsert_sessions([_session(skills_used=[{"name": "x", "count": 2}],
+                                delegation={"spawn_count": 3})])
+    r = h.query()[0]
+    assert r.get("skills_used") == [{"name": "x", "count": 2}]
+    assert r.get("delegation") == {"spawn_count": 3}
+
+
+def test_transcript_delete_keeps_rollup_and_summary():
+    h = _fresh_store()
+    h.upsert_sessions([_session()])
+    h.put_transcript("claude", "s1", "full transcript text")
+    h.put_summary("claude", "s1", "a short summary")
+    assert h.get_transcript("claude", "s1") == "full transcript text"
+    deleted = h.delete_transcripts(agent="claude")
+    assert deleted == 1
+    assert h.get_transcript("claude", "s1") is None, "blob should be gone"
+    assert h.get_summary("claude", "s1") == "a short summary", "summary must survive"
+    r = h.query()[0]
+    assert r["transcript_archived"] is False
+    assert r["summary_present"] is True
+    assert r["tokens"]["total"] == 17, "core rollup must survive the purge"
+
+
+def test_date_and_allowlist_filters():
+    h = _fresh_store()
+    old = datetime.now(timezone.utc) - timedelta(days=10)
+    new = datetime.now(timezone.utc)
+    h.upsert_sessions([
+        _session("old", agent="claude", ts=old),
+        _session("new", agent="codex", ts=new, model="gpt-5"),
+    ])
+    # Date window: only the last 3 days.
+    frm = (datetime.now(timezone.utc) - timedelta(days=3)).isoformat()
+    recent = h.query(from_=frm)
+    assert {r["id"] for r in recent} == {"new"}, "from_ must exclude the old row"
+    # Agent allow-list.
+    assert {r["id"] for r in h.query(agents=["claude"])} == {"old"}
+    # Model allow-list.
+    assert {r["id"] for r in h.query(models=["gpt-5"])} == {"new"}
+    # Empty list == no filter (All).
+    assert len(h.query(agents=[])) == 2
+
+
+def test_storage_and_coverage():
+    h = _fresh_store()
+    h.upsert_sessions([_session("a"), _session("b", agent="codex")])
+    h.put_transcript("claude", "a", "x" * 500)
+    cov = h.coverage()
+    assert cov["total_sessions"] == 2
+    assert cov["earliest"] is not None
+    stats = h.storage_stats()
+    assert stats["by_agent"]["claude"]["sessions"] == 1
+    assert stats["by_agent"]["claude"]["transcripts"] == 1
+    assert stats["transcript_bytes"] > 0
+
+
+def test_bucket_key_day_week_month():
+    # _bucket_key lives in the analytics endpoint module; import lazily so a
+    # missing FastAPI dep degrades to a skip rather than a hard failure.
+    try:
+        import main
+    except Exception as e:  # noqa: BLE001
+        print(f"SKIP  bucket_key (main not importable: {e})")
+        return
+    d = datetime(2026, 6, 10, 12, 0, tzinfo=timezone.utc)  # a Wednesday
+    assert main._bucket_key(d, "day").endswith("-10")
+    # Week collapses to that week's Monday (the 8th, local time).
+    assert main._bucket_key(d, "week")[:7] == "2026-06"
+    assert main._bucket_key(d, "month").endswith("-01")
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS  {t.__name__}")
+        except Exception as e:  # noqa: BLE001
+            failed += 1
+            print(f"FAIL  {t.__name__}: {e!r}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    sys.exit(1 if failed else 0)

--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,0 +1,31 @@
+# ADR-NNNN: <short title in the imperative, e.g. "Cache pricing data at build time">
+
+- **Status:** Proposed | Accepted | Superseded by ADR-XXXX
+- **Date:** YYYY-MM-DD
+- **Deciders:** <who>
+- **Related:** issue #__, PR #__, [design doc](../design/<feature>.md)
+
+## Context
+
+What forced this decision? The problem, the constraints (local-first, free,
+solo-maintainer, cross-platform…), and anything we learned that narrowed the
+options. State facts, not the conclusion.
+
+## Decision
+
+The choice, stated plainly. "We will …". One paragraph is usually enough.
+
+## Alternatives considered
+
+- **<Option A>** — why rejected.
+- **<Option B>** — why rejected.
+
+## Consequences
+
+What we now live with — good and bad. Be honest about the costs and the blast
+radius, because this is the section a future reader checks before changing or
+reverting the decision.
+
+- ✅ <upside>
+- ⚠️ <cost / limitation>
+- 🔁 <what would have to change to undo this>

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,44 @@
+# ADR-0001: Record architecture decisions in the repo
+
+- **Status:** Accepted
+- **Date:** 2026-06-13
+- **Deciders:** VasiHemanth
+- **Related:** [TokenTelemetry Roadmap board](https://github.com/users/VasiHemanth/projects/1)
+
+## Context
+
+TokenTelemetry is a solo-maintained, local-first project with a growing community
+on GitHub Issues/Discussions. There is no Jira/Linear and a strong preference to
+stay on free, GitHub-native tooling. The recurring pain: months after a feature
+ships, it's hard to reconstruct *why* it was built a certain way, and therefore
+risky to change or revert it. We need a durable record of decisions that cannot
+drift out of sync with the code.
+
+## Decision
+
+We will keep **Architecture Decision Records** as markdown files under `docs/adr/`,
+one per significant decision, each committed **in the same PR as the code it
+describes**. A GitHub Projects board tracks *work*; the repo holds the *decisions
+and designs*; each board card links to its ADR. Discord is for community/support
+only, never as a decision record.
+
+## Alternatives considered
+
+- **Google Sheets / external doc** — drifts from the code, no link to commits,
+  manual upkeep. Rejected.
+- **Linear / Jira** — another silo to keep in sync; overkill and not free for a
+  solo maintainer. Rejected for now.
+- **Only the board / draft-issue bodies** — not versioned with the code, invisible
+  to `git blame`, can't be reverted alongside a PR. Rejected as the system of record.
+- **GitHub Wiki** — separate git history from the code; a doc and its
+  implementing commit can't travel together. Rejected in favour of in-tree docs.
+
+## Consequences
+
+- ✅ Every decision is versioned with the code and discoverable via `git blame`,
+  the PR, and the board card — so backtracking is "revert the PR, read the ADR".
+- ✅ Zero new tools or cost; works offline, matches the local-first ethos.
+- ⚠️ Requires discipline: an ADR (and design doc, where relevant) must be written
+  as part of each feature PR. This is mirrored by the existing UPDATE.json hook habit.
+- 🔁 To undo: stop writing ADRs and delete `docs/adr/` — but the existing records
+  remain useful history regardless.

--- a/docs/adr/0002-durable-history-rollup.md
+++ b/docs/adr/0002-durable-history-rollup.md
@@ -1,0 +1,64 @@
+# ADR-0002: Durable SQLite rollup for analytics history
+
+- **Status:** Accepted
+- **Date:** 2026-06-13
+- **Deciders:** VasiHemanth
+- **Related:** issue #83, discussion #27, [design doc](../design/durable-history.md)
+
+## Context
+
+TokenTelemetry was a pure live-scanner: every `/analytics` and `/sessions` request
+re-read the coding agents' on-disk transcripts and kept the result only in a 30-second
+in-RAM cache (`SESSIONS_TTL_SEC`, `get_sessions_cached` in `backend/main.py`). Nothing
+was persisted.
+
+But agents prune their own transcripts on a schedule — Claude Code deletes
+`~/.claude/projects/**/*.jsonl` after `cleanupPeriodDays` (default **30**), Gemini CLI
+defaults to 30 days, others vary. So the date-range filtering users asked for (issue
+#83: "this month/this year"; discussion #27: ranges finer/longer than the 7-day floor)
+was *structurally impossible* — a "this year" view could only ever show what each agent
+still had on disk. A constraint reinforced by [[local-first-no-user-network]]: the fix
+must work entirely on the user's machine, no external storage.
+
+## Decision
+
+We will give TokenTelemetry its own **durable local SQLite store** at
+`~/.tokentelemetry/history.db` (honouring `TOKENTELEMETRY_DATA_DIR`), upserted on every
+scan from a background thread. Analytics reads the store (full history, filtered in SQL)
+**merged with** the live scan (freshest in-flight sessions, live wins). We store **raw
+facts** (tokens, cost, model, tok/s, timestamps + a small ecosystem JSON) and recompute
+derived insights (energy/savings/CO₂) at read time, so power-config changes apply
+retroactively.
+
+Storage is **tiered** so users control disk: a tiny **core rollup** is always kept;
+**full transcripts** are opt-in per agent and deletable; generated **summaries** persist
+even after a transcript is deleted.
+
+## Alternatives considered
+
+- **Keep live-scanning only** — simplest, but the feature is impossible (history dies
+  with the agents' pruning). Rejected.
+- **Archive every full transcript by default** — durable, but heavy on disk and copies
+  data the user didn't ask us to keep. Rejected as the default; offered as an opt-in tier.
+- **Store derived insights (energy/cost) directly** — would freeze them against the
+  power config at write time, so later config changes wouldn't apply. Rejected in favour
+  of storing raw facts and recomputing at read.
+- **Load all history into Python per request** — the obvious latency trap. Rejected in
+  favour of SQL-side date/allow-list filtering on indexed `last_ts`.
+
+## Consequences
+
+- ✅ Analytics history survives agent pruning; date/granularity/agent/model filters work
+  over the full retained range (issue #83, discussion #27).
+- ✅ Historical-only windows are served entirely from SQLite — often *faster* than the
+  old always-scan path; only windows reaching "today" merge the live scan.
+- ✅ Raw-fact storage means power-config changes retroactively re-price old sessions.
+- ⚠️ **Start-from-now:** we can only capture sessions present on disk at first run;
+  already-pruned history is unrecoverable. The analytics UI states this explicitly.
+- ⚠️ **Summary-only rows:** once an agent prunes a transcript (and the user didn't opt
+  into archiving), the session shows in aggregates but has no transcript drill-in.
+- ⚠️ Transcript archival currently resolves single-file transcripts for **claude/codex**
+  only (`_resolve_transcript_path`); other agents are rollup-only until extended
+  (tracked on the board).
+- 🔁 To undo: revert the feature PR. `history.db` is self-contained under the data dir
+  and can simply be deleted; no agent data is ever modified.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,37 @@
+# Architecture Decision Records (ADRs)
+
+This folder holds the **why** behind TokenTelemetry's architecture — one short file
+per significant decision, written *when the decision is made* and committed in the
+same PR as the code that implements it.
+
+An ADR is not a spec and not a design doc. It captures a single choice: the
+context that forced it, the decision taken, the alternatives rejected, and the
+consequences you'll live with. Months later it answers "why is it built this
+way, and what breaks if I change it?" without anyone reconstructing it from memory.
+
+## Where this fits
+
+- **Board** ([TokenTelemetry Roadmap](https://github.com/users/VasiHemanth/projects/1)) — the *index* of work. Each card's `ADR` field links here.
+- **ADRs** (this folder) — the *why*.
+- **Design docs** (`../design/`) — the *what & how* of a feature.
+- **PRs** — the *change itself* + validation (diff, tests, review).
+- **CHANGELOG.md / UPDATE.json** — what *users* get.
+
+The board is the index; the repo is the truth. An ADR can never drift out of
+sync with the code because it ships in the same commit.
+
+## How to add one
+
+1. Copy [`0000-template.md`](0000-template.md) to `NNNN-short-title.md` (next number).
+2. Fill in Context / Decision / Consequences. Keep it to ~1 page.
+3. Set **Status** to `Accepted` (or `Proposed` if still under discussion).
+4. Commit it **in the feature's PR**, and paste its URL into the board card's `ADR` field.
+5. If a later decision overturns this one, set this ADR's Status to
+   `Superseded by ADR-XXXX` rather than editing history — the trail is the point.
+
+## Index
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [0001](0001-record-architecture-decisions.md) | Record architecture decisions in the repo | Accepted |
+| [0002](0002-durable-history-rollup.md) | Durable SQLite rollup for analytics history | Accepted |

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,14 @@
+# Design docs
+
+The **what & how** of each feature — the counterpart to the decision records in
+[`../adr/`](../adr/) (the *why*) and the board cards (the *tracking*).
+
+Write a design doc for any feature that's more than a trivial change, and commit
+it in the feature's PR.
+
+## Index
+
+| Feature | Doc | ADR |
+|---------|-----|-----|
+| Durable history + analytics date filters | [durable-history.md](durable-history.md) | [ADR-0002](../adr/0002-durable-history-rollup.md) |
+| Delegation & ecosystem telemetry | [`../../DESIGN.md`](../../DESIGN.md) | — (pre-ADR) |

--- a/docs/design/durable-history.md
+++ b/docs/design/durable-history.md
@@ -1,0 +1,82 @@
+# Design: Durable history + date/range analytics filters
+
+Implements issue #83 and discussion #27. Decision recorded in
+[ADR-0002](../adr/0002-durable-history-rollup.md).
+
+## Goal
+
+Let analytics be filtered by date range / granularity / agent / model, and make
+that history survive after coding agents prune their own transcripts.
+
+## Architecture
+
+```
+_scan_sessions_sync() ──► live session list ──► 30s RAM cache (unchanged)
+                                  │
+                  (background thread, fire-and-forget)
+                                  ▼
+              history_store.upsert_sessions() + mark_absent()
+                                  ▼
+                    ~/.tokentelemetry/history.db
+                  (sessions / transcripts / summaries)
+
+GET /analytics?from&to&granularity&agents&models&projects
+    stored = history_store.query(...)        # full history, filtered in SQL
+    + live  (only if window reaches today)   # merged by (agent,id), live wins
+    → existing aggregation loop (granularity-bucketed, insights recomputed)
+    → response + coverage{}
+```
+
+## Components
+
+### `backend/history_store.py`
+Self-contained SQLite layer at `tt_paths.data_dir()/history.db` (WAL, lazy
+create, `PRAGMA user_version` migrations, short-lived connections). Reads never
+raise; a store failure never breaks a request.
+
+- **`sessions`** (core rollup, PK `(agent, id)`): agent, id, project, model,
+  provider, endpoint, billing_mode, first/last_ts (UTC ISO), input/output/cached/
+  total, cost, tok_per_sec, `ecosystem_json` (skills/MCP/delegation/subagent/parent),
+  first/last_seen_at, `source_present`, `transcript_archived`, `summary_present`.
+- **`transcripts`** (tier 2): zlib-compressed blob + bytes + archived_at.
+- **`summaries`** (tier 3): summary text + created_at.
+- API: `upsert_sessions` (idempotent by PK — a growing session updates one row),
+  `mark_absent` (flags pruned rows `source_present=0`, never deletes), `query`
+  (date range + IN-list filters applied in SQL on indexed `last_ts`; returns
+  *session-shaped dicts*), `coverage`, `storage_stats`, and transcript/summary
+  get/put/delete helpers.
+
+### `backend/agent_retention.py`
+Per-agent transcript-retention metadata (Claude 30d via real `cleanupPeriodDays`,
+Gemini/Qwen 30d, Codex/DB-backed agents = no auto-cleanup) + archive opt-in flags
+persisted to `retention.json`. `archive_enabled(agent)` gates tier-2 archival.
+
+### `backend/main.py`
+- `get_sessions_cached` fires `_persist_history_async(data)` after each scan
+  (upsert + mark_absent + opt-in transcript archival for claude/codex).
+- `/analytics` rewritten: new query params, DB∪live merge, `_bucket_key` for
+  day/week/month, `coverage` in the response. Default (no params) = prior behaviour.
+- Endpoints: `GET/POST /config/retention`, `DELETE /history/transcripts`.
+
+### Frontend
+- `app/analytics/page.tsx`: date presets (7d/30d/month/year/all/custom),
+  granularity toggle, agent/model multi-select chips, data-availability notice.
+  Filters are server-driven via the `useResource` query string.
+- `app/settings/page.tsx` + `components/settings/RetentionSettings.tsx` +
+  `lib/retention.ts`: "Agent history & retention" section — per-agent retention,
+  archive toggle, storage readout, delete-transcripts (keeps core stats).
+
+## Key invariants
+- **Live wins** over stored for sessions still on disk (freshest tokens).
+- **Store raw, derive at read** — energy/savings/CO₂ recomputed from current power config.
+- **Never delete the rollup** — only `source_present` flips; transcripts/summaries
+  are the only user-deletable tiers.
+
+## Tests
+`backend/test_history_store.py`, `backend/test_agent_retention.py` (pytest-free,
+run directly). Cover upsert idempotency, absent-marking, tier-2 delete preserving
+rollup+summary, SQL filters, bucketing, and retention accuracy.
+
+## Out of scope (tracked on the board)
+Backfilling pruned data (impossible); per-profile views (`profile` is hermes-only);
+CSV/Sheets export; transcript archival for agents beyond claude/codex.

--- a/frontend/src/app/analytics/page.tsx
+++ b/frontend/src/app/analytics/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { cn } from "@/lib/cn";
 import {
   BarChart3, TrendingUp, ArrowDownToLine, ArrowUpFromLine,
@@ -33,6 +33,12 @@ interface AnalyticsData {
     by_agent?: Record<string, { parents: number; spawns: number; children: number; child_tokens: number; child_cost: number; delegated_tokens: number; delegated_cost: number }>;
   };
   total: { input: number; output: number; cached: number; total: number; cost: number };
+  coverage?: {
+    earliest: string | null;
+    total_sessions: number;
+    by_agent: Record<string, { present: number; pruned: number; summarized: number }>;
+  };
+  granularity?: string;
   pricing_updated?: string;
 }
 
@@ -63,41 +69,87 @@ function useChartTheme() {
   };
 }
 
-type DayRange = "7d" | "30d" | "90d" | "all";
-const RANGES: { key: DayRange; label: string; days: number | null }[] = [
-  { key: "7d",  label: "7d",  days: 7 },
-  { key: "30d", label: "30d", days: 30 },
-  { key: "90d", label: "90d", days: 90 },
-  { key: "all", label: "All", days: null },
+type RangeKey = "7d" | "30d" | "90d" | "month" | "year" | "all" | "custom";
+const PRESETS: { key: RangeKey; label: string }[] = [
+  { key: "7d",    label: "7d" },
+  { key: "30d",   label: "30d" },
+  { key: "90d",   label: "90d" },
+  { key: "month", label: "Month" },
+  { key: "year",  label: "Year" },
+  { key: "all",   label: "All" },
 ];
+type Granularity = "day" | "week" | "month";
+const GRANULARITIES: Granularity[] = ["day", "week", "month"];
+
+// Local YYYY-MM-DD — matches the backend's local-day bucket keys.
+function ymd(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+function presetBounds(key: RangeKey): { from: string | null; to: string | null } {
+  const now = new Date();
+  const to = ymd(now);
+  if (key === "all") return { from: null, to: null };
+  if (key === "month") return { from: ymd(new Date(now.getFullYear(), now.getMonth(), 1)), to };
+  if (key === "year")  return { from: ymd(new Date(now.getFullYear(), 0, 1)), to };
+  const days = key === "7d" ? 7 : key === "30d" ? 30 : 90;
+  const f = new Date(now); f.setDate(f.getDate() - (days - 1));
+  return { from: ymd(f), to };
+}
 
 export default function AnalyticsPage() {
-  const { data, loading } = useResource<AnalyticsData>("/analytics", { pollMs: 30_000 });
+  // Filter state. The query string is derived from it and used as the
+  // useResource path — changing any filter refetches a freshly-windowed,
+  // server-aggregated dataset (history store + live scan merged on the backend).
+  const [range, setRange] = useState<RangeKey>("30d");
+  const [granularity, setGranularity] = useState<Granularity>("day");
+  const [customFrom, setCustomFrom] = useState("");
+  const [customTo, setCustomTo] = useState("");
+  const [selAgents, setSelAgents] = useState<string[]>([]);
+  const [selModels, setSelModels] = useState<string[]>([]);
+
+  const queryPath = useMemo(() => {
+    const p = new URLSearchParams();
+    let from: string | null, to: string | null;
+    if (range === "custom") { from = customFrom || null; to = customTo || null; }
+    else ({ from, to } = presetBounds(range));
+    if (from) p.set("from", from);
+    if (to) p.set("to", to);
+    if (granularity !== "day") p.set("granularity", granularity);
+    selAgents.forEach(a => p.append("agents", a));
+    selModels.forEach(m => p.append("models", m));
+    const qs = p.toString();
+    return qs ? `/analytics?${qs}` : "/analytics";
+  }, [range, granularity, customFrom, customTo, selAgents, selModels]);
+
+  const { data, loading } = useResource<AnalyticsData>(queryPath, { pollMs: 30_000 });
+  const agentOptions = useResource<string[]>("/agents").data ?? [];
   const ct = useChartTheme();
   const AXIS = { stroke: ct.axisStroke, fontSize: 10, tickLine: false, axisLine: false, tick: { fill: ct.tickFill } } as const;
-  const [range, setRange] = useState<DayRange>("30d");
 
-  // Filter by_day to the selected window. Dates are local "YYYY-MM-DD"
-  // strings (see backend A10 fix), so a lex compare against a cutoff string works.
-  const filteredByDay = useMemo(() => {
-    if (!data?.by_day) return [];
-    const cfg = RANGES.find(r => r.key === range);
-    if (!cfg?.days) return data.by_day;
-    const cutoff = new Date();
-    cutoff.setDate(cutoff.getDate() - (cfg.days - 1));
-    const cutoffStr = cutoff.toISOString().slice(0, 10);
-    return data.by_day.filter(d => d.date >= cutoffStr);
-  }, [data, range]);
+  // Accumulate every model we've seen so selecting one doesn't collapse the
+  // option list (the response only carries models in the current window).
+  const [allModels, setAllModels] = useState<string[]>([]);
+  useEffect(() => {
+    if (data?.by_model) {
+      setAllModels(prev => {
+        const next = new Set(prev);
+        Object.keys(data.by_model!).forEach(m => next.add(m));
+        return next.size === prev.length ? prev : Array.from(next).sort();
+      });
+    }
+  }, [data]);
 
+  const toggle = (list: string[], v: string, set: (x: string[]) => void) =>
+    set(list.includes(v) ? list.filter(x => x !== v) : [...list, v]);
+
+  // Server already returns by_day windowed to the selected range/granularity.
   const rangeTotals = useMemo(() => {
-    return filteredByDay.reduce(
-      (acc, d) => ({
-        total: acc.total + (d.total || 0),
-        cost:  acc.cost  + (d.cost  || 0),
-      }),
+    return (data?.by_day ?? []).reduce(
+      (acc, d) => ({ total: acc.total + (d.total || 0), cost: acc.cost + (d.cost || 0) }),
       { total: 0, cost: 0 }
     );
-  }, [filteredByDay]);
+  }, [data]);
 
   const modelData = useMemo(() => {
     if (!data?.by_model) return [];
@@ -144,6 +196,105 @@ export default function AnalyticsPage() {
         }
       />
 
+      {/* Filter toolbar: granularity + custom range + agent/model selection.
+          The date-range presets live on the consumption chart header. */}
+      <div className="flex flex-wrap items-center gap-x-6 gap-y-3 -mt-4">
+        <div className="flex items-center gap-2">
+          <span className="text-[10px] uppercase tracking-[0.16em] text-[var(--tt-fg-dim)]">Bucket</span>
+          <div className="flex gap-0.5 bg-[var(--tt-sunken)] border border-[var(--tt-border)] rounded-[var(--tt-radius)] p-0.5">
+            {GRANULARITIES.map(g => (
+              <button
+                key={g}
+                onClick={() => setGranularity(g)}
+                className={cn(
+                  "px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.16em] rounded-[calc(var(--tt-radius)-2px)] transition-colors",
+                  granularity === g
+                    ? "bg-[var(--tt-panel)] text-[var(--tt-fg)] shadow-sm"
+                    : "text-[var(--tt-fg-dim)] hover:text-[var(--tt-fg)]"
+                )}
+              >
+                {g}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <span className="text-[10px] uppercase tracking-[0.16em] text-[var(--tt-fg-dim)]">Custom</span>
+          <input
+            type="date" value={customFrom}
+            onChange={e => { setCustomFrom(e.target.value); setRange("custom"); }}
+            className="bg-[var(--tt-sunken)] border border-[var(--tt-border)] rounded-[var(--tt-radius)] px-2 py-1 text-[11px] text-[var(--tt-fg)]"
+          />
+          <span className="text-[var(--tt-fg-dim)] text-[11px]">→</span>
+          <input
+            type="date" value={customTo}
+            onChange={e => { setCustomTo(e.target.value); setRange("custom"); }}
+            className="bg-[var(--tt-sunken)] border border-[var(--tt-border)] rounded-[var(--tt-radius)] px-2 py-1 text-[11px] text-[var(--tt-fg)]"
+          />
+        </div>
+
+        {agentOptions.length > 0 && (
+          <div className="flex items-center gap-1.5 flex-wrap">
+            <span className="text-[10px] uppercase tracking-[0.16em] text-[var(--tt-fg-dim)]">Agents</span>
+            {agentOptions.map(a => (
+              <button
+                key={a}
+                onClick={() => toggle(selAgents, a, setSelAgents)}
+                className={cn(
+                  "px-2 py-0.5 text-[10px] font-medium rounded-full border transition-colors",
+                  selAgents.includes(a)
+                    ? "border-[var(--tt-brand)] text-[var(--tt-fg)] bg-[var(--tt-brand)]/10"
+                    : "border-[var(--tt-border)] text-[var(--tt-fg-dim)] hover:text-[var(--tt-fg)]"
+                )}
+              >
+                {getAgent(a).label}
+              </button>
+            ))}
+            {selAgents.length > 0 && (
+              <button onClick={() => setSelAgents([])} className="text-[10px] text-[var(--tt-fg-dim)] underline ml-1">clear</button>
+            )}
+          </div>
+        )}
+
+        {allModels.length > 1 && (
+          <div className="flex items-center gap-1.5 flex-wrap max-w-full">
+            <span className="text-[10px] uppercase tracking-[0.16em] text-[var(--tt-fg-dim)]">Models</span>
+            {allModels.map(m => (
+              <button
+                key={m}
+                onClick={() => toggle(selModels, m, setSelModels)}
+                className={cn(
+                  "px-2 py-0.5 text-[10px] font-medium rounded-full border transition-colors truncate max-w-[180px]",
+                  selModels.includes(m)
+                    ? "border-[var(--tt-brand)] text-[var(--tt-fg)] bg-[var(--tt-brand)]/10"
+                    : "border-[var(--tt-border)] text-[var(--tt-fg-dim)] hover:text-[var(--tt-fg)]"
+                )}
+              >
+                {m}
+              </button>
+            ))}
+            {selModels.length > 0 && (
+              <button onClick={() => setSelModels([])} className="text-[10px] text-[var(--tt-fg-dim)] underline ml-1">clear</button>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Data-availability notice: history only accrues from the first run, and
+          agents prune their own transcripts — older rows are summary-only. */}
+      {data.coverage?.earliest && (
+        <div className="flex items-start gap-2 text-[11px] text-[var(--tt-fg-dim)] rounded-[var(--tt-radius)] border border-[var(--tt-border)] bg-[var(--tt-sunken)] px-3 py-2 -mt-4">
+          <BarChart3 size={13} className="mt-0.5 shrink-0 text-[var(--tt-fg-dim)]" />
+          <span>
+            Durable history since <span className="text-[var(--tt-fg)]">{data.coverage.earliest.slice(0, 10)}</span>.
+            TokenTelemetry only records sessions present on disk from its first run — usage before then can't be
+            recovered, and agents prune their own transcripts over time, so older entries may be summary-only
+            (no transcript drill-in).
+          </span>
+        </div>
+      )}
+
       {/* KPI strip */}
       <Section title="Totals">
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
@@ -188,7 +339,7 @@ export default function AnalyticsPage() {
                 {compact(rangeTotals.total)} tokens · ${rangeTotals.cost.toFixed(2)}
               </span>
               <div className="flex gap-0.5 bg-[var(--tt-sunken)] border border-[var(--tt-border)] rounded-[var(--tt-radius)] p-0.5">
-                {RANGES.map(r => (
+                {PRESETS.map(r => (
                   <button
                     key={r.key}
                     onClick={() => setRange(r.key)}
@@ -207,7 +358,7 @@ export default function AnalyticsPage() {
           </CardHeader>
           <div className="h-72 w-full">
             <ResponsiveContainer width="100%" height="100%">
-              <AreaChart data={filteredByDay} margin={{ top: 10, right: 16, bottom: 0, left: 0 }}>
+              <AreaChart data={data.by_day} margin={{ top: 10, right: 16, bottom: 0, left: 0 }}>
                 <defs>
                   <linearGradient id="ttArea" x1="0" y1="0" x2="0" y2="1">
                     <stop offset="0%"   stopColor="#60a5fa" stopOpacity={0.45} />

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/cn";
 import { PageHeader, Section, Card, CardHeader, CardTitle, Button, Badge, Skeleton } from "@/components/ui";
 import { BackendPicker } from "@/components/summarizer/BackendPicker";
 import { BillingSettings } from "@/components/settings/BillingSettings";
+import { RetentionSettings } from "@/components/settings/RetentionSettings";
 import { ConnectDevice } from "@/components/ConnectDevice";
 import {
   getSummarizerConfig, getAvailableBackends, putSummarizerConfig,
@@ -211,6 +212,13 @@ export default function SettingsPage() {
         <div className="space-y-4">
           <BillingSettings />
         </div>
+      </Section>
+
+      <Section
+        title="Agent history & retention"
+        description="Keep analytics history alive after agents prune their own transcripts. Core session stats are always retained; opt in per agent to also archive full transcripts, and reclaim space anytime without losing your history."
+      >
+        <RetentionSettings />
       </Section>
 
       <Section

--- a/frontend/src/components/settings/RetentionSettings.tsx
+++ b/frontend/src/components/settings/RetentionSettings.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Archive, Trash2, Loader2 } from "lucide-react";
+import { cn } from "@/lib/cn";
+import { CardTitle } from "@/components/ui";
+import {
+  getRetention, setArchive, deleteTranscripts,
+  type RetentionState, type AgentRetention,
+} from "@/lib/retention";
+
+function fmtBytes(n: number): string {
+  if (!n) return "0 B";
+  const u = ["B", "KB", "MB", "GB"];
+  let i = 0; let v = n;
+  while (v >= 1024 && i < u.length - 1) { v /= 1024; i++; }
+  return `${v.toFixed(v < 10 && i > 0 ? 1 : 0)} ${u[i]}`;
+}
+
+function retentionLabel(a: AgentRetention): string {
+  if (a.effective_days == null) return "No automatic cleanup";
+  const src = a.detected_override != null ? " (your setting)" : "";
+  return `${a.effective_days} days, then auto-deleted${src}`;
+}
+
+function Toggle({ on, busy, disabled, onClick, label }: {
+  on: boolean; busy: boolean; disabled?: boolean; onClick: () => void; label: string;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      role="switch"
+      aria-checked={on}
+      aria-label={label}
+      disabled={busy || disabled}
+      className={cn(
+        "relative inline-flex h-5 w-9 shrink-0 items-center rounded-full border transition-colors mt-0.5 border-[var(--tt-border)]",
+        on ? "tt-tint-1" : "",
+        busy || disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer",
+      )}
+    >
+      <span className={cn(
+        "absolute h-3.5 w-3.5 rounded-full transition-transform",
+        on ? "translate-x-[18px] bg-[var(--tt-brand)]" : "translate-x-0.5 bg-[var(--tt-fg-muted)]",
+      )} />
+    </button>
+  );
+}
+
+export function RetentionSettings() {
+  const [state, setState] = useState<RetentionState | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    getRetention().then(s => { if (!cancelled) setState(s); }).catch(() => {});
+    return () => { cancelled = true; };
+  }, []);
+
+  if (!state) return null;
+
+  const refresh = () => getRetention().then(setState).catch(() => {});
+
+  const onToggle = async (agent: string, next: boolean) => {
+    setBusy(agent);
+    try { await setArchive(agent, next); await refresh(); }
+    finally { setBusy(null); }
+  };
+
+  const onDelete = async (agent: string) => {
+    setBusy(`del:${agent}`);
+    try { await deleteTranscripts(agent); await refresh(); }
+    finally { setBusy(null); }
+  };
+
+  const agents = Object.entries(state.agents);
+
+  return (
+    <div className="space-y-3">
+      <p className="text-[12px] text-[var(--tt-fg-dim)] max-w-[640px]">
+        Coding agents prune their own session transcripts on a schedule, after which they vanish from
+        analytics. TokenTelemetry always keeps a tiny <span className="text-[var(--tt-fg)]">core summary</span> of
+        every session (tokens, cost, model — used for history & charts). For agents below you can also
+        keep the <span className="text-[var(--tt-fg)]">full transcript</span> so it survives past the agent&apos;s
+        own cleanup. Deleting archived transcripts frees space but <span className="text-[var(--tt-fg)]">keeps the
+        core stats</span> — your history stays intact.
+      </p>
+
+      {agents.map(([id, a]) => {
+        const st = state.storage.by_agent[id];
+        const tbytes = st?.transcript_bytes ?? 0;
+        return (
+          <div
+            key={id}
+            className="flex items-start justify-between gap-4 rounded-[var(--tt-radius)] border border-[var(--tt-border)] bg-[var(--tt-sunken)] px-4 py-3"
+          >
+            <div className="min-w-0">
+              <CardTitle className="text-[13px] mb-0.5">{a.label}</CardTitle>
+              <p className="text-[11px] text-[var(--tt-fg-dim)]">
+                Default retention: <span className="text-[var(--tt-fg-muted)]">{retentionLabel(a)}</span>
+                {a.settings_hint && <span className="text-[var(--tt-fg-dim)]"> · {a.settings_hint}</span>}
+              </p>
+              <p className="text-[11px] text-[var(--tt-fg-dim)] mt-0.5">{a.note}</p>
+              {st && (
+                <p className="text-[10px] text-[var(--tt-fg-dim)] mt-1 tabular">
+                  {st.sessions} sessions kept · {st.transcripts} transcripts ({fmtBytes(tbytes)}) · {st.summaries} summaries
+                </p>
+              )}
+            </div>
+
+            <div className="flex items-center gap-3 shrink-0">
+              {a.archivable && tbytes > 0 && (
+                <button
+                  onClick={() => onDelete(id)}
+                  disabled={busy === `del:${id}`}
+                  className="inline-flex items-center gap-1 text-[11px] text-[var(--tt-fg-dim)] hover:text-[var(--tt-danger)] transition-colors disabled:opacity-50"
+                  title="Delete archived transcripts (keeps core stats)"
+                >
+                  {busy === `del:${id}` ? <Loader2 size={12} className="animate-spin" /> : <Trash2 size={12} />}
+                  Free space
+                </button>
+              )}
+              <div className="flex items-center gap-1.5" title={a.archivable ? "Keep full transcripts in TokenTelemetry" : "Archiving not available for this agent yet"}>
+                <Archive size={12} className="text-[var(--tt-fg-dim)]" />
+                <Toggle
+                  on={a.archive_enabled}
+                  busy={busy === id}
+                  disabled={!a.archivable}
+                  onClick={() => onToggle(id, !a.archive_enabled)}
+                  label={`Keep full transcripts for ${a.label}`}
+                />
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/lib/retention.ts
+++ b/frontend/src/lib/retention.ts
@@ -1,0 +1,55 @@
+import { api } from "@/lib/api";
+
+/** One agent's transcript-retention story + TT's durable-archive opt-in. */
+export interface AgentRetention {
+  label: string;
+  /** Documented auto-cleanup window in days, or null if the agent never prunes. */
+  default_days: number | null;
+  /** The user's real configured window (e.g. Claude's cleanupPeriodDays), if read. */
+  detected_override: number | null;
+  /** Window actually in effect (override ?? default). */
+  effective_days: number | null;
+  configurable: boolean;
+  settings_hint: string | null;
+  note: string;
+  /** Whether TT can archive this agent's transcripts (single-file transcript). */
+  archivable: boolean;
+  /** Whether the user opted into TT keeping full transcripts for this agent. */
+  archive_enabled: boolean;
+}
+
+export interface RetentionStorage {
+  total_sessions: number;
+  transcript_bytes: number;
+  by_agent: Record<
+    string,
+    { sessions: number; transcripts: number; transcript_bytes: number; summaries: number }
+  >;
+}
+
+export interface RetentionState {
+  agents: Record<string, AgentRetention>;
+  storage: RetentionStorage;
+  coverage: {
+    earliest: string | null;
+    total_sessions: number;
+    by_agent: Record<string, { present: number; pruned: number; summarized: number }>;
+  };
+}
+
+export function getRetention(): Promise<RetentionState> {
+  return api<RetentionState>("/config/retention");
+}
+
+export function setArchive(agent: string, enabled: boolean): Promise<{ ok: boolean }> {
+  return api("/config/retention", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ agent, enabled }),
+  });
+}
+
+export function deleteTranscripts(agent?: string): Promise<{ ok: boolean; deleted: number; storage: RetentionStorage }> {
+  const q = agent ? `?agent=${encodeURIComponent(agent)}` : "";
+  return api(`/history/transcripts${q}`, { method: "DELETE" });
+}


### PR DESCRIPTION
## What & why

TokenTelemetry was a pure live-scanner with only a 30s RAM cache, so once agents prune their own transcripts (Claude Code after `cleanupPeriodDays`, default 30) older analytics vanished — making the date filtering users asked for (**#83**, discussion **#27**: "this month/this year", finer/longer ranges) structurally impossible.

This adds a **durable local SQLite store** (`~/.tokentelemetry/history.db`) upserted on every scan, so a tiny per-session rollup outlives agent pruning. Analytics reads the store (full history, filtered in SQL) **merged with** the live scan (live wins), with **day/week/month** bucketing and **agent/model** filters. Storage is **tiered**: core rollup always kept; full transcripts opt-in & deletable; summaries persist past transcript deletion.

Decision recorded in [ADR-0002](docs/adr/0002-durable-history-rollup.md); design in [docs/design/durable-history.md](docs/design/durable-history.md).

## Backend
- `history_store.py` — WAL SQLite, `sessions`/`transcripts`/`summaries` tiers; `upsert_sessions`/`mark_absent`/`query`/`coverage`/`storage_stats` + transcript/summary helpers.
- `agent_retention.py` — per-agent retention metadata (Claude `cleanupPeriodDays` read from settings.json) + archive opt-in flags.
- `main.py` — non-blocking write-path off the scan; `/analytics` rewritten with `from`/`to`/`granularity`/`agents`/`models`/`projects` + `coverage`; `GET/POST /config/retention`, `DELETE /history/transcripts`.

## Frontend
- Analytics page: date presets, granularity toggle, agent/model filters, data-availability notice (server-driven via query string).
- Settings: "Agent history & retention" section + `lib/retention.ts`.

## Process / docs
- `docs/adr/` (ADR system + 0001 meta + 0002 for this feature) and `docs/design/`.
- `CONTRIBUTING.md` — minimal contributor path + ADR/design prompt for big features.
- `UPDATE.json` release entry; defensive `history.db` gitignore.

## Validation
- New backend tests pass: `test_history_store.py` (7/7), `test_agent_retention.py` (4/4); no regressions.
- E2E verified in-browser via Claude-in-Chrome: filters drive server-side aggregation (746-session durable store populated from real on-disk history), Settings retention toggle persists, no console errors.

> ⚠️ Frontend was not `npm run build`-checked (deps not installed in the worktree). Recommend a build/lint pass before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)