### PR TITLE
Track budget feature usage (adoption + configure) via existing telemetry

### DIFF
--- a/backend/telemetry.py
+++ b/backend/telemetry.py
@@ -139,7 +139,12 @@ _ENUMS: Dict[str, set] = {
     "name": {
         "plan-library", "project-insights", "delegation-view", "power-cost",
         "billing-mode", "search", "artifact-viewer", "share-stats",
-        "hermes-dashboard", "other",
+        "hermes-dashboard",
+        # Budgets & alerts: "budgets" = opened the editor (adoption),
+        # "budget-set" = saved a budget (the configuring action). No limit
+        # value/cost ever rides along — only these two enum labels.
+        "budgets", "budget-set",
+        "other",
     },
     "tier": {"full", "rollup", "other"},
 }

--- a/backend/test_telemetry_redaction.py
+++ b/backend/test_telemetry_redaction.py
@@ -79,6 +79,21 @@ def test_build_event_never_contains_sensitive_content():
     assert payload["props"]["route"] == "other"
 
 
+def test_budget_feature_labels_survive_but_values_cannot():
+    # The two budget adoption/conversion labels are allowlisted enum values.
+    for label in ("budgets", "budget-set"):
+        out = telemetry._sanitize_props("feature.used", {"name": label})
+        assert out == {"name": label}
+    # A made-up label collapses to "other" — never the raw string.
+    assert telemetry._sanitize_props("feature.used", {"name": "budget-$150"}) == {"name": "other"}
+    # A budget limit/amount stuffed into props can never leak: "limit_value"
+    # isn't an allowlisted key for feature.used, so it's dropped entirely.
+    out = telemetry._sanitize_props("feature.used", {"name": "budget-set", "limit_value": 150})
+    assert out == {"name": "budget-set"}
+    payload = telemetry.build_event("feature.used", {"name": "budget-set", "limit_value": 150, "currency": "usd"})
+    assert "150" not in _blob(payload)
+
+
 def test_unknown_event_name_is_bucketed():
     payload = telemetry.build_event("evil.exfiltrate", {"x": "/etc/passwd"})
     assert payload["eventName"] == "other"

--- a/frontend/src/components/budgets/BudgetEditor.tsx
+++ b/frontend/src/components/budgets/BudgetEditor.tsx
@@ -5,6 +5,7 @@ import { Wallet, Plus, Trash2, Check, Loader2 } from "lucide-react";
 
 import { cn } from "@/lib/cn";
 import { getAgent } from "@/lib/agents";
+import { trackEvent } from "@/lib/telemetry";
 import { Card, CardHeader, CardTitle, Button } from "@/components/ui";
 import {
   getBudgets, putBudgets,
@@ -60,6 +61,12 @@ export default function BudgetEditor({
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Anonymous adoption signal: someone opened the budget editor. Content-free —
+  // just the "budgets" feature label; the backend re-sanitizes regardless.
+  useEffect(() => {
+    trackEvent("feature.used", { name: "budgets" });
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -139,6 +146,8 @@ export default function BudgetEditor({
       setRows(mineSaved);
       setOtherBudgets(others);
       setSaved(true);
+      // Conversion signal: a budget was actually configured (>=1 saved row).
+      if (mine.length > 0) trackEvent("feature.used", { name: "budget-set" });
       setTimeout(() => setSaved(false), 2500);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));

--- a/frontend/src/components/settings/UsagePrivacySettings.tsx
+++ b/frontend/src/components/settings/UsagePrivacySettings.tsx
@@ -134,7 +134,8 @@ export default function UsagePrivacySettings() {
                   <h3 className="text-[12px] font-medium text-[var(--tt-fg-muted)] mb-2">What we collect</h3>
                   <ul className="text-[12px] text-[var(--tt-fg-dim)] space-y-1 pl-4">
                     <li className="list-disc">Which pages you open</li>
-                    <li className="list-disc">Which features you use (summaries, filters, Hermes, etc.)</li>
+                    <li className="list-disc">Which features you use (summaries, filters, budgets, Hermes, etc.)</li>
+                    <li className="list-disc">When you open or save a budget — the count only, never the limit or amount</li>
                     <li className="list-disc">Whether a summary succeeded or failed, and which engine</li>
                     <li className="list-disc">Your OS, CPU type, and app version</li>
                     <li className="list-disc">Your country (from the network edge — never your IP)</li>

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -67,6 +67,29 @@ curl "https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/analytics_engin
       GROUP BY event ORDER BY n DESC"
 ```
 
+#### Budgets & alerts adoption
+
+The budget feature emits `feature.used` with `blob8` set to one of two labels:
+`budgets` (opened the editor) and `budget-set` (saved a budget). No limit value
+or amount is ever sent — only the label. To see how many people use it and how
+often they configure one, over the last 30 days:
+
+```sql
+SELECT blob8 AS action,
+       count() AS events,
+       count(DISTINCT blob2) AS sessions   -- blob2 = per-launch session id
+FROM tt_telemetry
+WHERE blob1 = 'feature.used'
+  AND blob8 IN ('budgets', 'budget-set')
+  AND timestamp > now() - INTERVAL '30' DAY
+GROUP BY action
+```
+
+`sessions` for `budgets` is the adoption number (how many launches opened the
+editor); `events` for `budget-set` is the configure count (the "clicks").
+sessionId resets every launch and isn't linkable, so this is a usage floor, not
+a unique-user count.
+
 ### 2. Grafana (the "holistic picture")
 Install the official **Cloudflare Analytics Engine** Grafana data-source plugin,
 point it at the SQL API with the same token, and build panels (DAU, top routes,


### PR DESCRIPTION
## Summary

- Adds two anonymous `feature.used` labels to the existing telemetry pipeline: **`budgets`** (fired when the budget editor opens → adoption) and **`budget-set`** (fired on a successful save → the configure action).
- Reuses the established path end-to-end — frontend `trackEvent` → `/telemetry/event` → backend `telemetry.emit()` → Cloudflare Analytics Engine (`tt_telemetry`). The Worker already allows `feature.used` and writes `props.name` to `blob8` verbatim, so **no Worker redeploy** is required; the values appear on the next dashboard launch.
- Privacy-preserving by construction: only the two enum labels are sent — never a budget limit, amount, or currency. Inherits the existing opt-out toggle, `DO_NOT_TRACK`/`TT_NO_TELEMETRY`, and CI suppression.
- Settings → "Anonymous usage stats" disclosure now names budgets explicitly ("…filters, budgets, Hermes…" + "the count only, never the limit or amount").
- `proxy/README.md` gains a SQL snippet for reading adoption (distinct sessions) and configure counts from Analytics Engine.

## Test plan

- [x] `pytest backend/test_telemetry_redaction.py` — 12 passed (new test asserts the budget labels survive, off-enum → `other`, and a stuffed `limit_value` can't leak).
- [x] `tsc --noEmit` in `frontend/` — clean.
- [x] End-to-end `build_event` check: `budgets`/`budget-set` pass through, `budget-bogus` → `other`, `150` never present in payload.
- [ ] After deploy, open a project's Config tab and save a budget; confirm `blob8 IN ('budgets','budget-set')` rows appear in the `tt_telemetry` dataset.
- [ ] With telemetry toggled off (or `DO_NOT_TRACK=1`), confirm no budget events are emitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)