### PR TITLE
docs: index /docs in llms.txt + sitemap, fix stale telemetry copy

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -18,7 +18,7 @@ It reads session logs and SQLite state directly from the filesystem (no SDK, no 
 - **Category:** AI observability, LLM monitoring, autonomous agent observability, developer tools
 - **Tech stack:** Node.js (frontend: Next.js 16), Python (backend: FastAPI)
 - **Platforms:** macOS, Linux, Windows
-- **Privacy:** 100% local — no telemetry, no cloud, no account
+- **Privacy:** Local-first — your logs, prompts, tokens, and costs never leave your machine; no cloud, no account. Sends anonymous, content-free usage stats (which features are used) on by default, opt out in Settings or with DO_NOT_TRACK=1.
 
 ## Supported Agents
 
@@ -135,7 +135,7 @@ A: Hermes can route the same model through different inference providers (direct
 A: Yes — TokenTelemetry is free, open-source (MIT), and runs 100% locally. No account, no signup, no cloud.
 
 **Q: Does TokenTelemetry send my data to the cloud?**
-A: No. Everything runs on your machine. The dashboard reads session log files from your local filesystem and serves a UI on localhost. Nothing leaves your computer.
+A: Your logs, sessions, prompts, tokens, and costs never leave your computer — the dashboard reads local files and serves a UI on localhost. The app does send anonymous, content-free usage stats (which pages and features you use — never your code, prompts, paths, or costs) to help prioritize improvements; it's on by default and can be turned off in Settings → Usage & privacy or with DO_NOT_TRACK=1.
 
 **Q: How does TokenTelemetry compare to Langfuse or Helicone?**
 A: TokenTelemetry is purpose-built for AI coding agents and autonomous agents, and is zero-config — no SDK instrumentation. Langfuse and Helicone are general LLM-app observability platforms that require code changes and (typically) a cloud account. Neither supports Hermes Agent specifically.
@@ -143,9 +143,47 @@ A: TokenTelemetry is purpose-built for AI coding agents and autonomous agents, a
 **Q: What is the best open source LLM observability tool for coding agents?**
 A: TokenTelemetry is purpose-built for AI coding agents (Claude Code, Codex, Gemini CLI, Cursor) and autonomous agents (Hermes). For general LLM-app monitoring, alternatives include Langfuse and LangSmith (both require cloud setup and SDK instrumentation).
 
-## Docs
+## Documentation
 
-- Full documentation: https://tokentelemetry.com
+Full docs site: https://tokentelemetry.com/docs
+
+### Getting started
+
+- [Introduction](https://tokentelemetry.com/docs): What TokenTelemetry is and who it's for.
+- [Installation](https://tokentelemetry.com/docs/installation): One-line curl install, Windows PowerShell script, or clone from source.
+- [Quick Start](https://tokentelemetry.com/docs/quick-start): First launch, agent auto-detection, and opening the dashboard.
+- [Supported Agents](https://tokentelemetry.com/docs/supported-agents): The 10 coding agents and Hermes, how each is detected, and what data each captures.
+
+### Features
+
+- [Dashboard](https://tokentelemetry.com/docs/features/dashboard): Bird's-eye view of your agent fleet — live KPIs, agent distribution, model leaderboard, recent activity.
+- [Analytics](https://tokentelemetry.com/docs/features/analytics): Token trends by agent, model, and day with date-range filters, cache efficiency, and delegation graphs.
+- [Projects](https://tokentelemetry.com/docs/features/projects): Per-working-directory cards with activity heatmaps, tool usage, config overlays, a plans library, and git-worktree rollups.
+- [Budgets & Alerts](https://tokentelemetry.com/docs/features/budgets): Spend or token limits per project (and per agent), with 80% / 100% alerts — observational, never blocks an agent.
+- [Traces](https://tokentelemetry.com/docs/features/traces): Replay every session step by step — events, messages, tool calls, artifacts, and plans.
+- [Summarization](https://tokentelemetry.com/docs/features/summarization): One-click LLM summaries of any session, cached by content hash, with classified error cards.
+- [Artifacts](https://tokentelemetry.com/docs/features/artifacts): Screenshots, browser recordings, and documents captured by your agents, viewable inline.
+- [Hermes Agent](https://tokentelemetry.com/docs/features/hermes): Dedicated autonomous-agent observability — gateway health, 38 source platforms, skills, and memory.
+
+### Configuration
+
+- [Billing & Cost Modes](https://tokentelemetry.com/docs/configuration/billing): How sessions are classified as subscription, API, local, or unknown — and how to override per agent.
+- [Configure the Summarizer](https://tokentelemetry.com/docs/configuration/configure-summarizer): Pick a summarization backend (Claude, Codex, Gemini, Qwen, Ollama, Antigravity, or OpenAI-compatible).
+- [Custom Data Directory](https://tokentelemetry.com/docs/configuration/data-directory): Relocate config and state via --data-dir, TOKENTELEMETRY_DATA_DIR, or TOKENTELEMETRY_HOME.
+- [Local Models & Power Cost](https://tokentelemetry.com/docs/configuration/local-models): Wattage, electricity rate, and carbon intensity to estimate energy cost and CO₂ for local sessions.
+- [Ports & Networking](https://tokentelemetry.com/docs/configuration/ports-networking): Change frontend/backend ports and understand NEXT_PUBLIC_API_PORT.
+- [Update Check & Privacy](https://tokentelemetry.com/docs/configuration/privacy): Control the optional update check and anonymous product telemetry — what's sent and how to disable each.
+- [Remote Access](https://tokentelemetry.com/docs/configuration/remote-access): Expose the dashboard to other devices (tailnet, LAN, SSH tunnel) with token auth.
+- [History & Retention](https://tokentelemetry.com/docs/configuration/retention): How long session data is kept, durable history, and transcript archival.
+
+### Reference
+
+- [CLI & Environment Reference](https://tokentelemetry.com/docs/reference/cli): Every CLI flag and environment variable TokenTelemetry recognizes.
+- [FAQ](https://tokentelemetry.com/docs/reference/faq): Frequently asked questions.
+- [Troubleshooting](https://tokentelemetry.com/docs/reference/troubleshooting): Agent not detected, ports in use, summarizer failures, remote access.
+
+### Other links
+
 - GitHub README: https://github.com/VasiHemanth/tokentelemetry#readme
 - Hermes Dashboard plugin: https://github.com/VasiHemanth/tokentelemetry/tree/main/plugin/hermes-dashboard
 - Hermes Agent (upstream): https://github.com/NousResearch/hermes-agent

--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -1,19 +1,19 @@
 ---
 title: Introduction
-description: TokenTelemetry is a free, local-first observability dashboard for AI coding agents — no signup, no cloud, no telemetry.
+description: TokenTelemetry is a free, local-first observability dashboard for AI coding agents — no signup, no cloud, your logs stay on your machine.
 ---
 
 ## What is TokenTelemetry?
 
 **TokenTelemetry** is a free, open-source, 100% local dashboard that reads the log files your AI coding agents already write and surfaces them in one unified place. It tracks token usage, LLM costs, tool calls, session traces, and reasoning steps across Claude Code, Codex, Gemini CLI, Cursor, Copilot, Qwen, OpenCode, Vibe, Antigravity, Grok Build, and Hermes Agent.
 
-**No signup. No cloud. No data leaves your machine.** One command to start.
+**No signup. No cloud. Your logs, prompts, and costs never leave your machine.** One command to start.
 
 ![Dashboard](/screenshots/dashboard.png)
 
 ## The local-first promise
 
-All data stays in `~/.tokentelemetry/` on your machine. TokenTelemetry reads the log files agents already write — it never modifies them. The only outbound call is an optional hourly update-check to GitHub (no usage data, just a version request). You can disable that too.
+All your agent data stays in `~/.tokentelemetry/` on your machine — TokenTelemetry reads the log files agents already write and never modifies them. Two narrow outbound features exist, both content-free and both optional: an hourly update-check to GitHub (just a version request) and anonymous product telemetry (which features are used — never your code, prompts, paths, or costs). Both are on by default and can be turned off independently in Settings → *Updates & privacy*, or with `DO_NOT_TRACK=1`. See [Update Check & Privacy](/docs/configuration/privacy).
 
 ## Who it's for
 

--- a/website/content/docs/reference/faq.mdx
+++ b/website/content/docs/reference/faq.mdx
@@ -7,7 +7,7 @@ description: Frequently asked questions about TokenTelemetry.
 
 **Does TokenTelemetry send any data to the cloud?**
 
-No usage data, ever. It reads log files from your filesystem and serves a local web dashboard — your logs, sessions, tokens, and costs never leave your machine. The only outbound call is an optional update check that fetches the latest version and release notes from GitHub (no usage data sent). Disable it in Settings → *Updates & privacy* or with `TT_NO_UPDATE_CHECK=1`. See [Update Check & Privacy](/docs/configuration/privacy).
+Your logs, sessions, tokens, and costs never leave your machine — TokenTelemetry reads log files from your filesystem and serves a local web dashboard. Two narrow, content-free outbound features exist, both optional and both on by default: an update check that fetches the latest version and release notes from GitHub (no usage data), and anonymous product telemetry that reports which features are used (never your code, prompts, paths, or costs). Turn either off in Settings → *Updates & privacy* — or with `TT_NO_UPDATE_CHECK=1` / `TT_NO_TELEMETRY=1` (`DO_NOT_TRACK=1` also disables telemetry). See [Update Check & Privacy](/docs/configuration/privacy).
 
 **How does it track Claude Code token usage?**
 

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -143,9 +143,47 @@ A: TokenTelemetry is purpose-built for AI coding agents and autonomous agents, a
 **Q: What is the best open source LLM observability tool for coding agents?**
 A: TokenTelemetry is purpose-built for AI coding agents (Claude Code, Codex, Gemini CLI, Cursor) and autonomous agents (Hermes). For general LLM-app monitoring, alternatives include Langfuse and LangSmith (both require cloud setup and SDK instrumentation).
 
-## Docs
+## Documentation
 
-- Full documentation: https://tokentelemetry.com
+Full docs site: https://tokentelemetry.com/docs
+
+### Getting started
+
+- [Introduction](https://tokentelemetry.com/docs): What TokenTelemetry is and who it's for.
+- [Installation](https://tokentelemetry.com/docs/installation): One-line curl install, Windows PowerShell script, or clone from source.
+- [Quick Start](https://tokentelemetry.com/docs/quick-start): First launch, agent auto-detection, and opening the dashboard.
+- [Supported Agents](https://tokentelemetry.com/docs/supported-agents): The 10 coding agents and Hermes, how each is detected, and what data each captures.
+
+### Features
+
+- [Dashboard](https://tokentelemetry.com/docs/features/dashboard): Bird's-eye view of your agent fleet — live KPIs, agent distribution, model leaderboard, recent activity.
+- [Analytics](https://tokentelemetry.com/docs/features/analytics): Token trends by agent, model, and day with date-range filters, cache efficiency, and delegation graphs.
+- [Projects](https://tokentelemetry.com/docs/features/projects): Per-working-directory cards with activity heatmaps, tool usage, config overlays, a plans library, and git-worktree rollups.
+- [Budgets & Alerts](https://tokentelemetry.com/docs/features/budgets): Spend or token limits per project (and per agent), with 80% / 100% alerts — observational, never blocks an agent.
+- [Traces](https://tokentelemetry.com/docs/features/traces): Replay every session step by step — events, messages, tool calls, artifacts, and plans.
+- [Summarization](https://tokentelemetry.com/docs/features/summarization): One-click LLM summaries of any session, cached by content hash, with classified error cards.
+- [Artifacts](https://tokentelemetry.com/docs/features/artifacts): Screenshots, browser recordings, and documents captured by your agents, viewable inline.
+- [Hermes Agent](https://tokentelemetry.com/docs/features/hermes): Dedicated autonomous-agent observability — gateway health, 38 source platforms, skills, and memory.
+
+### Configuration
+
+- [Billing & Cost Modes](https://tokentelemetry.com/docs/configuration/billing): How sessions are classified as subscription, API, local, or unknown — and how to override per agent.
+- [Configure the Summarizer](https://tokentelemetry.com/docs/configuration/configure-summarizer): Pick a summarization backend (Claude, Codex, Gemini, Qwen, Ollama, Antigravity, or OpenAI-compatible).
+- [Custom Data Directory](https://tokentelemetry.com/docs/configuration/data-directory): Relocate config and state via --data-dir, TOKENTELEMETRY_DATA_DIR, or TOKENTELEMETRY_HOME.
+- [Local Models & Power Cost](https://tokentelemetry.com/docs/configuration/local-models): Wattage, electricity rate, and carbon intensity to estimate energy cost and CO₂ for local sessions.
+- [Ports & Networking](https://tokentelemetry.com/docs/configuration/ports-networking): Change frontend/backend ports and understand NEXT_PUBLIC_API_PORT.
+- [Update Check & Privacy](https://tokentelemetry.com/docs/configuration/privacy): Control the optional update check and anonymous product telemetry — what's sent and how to disable each.
+- [Remote Access](https://tokentelemetry.com/docs/configuration/remote-access): Expose the dashboard to other devices (tailnet, LAN, SSH tunnel) with token auth.
+- [History & Retention](https://tokentelemetry.com/docs/configuration/retention): How long session data is kept, durable history, and transcript archival.
+
+### Reference
+
+- [CLI & Environment Reference](https://tokentelemetry.com/docs/reference/cli): Every CLI flag and environment variable TokenTelemetry recognizes.
+- [FAQ](https://tokentelemetry.com/docs/reference/faq): Frequently asked questions.
+- [Troubleshooting](https://tokentelemetry.com/docs/reference/troubleshooting): Agent not detected, ports in use, summarizer failures, remote access.
+
+### Other links
+
 - GitHub README: https://github.com/VasiHemanth/tokentelemetry#readme
 - Hermes Dashboard plugin: https://github.com/VasiHemanth/tokentelemetry/tree/main/plugin/hermes-dashboard
 - Hermes Agent (upstream): https://github.com/NousResearch/hermes-agent

--- a/website/src/app/sitemap.ts
+++ b/website/src/app/sitemap.ts
@@ -1,14 +1,27 @@
 import type { MetadataRoute } from "next";
+import { source } from "@/lib/source";
 
 export const dynamic = "force-static";
 
+const BASE = "https://tokentelemetry.com";
+
 export default function sitemap(): MetadataRoute.Sitemap {
-  return [
-    {
-      url: "https://tokentelemetry.com",
-      lastModified: new Date(),
-      changeFrequency: "weekly",
-      priority: 1,
-    },
+  const now = new Date();
+
+  const staticRoutes: MetadataRoute.Sitemap = [
+    { url: BASE, lastModified: now, changeFrequency: "weekly", priority: 1 },
+    { url: `${BASE}/resources`, lastModified: now, changeFrequency: "weekly", priority: 0.7 },
+    { url: `${BASE}/privacy`, lastModified: now, changeFrequency: "monthly", priority: 0.3 },
   ];
+
+  // Every docs page, derived from the Fumadocs source so the sitemap stays in
+  // sync as docs are added/removed (no hardcoded list to forget to update).
+  const docRoutes: MetadataRoute.Sitemap = source.getPages().map((page) => ({
+    url: `${BASE}${page.url}`,
+    lastModified: now,
+    changeFrequency: "weekly",
+    priority: page.url === "/docs" ? 0.9 : 0.6,
+  }));
+
+  return [...staticRoutes, ...docRoutes];
 }


### PR DESCRIPTION
## What

The docs site now has a full `/docs` tree (getting-started, 8 feature pages, 8 configuration pages, 3 reference pages), but the discovery surfaces still pointed only at the bare homepage. This syncs them and fixes stale privacy copy two docs pages missed.

### `llms.txt` (root + `website/public/`)
- Replaced the generic "Full documentation: tokentelemetry.com" link with a complete, per-page docs index (Getting started / Features / Configuration / Reference), each entry a `[Title](url): description` so an LLM can fetch the right page.
- Reconciled the **root** copy's two stale "100% local — no telemetry" privacy lines to match the already-corrected public copy — product telemetry now ships on-by-default, one-click off. The two files are byte-identical again.

### `sitemap.ts`
- Now derives every `/docs/*` URL from the Fumadocs source instead of listing only the homepage. Build emits **26 URLs** (3 static + 23 docs), verified in `out/sitemap.xml`. Stays in sync automatically as docs are added.

### `docs/index.mdx` + `docs/reference/faq.mdx`
- Dropped the absolute "no telemetry / the only outbound call is the update check" claims (false since telemetry shipped — flagged as a release gate in `docs/design/product-telemetry.md`). Replaced with the precise framing already used in `configuration/privacy.mdx`: two optional, content-free outbound features (update check + anonymous usage stats), both on by default, both switchable off in Settings → *Updates & privacy* or via env (`DO_NOT_TRACK=1` / `TT_NO_TELEMETRY=1` / `TT_NO_UPDATE_CHECK=1`).

## Verification
- `npm run build` in `website/` passes; `out/sitemap.xml` contains all 23 doc pages + 3 static routes.
- Every doc URL in `llms.txt` cross-checked against the built page tree.
- Both `llms.txt` files confirmed byte-identical.

## Notes / left for a follow-up
- **README + homepage were already reconciled** when telemetry shipped (README "Privacy & outbound calls" section + FAQ, homepage `faq-items.ts`, `Privacy.tsx`, `Hero.tsx` all disclose on-by-default telemetry with the off switch). The `100% local` taglines were kept — they describe your *data* staying local, which is still true; they aren't denials of telemetry.
- **`CHANGELOG.md` 1.0.0 line** ("100% local — no signup, no cloud, no telemetry") left as-is: it's a historical release note, and rewriting a past release's description misrepresents history.
- **Settings label mismatch (not touched here):** the shipped UI renders the section as **"Updates & privacy"** with an **"Anonymous usage stats"** card, but README / homepage / `Privacy.tsx` / the design doc call it **"Usage & privacy"** — a name that appears nowhere in the rendered UI. Worth picking one canonical label; flagged for a decision rather than mass-rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)