### PR TITLE
feat: multi-agent metrics — process monitor, concurrency, attribution tree, workflows

### DIFF
--- a/UPDATE.json
+++ b/UPDATE.json
@@ -1,34 +1,60 @@
 {
   "releases": [
     {
+      "tag": "2026-06-23",
+      "title": "See exactly what your agents cost \u2014 and consume",
+      "highlights": [
+        {
+          "title": "Live agent process monitor",
+          "description": "A new System panel on the dashboard shows real-time disk IO, CPU, and memory for every AI agent process running on your machine (Claude Code, Codex, Ollama, local models). Write rates above 5 MB/s trigger a warning banner \u2014 the exact issue that caused Codex Desktop to write ~222 TB/year unnoticed.",
+          "href": "/"
+        },
+        {
+          "title": "Concurrency timeline",
+          "description": "See which agent sessions were running at the same time and the combined cost per hour during those overlaps. Useful when you run multiple agents in parallel and want to understand the cumulative burn rate.",
+          "href": "/"
+        },
+        {
+          "title": "Attribution cost tree",
+          "description": "When a parent agent spawns subagents, its session now shows the total cost of the entire delegation tree \u2014 not just its own tokens. Open any session that has children to see the full breakdown.",
+          "href": "/sessions"
+        },
+        {
+          "title": "Workflow grouping",
+          "description": "Tag sessions from any agent into a named workflow and see the total cost, token count, and active agents for that task. Great for understanding how much a feature, bug fix, or research task actually cost across all the agents you used.",
+          "href": "/workflows"
+        }
+      ]
+    },
+    {
       "tag": "2026-06-17",
       "title": "See an agent's files right in its trace",
       "highlights": [
         {
           "title": "Antigravity session artifacts now show in the Artifacts tab",
-          "description": "Open an Antigravity session and the files it produced are right there in the trace's Artifacts tab — its markdown audit/QA reports render formatted (with their embedded screenshots inline) and every captured screenshot appears as a thumbnail. Click any artifact, or the new expand icon, to open it full-screen, and download any file in one click. No more digging through ~/.gemini to find what a run created.",
+          "description": "Open an Antigravity session and the files it produced are right there in the trace's Artifacts tab \u2014 its markdown audit/QA reports render formatted (with their embedded screenshots inline) and every captured screenshot appears as a thumbnail. Click any artifact, or the new expand icon, to open it full-screen, and download any file in one click. No more digging through ~/.gemini to find what a run created.",
           "href": "/sessions"
         }
       ]
     },
     {
       "tag": "2026-06-15",
-      "title": "Privacy you can see — and switch off",
+      "title": "Privacy you can see \u2014 and switch off",
       "highlights": [
         {
           "title": "Anonymous usage stats, explained plainly",
-          "description": "As TokenTelemetry evolves we need to understand how it's actually used — which features deliver value — so we can make it better for everyone. The app now shares a small set of anonymous usage signals: which pages and features you use, your OS and app version, and a coarse country derived at the network edge (never your IP). It carries nothing about your work — no code, prompts, file paths, project names, tokens, or costs. It's on by default so the picture is representative, but one click turns it off under Settings → Usage & privacy, and DO_NOT_TRACK=1 (or TT_NO_TELEMETRY=1) forces it off for restricted or enterprise environments.",
+          "description": "As TokenTelemetry evolves we need to understand how it's actually used \u2014 which features deliver value \u2014 so we can make it better for everyone. The app now shares a small set of anonymous usage signals: which pages and features you use, your OS and app version, and a coarse country derived at the network edge (never your IP). It carries nothing about your work \u2014 no code, prompts, file paths, project names, tokens, or costs. It's on by default so the picture is representative, but one click turns it off under Settings \u2192 Usage & privacy, and DO_NOT_TRACK=1 (or TT_NO_TELEMETRY=1) forces it off for restricted or enterprise environments.",
           "href": "/settings#usage-privacy"
         }
       ]
     },
     {
       "tag": "2026-06-13",
-      "title": "Analytics by date — and history that survives cleanup",
+      "title": "Analytics by date \u2014 and history that survives cleanup",
       "highlights": [
         {
           "title": "Filter analytics by date range, week, or month",
-          "description": "The graph is no longer stuck at the last 7 days. Pick a preset (7d, 30d, this month, this year), set a custom range, or switch the buckets to weekly/monthly — and narrow to specific agents or models. Everything is filtered server-side, so even a full year stays fast.",
+          "description": "The graph is no longer stuck at the last 7 days. Pick a preset (7d, 30d, this month, this year), set a custom range, or switch the buckets to weekly/monthly \u2014 and narrow to specific agents or models. Everything is filtered server-side, so even a full year stays fast.",
           "href": "/analytics"
         },
         {
@@ -44,12 +70,12 @@
       "highlights": [
         {
           "title": "Local-model power cost now reads your actual chip",
-          "description": "Self-hosted models are priced by electricity, and the default wattage now comes from your detected chip (e.g. an Apple M-series part) instead of a one-size-fits-all 80 W. On machines we can't auto-detect, the field stops pretending and asks you to enter your draw under load (or click Measure) — so the estimate is honest rather than a silent placeholder.",
+          "description": "Self-hosted models are priced by electricity, and the default wattage now comes from your detected chip (e.g. an Apple M-series part) instead of a one-size-fits-all 80 W. On machines we can't auto-detect, the field stops pretending and asks you to enter your draw under load (or click Measure) \u2014 so the estimate is honest rather than a silent placeholder.",
           "href": "/local-models"
         },
         {
           "title": "See which credit pool each agent actually drains",
-          "description": "Providers no longer bill an agent through one bucket. Expand any agent under Settings to see its drain order, split by interactive vs programmatic use — including Claude's separate Agent-SDK credit pool (claude -p, SDK, CI) that has no auto-fallback, plus pool sizes and stops-at-$0 warnings. Pick your plan tier to size the pools. It explains the cost framing; it doesn't change the math.",
+          "description": "Providers no longer bill an agent through one bucket. Expand any agent under Settings to see its drain order, split by interactive vs programmatic use \u2014 including Claude's separate Agent-SDK credit pool (claude -p, SDK, CI) that has no auto-fallback, plus pool sizes and stops-at-$0 warnings. Pick your plan tier to size the pools. It explains the cost framing; it doesn't change the math.",
           "href": "/settings"
         }
       ]
@@ -60,26 +86,26 @@
       "highlights": [
         {
           "title": "Subagent spend, finally visible",
-          "description": "When a Claude Code session spawns subagents (Explore, general-purpose, custom agents), their tokens were invisible until now — on a typical machine that's millions of tokens. Session pages show a \"Delegated work\" card with each subagent's task, model, tokens and cost, priced by the model the subagent actually ran (an Explore on Haiku no longer hides inside an Opus session).",
+          "description": "When a Claude Code session spawns subagents (Explore, general-purpose, custom agents), their tokens were invisible until now \u2014 on a typical machine that's millions of tokens. Session pages show a \"Delegated work\" card with each subagent's task, model, tokens and cost, priced by the model the subagent actually ran (an Explore on Haiku no longer hides inside an Opus session).",
           "href": "/"
         },
         {
           "title": "Which subagent types earn their keep",
-          "description": "Analytics gains a Delegation & ecosystem section: total delegated tokens and cost, plus a per-type ranking. If general-purpose agents cost you 5× what Explore agents do for similar work, you'll see it — and can change how you delegate.",
+          "description": "Analytics gains a Delegation & ecosystem section: total delegated tokens and cost, plus a per-type ranking. If general-purpose agents cost you 5\u00d7 what Explore agents do for similar work, you'll see it \u2014 and can change how you delegate.",
           "href": "/analytics"
         },
         {
           "title": "Skill & MCP usage, cross-linked to your inventory",
-          "description": "Sessions now record which skills you invoked and how often each MCP server was actually called. Your project's Config page overlays that usage on every installed skill, command, subagent and MCP server — anything marked \"no recorded use\" is a candidate to clean up.",
+          "description": "Sessions now record which skills you invoked and how often each MCP server was actually called. Your project's Config page overlays that usage on every installed skill, command, subagent and MCP server \u2014 anything marked \"no recorded use\" is a candidate to clean up.",
           "href": "/analytics"
         },
         {
           "title": "Delegation across Grok Build, Codex & Antigravity too",
-          "description": "Grok Build, Codex and Antigravity CLI all spawn subagents as separate sessions — those are now linked: the parent session shows each spawn (task, duration, role) with a jump to the child session, and children link back to their parent. Cursor shows spawn counts; agents that don't log spawns say so honestly instead of showing a misleading 0."
+          "description": "Grok Build, Codex and Antigravity CLI all spawn subagents as separate sessions \u2014 those are now linked: the parent session shows each spawn (task, duration, role) with a jump to the child session, and children link back to their parent. Cursor shows spawn counts; agents that don't log spawns say so honestly instead of showing a misleading 0."
         },
         {
-          "title": "Recent Codex sessions were missing — now found",
-          "description": "Newer Codex versions stopped updating the session index TokenTelemetry relied on, so sessions from the last weeks never appeared. Sessions are now discovered from the session files themselves — expect your Codex session count (and totals) to jump to reality."
+          "title": "Recent Codex sessions were missing \u2014 now found",
+          "description": "Newer Codex versions stopped updating the session index TokenTelemetry relied on, so sessions from the last weeks never appeared. Sessions are now discovered from the session files themselves \u2014 expect your Codex session count (and totals) to jump to reality."
         }
       ]
     },
@@ -94,11 +120,11 @@
         },
         {
           "title": "Protected by an access token",
-          "description": "Exposing the dashboard puts your data on the network, so remote access now requires a token: when you start with a non-loopback --host, a random token is printed once in the server console — enter it on the other device when prompted. Your own browser on the server is exempt, and a fully trusted private network can opt out with --insecure-no-auth."
+          "description": "Exposing the dashboard puts your data on the network, so remote access now requires a token: when you start with a non-loopback --host, a random token is printed once in the server console \u2014 enter it on the other device when prompted. Your own browser on the server is exempt, and a fully trusted private network can opt out with --insecure-no-auth."
         },
         {
-          "title": "Scan to connect — no typing",
-          "description": "When remote access is on, Settings shows a \"Connect a device\" panel with a QR code. Scan it from your phone or tablet and the dashboard opens already signed in — the token rides along in the link, gets stored on the device, and is cleared from the address bar automatically.",
+          "title": "Scan to connect \u2014 no typing",
+          "description": "When remote access is on, Settings shows a \"Connect a device\" panel with a QR code. Scan it from your phone or tablet and the dashboard opens already signed in \u2014 the token rides along in the link, gets stored on the device, and is cleared from the address bar automatically.",
           "href": "/settings"
         }
       ]
@@ -109,18 +135,18 @@
       "highlights": [
         {
           "title": "Choose where TokenTelemetry keeps its data",
-          "description": "Config and state no longer have to live in ~/.tokentelemetry on your system drive. Launch with --data-dir /your/path (or set TOKENTELEMETRY_DATA_DIR) and everything — aliases, hidden projects, preferences, billing/power overrides, the summaries cache — moves together to that folder. Handy for keeping your main drive clear or putting app data on a secondary disk.",
+          "description": "Config and state no longer have to live in ~/.tokentelemetry on your system drive. Launch with --data-dir /your/path (or set TOKENTELEMETRY_DATA_DIR) and everything \u2014 aliases, hidden projects, preferences, billing/power overrides, the summaries cache \u2014 moves together to that folder. Handy for keeping your main drive clear or putting app data on a secondary disk.",
           "href": "/settings"
         }
       ]
     },
     {
       "tag": "2026-06-08",
-      "title": "Local model insights: energy, savings & CO₂",
+      "title": "Local model insights: energy, savings & CO\u2082",
       "highlights": [
         {
           "title": "Dedicated Local & Power insights surface",
-          "description": "A new dashboard card brings your local model usage front and center — total local energy (Wh/kWh), estimated cloud savings from running locally, and a breakdown of which local models you use most.",
+          "description": "A new dashboard card brings your local model usage front and center \u2014 total local energy (Wh/kWh), estimated cloud savings from running locally, and a breakdown of which local models you use most.",
           "href": "/"
         },
         {
@@ -135,7 +161,7 @@
         },
         {
           "title": "Carbon footprint estimate",
-          "description": "Set your grid's carbon intensity alongside your power rate, and TokenTelemetry tracks the CO₂ grams generated by your local AI sessions based on real hardware draw and session duration.",
+          "description": "Set your grid's carbon intensity alongside your power rate, and TokenTelemetry tracks the CO\u2082 grams generated by your local AI sessions based on real hardware draw and session duration.",
           "href": "/settings"
         }
       ]
@@ -146,12 +172,12 @@
       "highlights": [
         {
           "title": "Local models priced by your actual hardware",
-          "description": "Sessions on Ollama, llama.cpp or vLLM are now detected by their endpoint/provider — not by guessing — so a local model is always costed by electricity, never at cloud API rates (even when it shares a name with a cloud model). Generation time uses each model's real throughput where measurable (a 4B isn't costed like a 70B).",
+          "description": "Sessions on Ollama, llama.cpp or vLLM are now detected by their endpoint/provider \u2014 not by guessing \u2014 so a local model is always costed by electricity, never at cloud API rates (even when it shares a name with a cloud model). Generation time uses each model's real throughput where measurable (a 4B isn't costed like a 70B).",
           "href": "/settings"
         },
         {
           "title": "Set or measure your machine's power",
-          "description": "A new Settings → Local power & electricity card lets you set your watts-under-load and kWh rate, mark local/LAN and flat-subscription endpoints, and — where your OS allows it without admin — measure real power draw directly. The estimate is honest about where its numbers come from.",
+          "description": "A new Settings \u2192 Local power & electricity card lets you set your watts-under-load and kWh rate, mark local/LAN and flat-subscription endpoints, and \u2014 where your OS allows it without admin \u2014 measure real power draw directly. The estimate is honest about where its numbers come from.",
           "href": "/settings"
         }
       ]
@@ -162,12 +188,12 @@
       "highlights": [
         {
           "title": "2000+ models priced for accurate cost estimates",
-          "description": "Cost estimates now draw on a much larger, regularly-refreshed pricing dataset (sourced from models.dev), so far more models — and provider-specific rates — get an accurate price instead of a generic fallback. The data ships with each update and is read entirely on your machine: no new outbound calls, same local-first privacy.",
+          "description": "Cost estimates now draw on a much larger, regularly-refreshed pricing dataset (sourced from models.dev), so far more models \u2014 and provider-specific rates \u2014 get an accurate price instead of a generic fallback. The data ships with each update and is read entirely on your machine: no new outbound calls, same local-first privacy.",
           "href": "/"
         },
         {
           "title": "Local models priced by electricity, not fake API rates",
-          "description": "Models you run yourself (Ollama, llama.cpp, vLLM) have no API bill — their real cost is power. Set your machine's watts under load and your kWh rate, and TokenTelemetry estimates the electricity cost instead of inventing a per-token charge."
+          "description": "Models you run yourself (Ollama, llama.cpp, vLLM) have no API bill \u2014 their real cost is power. Set your machine's watts under load and your kWh rate, and TokenTelemetry estimates the electricity cost instead of inventing a per-token charge."
         },
         {
           "title": "Flat subscriptions now show $0 per call",
@@ -175,23 +201,23 @@
         },
         {
           "title": "Full subscription-cost disclaimer",
-          "description": "The dashboard's \"API equiv. (est.)\" figure used to cut off mid-sentence at \"Subscription users p…\". The disclaimer now shows in full, plus a persistent callout makes clear the number re-prices your usage at API list rates for comparing sessions — it is not an invoice. On a flat-fee plan like Claude Pro/Max or Copilot, your actual spend is much lower.",
+          "description": "The dashboard's \"API equiv. (est.)\" figure used to cut off mid-sentence at \"Subscription users p\u2026\". The disclaimer now shows in full, plus a persistent callout makes clear the number re-prices your usage at API list rates for comparing sessions \u2014 it is not an invoice. On a flat-fee plan like Claude Pro/Max or Copilot, your actual spend is much lower.",
           "href": "/"
         },
         {
-          "title": "Per-agent billing mode — bill vs. estimate, framed right",
-          "description": "If you pay per token (API key) for an agent, the cost figure approximates your real bill; on a flat subscription it's only an API-list-price equivalent. TokenTelemetry now auto-detects which one you're on per agent (from each agent's own auth — e.g. ~/.codex/auth.json) and frames the number accordingly, with a Settings → Billing & cost control to override any agent.",
+          "title": "Per-agent billing mode \u2014 bill vs. estimate, framed right",
+          "description": "If you pay per token (API key) for an agent, the cost figure approximates your real bill; on a flat subscription it's only an API-list-price equivalent. TokenTelemetry now auto-detects which one you're on per agent (from each agent's own auth \u2014 e.g. ~/.codex/auth.json) and frames the number accordingly, with a Settings \u2192 Billing & cost control to override any agent.",
           "href": "/settings"
         }
       ]
     },
     {
       "tag": "2026-06-07",
-      "title": "Update check — now visible and yours to control",
+      "title": "Update check \u2014 now visible and yours to control",
       "highlights": [
         {
           "title": "Check-for-updates toggle",
-          "description": "TokenTelemetry's one outbound call — an optional check that tells you when new features ship — now has a switch in Settings → Updates & privacy. It sends no usage data; turn it off any time, or set TT_NO_UPDATE_CHECK=1 to enforce it off.",
+          "description": "TokenTelemetry's one outbound call \u2014 an optional check that tells you when new features ship \u2014 now has a switch in Settings \u2192 Updates & privacy. It sends no usage data; turn it off any time, or set TT_NO_UPDATE_CHECK=1 to enforce it off.",
           "href": "/settings"
         },
         {
@@ -202,7 +228,7 @@
     },
     {
       "tag": "2026-06-07",
-      "title": "Antigravity CLI — real model & accurate projects",
+      "title": "Antigravity CLI \u2014 real model & accurate projects",
       "highlights": [
         {
           "title": "Real model for Antigravity CLI sessions",
@@ -211,7 +237,7 @@
         },
         {
           "title": "Accurate, stable project for Antigravity CLI sessions",
-          "description": "CLI sessions are now grouped under the exact folder they worked in, read from each session's own saved record — so the grouping stays correct over time instead of guessing from task text. Sessions that genuinely never entered a project (pure chat/research) stay grouped separately, off the Projects view.",
+          "description": "CLI sessions are now grouped under the exact folder they worked in, read from each session's own saved record \u2014 so the grouping stays correct over time instead of guessing from task text. Sessions that genuinely never entered a project (pure chat/research) stay grouped separately, off the Projects view.",
           "href": "/"
         }
       ]
@@ -222,14 +248,14 @@
       "highlights": [
         {
           "title": "OpenAI-compatible summarizer backend",
-          "description": "Point TokenTelemetry at any server speaking the OpenAI /v1/chat/completions API — llama.cpp, vLLM, LM Studio, LocalAI, or Ollama's OpenAI endpoint — to generate trace summaries. No extra CLI to install: set the endpoint, model, and (optionally) an API key, tune sampling, and hit Test connection.",
+          "description": "Point TokenTelemetry at any server speaking the OpenAI /v1/chat/completions API \u2014 llama.cpp, vLLM, LM Studio, LocalAI, or Ollama's OpenAI endpoint \u2014 to generate trace summaries. No extra CLI to install: set the endpoint, model, and (optionally) an API key, tune sampling, and hit Test connection.",
           "href": "/settings"
         }
       ]
     },
     {
       "tag": "2026-06-04",
-      "title": "Antigravity — tokens, IDE coverage, surface labels",
+      "title": "Antigravity \u2014 tokens, IDE coverage, surface labels",
       "highlights": [
         {
           "title": "Antigravity token usage",
@@ -254,7 +280,7 @@
       "highlights": [
         {
           "title": "GitHub Copilot CLI sessions tracked",
-          "description": "TokenTelemetry now reads GitHub Copilot CLI / agent sessions from ~/.copilot/session-state, so your terminal Copilot usage shows up alongside everything else — model, tokens, project, and full trace.",
+          "description": "TokenTelemetry now reads GitHub Copilot CLI / agent sessions from ~/.copilot/session-state, so your terminal Copilot usage shows up alongside everything else \u2014 model, tokens, project, and full trace.",
           "href": "/"
         },
         {
@@ -270,7 +296,7 @@
       "highlights": [
         {
           "title": "Grok Build (xAI) support",
-          "description": "TokenTelemetry now tracks xAI's Grok Build coding agent — sessions, context usage, tool calls, permission decisions, and plan mode — with a dedicated forensics card. That's 11 agents tracked in total.",
+          "description": "TokenTelemetry now tracks xAI's Grok Build coding agent \u2014 sessions, context usage, tool calls, permission decisions, and plan mode \u2014 with a dedicated forensics card. That's 11 agents tracked in total.",
           "href": "/"
         },
         {
@@ -280,7 +306,7 @@
         },
         {
           "title": "Smarter 'Back' from a session",
-          "description": "Opening a session and hitting Back now returns you to the page you came from — e.g. the project you were viewing — instead of always jumping to the dashboard."
+          "description": "Opening a session and hitting Back now returns you to the page you came from \u2014 e.g. the project you were viewing \u2014 instead of always jumping to the dashboard."
         }
       ]
     },
@@ -305,7 +331,7 @@
       "highlights": [
         {
           "title": "Hermes Agent dashboard",
-          "description": "New sub-pages for Gateway, Memory, Profiles, Schedules, Skills, Soul, and Tools — all read directly from your local ~/.hermes state.",
+          "description": "New sub-pages for Gateway, Memory, Profiles, Schedules, Skills, Soul, and Tools \u2014 all read directly from your local ~/.hermes state.",
           "href": "/hermes"
         }
       ]

--- a/backend/harness_config.py
+++ b/backend/harness_config.py
@@ -28,6 +28,7 @@ HARNESS_DIR = data_dir()
 ALIASES_FILE = HARNESS_DIR / "aliases.json"
 HIDDEN_FILE = HARNESS_DIR / "hidden.json"
 PREFERENCES_FILE = HARNESS_DIR / "preferences.json"
+WORKFLOWS_FILE = HARNESS_DIR / "workflows.json"
 VERSION_FILE = HARNESS_DIR / "VERSION"
 SCHEMA_VERSION = 1
 
@@ -168,3 +169,25 @@ def list_aliases() -> Dict[str, str]:
 def save_aliases(aliases: Dict[str, str]) -> None:
     """Overwrite the alias file. Caller is responsible for validation."""
     _atomic_write_json(ALIASES_FILE, aliases)
+
+
+def load_workflows() -> Dict[str, Any]:
+    """Load workflow definitions.
+
+    Returns {workflow_id: {name, description, session_ids, created_at, color}}.
+    Never raises: a missing or malformed file yields an empty dict so callers
+    can treat "no workflows" and "broken file" the same way."""
+    if not WORKFLOWS_FILE.exists():
+        return {}
+    try:
+        data = json.loads(WORKFLOWS_FILE.read_text())
+    except Exception:
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return data
+
+
+def save_workflows(workflows: Dict[str, Any]) -> None:
+    """Persist the workflow map atomically (tmp + rename)."""
+    _atomic_write_json(WORKFLOWS_FILE, workflows)

--- a/backend/main.py
+++ b/backend/main.py
@@ -2354,6 +2354,57 @@ def _claude_subagent_usage(session_file: Path, sid: str) -> Optional[Dict[str, A
     }
 
 
+def _rollup_delegation_costs(sessions: List[Dict[str, Any]]) -> None:
+    """Annotate each session with total_cost_usd = own cost + all descendant costs.
+
+    Sessions carry a `cost` field (USD) and a `child_session_ids` list linking the
+    parent -> spawned subagent sessions. This walks the delegation tree from each
+    root (a session with no parent_session_id) and records, per session:
+
+      - ``total_cost_usd``    own cost + recursive cost of every descendant
+      - ``children_cost_usd`` the descendant portion only
+      - ``child_count``       number of direct children
+
+    Idempotent: it always recomputes from `cost` + `child_session_ids`, so calling
+    it twice yields the same numbers (no accumulation). A `visited` set guards
+    against cycles in corrupt link data. Missing/None `cost` is treated as 0.
+    """
+    by_id = {s["id"]: s for s in sessions}
+
+    def _total_cost(session_id: str, visited: set) -> float:
+        if session_id in visited:
+            return 0.0  # cycle guard — don't re-enter a node on this path
+        visited.add(session_id)
+        s = by_id.get(session_id)
+        if s is None:
+            return 0.0
+        own = s.get("cost") or 0.0
+        children_cost = sum(
+            _total_cost(cid, visited)
+            for cid in (s.get("child_session_ids") or [])
+        )
+        s["children_cost_usd"] = children_cost
+        s["child_count"] = len(s.get("child_session_ids") or [])
+        s["total_cost_usd"] = own + children_cost
+        return s["total_cost_usd"]
+
+    # Compute from roots first so each subtree is walked once per root path.
+    roots = [s for s in sessions if not s.get("parent_session_id")]
+    for root in roots:
+        _total_cost(root["id"], set())
+
+    # Children whose parent isn't in our dataset never got visited above; give
+    # them a self-only (or own-subtree) total so every session carries the fields.
+    for s in sessions:
+        if "total_cost_usd" not in s:
+            if s.get("child_session_ids"):
+                _total_cost(s["id"], set())
+            else:
+                s["total_cost_usd"] = s.get("cost") or 0.0
+                s["children_cost_usd"] = 0.0
+                s["child_count"] = 0
+
+
 def _scan_sessions_sync():
     sessions = []
     aliases = _load_project_aliases()
@@ -3609,6 +3660,10 @@ def _scan_sessions_sync():
     for s in sessions:
         s.setdefault("delegation", {"supported": s.get("agent") in _DELEGATION_CAPABLE_AGENTS})
 
+    # Roll up delegation/subagent costs: parent.total_cost_usd = own + descendants.
+    # Runs after all parent/child linking above so child_session_ids are complete.
+    _rollup_delegation_costs(sessions)
+
     # Concurrency: which sessions overlapped in time and the combined burn rate
     # during those windows. Annotates each session in place and stashes the
     # top-10 windows + summary for the /sessions/concurrency endpoint.
@@ -4778,6 +4833,46 @@ async def session_delegation(session_id: str, agent: str):
                 "child_session_ids": kids, "linked_children": len(kids)}
 
     return {"supported": False}
+
+
+@app.get("/sessions/{session_id}/tree")
+async def get_session_tree(session_id: str):
+    """Cost attribution tree for a session and all its descendants.
+
+    Returns the session plus a recursively-nested `children` array, each node
+    carrying its own cost and the rolled-up subtree total (computed in
+    `_rollup_delegation_costs` during the scan). Cycles in corrupt link data are
+    broken with a visited set. 404 if the session isn't in the cache.
+    """
+    sessions = await get_sessions_cached()
+    by_id = {s["id"]: s for s in sessions}
+    root = by_id.get(session_id)
+    if root is None:
+        return JSONResponse(status_code=404, content={"error": "Session not found"})
+
+    def _node(sid: str, depth: int, visited: set) -> Dict[str, Any]:
+        s = by_id.get(sid) or {}
+        children: List[Dict[str, Any]] = []
+        if sid not in visited:
+            visited.add(sid)
+            for cid in (s.get("child_session_ids") or []):
+                if cid in by_id and cid not in visited:
+                    children.append(_node(cid, depth + 1, visited))
+        own = s.get("cost") or 0.0
+        return {
+            "session_id": sid,
+            "agent": s.get("agent"),
+            "project": s.get("project"),
+            "display": s.get("display") or s.get("text"),
+            "cost_usd": own,
+            "total_cost_usd": s.get("total_cost_usd", own),
+            "children_cost_usd": s.get("children_cost_usd", 0.0),
+            "child_count": s.get("child_count", len(s.get("child_session_ids") or [])),
+            "depth": depth,
+            "children": children,
+        }
+
+    return _node(session_id, 0, set())
 
 
 @app.get("/projects")

--- a/backend/main.py
+++ b/backend/main.py
@@ -3609,9 +3609,233 @@ def _scan_sessions_sync():
     for s in sessions:
         s.setdefault("delegation", {"supported": s.get("agent") in _DELEGATION_CAPABLE_AGENTS})
 
+    # Concurrency: which sessions overlapped in time and the combined burn rate
+    # during those windows. Annotates each session in place and stashes the
+    # top-10 windows + summary for the /sessions/concurrency endpoint.
+    try:
+        windows, summary = _compute_concurrency(sessions)
+        _concurrency_cache["windows"] = windows
+        _concurrency_cache["summary"] = summary
+    except Exception:
+        _concurrency_cache["windows"] = []
+        _concurrency_cache["summary"] = {
+            "peak_concurrent_count": 0,
+            "peak_combined_cost_per_hour": 0.0,
+            "total_concurrent_hours": 0.0,
+        }
+
     # Global sort by timestamp descending
     sessions.sort(key=lambda x: x["timestamp"], reverse=True)
     return sessions
+
+
+# ---------------------------------------------------------------------------
+# Concurrency timeline
+# ---------------------------------------------------------------------------
+# Sessions only carry a single `timestamp` (last-activity / end-of-session
+# datetime); there's no logged start or duration. We derive a window per
+# session: end = timestamp, and length = output_tokens / tok_per_sec (the same
+# generation-latency model the power feature uses), clamped to a sane floor/
+# ceiling so a token-less session still occupies a believable slice rather than
+# a zero-width point. A sweep line over the interval endpoints (sorted, so
+# O(n log n)) finds every moment where 2+ sessions were live, annotates each
+# session with its peak overlap, and emits the most expensive overlap windows.
+
+# Min/max derived session length (seconds). Floor keeps token-less or
+# instant sessions from collapsing to a point; ceiling stops a huge-output
+# session from swallowing the whole timeline.
+_CONCURRENCY_MIN_DURATION_SEC = 60.0          # 1 min
+_CONCURRENCY_MAX_DURATION_SEC = 6.0 * 3600.0  # 6 h
+_CONCURRENCY_DEFAULT_DURATION_SEC = 300.0     # 5 min when nothing else to go on
+
+# Filled by _scan_sessions_sync; read by GET /sessions/concurrency.
+_concurrency_cache: Dict[str, Any] = {"windows": [], "summary": {}}
+
+
+def _session_epoch(ts) -> Optional[float]:
+    """Best-effort epoch seconds from a session `timestamp` (datetime or ISO/epoch)."""
+    if ts is None:
+        return None
+    if isinstance(ts, datetime):
+        try:
+            return _aware(ts).timestamp()
+        except Exception:
+            return None
+    if isinstance(ts, (int, float)):
+        v = float(ts)
+        # Heuristic: values that look like milliseconds → seconds.
+        return v / 1000.0 if v > 1e11 else v
+    if isinstance(ts, str):
+        try:
+            return _aware(datetime.fromisoformat(ts.replace("Z", "+00:00"))).timestamp()
+        except Exception:
+            return None
+    return None
+
+
+def _session_duration_sec(sess: Dict[str, Any]) -> float:
+    """Derive a session's wall-clock length in seconds.
+
+    Prefers an explicit ``duration_seconds`` if a future builder ever sets one;
+    otherwise estimates generation latency from output tokens / throughput, then
+    clamps to [min, max]."""
+    explicit = sess.get("duration_seconds")
+    if isinstance(explicit, (int, float)) and explicit > 0:
+        return max(_CONCURRENCY_MIN_DURATION_SEC,
+                   min(float(explicit), _CONCURRENCY_MAX_DURATION_SEC))
+    tokens = sess.get("tokens") or {}
+    out = tokens.get("output") or 0
+    tps = sess.get("tok_per_sec")
+    if not (isinstance(tps, (int, float)) and tps > 0):
+        try:
+            from power_config import default_tok_per_sec_for_model
+            tps = default_tok_per_sec_for_model(sess.get("model"))
+        except Exception:
+            tps = 0.0
+    if out and tps and tps > 0:
+        secs = float(out) / float(tps)
+    else:
+        secs = _CONCURRENCY_DEFAULT_DURATION_SEC
+    return max(_CONCURRENCY_MIN_DURATION_SEC,
+               min(secs, _CONCURRENCY_MAX_DURATION_SEC))
+
+
+def _compute_concurrency(sessions: List[Dict[str, Any]]):
+    """Annotate each session with its peak concurrency and return (windows, summary).
+
+    Each session gains:
+      - concurrent_sessions_count: # of OTHER sessions live at this session's peak
+      - concurrent_peak_cost_per_hour: combined $/hr of all sessions live at that peak
+      - concurrent_session_ids: ids of the other sessions in that peak overlap
+
+    Returns:
+      windows: top-10 most expensive overlap windows (2+ sessions), each
+        {start, end, session_ids, agent_types, combined_cost_usd, combined_write_mb_estimate}
+      summary: {peak_concurrent_count, peak_combined_cost_per_hour, total_concurrent_hours}
+    """
+    # 1. Build a clean interval per session (skip ones with no usable timestamp).
+    intervals = []  # (start_epoch, end_epoch, session_ref)
+    for s in sessions:
+        # Reset any stale annotations from a prior scan.
+        s["concurrent_sessions_count"] = 0
+        s["concurrent_peak_cost_per_hour"] = 0.0
+        s["concurrent_session_ids"] = []
+        end = _session_epoch(s.get("timestamp"))
+        if end is None:
+            continue
+        dur = _session_duration_sec(s)
+        start = end - dur
+        dur_hours = dur / 3600.0
+        cost = s.get("cost")
+        if not isinstance(cost, (int, float)):
+            cost = 0.0
+        cost_per_hour = (float(cost) / dur_hours) if dur_hours > 0 else 0.0
+        intervals.append({
+            "start": start, "end": end, "sess": s,
+            "cost": float(cost), "cost_per_hour": cost_per_hour,
+        })
+
+    if len(intervals) < 2:
+        return [], {
+            "peak_concurrent_count": 1 if intervals else 0,
+            "peak_combined_cost_per_hour": 0.0,
+            "total_concurrent_hours": 0.0,
+        }
+
+    # 2. Sweep line over endpoints. +1 at a start, -1 at an end. Sorting the
+    #    events is the O(n log n) step; the sweep itself is linear.
+    EPS = 1e-9
+    events = []  # (time, delta, ordinal) — process ends before starts at a tie
+    for idx, iv in enumerate(intervals):
+        events.append((iv["start"], 1, idx))
+        events.append((iv["end"], -1, idx))
+    # At equal timestamps, apply ends (-1) before starts (+1) so back-to-back
+    # sessions that merely touch don't count as overlapping.
+    events.sort(key=lambda e: (e[0], e[1]))
+
+    active: Set[int] = set()
+    total_concurrent_seconds = 0.0
+    peak_count = 1
+    peak_combined_cph = 0.0
+    # Segments where 2+ were active: (seg_start, seg_end, frozenset(active idxs))
+    segments = []
+    prev_t = None
+    for t, delta, idx in events:
+        if prev_t is not None and t > prev_t and len(active) >= 1:
+            seg_len = t - prev_t
+            if len(active) >= 2:
+                total_concurrent_seconds += seg_len
+                segments.append((prev_t, t, frozenset(active)))
+                if len(active) > peak_count:
+                    peak_count = len(active)
+                cph = sum(intervals[i]["cost_per_hour"] for i in active)
+                if cph > peak_combined_cph:
+                    peak_combined_cph = cph
+        if delta == 1:
+            active.add(idx)
+        else:
+            active.discard(idx)
+        prev_t = t
+
+    # 3. Per-session peak overlap: for each session, scan the segments it
+    #    belongs to and keep the one with the most concurrent sessions.
+    for idx, iv in enumerate(intervals):
+        best_others: Set[int] = set()
+        best_n = 0
+        for seg_start, seg_end, members in segments:
+            if idx in members and len(members) > best_n:
+                best_n = len(members)
+                best_others = set(members) - {idx}
+        if best_n >= 2:
+            s = iv["sess"]
+            others = list(best_others)
+            s["concurrent_sessions_count"] = len(others)
+            s["concurrent_session_ids"] = [intervals[i]["sess"].get("id") for i in others]
+            s["concurrent_peak_cost_per_hour"] = round(
+                iv["cost_per_hour"] + sum(intervals[i]["cost_per_hour"] for i in others), 6)
+
+    # 4. Merge contiguous segments sharing the same member set into windows,
+    #    then rank by combined cost and keep the top 10.
+    windows = []
+    for seg_start, seg_end, members in segments:
+        mlist = sorted(members)
+        member_ids = [intervals[i]["sess"].get("id") for i in mlist]
+        agent_types = sorted({intervals[i]["sess"].get("agent") for i in mlist if intervals[i]["sess"].get("agent")})
+        # combined cost over this segment = sum(cost_per_hour) * segment_hours
+        seg_hours = (seg_end - seg_start) / 3600.0
+        combined_cost = sum(intervals[i]["cost_per_hour"] for i in mlist) * seg_hours
+        windows.append({
+            "start": int(seg_start),
+            "end": int(seg_end),
+            "session_ids": member_ids,
+            "agent_types": agent_types,
+            "combined_cost_usd": round(combined_cost, 6),
+            # Per-second write throughput isn't tracked per session yet.
+            "combined_write_mb_estimate": None,
+        })
+
+    # Collapse adjacent windows with identical membership (the sweep can split a
+    # single overlap into pieces when an unrelated session starts/ends nearby).
+    windows.sort(key=lambda w: w["start"])
+    merged: List[Dict[str, Any]] = []
+    for w in windows:
+        if (merged and merged[-1]["session_ids"] == w["session_ids"]
+                and abs(merged[-1]["end"] - w["start"]) <= 1):
+            merged[-1]["end"] = w["end"]
+            merged[-1]["combined_cost_usd"] = round(
+                merged[-1]["combined_cost_usd"] + w["combined_cost_usd"], 6)
+        else:
+            merged.append(dict(w))
+
+    merged.sort(key=lambda w: w["combined_cost_usd"], reverse=True)
+    top = merged[:10]
+
+    summary = {
+        "peak_concurrent_count": peak_count,
+        "peak_combined_cost_per_hour": round(peak_combined_cph, 6),
+        "total_concurrent_hours": round(total_concurrent_seconds / 3600.0, 4),
+    }
+    return top, summary
 
 
 # ---------------------------------------------------------------------------
@@ -3749,8 +3973,30 @@ async def get_sessions_cached(fresh: bool = False) -> List[Dict[str, Any]]:
 
 @app.get("/sessions")
 async def get_sessions(fresh: bool = False):
-    """Return the session list. Pass ?fresh=1 to force a re-scan."""
+    """Return the session list. Pass ?fresh=1 to force a re-scan.
+
+    Each session is annotated with its peak concurrency
+    (``concurrent_sessions_count``, ``concurrent_peak_cost_per_hour``,
+    ``concurrent_session_ids``). The overlap *windows* themselves are served by
+    GET /sessions/concurrency so the timeline view can fetch them without
+    pulling the whole session list."""
     return await get_sessions_cached(fresh=fresh)
+
+
+@app.get("/sessions/concurrency")
+async def get_sessions_concurrency(fresh: bool = False):
+    """Concurrency timeline: when multiple agents ran at once and the combined
+    burn rate during those windows. Re-uses the cached session scan (which
+    computes this as a side effect), so it's cheap on a warm cache."""
+    # Ensure the cache (and thus _concurrency_cache) is populated/fresh.
+    await get_sessions_cached(fresh=fresh)
+    summary = _concurrency_cache.get("summary") or {}
+    return {
+        "windows": _concurrency_cache.get("windows") or [],
+        "peak_concurrent_count": summary.get("peak_concurrent_count", 0),
+        "peak_combined_cost_per_hour": summary.get("peak_combined_cost_per_hour", 0.0),
+        "total_concurrent_hours": summary.get("total_concurrent_hours", 0.0),
+    }
 
 
 @app.get("/pricing")

--- a/backend/main.py
+++ b/backend/main.py
@@ -18,6 +18,7 @@ from harness_config import (
     load_hidden, hide_project, unhide_project,
     list_aliases, save_aliases,
     load_preferences, save_preferences,
+    load_workflows, save_workflows,
 )
 from tt_paths import data_dir
 
@@ -3661,12 +3662,9 @@ def _scan_sessions_sync():
         s.setdefault("delegation", {"supported": s.get("agent") in _DELEGATION_CAPABLE_AGENTS})
 
     # Roll up delegation/subagent costs: parent.total_cost_usd = own + descendants.
-    # Runs after all parent/child linking above so child_session_ids are complete.
     _rollup_delegation_costs(sessions)
 
-    # Concurrency: which sessions overlapped in time and the combined burn rate
-    # during those windows. Annotates each session in place and stashes the
-    # top-10 windows + summary for the /sessions/concurrency endpoint.
+    # Concurrency: annotates sessions in place, stashes windows for /sessions/concurrency.
     try:
         windows, summary = _compute_concurrency(sessions)
         _concurrency_cache["windows"] = windows
@@ -3678,6 +3676,20 @@ def _scan_sessions_sync():
             "peak_combined_cost_per_hour": 0.0,
             "total_concurrent_hours": 0.0,
         }
+
+    # Workflow membership: stamp each session with workflow_ids from inverted index.
+    try:
+        _wf_index: Dict[str, List[str]] = {}
+        for wf_id, wf in load_workflows().items():
+            if not isinstance(wf, dict):
+                continue
+            for sid in wf.get("session_ids", []) or []:
+                if isinstance(sid, str):
+                    _wf_index.setdefault(sid, []).append(wf_id)
+    except Exception:
+        _wf_index = {}
+    for s in sessions:
+        s["workflow_ids"] = _wf_index.get(s["id"], [])
 
     # Global sort by timestamp descending
     sessions.sort(key=lambda x: x["timestamp"], reverse=True)
@@ -5330,6 +5342,201 @@ async def post_aliases(aliases: Dict[str, str]):
     save_aliases(cleaned)
     _invalidate_sessions_cache()
     return {"ok": True, "aliases": cleaned}
+
+
+# ---------------------------------------------------------------------------
+# Workflow grouping
+# ---------------------------------------------------------------------------
+# Workflows let a user bundle N sessions (across agents) into a named task and
+# read the aggregated cost/tokens. Definitions live in workflows.json via
+# harness_config; stats are computed on read by joining against the cached
+# session list. Session IDs that no longer resolve are skipped, never fatal.
+import uuid as _uuid
+
+# Six preset colors offered in the UI; we don't validate against this list
+# server-side (any hex the client sends is stored), it's just the default.
+_DEFAULT_WORKFLOW_COLOR = "#6366f1"
+
+
+class WorkflowCreate(BaseModel):
+    name: str
+    description: Optional[str] = ""
+    color: Optional[str] = _DEFAULT_WORKFLOW_COLOR
+    session_ids: Optional[List[str]] = None
+
+
+class WorkflowUpdate(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None
+    color: Optional[str] = None
+    session_ids: Optional[List[str]] = None
+
+
+class WorkflowSessions(BaseModel):
+    session_ids: List[str]
+
+
+def _workflow_with_stats(wf_id: str, wf: Dict[str, Any], sessions_by_id: Dict[str, Dict[str, Any]]) -> Dict[str, Any]:
+    """Project a stored workflow into the API shape with aggregated stats.
+
+    Joins session_ids against the cached sessions. Sessions that no longer
+    exist (deleted logs, rotated history) are silently skipped — they stay in
+    the stored list so they reappear if the session comes back, but they don't
+    contribute to totals and never raise."""
+    session_ids = [s for s in (wf.get("session_ids") or []) if isinstance(s, str)]
+    total_cost = 0.0
+    total_tokens = 0
+    agent_types: List[str] = []
+    last_active: Optional[float] = None
+    for sid in session_ids:
+        sess = sessions_by_id.get(sid)
+        if not sess:
+            continue
+        total_cost += float(sess.get("cost") or 0.0)
+        total_tokens += int((sess.get("tokens") or {}).get("total") or 0)
+        agent = sess.get("agent")
+        if agent and agent not in agent_types:
+            agent_types.append(agent)
+        ts = sess.get("timestamp")
+        if isinstance(ts, datetime):
+            epoch = ts.timestamp()
+            if last_active is None or epoch > last_active:
+                last_active = epoch
+    return {
+        "id": wf_id,
+        "name": wf.get("name", ""),
+        "description": wf.get("description", ""),
+        "color": wf.get("color") or _DEFAULT_WORKFLOW_COLOR,
+        "session_ids": session_ids,
+        "session_count": len(session_ids),
+        "total_cost_usd": round(total_cost, 6),
+        "total_tokens": total_tokens,
+        "agent_types": agent_types,
+        "created_at": wf.get("created_at"),
+        "last_active": last_active,
+    }
+
+
+async def _sessions_by_id() -> Dict[str, Dict[str, Any]]:
+    """Index the cached session list by id for workflow stat joins."""
+    out: Dict[str, Dict[str, Any]] = {}
+    for s in await get_sessions_cached():
+        out[s["id"]] = s
+    return out
+
+
+@app.get("/workflows")
+async def list_workflows():
+    """All workflows with aggregated cost/token/agent stats."""
+    sessions_by_id = await _sessions_by_id()
+    workflows = load_workflows()
+    out = [_workflow_with_stats(wf_id, wf, sessions_by_id)
+           for wf_id, wf in workflows.items() if isinstance(wf, dict)]
+    # Newest first by creation time (None sorts last).
+    out.sort(key=lambda w: w.get("created_at") or 0, reverse=True)
+    return out
+
+
+@app.post("/workflows")
+async def create_workflow(payload: WorkflowCreate):
+    from fastapi import HTTPException
+    name = (payload.name or "").strip()
+    if not name:
+        raise HTTPException(status_code=400, detail="'name' is required")
+    wf_id = "wf_" + _uuid.uuid4().hex[:8]
+    # De-dupe session_ids while preserving order.
+    seen: Set[str] = set()
+    session_ids: List[str] = []
+    for sid in (payload.session_ids or []):
+        if isinstance(sid, str) and sid and sid not in seen:
+            seen.add(sid); session_ids.append(sid)
+    workflows = load_workflows()
+    workflows[wf_id] = {
+        "name": name,
+        "description": (payload.description or "").strip(),
+        "color": payload.color or _DEFAULT_WORKFLOW_COLOR,
+        "session_ids": session_ids,
+        "created_at": _now().timestamp(),
+    }
+    save_workflows(workflows)
+    _invalidate_sessions_cache()
+    return _workflow_with_stats(wf_id, workflows[wf_id], await _sessions_by_id())
+
+
+@app.put("/workflows/{workflow_id}")
+async def update_workflow(workflow_id: str, payload: WorkflowUpdate):
+    from fastapi import HTTPException
+    workflows = load_workflows()
+    wf = workflows.get(workflow_id)
+    if not isinstance(wf, dict):
+        raise HTTPException(status_code=404, detail="workflow not found")
+    if payload.name is not None:
+        name = payload.name.strip()
+        if not name:
+            raise HTTPException(status_code=400, detail="'name' cannot be empty")
+        wf["name"] = name
+    if payload.description is not None:
+        wf["description"] = payload.description.strip()
+    if payload.color is not None:
+        wf["color"] = payload.color or _DEFAULT_WORKFLOW_COLOR
+    if payload.session_ids is not None:
+        seen: Set[str] = set()
+        cleaned: List[str] = []
+        for sid in payload.session_ids:
+            if isinstance(sid, str) and sid and sid not in seen:
+                seen.add(sid); cleaned.append(sid)
+        wf["session_ids"] = cleaned
+    workflows[workflow_id] = wf
+    save_workflows(workflows)
+    _invalidate_sessions_cache()
+    return _workflow_with_stats(workflow_id, wf, await _sessions_by_id())
+
+
+@app.delete("/workflows/{workflow_id}")
+async def delete_workflow(workflow_id: str):
+    from fastapi import HTTPException
+    workflows = load_workflows()
+    if workflow_id not in workflows:
+        raise HTTPException(status_code=404, detail="workflow not found")
+    del workflows[workflow_id]
+    save_workflows(workflows)
+    _invalidate_sessions_cache()
+    return {"ok": True}
+
+
+@app.post("/workflows/{workflow_id}/sessions")
+async def add_workflow_sessions(workflow_id: str, payload: WorkflowSessions):
+    from fastapi import HTTPException
+    workflows = load_workflows()
+    wf = workflows.get(workflow_id)
+    if not isinstance(wf, dict):
+        raise HTTPException(status_code=404, detail="workflow not found")
+    existing = [s for s in (wf.get("session_ids") or []) if isinstance(s, str)]
+    seen = set(existing)
+    for sid in payload.session_ids:
+        if isinstance(sid, str) and sid and sid not in seen:
+            seen.add(sid); existing.append(sid)
+    wf["session_ids"] = existing
+    workflows[workflow_id] = wf
+    save_workflows(workflows)
+    _invalidate_sessions_cache()
+    return _workflow_with_stats(workflow_id, wf, await _sessions_by_id())
+
+
+@app.delete("/workflows/{workflow_id}/sessions/{session_id}")
+async def remove_workflow_session(workflow_id: str, session_id: str):
+    from fastapi import HTTPException
+    workflows = load_workflows()
+    wf = workflows.get(workflow_id)
+    if not isinstance(wf, dict):
+        raise HTTPException(status_code=404, detail="workflow not found")
+    wf["session_ids"] = [s for s in (wf.get("session_ids") or [])
+                         if isinstance(s, str) and s != session_id]
+    workflows[workflow_id] = wf
+    save_workflows(workflows)
+    _invalidate_sessions_cache()
+    return _workflow_with_stats(workflow_id, wf, await _sessions_by_id())
+
 
 # def _quality_summary(edit_turns: int, retry_turns: int, measured_sessions: int) -> Dict[str, Any]:
 #     if edit_turns > 0:

--- a/backend/main.py
+++ b/backend/main.py
@@ -6037,6 +6037,148 @@ async def summarize_recent(limit: int = 20):
             failed += 1
     return {"requested": len(sessions), "summarized": done, "skipped": skipped, "failed": failed}
 
+# ---------------------------------------------------------------------------
+# Agent process resource monitor
+# ---------------------------------------------------------------------------
+# Token cost is only half the picture: agents running 24/7 also burn local disk,
+# CPU, and memory (e.g. Codex Desktop spinning ~7MB/s into its sqlite log). This
+# endpoint scans live processes for known agent runtimes and reports per-process
+# resource use. IO rates need two samples over time, so we cache the last
+# io_counters snapshot per PID and compute deltas across requests; the first hit
+# for a PID reports 0 until there's a prior reading to diff against.
+
+# (pattern, agent_type) — matched against lowercased name + full cmdline. Order
+# matters: more specific entries first so "claude" doesn't shadow nothing here,
+# but ".codex" paths win for codex before a generic match.
+_AGENT_PROCESS_PATTERNS = [
+    (".codex", "codex"),
+    ("codex", "codex"),
+    ("app-server", "codex"),
+    ("claude-code", "claude-code"),
+    ("claude", "claude-code"),
+    ("ollama", "ollama"),
+    ("llamafile", "local-models"),
+    ("lm-studio", "local-models"),
+    ("lmstudio", "local-models"),
+    ("llama", "local-models"),
+    ("hermes", "hermes"),
+    ("grok", "grok"),
+]
+
+# pid -> (io_read_bytes, io_write_bytes, monotonic_ts)
+_proc_io_cache: Dict[int, tuple] = {}
+
+
+def _classify_agent_process(name: str, cmdline: str) -> Optional[str]:
+    hay = f"{name}\n{cmdline}".lower()
+    for needle, agent_type in _AGENT_PROCESS_PATTERNS:
+        if needle in hay:
+            return agent_type
+    return None
+
+
+def _scan_agent_processes_sync() -> Dict[str, Any]:
+    try:
+        import psutil
+    except ImportError:
+        return {"error": "psutil not installed", "processes": []}
+
+    import time as _t
+
+    matched = []
+    for proc in psutil.process_iter(["pid", "name", "cmdline"]):
+        try:
+            info = proc.info
+            name = info.get("name") or ""
+            cmdline = " ".join(info.get("cmdline") or [])
+            agent_type = _classify_agent_process(name, cmdline)
+            if agent_type is None:
+                continue
+            matched.append((proc, name, agent_type))
+        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+            continue
+
+    # Prime cpu_percent for every match, then sleep once so the next read covers
+    # a real interval. One shared 0.1s window keeps the whole scan well under 2s.
+    for proc, _name, _at in matched:
+        try:
+            proc.cpu_percent(None)
+        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+            pass
+    _t.sleep(0.1)
+
+    now = _t.monotonic()
+    seen_pids = set()
+    processes = []
+    for proc, name, agent_type in matched:
+        try:
+            pid = proc.pid
+            seen_pids.add(pid)
+
+            try:
+                cpu = round(proc.cpu_percent(None), 1)
+            except (psutil.AccessDenied, psutil.NoSuchProcess):
+                cpu = 0.0
+            try:
+                rss = round(proc.memory_info().rss / (1024 * 1024), 1)
+            except (psutil.AccessDenied, psutil.NoSuchProcess):
+                rss = 0.0
+            try:
+                status = proc.status()
+            except (psutil.AccessDenied, psutil.NoSuchProcess):
+                status = "unknown"
+            try:
+                uptime = max(0, int(_t.time() - proc.create_time()))
+            except (psutil.AccessDenied, psutil.NoSuchProcess):
+                uptime = 0
+
+            read_rate = write_rate = 0.0
+            try:
+                io = proc.io_counters()
+                prev = _proc_io_cache.get(pid)
+                _proc_io_cache[pid] = (io.read_bytes, io.write_bytes, now)
+                if prev:
+                    dt = now - prev[2]
+                    if dt > 0:
+                        read_rate = round(max(0, io.read_bytes - prev[0]) / dt / (1024 * 1024), 2)
+                        write_rate = round(max(0, io.write_bytes - prev[1]) / dt / (1024 * 1024), 2)
+            except (psutil.AccessDenied, NotImplementedError, AttributeError):
+                pass
+
+            processes.append({
+                "pid": pid,
+                "name": name,
+                "agent_type": agent_type,
+                "cpu_percent": cpu,
+                "memory_rss_mb": rss,
+                "io_read_mb_s": read_rate,
+                "io_write_mb_s": write_rate,
+                "status": status,
+                "uptime_seconds": uptime,
+            })
+        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+            continue
+
+    # Drop cache entries for dead PIDs so it doesn't grow unbounded.
+    for dead in [p for p in _proc_io_cache if p not in seen_pids]:
+        _proc_io_cache.pop(dead, None)
+
+    processes.sort(key=lambda p: p["io_write_mb_s"], reverse=True)
+
+    return {
+        "processes": processes,
+        "total_write_mb_s": round(sum(p["io_write_mb_s"] for p in processes), 2),
+        "total_read_mb_s": round(sum(p["io_read_mb_s"] for p in processes), 2),
+        "total_memory_rss_mb": round(sum(p["memory_rss_mb"] for p in processes), 1),
+        "sampled_at": int(_time.time()),
+    }
+
+
+@app.get("/api/agent-processes")
+async def get_agent_processes():
+    return await _asyncio.to_thread(_scan_agent_processes_sync)
+
+
 if __name__ == "__main__":
     import uvicorn
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
 fastapi>=0.110
 uvicorn[standard]>=0.27
 pyyaml>=6.0
+psutil>=5.9

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -32,6 +32,10 @@ interface Session {
   text?: string;
   tokens?: { input: number; output: number; cached: number; total: number };
   cost?: number;
+  /** Delegation cost rollup (own + descendants), set by _rollup_delegation_costs. */
+  total_cost_usd?: number;
+  children_cost_usd?: number;
+  child_count?: number;
   /** Copilot-only: cli / vscode */
   copilot_source?: string;
   /** Antigravity-only: cli / ide / app */
@@ -286,12 +290,20 @@ export default function Home() {
                           )}
                         </Link>
                       </TD>
-                      <TD className="text-[var(--tt-fg)] max-w-[480px] truncate">
+                      <TD className="text-[var(--tt-fg)] max-w-[480px]">
                         <Link href={`/sessions/${s.id}?agent=${s.agent}&from=${encodeURIComponent(pathname)}`} className="block truncate">
                           {s.display || s.text || (
                             <span className="italic text-[var(--tt-fg-faint)]">No message content</span>
                           )}
                         </Link>
+                        {(s.child_count ?? 0) > 0 && (s.total_cost_usd ?? 0) > (s.cost ?? 0) + 1e-9 && (
+                          <span
+                            className="mt-0.5 inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-[10px] font-medium tabular-nums bg-[var(--tt-warn-bg)] text-[var(--tt-warn-fg)] border-[var(--tt-warn-bd)]"
+                            title={`${formatCost(s.cost)} own + ${formatCost(s.children_cost_usd)} across ${s.child_count} child session(s)`}
+                          >
+                            {formatCost(s.cost)} own + {formatCost(s.children_cost_usd)} children = {formatCost(s.total_cost_usd)} total
+                          </span>
+                        )}
                       </TD>
                       <TD className="text-right pr-5 tabular text-[11px] text-[var(--tt-fg-muted)] group-hover:text-[var(--tt-brand)] transition-colors">
                         <Link href={`/sessions/${s.id}?agent=${s.agent}&from=${encodeURIComponent(pathname)}`} className="block">

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -15,6 +15,7 @@ import CopilotSourceBadge from "@/components/CopilotSourceBadge";
 import AntigravitySourceBadge from "@/components/AntigravitySourceBadge";
 import LocalPowerInsights from "@/components/insights/LocalPowerInsights";
 import AgentProcessCard from "@/components/AgentProcessCard";
+import ConcurrencyTimelineCard from "@/components/ConcurrencyTimelineCard";
 import { formatTokens, formatCost } from "@/lib/format";
 import { costFraming, type BillingConfig } from "@/lib/billing";
 import {
@@ -149,6 +150,11 @@ export default function Home() {
       </Section>
 
       {showLocalPower && <LocalPowerInsights forceShow={true} />}
+
+      {/* Concurrency timeline — when multiple agents ran at once */}
+      <Section title="Concurrency timeline" description="When agents overlapped and the combined cost of running them at the same time.">
+        <ConcurrencyTimelineCard />
+      </Section>
 
       {/* Connected agents — split into coding vs autonomous */}
       {availableAgents.length > 0 && (() => {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -13,6 +13,7 @@ import { AGENTS, getAgent, type AgentKey } from "@/lib/agents";
 import SourceBadge from "@/components/SourceBadge";
 import CopilotSourceBadge from "@/components/CopilotSourceBadge";
 import AntigravitySourceBadge from "@/components/AntigravitySourceBadge";
+import AddToWorkflowPopover from "@/components/AddToWorkflowPopover";
 import LocalPowerInsights from "@/components/insights/LocalPowerInsights";
 import AgentProcessCard from "@/components/AgentProcessCard";
 import ConcurrencyTimelineCard from "@/components/ConcurrencyTimelineCard";
@@ -42,6 +43,8 @@ interface Session {
   antigravity_source?: string;
   /** Hermes-only: cli / telegram / cron / etc. */
   source_subtype?: string;
+  /** Workflows this session belongs to (annotated by the backend). */
+  workflow_ids?: string[];
 }
 
 interface AnalyticsResponse {
@@ -268,6 +271,7 @@ export default function Home() {
                     <TH className="pl-5">Agent</TH>
                     <TH>Project</TH>
                     <TH>Context</TH>
+                    <TH className="text-center">Workflow</TH>
                     <TH className="text-right pr-5">Time</TH>
                   </TR>
                 </THead>
@@ -304,6 +308,9 @@ export default function Home() {
                             {formatCost(s.cost)} own + {formatCost(s.children_cost_usd)} children = {formatCost(s.total_cost_usd)} total
                           </span>
                         )}
+                      </TD>
+                      <TD className="text-center">
+                        <AddToWorkflowPopover sessionId={s.id} initialWorkflowIds={s.workflow_ids} />
                       </TD>
                       <TD className="text-right pr-5 tabular text-[11px] text-[var(--tt-fg-muted)] group-hover:text-[var(--tt-brand)] transition-colors">
                         <Link href={`/sessions/${s.id}?agent=${s.agent}&from=${encodeURIComponent(pathname)}`} className="block">

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -14,6 +14,7 @@ import SourceBadge from "@/components/SourceBadge";
 import CopilotSourceBadge from "@/components/CopilotSourceBadge";
 import AntigravitySourceBadge from "@/components/AntigravitySourceBadge";
 import LocalPowerInsights from "@/components/insights/LocalPowerInsights";
+import AgentProcessCard from "@/components/AgentProcessCard";
 import { formatTokens, formatCost } from "@/lib/format";
 import { costFraming, type BillingConfig } from "@/lib/billing";
 import {
@@ -217,6 +218,14 @@ export default function Home() {
           </>
         );
       })()}
+
+      {/* System — live machine cost of running agents */}
+      <Section
+        title="System"
+        description="Live disk, CPU, and memory use of agent processes on this machine — the machine cost behind the token cost."
+      >
+        <AgentProcessCard />
+      </Section>
 
       {/* Activity + sidebars */}
       <div className="grid grid-cols-1 xl:grid-cols-3 gap-6 items-start">

--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -13,6 +13,7 @@ import SourceBadge from "@/components/SourceBadge";
 import CopilotSourceBadge from "@/components/CopilotSourceBadge";
 import AntigravitySourceBadge from "@/components/AntigravitySourceBadge";
 import SummaryPanel from "@/components/summarizer/SummaryPanel";
+import DelegationTreeCard from "@/components/DelegationTreeCard";
 import { apiFetch, artifactUrl } from "@/lib/api";
 import { formatTokens, formatCost } from "@/lib/format";
 import { resolveSessionBackTarget } from "@/lib/navigation";
@@ -680,6 +681,8 @@ export default function SessionDetailPage() {
              {agent === "grok" && grokForensics && <GrokForensicsCard forensics={grokForensics} cost={sessionInfo?.tokens?.cost ?? sessionInfo?.cost} />}
              {/* Delegated work — subagent spawns and what they actually cost */}
              {delegation && agent && <DelegationCard delegation={delegation} agent={agent} sessionId={id} onOpenSubagent={setSubagentView} />}
+             {/* Cost attribution tree — rolled-up cost of this session + all descendants */}
+             {id && <DelegationTreeCard sessionId={id} />}
              <div className={splitView ? "grid grid-cols-2 gap-8" : "space-y-8"}>
                 <div className="space-y-8">
                    {splitView && <h3 className="text-[10px] font-black text-[var(--tt-fg-dim)] uppercase tracking-[0.2em] ml-2 mb-2 flex items-center gap-2"><User size={14}/> User & Agent Dialogue</h3>}

--- a/frontend/src/app/workflows/page.tsx
+++ b/frontend/src/app/workflows/page.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { formatDistanceToNow } from "date-fns";
+import {
+  Layers, Plus, Trash2, ChevronDown, ChevronRight, X, Coins, Hash, Boxes,
+} from "lucide-react";
+
+import { formatCost, formatTokens } from "@/lib/format";
+import {
+  type Workflow, WORKFLOW_COLORS,
+  getWorkflows, createWorkflow, deleteWorkflow, removeSessionFromWorkflow,
+} from "@/lib/workflows";
+import {
+  PageHeader, Section, Card, Button, EmptyState, Skeleton, AgentBadge,
+} from "@/components/ui";
+import { cn } from "@/lib/cn";
+
+export default function WorkflowsPage() {
+  const [workflows, setWorkflows] = useState<Workflow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [showForm, setShowForm] = useState(false);
+
+  const refresh = useCallback(() => {
+    return getWorkflows()
+      .then((data) => { setWorkflows(data); setError(null); })
+      .catch((e) => setError(e instanceof Error ? e.message : String(e)))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    getWorkflows()
+      .then((data) => { if (!cancelled) { setWorkflows(data); setError(null); } })
+      .catch((e) => { if (!cancelled) setError(e instanceof Error ? e.message : String(e)); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, []);
+
+  return (
+    <div className="px-8 py-8 max-w-[1200px] mx-auto space-y-8 pb-20">
+      <PageHeader
+        eyebrow="Cost legibility"
+        title="Workflows"
+        description="Group sessions into named tasks and read the total cost across every agent that worked on them."
+        icon={<Layers size={20} strokeWidth={2.25} />}
+        actions={
+          <Button variant="primary" size="md" onClick={() => setShowForm((v) => !v)}>
+            <Plus size={14} /> New Workflow
+          </Button>
+        }
+      />
+
+      {showForm && (
+        <NewWorkflowForm
+          onCreated={() => { setShowForm(false); refresh(); }}
+          onCancel={() => setShowForm(false)}
+        />
+      )}
+
+      <Section title="Your workflows">
+        {loading ? (
+          <div className="space-y-4">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <Skeleton key={i} className="h-28 w-full rounded-[var(--tt-radius-lg)]" />
+            ))}
+          </div>
+        ) : error ? (
+          <Card><div className="text-[13px] text-[var(--tt-danger-fg)]">Failed to load workflows: {error}</div></Card>
+        ) : workflows.length === 0 ? (
+          <EmptyState
+            icon={<Boxes size={20} />}
+            title="No workflows yet"
+            description="Create a workflow, then add sessions to it from the Dashboard using the “Add to workflow” button on each session row."
+            action={
+              <Button variant="primary" size="md" onClick={() => setShowForm(true)}>
+                <Plus size={14} /> New Workflow
+              </Button>
+            }
+          />
+        ) : (
+          <div className="space-y-4">
+            {workflows.map((wf) => (
+              <WorkflowCard key={wf.id} wf={wf} onChange={refresh} />
+            ))}
+          </div>
+        )}
+      </Section>
+    </div>
+  );
+}
+
+function NewWorkflowForm({ onCreated, onCancel }: { onCreated: () => void; onCancel: () => void }) {
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [color, setColor] = useState(WORKFLOW_COLORS[0]);
+  const [saving, setSaving] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const submit = async () => {
+    if (!name.trim()) { setErr("Name is required"); return; }
+    setSaving(true); setErr(null);
+    try {
+      await createWorkflow({ name: name.trim(), description: description.trim(), color });
+      onCreated();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Card tone="raised">
+      <div className="space-y-3">
+        <div>
+          <label className="block text-[11px] uppercase tracking-[0.16em] text-[var(--tt-fg-dim)] mb-1.5">Name</label>
+          <input
+            autoFocus
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            onKeyDown={(e) => { if (e.key === "Enter") submit(); }}
+            placeholder="Auth refactor"
+            className="w-full rounded-[var(--tt-radius)] border border-[var(--tt-border)] bg-[var(--tt-sunken)] px-3 py-2 text-[13px] text-[var(--tt-fg)] outline-none focus:border-[var(--tt-brand)]"
+          />
+        </div>
+        <div>
+          <label className="block text-[11px] uppercase tracking-[0.16em] text-[var(--tt-fg-dim)] mb-1.5">Description</label>
+          <input
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Rewriting the auth middleware (optional)"
+            className="w-full rounded-[var(--tt-radius)] border border-[var(--tt-border)] bg-[var(--tt-sunken)] px-3 py-2 text-[13px] text-[var(--tt-fg)] outline-none focus:border-[var(--tt-brand)]"
+          />
+        </div>
+        <div>
+          <label className="block text-[11px] uppercase tracking-[0.16em] text-[var(--tt-fg-dim)] mb-1.5">Color</label>
+          <div className="flex items-center gap-2">
+            {WORKFLOW_COLORS.map((c) => (
+              <button
+                key={c}
+                type="button"
+                aria-label={`Color ${c}`}
+                onClick={() => setColor(c)}
+                className={cn(
+                  "h-6 w-6 rounded-full transition-transform",
+                  color === c ? "ring-2 ring-offset-2 ring-offset-[var(--tt-raised)] scale-110" : "hover:scale-105",
+                )}
+                style={{ backgroundColor: c, boxShadow: color === c ? `0 0 0 2px ${c}` : undefined }}
+              />
+            ))}
+          </div>
+        </div>
+        {err && <div className="text-[12px] text-[var(--tt-danger-fg)]">{err}</div>}
+        <div className="flex items-center gap-2 pt-1">
+          <Button variant="primary" size="md" onClick={submit} disabled={saving}>
+            {saving ? "Creating…" : "Create workflow"}
+          </Button>
+          <Button variant="ghost" size="md" onClick={onCancel} disabled={saving}>Cancel</Button>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+function WorkflowCard({ wf, onChange }: { wf: Workflow; onChange: () => void }) {
+  const [expanded, setExpanded] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  const onDelete = async () => {
+    if (!confirm(`Delete workflow “${wf.name}”? This removes the grouping, not the sessions.`)) return;
+    setBusy(true);
+    try { await deleteWorkflow(wf.id); onChange(); } finally { setBusy(false); }
+  };
+
+  const onRemoveSession = async (sid: string) => {
+    setBusy(true);
+    try { await removeSessionFromWorkflow(wf.id, sid); onChange(); } finally { setBusy(false); }
+  };
+
+  return (
+    <Card
+      padding="none"
+      className="overflow-hidden border-l-2"
+      style={{ borderLeftColor: wf.color }}
+    >
+      <div className="p-5">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <span className="h-2.5 w-2.5 rounded-full shrink-0" style={{ backgroundColor: wf.color }} />
+              <h3 className="text-[15px] font-semibold tracking-tight text-[var(--tt-fg)] truncate">{wf.name}</h3>
+            </div>
+            {wf.description && (
+              <p className="mt-1 text-[13px] text-[var(--tt-fg-muted)] leading-relaxed">{wf.description}</p>
+            )}
+          </div>
+          <Button variant="danger" size="sm" onClick={onDelete} disabled={busy} title="Delete workflow">
+            <Trash2 size={13} />
+          </Button>
+        </div>
+
+        {/* Stats */}
+        <div className="mt-4 flex flex-wrap items-center gap-x-5 gap-y-2 text-[12px]">
+          <Stat icon={<Boxes size={13} />} label={`${wf.session_count} ${wf.session_count === 1 ? "session" : "sessions"}`} />
+          <Stat icon={<Coins size={13} />} label={`${formatCost(wf.total_cost_usd)} total`} />
+          <Stat icon={<Hash size={13} />} label={`${formatTokens(wf.total_tokens)} tokens`} />
+          {wf.agent_types.length > 0 && (
+            <span className="flex items-center gap-1.5 flex-wrap">
+              <span className="text-[var(--tt-fg-dim)]">agents:</span>
+              {wf.agent_types.map((a) => <AgentBadge key={a} agent={a} size="xs" />)}
+            </span>
+          )}
+        </div>
+
+        <div className="mt-3 flex items-center justify-between">
+          <span className="text-[11px] text-[var(--tt-fg-dim)]">
+            {wf.last_active
+              ? `Last active ${formatDistanceToNow(new Date(wf.last_active * 1000), { addSuffix: true })}`
+              : "No active sessions"}
+          </span>
+          {wf.session_count > 0 && (
+            <button
+              onClick={() => setExpanded((v) => !v)}
+              className="flex items-center gap-1 text-[11px] text-[var(--tt-fg-muted)] hover:text-[var(--tt-fg)] transition-colors"
+            >
+              {expanded ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
+              {expanded ? "Hide sessions" : "Show sessions"}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {expanded && wf.session_ids.length > 0 && (
+        <div className="border-t border-[var(--tt-border)] bg-[var(--tt-sunken)] p-4 space-y-2">
+          {wf.session_ids.map((sid) => (
+            <SessionPill key={sid} sessionId={sid} onRemove={() => onRemoveSession(sid)} disabled={busy} />
+          ))}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+function Stat({ icon, label }: { icon: React.ReactNode; label: string }) {
+  return (
+    <span className="flex items-center gap-1.5 text-[var(--tt-fg-muted)]">
+      <span className="text-[var(--tt-fg-dim)]">{icon}</span>
+      <span className="tabular">{label}</span>
+    </span>
+  );
+}
+
+/** A single session in the expanded list. Workflows store only session ids
+ *  (stats are aggregated server-side and the per-session agent isn't carried
+ *  here), so the pill shows the id and a remove control. */
+function SessionPill({ sessionId, onRemove, disabled }: { sessionId: string; onRemove: () => void; disabled: boolean }) {
+  return (
+    <div className="flex items-center justify-between gap-2 rounded-[var(--tt-radius)] border border-[var(--tt-border)] bg-[var(--tt-panel)] px-3 py-1.5">
+      <span className="font-mono text-[11px] text-[var(--tt-fg-muted)] truncate" title={sessionId}>
+        {sessionId.slice(0, 28)}{sessionId.length > 28 ? "…" : ""}
+      </span>
+      <button
+        onClick={onRemove}
+        disabled={disabled}
+        aria-label="Remove session from workflow"
+        className="shrink-0 text-[var(--tt-fg-dim)] hover:text-[var(--tt-danger-fg)] transition-colors disabled:opacity-50"
+      >
+        <X size={13} />
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/AddToWorkflowPopover.tsx
+++ b/frontend/src/components/AddToWorkflowPopover.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Layers, Plus, Check, Loader2 } from "lucide-react";
+
+import {
+  type Workflow, WORKFLOW_COLORS,
+  getWorkflows, createWorkflow, addSessionsToWorkflow, removeSessionFromWorkflow,
+} from "@/lib/workflows";
+import { cn } from "@/lib/cn";
+
+/** Per-session "Add to workflow" control for the dashboard rows. Renders a
+ *  small button that opens a popover listing workflows (checkbox = membership)
+ *  plus an inline "New workflow" creator. Memberships come from the session's
+ *  own workflow_ids (annotated by the backend) but we keep a local optimistic
+ *  copy so toggles feel instant without a full sessions refetch. */
+export default function AddToWorkflowPopover({
+  sessionId,
+  initialWorkflowIds = [],
+}: {
+  sessionId: string;
+  initialWorkflowIds?: string[];
+}) {
+  const [open, setOpen] = useState(false);
+  const [workflows, setWorkflows] = useState<Workflow[]>([]);
+  const [loading, setLoading] = useState(false);
+  // Membership starts from the backend-annotated ids and is then reconciled
+  // against the freshly loaded workflow list, with optimistic toggles applied
+  // on top. We never sync the prop via an effect (that triggers cascading
+  // renders) — the loaded list is authoritative once the popover is open.
+  const [member, setMember] = useState<Set<string>>(new Set(initialWorkflowIds));
+  const [pending, setPending] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [newName, setNewName] = useState("");
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Load workflows when the popover opens. setLoading(true) happens in the
+  // open handler, not here, so the effect body never setStates synchronously.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    getWorkflows()
+      .then((wf) => {
+        if (cancelled) return;
+        setWorkflows(wf);
+        // Reconcile membership from authoritative server data for this session.
+        setMember(new Set(wf.filter((w) => w.session_ids.includes(sessionId)).map((w) => w.id)));
+      })
+      .catch(() => { /* non-fatal — popover shows empty */ })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [open, sessionId]);
+
+  // Close on outside click / Escape.
+  useEffect(() => {
+    if (!open) return;
+    const onDoc = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setOpen(false); };
+    document.addEventListener("mousedown", onDoc);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDoc);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const toggle = async (wf: Workflow) => {
+    const isMember = member.has(wf.id);
+    setPending(wf.id);
+    try {
+      if (isMember) {
+        await removeSessionFromWorkflow(wf.id, sessionId);
+        setMember((m) => { const n = new Set(m); n.delete(wf.id); return n; });
+      } else {
+        await addSessionsToWorkflow(wf.id, [sessionId]);
+        setMember((m) => new Set(m).add(wf.id));
+      }
+    } catch { /* leave state unchanged on failure */ } finally {
+      setPending(null);
+    }
+  };
+
+  const create = async () => {
+    const name = newName.trim();
+    if (!name) return;
+    setPending("__new__");
+    try {
+      const color = WORKFLOW_COLORS[workflows.length % WORKFLOW_COLORS.length];
+      const wf = await createWorkflow({ name, color, session_ids: [sessionId] });
+      setWorkflows((ws) => [wf, ...ws]);
+      setMember((m) => new Set(m).add(wf.id));
+      setNewName("");
+      setCreating(false);
+    } catch { /* non-fatal */ } finally {
+      setPending(null);
+    }
+  };
+
+  return (
+    <div className="relative inline-block" ref={ref}>
+      <button
+        onClick={(e) => {
+          e.preventDefault(); e.stopPropagation();
+          if (!open) setLoading(true);
+          setOpen((v) => !v);
+        }}
+        title="Add to workflow"
+        aria-label="Add to workflow"
+        className={cn(
+          "inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-[10px] transition-colors",
+          member.size > 0
+            ? "border-[var(--tt-brand)]/30 text-[var(--tt-brand)] bg-[color:var(--tt-brand-glow)]"
+            : "border-[var(--tt-border)] text-[var(--tt-fg-dim)] hover:text-[var(--tt-fg)] hover:border-[var(--tt-border-strong)]",
+        )}
+      >
+        <Layers size={11} />
+        {member.size > 0 ? member.size : ""}
+      </button>
+
+      {open && (
+        <div
+          className="absolute right-0 z-[200] mt-1 w-60 rounded-[var(--tt-radius-lg)] border border-[var(--tt-border-strong)] bg-[var(--tt-panel)] shadow-[0_24px_60px_-20px_rgba(0,0,0,0.5)] p-1.5"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="px-2 py-1.5 text-[10px] uppercase tracking-[0.16em] text-[var(--tt-fg-dim)]">
+            Add to workflow
+          </div>
+
+          <div className="max-h-56 overflow-y-auto">
+            {loading ? (
+              <div className="flex items-center gap-2 px-2 py-2 text-[12px] text-[var(--tt-fg-dim)]">
+                <Loader2 size={13} className="animate-spin" /> Loading…
+              </div>
+            ) : workflows.length === 0 ? (
+              <div className="px-2 py-2 text-[12px] text-[var(--tt-fg-dim)]">No workflows yet.</div>
+            ) : (
+              workflows.map((wf) => {
+                const checked = member.has(wf.id);
+                return (
+                  <button
+                    key={wf.id}
+                    onClick={() => toggle(wf)}
+                    disabled={pending === wf.id}
+                    className="w-full flex items-center gap-2 rounded-[var(--tt-radius)] px-2 py-1.5 text-left text-[12px] text-[var(--tt-fg)] hover:tt-tint-1 transition-colors disabled:opacity-50"
+                  >
+                    <span
+                      className={cn(
+                        "grid place-items-center h-4 w-4 rounded border shrink-0",
+                        checked ? "border-transparent" : "border-[var(--tt-border-strong)]",
+                      )}
+                      style={checked ? { backgroundColor: wf.color } : undefined}
+                    >
+                      {pending === wf.id
+                        ? <Loader2 size={10} className="animate-spin text-[var(--tt-fg-dim)]" />
+                        : checked ? <Check size={11} className="text-white" /> : null}
+                    </span>
+                    <span className="h-2 w-2 rounded-full shrink-0" style={{ backgroundColor: wf.color }} />
+                    <span className="truncate">{wf.name}</span>
+                  </button>
+                );
+              })
+            )}
+          </div>
+
+          <div className="mt-1 border-t border-[var(--tt-border)] pt-1">
+            {creating ? (
+              <div className="flex items-center gap-1.5 px-1.5 py-1">
+                <input
+                  autoFocus
+                  value={newName}
+                  onChange={(e) => setNewName(e.target.value)}
+                  onKeyDown={(e) => { if (e.key === "Enter") create(); if (e.key === "Escape") setCreating(false); }}
+                  placeholder="Workflow name"
+                  className="flex-1 min-w-0 rounded-[var(--tt-radius)] border border-[var(--tt-border)] bg-[var(--tt-sunken)] px-2 py-1 text-[12px] text-[var(--tt-fg)] outline-none focus:border-[var(--tt-brand)]"
+                />
+                <button
+                  onClick={create}
+                  disabled={pending === "__new__" || !newName.trim()}
+                  className="shrink-0 rounded-[var(--tt-radius)] bg-[var(--tt-brand-strong)] px-2 py-1 text-[11px] text-white disabled:opacity-50"
+                >
+                  {pending === "__new__" ? <Loader2 size={12} className="animate-spin" /> : "Add"}
+                </button>
+              </div>
+            ) : (
+              <button
+                onClick={() => setCreating(true)}
+                className="w-full flex items-center gap-2 rounded-[var(--tt-radius)] px-2 py-1.5 text-left text-[12px] text-[var(--tt-fg-muted)] hover:tt-tint-1 hover:text-[var(--tt-fg)] transition-colors"
+              >
+                <Plus size={13} /> New workflow
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/AgentProcessCard.tsx
+++ b/frontend/src/components/AgentProcessCard.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { HardDrive, AlertTriangle } from "lucide-react";
+import { useResource } from "@/lib/api";
+import {
+  Card, CardHeader, CardTitle, CardEyebrow,
+  Table, THead, TBody, TR, TH, TD, EmptyState, Skeleton,
+} from "@/components/ui";
+
+interface AgentProcess {
+  pid: number;
+  name: string;
+  agent_type: string;
+  cpu_percent: number;
+  memory_rss_mb: number;
+  io_read_mb_s: number;
+  io_write_mb_s: number;
+  status: string;
+  uptime_seconds: number;
+}
+
+interface AgentProcessesResponse {
+  error?: string;
+  processes: AgentProcess[];
+  total_write_mb_s?: number;
+  total_read_mb_s?: number;
+  total_memory_rss_mb?: number;
+  sampled_at?: number;
+}
+
+const AGENT_LABELS: Record<string, string> = {
+  "claude-code": "Claude Code",
+  codex: "Codex",
+  ollama: "Ollama",
+  "local-models": "Local Models",
+  hermes: "Hermes",
+  grok: "Grok Build",
+};
+
+function agentLabel(t: string): string {
+  return AGENT_LABELS[t] ?? t;
+}
+
+// green < 1MB/s, yellow 1-5MB/s, red > 5MB/s
+function writeColor(rate: number): string {
+  if (rate > 5) return "text-[var(--tt-danger,#f87171)]";
+  if (rate >= 1) return "text-[var(--tt-warn,#fbbf24)]";
+  return "text-[var(--tt-success,#34d399)]";
+}
+
+function formatUptime(sec: number): string {
+  if (sec <= 0) return "—";
+  const d = Math.floor(sec / 86400);
+  const h = Math.floor((sec % 86400) / 3600);
+  const m = Math.floor((sec % 3600) / 60);
+  if (d > 0) return `${d}d ${h}h`;
+  if (h > 0) return `${h}h ${m}m`;
+  return `${m}m`;
+}
+
+export default function AgentProcessCard() {
+  const res = useResource<AgentProcessesResponse>("/api/agent-processes", { pollMs: 5_000 });
+  const data = res.data;
+  const processes = data?.processes ?? [];
+
+  const hot = processes.filter((p) => p.io_write_mb_s > 5);
+
+  return (
+    <Card padding="none" className="overflow-hidden">
+      <CardHeader className="px-5 py-4 mb-0 border-b border-[var(--tt-border)]">
+        <CardTitle>
+          <HardDrive size={14} className="text-[var(--tt-brand)]" />
+          Agent process monitor
+        </CardTitle>
+        <CardEyebrow>{processes.length} running · auto-sync 5s</CardEyebrow>
+      </CardHeader>
+
+      {hot.map((p) => (
+        <div
+          key={`warn-${p.pid}`}
+          className="flex items-center gap-2 px-5 py-2.5 text-[12px] text-[var(--tt-danger,#f87171)] bg-[var(--tt-danger,#f87171)]/8 border-b border-[var(--tt-border)]"
+        >
+          <AlertTriangle size={13} className="shrink-0" />
+          <span>
+            {agentLabel(p.agent_type)} is writing at {p.io_write_mb_s.toFixed(2)} MB/s — check for log bloat
+          </span>
+        </div>
+      ))}
+
+      {res.loading && !data ? (
+        <div className="p-5 space-y-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-5 w-full" />
+          ))}
+        </div>
+      ) : data?.error ? (
+        <EmptyState
+          icon={<HardDrive size={20} />}
+          title="Process monitor unavailable"
+          description={`${data.error}. Install it in the backend (pip install psutil) to see live agent resource use.`}
+        />
+      ) : processes.length === 0 ? (
+        <EmptyState
+          icon={<HardDrive size={20} />}
+          title="No agent processes running"
+          description="No known AI agent processes (Claude Code, Codex, Ollama, local models, Hermes, Grok) were found on this machine."
+        />
+      ) : (
+        <div className="max-h-[420px] overflow-y-auto">
+          <Table>
+            <THead>
+              <TR>
+                <TH className="pl-5">Agent</TH>
+                <TH>Process</TH>
+                <TH className="text-right">PID</TH>
+                <TH className="text-right">CPU %</TH>
+                <TH className="text-right">Mem (MB)</TH>
+                <TH className="text-right">Write MB/s</TH>
+                <TH className="text-right">Read MB/s</TH>
+                <TH className="text-right pr-5">Uptime</TH>
+              </TR>
+            </THead>
+            <TBody>
+              {processes.map((p) => (
+                <TR key={p.pid}>
+                  <TD className="pl-5 font-medium">{agentLabel(p.agent_type)}</TD>
+                  <TD className="font-mono text-[12px] text-[var(--tt-fg-muted)] max-w-[180px] truncate" title={p.name}>
+                    {p.name}
+                  </TD>
+                  <TD className="text-right tabular text-[var(--tt-fg-muted)]">{p.pid}</TD>
+                  <TD className="text-right tabular">{p.cpu_percent.toFixed(1)}</TD>
+                  <TD className="text-right tabular">{p.memory_rss_mb.toFixed(1)}</TD>
+                  <TD className={`text-right tabular font-semibold ${writeColor(p.io_write_mb_s)}`}>
+                    {p.io_write_mb_s.toFixed(2)}
+                  </TD>
+                  <TD className="text-right tabular text-[var(--tt-fg-muted)]">{p.io_read_mb_s.toFixed(2)}</TD>
+                  <TD className="text-right pr-5 tabular text-[var(--tt-fg-muted)]">{formatUptime(p.uptime_seconds)}</TD>
+                </TR>
+              ))}
+              <TR className="font-semibold">
+                <TD className="pl-5 uppercase tracking-[0.14em] text-[10px] text-[var(--tt-fg-dim)]">Totals</TD>
+                <TD />
+                <TD />
+                <TD />
+                <TD className="text-right tabular">{(data?.total_memory_rss_mb ?? 0).toFixed(1)}</TD>
+                <TD className={`text-right tabular ${writeColor(data?.total_write_mb_s ?? 0)}`}>
+                  {(data?.total_write_mb_s ?? 0).toFixed(2)}
+                </TD>
+                <TD className="text-right tabular">{(data?.total_read_mb_s ?? 0).toFixed(2)}</TD>
+                <TD className="pr-5" />
+              </TR>
+            </TBody>
+          </Table>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/frontend/src/components/ConcurrencyTimelineCard.tsx
+++ b/frontend/src/components/ConcurrencyTimelineCard.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import React, { useMemo } from "react";
+import { Layers, Zap, DollarSign, Clock } from "lucide-react";
+import { useResource } from "@/lib/api";
+import { Card, CardHeader, CardTitle, CardEyebrow, Badge, Skeleton } from "@/components/ui";
+import { getAgent } from "@/lib/agents";
+import { formatCost } from "@/lib/format";
+
+interface ConcurrencyWindow {
+  start: number; // epoch seconds
+  end: number; // epoch seconds
+  session_ids: string[];
+  agent_types: string[];
+  combined_cost_usd: number;
+  combined_write_mb_estimate: number | null;
+}
+
+interface ConcurrencyResponse {
+  windows: ConcurrencyWindow[];
+  peak_concurrent_count: number;
+  peak_combined_cost_per_hour: number;
+  total_concurrent_hours: number;
+}
+
+const WINDOW_DAYS = 7;
+const WINDOW_MS = WINDOW_DAYS * 24 * 60 * 60 * 1000;
+
+// Bar colour by concurrency depth: 1 (shouldn't appear — windows are 2+) light,
+// 3+ dark. Uses the brand info hue so it reads as "activity" not "warning".
+function depthColor(n: number): string {
+  if (n >= 4) return "rgba(96,165,250,0.95)";
+  if (n === 3) return "rgba(96,165,250,0.75)";
+  return "rgba(96,165,250,0.5)"; // 2
+}
+
+export default function ConcurrencyTimelineCard() {
+  const res = useResource<ConcurrencyResponse>("/sessions/concurrency", {
+    pollMs: 30_000,
+  });
+
+  const data = res.data;
+  const loading = res.loading;
+
+  // Window of the last 7 days, in ms.
+  const now = Date.now();
+  const rangeStart = now - WINDOW_MS;
+
+  const rows = useMemo(() => {
+    if (!data?.windows) return [];
+    return data.windows
+      .map((w) => {
+        const startMs = w.start * 1000;
+        const endMs = w.end * 1000;
+        // Clamp to the visible 7-day range.
+        const vis0 = Math.max(startMs, rangeStart);
+        const vis1 = Math.min(endMs, now);
+        return { w, startMs, endMs, vis0, vis1 };
+      })
+      .filter((r) => r.vis1 > r.vis0) // intersects the visible range
+      .sort((a, b) => a.startMs - b.startMs);
+  }, [data, rangeStart, now]);
+
+  const hasRows = rows.length > 0;
+
+  // Day gridlines (7 slots).
+  const dayTicks = useMemo(() => {
+    const ticks: { left: number; label: string }[] = [];
+    for (let i = 0; i <= WINDOW_DAYS; i++) {
+      const t = rangeStart + (i / WINDOW_DAYS) * WINDOW_MS;
+      ticks.push({
+        left: (i / WINDOW_DAYS) * 100,
+        label: new Date(t).toLocaleDateString(undefined, { month: "short", day: "numeric" }),
+      });
+    }
+    return ticks;
+  }, [rangeStart]);
+
+  return (
+    <Card padding="lg">
+      <CardHeader>
+        <div>
+          <CardEyebrow>Concurrency</CardEyebrow>
+          <CardTitle className="mt-1">
+            <Layers size={15} /> Overlapping agent sessions
+          </CardTitle>
+        </div>
+        <Badge variant="info" size="sm">
+          Last {WINDOW_DAYS} days
+        </Badge>
+      </CardHeader>
+
+      {loading ? (
+        <div className="space-y-2">
+          <Skeleton className="h-6 w-full" />
+          <Skeleton className="h-6 w-3/4" />
+          <Skeleton className="h-6 w-1/2" />
+        </div>
+      ) : !hasRows ? (
+        <p className="text-[13px] text-[var(--tt-fg-muted)] py-6 text-center">
+          No overlapping sessions in the last {WINDOW_DAYS} days.
+        </p>
+      ) : (
+        <>
+          {/* Timeline */}
+          <div className="relative">
+            {/* Day gridlines */}
+            <div className="absolute inset-0 pointer-events-none">
+              {dayTicks.map((t, i) => (
+                <div
+                  key={i}
+                  className="absolute top-0 bottom-5 w-px bg-[var(--tt-border)]"
+                  style={{ left: `${t.left}%` }}
+                />
+              ))}
+            </div>
+
+            {/* Window bars */}
+            <div className="relative space-y-1.5 pb-5">
+              {rows.map(({ w, vis0, vis1 }, idx) => {
+                const left = ((vis0 - rangeStart) / WINDOW_MS) * 100;
+                const width = Math.max(((vis1 - vis0) / WINDOW_MS) * 100, 0.6);
+                const n = w.session_ids.length;
+                const durHours = (w.end - w.start) / 3600;
+                const cph = durHours > 0 ? w.combined_cost_usd / durHours : 0;
+                const tip = `${n} agents active — combined ${formatCost(cph)}/hr`;
+                return (
+                  <div key={idx} className="relative h-6">
+                    <div
+                      className="absolute top-0 h-6 rounded-[var(--tt-radius-sm)] flex items-center px-1.5 gap-1 overflow-hidden cursor-default transition-[filter] hover:brightness-110"
+                      style={{
+                        left: `${left}%`,
+                        width: `${width}%`,
+                        background: depthColor(n),
+                      }}
+                      title={tip}
+                    >
+                      <span className="text-[10px] font-semibold text-white/95 whitespace-nowrap">
+                        {n}×
+                      </span>
+                      <span className="flex items-center gap-0.5 overflow-hidden">
+                        {w.agent_types.slice(0, 4).map((a) => {
+                          const meta = getAgent(a);
+                          return (
+                            <span
+                              key={a}
+                              className="inline-block w-1.5 h-1.5 rounded-full shrink-0"
+                              style={{ background: meta.hex }}
+                              title={meta.label}
+                            />
+                          );
+                        })}
+                      </span>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+
+            {/* Day axis labels */}
+            <div className="relative h-4">
+              {dayTicks.map((t, i) => (
+                <span
+                  key={i}
+                  className="absolute -translate-x-1/2 text-[9px] text-[var(--tt-fg-dim)] tabular-nums"
+                  style={{ left: `${t.left}%` }}
+                >
+                  {i % 2 === 0 ? t.label : ""}
+                </span>
+              ))}
+            </div>
+          </div>
+
+          {/* Stat chips */}
+          <div className="mt-4 grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <StatChip
+              icon={<Zap size={14} />}
+              label="Peak concurrent"
+              value={`${data?.peak_concurrent_count ?? 0} agents`}
+            />
+            <StatChip
+              icon={<DollarSign size={14} />}
+              label="Most expensive overlap"
+              value={`${formatCost(data?.peak_combined_cost_per_hour ?? 0)}/hr`}
+            />
+            <StatChip
+              icon={<Clock size={14} />}
+              label="Total concurrent time"
+              value={`${(data?.total_concurrent_hours ?? 0).toFixed(1)}h`}
+            />
+          </div>
+        </>
+      )}
+    </Card>
+  );
+}
+
+function StatChip({
+  icon,
+  label,
+  value,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="flex items-center gap-2.5 rounded-[var(--tt-radius)] border border-[var(--tt-border)] bg-[var(--tt-sunken)] px-3 py-2.5">
+      <span className="text-[var(--tt-info)] shrink-0">{icon}</span>
+      <div className="min-w-0">
+        <div className="text-[10px] uppercase tracking-[0.12em] text-[var(--tt-fg-dim)] truncate">
+          {label}
+        </div>
+        <div className="text-[13px] font-semibold text-[var(--tt-fg)] tabular-nums truncate">
+          {value}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/DelegationTreeCard.tsx
+++ b/frontend/src/components/DelegationTreeCard.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+// Cost attribution tree for a session and its spawned subagents.
+//
+// When a parent agent delegates work to child sessions, the parent's own token
+// cost only tells part of the story — the work it kicked off may cost far more.
+// This card fetches GET /sessions/{id}/tree (backed by _rollup_delegation_costs
+// in backend/main.py) and renders the subtree with per-node own/total costs so a
+// user can see "this workflow cost $0.52 total" traced to the session that
+// started it.
+
+import React, { useState } from "react";
+import Link from "next/link";
+import { ChevronRight, ChevronDown, GitBranch, Layers } from "lucide-react";
+import { AgentBadge } from "@/components/ui";
+import { useResource } from "@/lib/api";
+import { formatCost } from "@/lib/format";
+
+interface TreeNode {
+  session_id: string;
+  agent?: string | null;
+  project?: string | null;
+  display?: string | null;
+  cost_usd: number;
+  total_cost_usd: number;
+  children_cost_usd: number;
+  child_count: number;
+  depth: number;
+  children: TreeNode[];
+}
+
+function shortId(id: string): string {
+  if (id.length <= 12) return id;
+  return `${id.slice(0, 8)}…${id.slice(-4)}`;
+}
+
+function TreeRow({ node }: { node: TreeNode }) {
+  const hasChildren = node.children.length > 0 || node.child_count > 0;
+  // Root (depth 0) defaults open so the user sees the breakdown immediately.
+  const [open, setOpen] = useState(node.depth < 2);
+  const hasSubtree = node.total_cost_usd > node.cost_usd + 1e-9;
+
+  return (
+    <div>
+      <div
+        className="flex items-center gap-2 py-1.5 pr-2 rounded-md hover:bg-[var(--tt-panel)]/60 transition-colors"
+        style={{ paddingLeft: `${node.depth * 16 + 4}px` }}
+      >
+        {hasChildren ? (
+          <button
+            type="button"
+            onClick={() => setOpen((v) => !v)}
+            aria-label={open ? "Collapse children" : "Expand children"}
+            className="shrink-0 text-[var(--tt-fg-dim)] hover:text-[var(--tt-fg)] transition-colors"
+          >
+            {open ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+          </button>
+        ) : (
+          <span className="shrink-0 w-[14px]" aria-hidden />
+        )}
+
+        {node.agent && <AgentBadge agent={node.agent} withLabel={false} />}
+
+        <Link
+          href={`/sessions/${node.session_id}?agent=${encodeURIComponent(node.agent || "")}`}
+          className="font-mono text-[11px] text-[var(--tt-fg-muted)] hover:text-[var(--tt-brand)] hover:underline truncate"
+          title={node.session_id}
+        >
+          {shortId(node.session_id)}
+        </Link>
+
+        <div className="ml-auto flex items-center gap-2 shrink-0">
+          <span className="text-[11px] text-[var(--tt-fg)] tabular-nums" title="Own token cost">
+            {formatCost(node.cost_usd)}
+          </span>
+          {hasSubtree && (
+            <span
+              className="inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-[10px] font-medium tabular-nums bg-[var(--tt-warn-bg)] text-[var(--tt-warn-fg)] border-[var(--tt-warn-bd)]"
+              title={`Subtree total: own ${formatCost(node.cost_usd)} + children ${formatCost(node.children_cost_usd)}`}
+            >
+              <Layers size={10} />
+              subtree {formatCost(node.total_cost_usd)}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {open && node.children.length > 0 && (
+        <div>
+          {node.children.map((child) => (
+            <TreeRow key={child.session_id} node={child} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function DelegationTreeCard({ sessionId }: { sessionId: string }) {
+  const { data, loading, error } = useResource<TreeNode>(
+    sessionId ? `/sessions/${encodeURIComponent(sessionId)}/tree` : null,
+  );
+
+  if (loading) {
+    return (
+      <div className="rounded-[var(--tt-radius-lg)] border border-[var(--tt-border)] bg-[var(--tt-panel)]/40 p-4">
+        <div className="h-4 w-40 rounded bg-[var(--tt-border)]/40 animate-pulse" />
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    // Tree is supplementary; if it can't load, stay quiet rather than erroring.
+    return null;
+  }
+
+  const noChildren = data.child_count === 0 && data.children.length === 0;
+
+  return (
+    <div className="rounded-[var(--tt-radius-lg)] border border-[var(--tt-border)] bg-[var(--tt-panel)]/40 p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="flex items-center gap-2 text-[10px] font-black text-[var(--tt-fg-dim)] uppercase tracking-[0.2em]">
+          <GitBranch size={14} /> Cost Attribution Tree
+        </h3>
+        {!noChildren && (
+          <span className="text-[10px] text-[var(--tt-fg-muted)] tabular-nums">
+            {formatCost(data.cost_usd)} own + {formatCost(data.children_cost_usd)} children
+            {" = "}
+            <span className="text-[var(--tt-warn-fg)] font-semibold">
+              {formatCost(data.total_cost_usd)} total
+            </span>
+          </span>
+        )}
+      </div>
+
+      {noChildren ? (
+        <div className="text-[11px] italic text-[var(--tt-fg-faint)]">
+          No child sessions. This session didn&apos;t spawn any subagents.
+        </div>
+      ) : (
+        <div className="text-[11px]">
+          <TreeRow node={data} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import {
   LayoutDashboard, Folder, BarChart3, Activity, Settings2,
-  PanelLeftOpen, PanelLeftClose, Zap,
+  PanelLeftOpen, PanelLeftClose, Zap, Layers,
 } from "lucide-react";
 import { useResource } from "@/lib/api";
 import { ALL_AGENT_KEYS, getAgent } from "@/lib/agents";
@@ -20,6 +20,7 @@ interface NavigationProps {
 const LINKS = [
   { name: "Dashboard", href: "/",         icon: LayoutDashboard },
   { name: "Projects",  href: "/projects", icon: Folder },
+  { name: "Workflows", href: "/workflows", icon: Layers },
   { name: "Analytics", href: "/analytics", icon: BarChart3 },
   { name: "Local Models", href: "/local-models", icon: Zap },
 ];

--- a/frontend/src/lib/workflows.ts
+++ b/frontend/src/lib/workflows.ts
@@ -1,0 +1,50 @@
+import { api } from "@/lib/api";
+
+/** A named grouping of sessions into a task, with aggregated stats computed
+ *  server-side by joining session_ids against the live session list. */
+export interface Workflow {
+  id: string;
+  name: string;
+  description?: string;
+  color: string;
+  session_ids: string[];
+  session_count: number;
+  total_cost_usd: number;
+  total_tokens: number;
+  agent_types: string[];
+  created_at: number;
+  last_active?: number;
+}
+
+/** Preset colors shown as circles in the create form. */
+export const WORKFLOW_COLORS = [
+  "#6366f1", // indigo
+  "#22c55e", // green
+  "#f97316", // orange
+  "#ec4899", // pink
+  "#06b6d4", // cyan
+  "#eab308", // amber
+];
+
+const jsonInit = (method: string, body: unknown): RequestInit => ({
+  method,
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify(body),
+});
+
+export const getWorkflows = () => api<Workflow[]>("/workflows");
+
+export const createWorkflow = (data: Partial<Workflow>) =>
+  api<Workflow>("/workflows", jsonInit("POST", data));
+
+export const updateWorkflow = (wfId: string, data: Partial<Workflow>) =>
+  api<Workflow>(`/workflows/${wfId}`, jsonInit("PUT", data));
+
+export const addSessionsToWorkflow = (wfId: string, sessionIds: string[]) =>
+  api<Workflow>(`/workflows/${wfId}/sessions`, jsonInit("POST", { session_ids: sessionIds }));
+
+export const removeSessionFromWorkflow = (wfId: string, sessionId: string) =>
+  api<Workflow>(`/workflows/${wfId}/sessions/${sessionId}`, { method: "DELETE" });
+
+export const deleteWorkflow = (wfId: string) =>
+  api<{ ok: boolean }>(`/workflows/${wfId}`, { method: "DELETE" });


### PR DESCRIPTION
## Summary

Four new features addressing the visibility gap for users running multiple agents simultaneously. Motivated by the r/codex thread where Codex Desktop was silently writing ~7 MB/s to its SQLite log (~222 TB/year) and users had no dashboard to see it.

- **Process resource monitor** — live disk IO, CPU, and memory per agent process (Claude Code, Codex, Ollama, local models, Hermes, Grok). Polls every 5s via `GET /api/agent-processes` (psutil). Warning banner fires when any process exceeds 5 MB/s write rate. Added to dashboard under a new "System" section.

- **Concurrency timeline** — O(n log n) sweep-line algorithm finds sessions that overlapped in time and computes combined $/hr burn rate at peak. Durations estimated from `output_tokens / tok_per_sec` since logs only record a single end-timestamp. `GET /sessions/concurrency` returns top-10 windows + summary. CSS/Tailwind timeline card added to dashboard.

- **Attribution cost tree** — `_rollup_delegation_costs()` walks the parent→child delegation graph and annotates every session with `total_cost_usd` (own + all descendants), cycle-guarded and idempotent. `GET /sessions/{id}/tree` returns the nested tree. `DelegationTreeCard` added to session detail with collapsible nodes and amber subtree badges.

- **Workflow grouping** — JSON-file-backed workflow definitions in `~/.tokentelemetry/workflows.json`. Six CRUD endpoints. Sessions stamped with `workflow_ids` from an inverted index built each scan. New `/workflows` page with inline create form, 6-color picker, expandable session lists. Per-session "Add to workflow" popover in the main table. Navigation entry between Projects and Analytics.

## Test plan

- [ ] Start the backend — verify `GET /api/agent-processes` returns running processes (run `ollama` or Claude Code to see a non-empty list)
- [ ] Check the dashboard "System" section shows the process table; write rate turns red above 5 MB/s
- [ ] Verify `GET /sessions/concurrency` returns windows if you have overlapping sessions across agents
- [ ] Open a session with subagents (Claude Code with Agent tool calls) — session detail shows `DelegationTreeCard` with children and subtree cost
- [ ] Create a workflow at `/workflows`, add sessions via the main table popover, confirm totals aggregate correctly
- [ ] Backend tests: `cd backend && python3 -m pytest -q` — 80 pass, 1 pre-existing failure in `test_delegation.py::test_analytics_ecosystem_aggregates`

🤖 Generated with [Claude Code](https://claude.com/claude-code)