### PR TITLE
fix(website): wire NEXT_PUBLIC_CLARITY_ID into GitHub Pages build

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -36,6 +36,10 @@ jobs:
           BING_VERIFICATION: ${{ secrets.BING_VERIFICATION }}
           GOOGLE_VERIFICATION: ${{ secrets.GOOGLE_VERIFICATION }}
           NEXT_PUBLIC_GA_ID: ${{ secrets.NEXT_PUBLIC_GA_ID }}
+          # Without this, NEXT_PUBLIC_CLARITY_ID is empty at build time and the
+          # Clarity <script> in Analytics.tsx never renders, so Clarity's
+          # dashboard stays stuck on "Almost There" with no insights.
+          NEXT_PUBLIC_CLARITY_ID: ${{ secrets.NEXT_PUBLIC_CLARITY_ID }}
       - uses: actions/upload-pages-artifact@v3
         with:
           path: website/out


### PR DESCRIPTION
## Problem
Microsoft Clarity (project \`wvzyf6jn0t\`) dashboard is stuck on **"Almost There — choose an installation method"** with no insights, despite the tracking integration existing in the code and the \`NEXT_PUBLIC_CLARITY_ID\` repo secret being configured.

## Root cause
`Analytics.tsx` only renders the Clarity `<script>` when **all three** hold: consent granted, not localhost, and `NEXT_PUBLIC_CLARITY_ID` set. On tokentelemetry.com the first two pass — GA4 loads fine — but **Clarity never loads** (`window.clarity` undefined, no script tag).

`NEXT_PUBLIC_*` vars are baked in at build time, and `deploy-website.yml` passed `NEXT_PUBLIC_GA_ID` but **never `NEXT_PUBLIC_CLARITY_ID`** — so even though the repo secret existed, the build never received it. The var was empty in the static export → no Clarity script → zero traffic → dashboard never advances.

## Fix
Reference the existing `NEXT_PUBLIC_CLARITY_ID` repo secret in the build step's `env`. (It's a repository secret, so the build job sees it without any `environment:` scoping.)

## After merge
The push to `main` triggers the deploy workflow, which rebuilds with the id. Once the redeployed site gets a real (non-localhost, consent-accepted) visit, Clarity starts receiving data — first insights can take up to ~2h.

🤖 Generated with [Claude Code](https://claude.com/claude-code)