### PR TITLE
feat(agents): add Cline and SmallCode session scanning

### DIFF
--- a/backend/agent_retention.py
+++ b/backend/agent_retention.py
@@ -112,6 +112,20 @@ _RETENTION: Dict[str, Dict[str, Any]] = {
         "settings_hint": None,
         "note": "Retention behaviour not documented — treated as kept until cleared.",
     },
+    "cline": {
+        "label": "Cline",
+        "default_days": None,
+        "configurable": False,
+        "settings_hint": None,
+        "note": "CLI sessions in ~/.cline SQLite + VS Code tasks in globalStorage; no auto-pruning.",
+    },
+    "smallcode": {
+        "label": "SmallCode",
+        "default_days": None,
+        "configurable": False,
+        "settings_hint": None,
+        "note": "Project-local .smallcode/traces JSON; no auto-pruning.",
+    },
 }
 
 # Which agents we can actually archive (single-file resolvable transcript).

--- a/backend/billing_mode.py
+++ b/backend/billing_mode.py
@@ -52,6 +52,8 @@ DEFAULT_MODES: Dict[str, str] = {
     "hermes": "api",               # autonomous; runs on provider keys
     "opencode": "api",             # bring-your-own-key
     "vibe": "unknown",
+    "cline": "api",                # BYOK across providers (Anthropic/OpenAI/Ollama/etc.)
+    "smallcode": "local",          # runs local models (e.g. ollama-served nemotron)
 }
 
 # Human-readable note on where a detected value came from (shown in Settings so

--- a/backend/billing_route.py
+++ b/backend/billing_route.py
@@ -297,6 +297,8 @@ _AGENT_BUILDERS = {
     "grok": _api_only_buckets,
     "hermes": _api_only_buckets,
     "opencode": _api_only_buckets,
+    "cline": _api_only_buckets,    # BYOK across providers, same drain shape as grok/opencode
+    "smallcode": _local_buckets,   # local models only — electricity, not an API charge
 }
 
 # Fallback builders keyed by coarse billing-mode for agents without a bespoke

--- a/backend/main.py
+++ b/backend/main.py
@@ -8,7 +8,7 @@ import json
 import yaml
 import sqlite3
 from pathlib import Path
-from typing import List, Optional, Dict, Any, Set
+from typing import List, Optional, Dict, Any, Set, Iterable
 from pydantic import BaseModel
 from datetime import datetime, timezone, timedelta, time as _dtime
 from urllib.parse import unquote, quote
@@ -303,6 +303,37 @@ ANTIGRAVITY_BRAIN_DIRS = [d for d, _ in ANTIGRAVITY_BRAIN_SOURCES]
 # display name and the exact project cwd — see _antigravity_cli_meta().
 ANTIGRAVITY_CLI_DIR = GEMINI_DIR / "antigravity-cli"
 PROJECT_ALIASES_FILE = data_dir() / "aliases.json"
+
+# Cline — two stores. (a) CLI: SQLite sessions.db under ~/.cline/data/db/,
+# overridable via TT_CLINE_DIR for relocated data dirs (containers, shared
+# hosts). (b) VS Code extension: JSON state under globalStorage, overridable
+# via TT_CLINE_VSCODE_DIR.
+CLINE_DIR = Path(os.environ.get("TT_CLINE_DIR") or (HOME / ".cline")).expanduser()
+CLINE_VSCODE_DIR = Path(
+    os.environ.get("TT_CLINE_VSCODE_DIR")
+    or (VSCODE_BASE / "User" / "globalStorage" / "saoudrizwan.claude-dev")
+).expanduser()
+
+
+def _split_roots_env(value: Optional[str]) -> List[str]:
+    """Split a roots env var on BOTH os.pathsep and comma so it works whether
+    the user quotes a single path list or a comma-separated one."""
+    if not value:
+        return []
+    parts: List[str] = []
+    for chunk in value.split(os.pathsep):
+        for p in chunk.split(","):
+            p = p.strip()
+            if p:
+                parts.append(p)
+    return parts
+
+
+# SmallCode traces are PROJECT-LOCAL (<project>/.smallcode/traces/*.json), not
+# under a home dir, so there's no single directory to scan. We discover roots
+# from projects already seen from other agents, plus any extra roots the user
+# points us at via TT_SMALLCODE_ROOTS (pathsep- or comma-separated).
+SMALLCODE_EXTRA_ROOTS: List[str] = _split_roots_env(os.environ.get("TT_SMALLCODE_ROOTS"))
 
 
 def _sqlite_ro_uri(db_path) -> str:
@@ -1736,6 +1767,13 @@ def _list_available_agents() -> list:
     if OPENCODE_DB.exists(): agents.append("opencode")
     if _hermes_dbs(): agents.append("hermes")
     if GROK_SESSIONS_DIR.exists(): agents.append("grok")
+    if (CLINE_DIR / "data" / "db" / "sessions.db").exists() or (CLINE_VSCODE_DIR / "state" / "taskHistory.json").exists():
+        agents.append("cline")
+    # SmallCode traces are project-local; cheaply check only the explicitly
+    # configured extra roots here (the full project-derived root set is only
+    # known after _scan_sessions_sync runs the other scanners).
+    if any((Path(r).expanduser() / ".smallcode" / "traces").is_dir() for r in SMALLCODE_EXTRA_ROOTS):
+        agents.append("smallcode")
     # if OLLAMA_DIR.exists(): agents.append("ollama")
     return agents
 
@@ -2022,6 +2060,321 @@ def _grok_subagent_meta(sess_dir: Path) -> List[Dict[str, Any]]:
     return entries
 
 
+def _scan_smallcode_sessions(roots: Iterable[str]) -> List[Dict[str, Any]]:
+    """Scan SmallCode traces, which are PROJECT-LOCAL (not under a home dir).
+
+    Verified shape (see testdata/cline_smallcode/smallcode/8fadca50.json):
+    ``<project>/.smallcode/traces/<id>.json`` with
+    ``{id, model, prompt, startedAt, endedAt, durationMs, steps, tokens:{prompt,completion}}``.
+    """
+    out: List[Dict[str, Any]] = []
+    seen_ids: Set[str] = set()
+
+    for root in roots:
+        if not root or root == "unknown":
+            continue
+        root_path = Path(root).expanduser()
+        traces_dir = root_path / ".smallcode" / "traces"
+        if not traces_dir.is_dir():
+            continue
+
+        for trace_path in sorted(traces_dir.glob("*.json")):
+            try:
+                with open(trace_path, "r", encoding="utf-8") as f:
+                    trace = json.load(f)
+            except Exception:
+                continue
+            if not isinstance(trace, dict):
+                continue
+
+            sid = trace.get("id") or trace_path.stem
+            if not sid or sid in seen_ids:
+                continue
+            seen_ids.add(sid)
+
+            model = trace.get("model") or "unknown"
+            started_at = trace.get("startedAt")
+            try:
+                ts = datetime.fromisoformat(str(started_at).replace("Z", "+00:00"))
+            except Exception:
+                ts = _file_mtime_utc(trace_path)
+
+            raw_tokens = trace.get("tokens") or {}
+            input_tokens = int(raw_tokens.get("prompt") or 0)
+            output_tokens = int(raw_tokens.get("completion") or 0)
+            tokens = {
+                "input": input_tokens, "output": output_tokens, "cached": 0,
+                "total": input_tokens + output_tokens, "cost": 0.0,
+            }
+            tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"])
+
+            prompt = trace.get("prompt") or ""
+            mcp_tools: List[str] = []
+            for step in trace.get("steps") or []:
+                if not isinstance(step, dict):
+                    continue
+                if step.get("type") == "tool_call":
+                    name = step.get("name")
+                    if name and name not in mcp_tools:
+                        mcp_tools.append(name)
+
+            out.append({
+                "id": sid,
+                "agent": "smallcode",
+                "project": str(root_path),
+                "timestamp": ts,
+                "display": prompt[:120],
+                "tokens": tokens,
+                "model": model,
+                "mcp_tools": mcp_tools,
+                "has_plan": False,
+                "plans": [],
+                "artifacts": [{"name": trace_path.name, "path": str(trace_path), "type": "document"}],
+                "cost": tokens["cost"],
+            })
+
+    return out
+
+
+def _scan_cline_sessions() -> List[Dict[str, Any]]:
+    """Scan Cline sessions from BOTH stores it writes to, deduping by session id
+    (the CLI row wins when a session id appears in both).
+
+    (a) CLI: SQLite ``sessions.db`` under ``CLINE_DIR/data/db/`` — verified schema
+    has a ``sessions`` table with session_id/started_at/.../metadata_json/messages_path.
+    Token usage lives in ``metadata_json``, preferring ``aggregateUsage`` over
+    ``usage``; if both are all-zero we fall back to summing each message's
+    ``metrics`` in the ``messages_path`` JSON transcript.
+
+    (b) VS Code extension: ``CLINE_VSCODE_DIR/state/taskHistory.json`` — an array
+    of HistoryItems (id, ts epoch-ms, task, tokensIn/Out, cacheWrites/Reads,
+    totalCost, size). This store is undocumented beyond that shape (the
+    extension isn't installed on the machine this was written on), so the
+    parser sticks to exactly those fields.
+    """
+    aliases = _load_project_aliases()
+    def _apply_alias(p: str) -> str:
+        return aliases.get(p, p)
+
+    out: List[Dict[str, Any]] = []
+    seen_ids: Set[str] = set()
+
+    # (a) CLI SQLite store
+    db_path = CLINE_DIR / "data" / "db" / "sessions.db"
+    if db_path.exists():
+        rows = []
+        try:
+            uri = _sqlite_ro_uri(db_path)
+            conn = sqlite3.connect(uri, uri=True, timeout=1.0)
+            conn.row_factory = sqlite3.Row
+            try:
+                # SELECT * (not a fixed column list) so older Cline DBs that
+                # predate is_subagent/parent_session_id still scan — missing
+                # columns are read defensively below rather than erroring the
+                # whole query to an empty result.
+                rows = conn.execute("SELECT * FROM sessions").fetchall()
+            finally:
+                conn.close()
+        except Exception:
+            rows = []
+
+        # Cline spawns subagents/teams: each subagent is its OWN row with
+        # is_subagent=1 and parent_session_id set, while the parent's
+        # metadata.aggregateUsage already SUMS the children in. Counting both
+        # the parent's aggregate AND each child row would double-count, so
+        # parents are billed on their own `usage` and linked via
+        # parent_session_id for the delegation view; children stay as their own
+        # rows. Leaf/standalone sessions have usage == aggregateUsage.
+        def _row_get(r, k, default=None):
+            return r[k] if k in r.keys() else default
+        parents_with_children = {
+            _row_get(r, "parent_session_id")
+            for r in rows
+            if _row_get(r, "is_subagent") and _row_get(r, "parent_session_id")
+        }
+
+        for row in rows:
+            sid = row["session_id"]
+            if not sid or sid in seen_ids:
+                continue
+
+            model = row["model"] or "unknown"
+            project_path = _apply_alias(row["workspace_root"] or row["cwd"] or "unknown")
+
+            try:
+                ts = datetime.fromisoformat(str(row["started_at"]).replace("Z", "+00:00"))
+            except Exception:
+                ts = _file_mtime_utc(db_path)
+
+            try:
+                metadata = json.loads(row["metadata_json"] or "{}") or {}
+            except Exception:
+                metadata = {}
+            if not isinstance(metadata, dict):
+                metadata = {}
+
+            # Parents (sessions that spawned subagents) bill on their OWN usage
+            # so the separately-counted child rows aren't double-counted; leaf
+            # and standalone sessions use aggregateUsage (== usage with no
+            # children).
+            is_parent = sid in parents_with_children
+            if is_parent:
+                usage = metadata.get("usage") or metadata.get("aggregateUsage") or {}
+            else:
+                usage = metadata.get("aggregateUsage") or {}
+            if not isinstance(usage, dict) or not any(
+                usage.get(k) for k in ("inputTokens", "outputTokens", "cacheReadTokens")
+            ):
+                fallback_usage = metadata.get("usage")
+                if isinstance(fallback_usage, dict):
+                    usage = fallback_usage
+
+            tokens = {
+                "input": int((usage or {}).get("inputTokens") or 0),
+                "output": int((usage or {}).get("outputTokens") or 0),
+                "cached": int((usage or {}).get("cacheReadTokens") or 0),
+                "total": 0, "cost": 0.0,
+            }
+
+            # Metadata usage is all zero (older/degenerate rows) — fall back to
+            # summing per-message metrics in the messages_path transcript.
+            messages_path = row["messages_path"]
+            if tokens["input"] == 0 and tokens["output"] == 0 and tokens["cached"] == 0 and messages_path:
+                mp = Path(messages_path)
+                if mp.exists():
+                    try:
+                        with open(mp, "r", encoding="utf-8", errors="replace") as f:
+                            mdata = json.load(f)
+                        for m in (mdata.get("messages") or []):
+                            if not isinstance(m, dict):
+                                continue
+                            metrics = m.get("metrics") or {}
+                            if not isinstance(metrics, dict):
+                                continue
+                            tokens["input"] += int(metrics.get("inputTokens") or 0)
+                            tokens["output"] += int(metrics.get("outputTokens") or 0)
+                            tokens["cached"] += int(metrics.get("cacheReadTokens") or 0)
+                    except Exception:
+                        pass
+
+            tokens["total"] = tokens["input"] + tokens["output"]
+
+            # metadata.totalCost is the AGGREGATE (parent + children); for a
+            # parent we switched to own-usage above, so derive own cost to match
+            # rather than inheriting the children's cost.
+            meta_cost = metadata.get("totalCost")
+            if not is_parent and isinstance(meta_cost, (int, float)) and meta_cost > 0:
+                tokens["cost"] = float(meta_cost)
+            else:
+                tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"])
+
+            display = (row["prompt"] or metadata.get("title") or "")[:120]
+
+            artifacts: List[Dict[str, Any]] = [{"name": "sessions.db", "path": str(db_path), "type": "document"}]
+            if messages_path:
+                artifacts.append({"name": "messages", "path": str(messages_path), "type": "document"})
+
+            is_subagent = bool(_row_get(row, "is_subagent"))
+            parent_sid = _row_get(row, "parent_session_id")
+            rec = {
+                "id": sid,
+                "agent": "cline",
+                "project": project_path,
+                "timestamp": ts,
+                "display": display,
+                "tokens": tokens,
+                "model": model,
+                "mcp_tools": [],
+                "has_plan": False,
+                "plans": [],
+                "artifacts": artifacts,
+                "cost": tokens["cost"],
+                "cline": {
+                    "source": "cli",
+                    "provider": row["provider"],
+                    "status": row["status"],
+                    "messages_path": messages_path,
+                    "is_subagent": is_subagent,
+                    "agent_id": _row_get(row, "agent_id"),
+                    "team_name": _row_get(row, "team_name"),
+                    "spawned_children": sid in parents_with_children,
+                },
+            }
+            # Link child -> parent so the delegation view attributes a spawned
+            # subagent's (own-counted) tokens to the session that spawned it,
+            # mirroring the Grok/Codex sibling-session model.
+            if is_subagent and parent_sid:
+                rec["parent_session_id"] = parent_sid
+                rec["is_subagent"] = True
+            out.append(rec)
+            seen_ids.add(sid)
+
+    # (b) VS Code extension store
+    history_path = CLINE_VSCODE_DIR / "state" / "taskHistory.json"
+    if history_path.exists():
+        try:
+            with open(history_path, "r", encoding="utf-8", errors="replace") as f:
+                history = json.load(f)
+        except Exception:
+            history = []
+
+        if isinstance(history, list):
+            for item in history:
+                if not isinstance(item, dict):
+                    continue
+                sid = str(item.get("id") or "")
+                if not sid or sid in seen_ids:
+                    continue
+
+                ts_ms = item.get("ts")
+                try:
+                    ts = datetime.fromtimestamp(int(ts_ms) / 1000, tz=timezone.utc)
+                except Exception:
+                    ts = _file_mtime_utc(history_path)
+
+                tokens_in = int(item.get("tokensIn") or 0)
+                tokens_out = int(item.get("tokensOut") or 0)
+                cache_reads = int(item.get("cacheReads") or 0)
+                model = item.get("model") or "unknown"
+                tokens = {
+                    "input": tokens_in, "output": tokens_out, "cached": cache_reads,
+                    "total": tokens_in + tokens_out, "cost": 0.0,
+                }
+                total_cost = item.get("totalCost")
+                if isinstance(total_cost, (int, float)) and total_cost > 0:
+                    tokens["cost"] = float(total_cost)
+                else:
+                    tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"])
+
+                transcript_path = CLINE_VSCODE_DIR / "tasks" / sid / "api_conversation_history.json"
+                artifacts: List[Dict[str, Any]] = []
+                if transcript_path.exists():
+                    artifacts.append({"name": "api_conversation_history.json", "path": str(transcript_path), "type": "document"})
+
+                out.append({
+                    "id": sid,
+                    "agent": "cline",
+                    "project": _apply_alias(item.get("cwd") or item.get("workspace") or "unknown"),
+                    "timestamp": ts,
+                    "display": (item.get("task") or "")[:120],
+                    "tokens": tokens,
+                    "model": model,
+                    "mcp_tools": [],
+                    "has_plan": False,
+                    "plans": [],
+                    "artifacts": artifacts,
+                    "cost": tokens["cost"],
+                    "cline": {
+                        "source": "vscode",
+                        "cache_writes": item.get("cacheWrites"),
+                        "transcript_path": str(transcript_path) if transcript_path.exists() else None,
+                    },
+                })
+                seen_ids.add(sid)
+
+    return out
+
+
 def _reconstruct_vscode_chat_jsonl(path) -> Dict[str, Any]:
     """Reconstruct a Copilot chat session object from VS Code's newer .jsonl
     delta-log format (VS Code ~1.100+ writes <id>.jsonl instead of <id>.json).
@@ -2119,7 +2472,7 @@ def _opencode_resolve_model(val):
 # conversation ids. (All verified empirically by running the CLIs — see
 # DESIGN.md "probe findings".)
 _DELEGATION_CAPABLE_AGENTS = {"claude", "cursor", "opencode", "hermes",
-                              "grok", "codex", "antigravity"}
+                              "grok", "codex", "antigravity", "cline"}
 
 
 # content is JSON-escaped inside the INVOKE_SUBAGENT step record, so the quote
@@ -3539,6 +3892,20 @@ def _scan_sessions_sync():
     # 8. Grok Build (xAI) — rich per-session directory with events, updates, chat history
     sessions.extend(_scan_grok_sessions())
 
+    # 8b. Cline — CLI SQLite store + VS Code extension JSON store
+    sessions.extend(_scan_cline_sessions())
+
+    # 8c. SmallCode — traces are PROJECT-LOCAL (<project>/.smallcode/traces/),
+    # so discover roots from projects already seen from other agents (they ran
+    # somewhere real) unioned with any user-configured extra roots, then scan.
+    smallcode_roots = {
+        s["project"] for s in sessions
+        if s.get("project") and s["project"] != "unknown"
+    }
+    smallcode_roots.update(SMALLCODE_EXTRA_ROOTS)
+    smallcode_roots = {r for r in smallcode_roots if r and Path(r).expanduser().is_dir()}
+    sessions.extend(_scan_smallcode_sessions(smallcode_roots))
+
     # 9. Hermes Agent (SQLite: sessions / messages, pre-aggregated tokens)
     hermes_cwd_map = _hermes_cwd_by_session() if _hermes_dbs() else {}
     hermes_by_id: Dict[str, Dict[str, Any]] = {}
@@ -4367,6 +4734,134 @@ async def get_session_detail(session_id: str, agent: str):
                     conn.close()
             except Exception:
                 continue
+        return {"error": "Not found"}
+    elif agent == "smallcode":
+        # Traces are project-local; use the cached session list (populated by
+        # GET /sessions, which any dashboard load already triggers) to find
+        # which project this trace lives under, falling back to the
+        # user-configured extra roots if the cache hasn't been built yet.
+        candidate_roots: List[str] = list(SMALLCODE_EXTRA_ROOTS)
+        cached_sessions = _sessions_cache.get("data")
+        if cached_sessions:
+            for s in cached_sessions:
+                if s.get("agent") == "smallcode" and s.get("project"):
+                    candidate_roots.append(s["project"])
+
+        trace_path = None
+        for root in dict.fromkeys(candidate_roots):  # dedupe, keep order
+            p = Path(root).expanduser() / ".smallcode" / "traces" / f"{session_id}.json"
+            if p.exists():
+                trace_path = p
+                break
+        if trace_path is None:
+            return {"error": "Not found"}
+
+        try:
+            with open(trace_path, "r", encoding="utf-8") as f:
+                trace = json.load(f)
+        except Exception:
+            return {"error": "Not found"}
+
+        base_ms = None
+        started_at = trace.get("startedAt")
+        if started_at:
+            try:
+                base_ms = _aware(datetime.fromisoformat(str(started_at).replace("Z", "+00:00"))).timestamp() * 1000
+            except Exception:
+                base_ms = None
+        if base_ms is None:
+            base_ms = _file_mtime_utc(trace_path).timestamp() * 1000
+
+        events = []
+        prompt = trace.get("prompt")
+        if prompt:
+            events.append({"type": "user", "payload": {"content": prompt},
+                            "timestamp": base_ms, "normalized_timestamp": base_ms})
+        for i, step in enumerate(trace.get("steps") or [], start=1):
+            if not isinstance(step, dict):
+                continue
+            ts_ms = step.get("timestamp")
+            if not isinstance(ts_ms, (int, float)):
+                ts_ms = base_ms + i * 1000
+            base = {"timestamp": ts_ms, "normalized_timestamp": ts_ms}
+            if step.get("type") == "tool_call":
+                events.append({"type": "tool_call", "payload": {
+                    "tool": step.get("name"), "args": step.get("args"),
+                }, **base})
+                events.append({"type": "tool_result", "payload": {
+                    "tool": step.get("name"), "content": step.get("result"),
+                }, **base})
+            else:
+                events.append({"type": step.get("type") or "assistant", "payload": step, **base})
+        return events
+    elif agent == "cline":
+        # (a) CLI store: session row -> messages_path transcript.
+        db_path = CLINE_DIR / "data" / "db" / "sessions.db"
+        if db_path.exists():
+            srow = None
+            try:
+                uri = _sqlite_ro_uri(db_path)
+                conn = sqlite3.connect(uri, uri=True, timeout=1.0)
+                conn.row_factory = sqlite3.Row
+                try:
+                    srow = conn.execute(
+                        "SELECT messages_path FROM sessions WHERE session_id=?", (session_id,)
+                    ).fetchone()
+                finally:
+                    conn.close()
+            except Exception:
+                srow = None
+            if srow and srow["messages_path"]:
+                mp = Path(srow["messages_path"])
+                if mp.exists():
+                    try:
+                        with open(mp, "r", encoding="utf-8", errors="replace") as f:
+                            mdata = json.load(f)
+                        events = []
+                        for i, m in enumerate(mdata.get("messages") or []):
+                            if not isinstance(m, dict):
+                                continue
+                            ts_ms = m.get("ts")
+                            if not isinstance(ts_ms, (int, float)):
+                                ts_ms = i * 1000
+                            base = {"timestamp": ts_ms, "normalized_timestamp": ts_ms}
+                            role = m.get("role")
+                            text_parts = []
+                            for block in (m.get("content") or []):
+                                if not isinstance(block, dict):
+                                    continue
+                                if block.get("type") == "text":
+                                    text_parts.append(block.get("text") or "")
+                                elif block.get("type") == "thinking":
+                                    events.append({"type": "assistant_thinking",
+                                                   "payload": {"text": block.get("thinking") or ""}, **base})
+                            text = "".join(text_parts)
+                            if role == "user" and text:
+                                events.append({"type": "user", "payload": {"content": text}, **base})
+                            elif role == "assistant" and text:
+                                events.append({"type": "assistant", "payload": {"content": text}, **base})
+                        return events
+                    except Exception:
+                        pass
+        # (b) VS Code store: transcript at tasks/<id>/api_conversation_history.json
+        transcript_path = CLINE_VSCODE_DIR / "tasks" / session_id / "api_conversation_history.json"
+        if transcript_path.exists():
+            try:
+                with open(transcript_path, "r", encoding="utf-8", errors="replace") as f:
+                    data = json.load(f)
+            except Exception:
+                data = None
+            if isinstance(data, list):
+                events = []
+                for i, m in enumerate(data):
+                    if not isinstance(m, dict):
+                        continue
+                    role = m.get("role")
+                    content = m.get("content")
+                    text = content if isinstance(content, str) else (json.dumps(content) if content else "")
+                    base = {"timestamp": i * 1000, "normalized_timestamp": i * 1000}
+                    events.append({"type": role or "assistant", "payload": {"content": text}, **base})
+                return events
         return {"error": "Not found"}
     # elif agent == "ollama":
     #     if (OLLAMA_DIR / "history").exists():

--- a/backend/test_cline_smallcode.py
+++ b/backend/test_cline_smallcode.py
@@ -1,0 +1,408 @@
+"""Tests for native session scanning of Cline and SmallCode.
+
+SmallCode traces are PROJECT-LOCAL (<project>/.smallcode/traces/<id>.json) —
+see testdata/cline_smallcode/smallcode/8fadca50.json for the verified shape.
+Cline writes to TWO stores: a CLI SQLite db (~/.cline/data/db/sessions.db,
+verified in testdata/cline_smallcode/cline_cli/) and a VS Code extension JSON
+store (globalStorage/saoudrizwan.claude-dev/state/taskHistory.json — not
+installed on the machine this was written on, so that parser sticks to the
+documented HistoryItem shape only).
+
+Run: pytest backend/test_cline_smallcode.py -q
+"""
+import asyncio
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+import main  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / builders
+# ---------------------------------------------------------------------------
+
+def _write_smallcode_trace(root: Path, trace_id="8fadca50", prompt_tokens=8331,
+                            completion_tokens=185) -> Path:
+    """Write a trace matching testdata/cline_smallcode/smallcode/8fadca50.json."""
+    traces_dir = root / ".smallcode" / "traces"
+    traces_dir.mkdir(parents=True, exist_ok=True)
+    trace = {
+        "id": trace_id,
+        "model": "nemotron-3-nano:4b",
+        "prompt": "Fix the bug in math.py: add() should return a+b not a-b. Edit the file.",
+        "startedAt": "2026-07-01T05:14:54.084Z",
+        "steps": [
+            {"type": "tool_call", "name": "read_file", "args": {"path": "math.py"},
+             "result": "math.py (3 lines)", "durationMs": 4, "timestamp": 1782882900675},
+            {"type": "tool_call", "name": "patch", "args": {"path": "math.py"},
+             "result": "Patched math.py", "durationMs": 5, "timestamp": 1782882908174},
+            {"type": "tool_call", "name": "read_file", "args": {"path": "math.py"},
+             "result": "math.py (3 lines)", "durationMs": 1, "timestamp": 1782882925975},
+        ],
+        "tokens": {"prompt": prompt_tokens, "completion": completion_tokens},
+        "endedAt": "2026-07-01T05:15:34.149Z",
+        "durationMs": 40065,
+    }
+    (traces_dir / f"{trace_id}.json").write_text(json.dumps(trace), encoding="utf-8")
+    return root
+
+
+def _build_cline_cli_db(db_path: Path, session_id: str, *, workspace_root: str,
+                         aggregate_usage=None, usage=None, total_cost=0,
+                         messages_path=None, model="claude-sonnet-4-6",
+                         provider="anthropic", prompt="Fix math.py so add returns a+b"):
+    """Build a tmp sessions.db with the real Cline CLI schema (columns verified
+    against testdata/cline_smallcode/cline_cli/sessions.db)."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE sessions (session_id TEXT, started_at TEXT, ended_at TEXT, "
+        "exit_code INTEGER, status TEXT, provider TEXT, model TEXT, cwd TEXT, "
+        "workspace_root TEXT, prompt TEXT, metadata_json TEXT, messages_path TEXT)"
+    )
+    metadata = {"title": prompt, "totalCost": total_cost}
+    if aggregate_usage is not None:
+        metadata["aggregateUsage"] = aggregate_usage
+    if usage is not None:
+        metadata["usage"] = usage
+    conn.execute(
+        "INSERT INTO sessions VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
+        (session_id, "2026-07-01T05:15:01.949Z", "2026-07-01T05:15:22.428Z", 0,
+         "completed", provider, model, workspace_root, workspace_root, prompt,
+         json.dumps(metadata), str(messages_path) if messages_path else None),
+    )
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture
+def scan_env(tmp_path, monkeypatch):
+    """Point every agent store at a nonexistent dir under tmp_path so a full
+    _scan_sessions_sync() run is hermetic (mirrors test_delegation.py's
+    scan_env — this module doesn't import it since it's private there)."""
+    missing = tmp_path / "missing"
+    for attr in ("CODEX_DIR", "GEMINI_DIR", "QWEN_DIR", "VIBE_DIR", "OLLAMA_DIR",
+                 "GROK_SESSIONS_DIR", "VSCODE_STORAGE", "CURSOR_STORAGE",
+                 "COPILOT_CLI_DIR", "ANTIGRAVITY_BRAIN_DIR", "ANTIGRAVITY_CLI_DIR",
+                 "HERMES_DIR"):
+        monkeypatch.setattr(main, attr, missing / attr.lower())
+    monkeypatch.setattr(main, "ANTIGRAVITY_BRAIN_SOURCES", [])
+    monkeypatch.setattr(main, "ANTIGRAVITY_BRAIN_DIRS", [])
+    monkeypatch.setattr(main, "_antigravity_cli_meta", lambda *a, **k: {})
+    monkeypatch.setattr(main, "CLAUDE_DIR", missing / "claude")
+    monkeypatch.setattr(main, "CURSOR_DIR", missing / "cursor")
+    monkeypatch.setattr(main, "OPENCODE_DB", missing / "opencode.db")
+    monkeypatch.setattr(main, "HERMES_DB", missing / "hermes-state.db")
+    monkeypatch.setattr(main, "HERMES_PROFILES_DIR", missing / "hermes-profiles")
+    monkeypatch.setattr(main, "PROJECT_ALIASES_FILE", tmp_path / "aliases.json")
+    monkeypatch.setattr(main, "CLINE_DIR", missing / "cline")
+    monkeypatch.setattr(main, "CLINE_VSCODE_DIR", missing / "cline-vscode")
+    monkeypatch.setattr(main, "SMALLCODE_EXTRA_ROOTS", [])
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# SmallCode
+# ---------------------------------------------------------------------------
+
+def test_split_roots_env_pathsep_and_comma():
+    value = f"/a/b{os.pathsep}/c/d,/e/f"
+    assert main._split_roots_env(value) == ["/a/b", "/c/d", "/e/f"]
+    assert main._split_roots_env(None) == []
+    assert main._split_roots_env("") == []
+
+
+def test_scan_smallcode_sessions_maps_fields(tmp_path):
+    root = _write_smallcode_trace(tmp_path / "proj")
+    out = main._scan_smallcode_sessions([str(root)])
+    assert len(out) == 1
+    rec = out[0]
+    assert rec["agent"] == "smallcode"
+    assert rec["id"] == "8fadca50"
+    assert rec["project"] == str(root)
+    assert rec["model"] == "nemotron-3-nano:4b"
+    assert rec["tokens"]["input"] == 8331
+    assert rec["tokens"]["output"] == 185
+    assert rec["tokens"]["cached"] == 0
+    assert rec["tokens"]["total"] == 8331 + 185
+    assert rec["display"].startswith("Fix the bug in math.py")
+    assert set(rec["mcp_tools"]) == {"read_file", "patch"}
+    assert rec["artifacts"][0]["path"].endswith("8fadca50.json")
+    assert rec["cost"] == rec["tokens"]["cost"]
+    assert rec["has_plan"] is False
+    assert rec["plans"] == []
+
+
+def test_scan_smallcode_sessions_skips_missing_and_nonproject_roots(tmp_path):
+    missing = tmp_path / "does-not-exist"
+    assert main._scan_smallcode_sessions([str(missing), "unknown", ""]) == []
+
+
+def test_smallcode_reuses_known_project_roots(scan_env, monkeypatch):
+    """SmallCode has no home-dir store; the scanner must discover roots from
+    projects other agents already ran in (union'd with the extra-roots env)."""
+    proj = scan_env / "cli-proj"
+    _write_smallcode_trace(proj, trace_id="reuse-1")
+
+    cline_dir = scan_env / ".cline"
+    monkeypatch.setattr(main, "CLINE_DIR", cline_dir)
+    db = cline_dir / "data" / "db" / "sessions.db"
+    _build_cline_cli_db(
+        db, "cli-sess", workspace_root=str(proj),
+        aggregate_usage={"inputTokens": 5, "outputTokens": 2, "cacheReadTokens": 0,
+                          "cacheWriteTokens": 0, "totalCost": 0},
+        total_cost=0,
+    )
+
+    sessions = main._scan_sessions_sync()
+    smallcode = [s for s in sessions if s["agent"] == "smallcode"]
+    assert len(smallcode) == 1
+    assert smallcode[0]["id"] == "reuse-1"
+    assert smallcode[0]["project"] == str(proj)
+
+
+def test_smallcode_extra_roots_env(scan_env, monkeypatch):
+    """TT_SMALLCODE_ROOTS (surfaced as main.SMALLCODE_EXTRA_ROOTS) must be
+    scanned even when no other agent ever touched that project."""
+    extra = scan_env / "extra-proj"
+    _write_smallcode_trace(extra, trace_id="extra-1")
+    monkeypatch.setattr(main, "SMALLCODE_EXTRA_ROOTS", [str(extra)])
+
+    sessions = main._scan_sessions_sync()
+    smallcode = [s for s in sessions if s["agent"] == "smallcode"]
+    assert len(smallcode) == 1
+    assert smallcode[0]["id"] == "extra-1"
+    assert smallcode[0]["project"] == str(extra)
+
+
+def test_session_detail_smallcode(tmp_path, monkeypatch):
+    proj = tmp_path / "proj"
+    _write_smallcode_trace(proj, trace_id="detail-1")
+    monkeypatch.setattr(main, "SMALLCODE_EXTRA_ROOTS", [str(proj)])
+    monkeypatch.setattr(main, "_sessions_cache", {"data": None, "at": 0.0, "building": False})
+
+    result = asyncio.run(main.get_session_detail("detail-1", "smallcode"))
+    assert isinstance(result, list)
+    assert result[0]["type"] == "user"
+    tool_calls = [e for e in result if e["type"] == "tool_call"]
+    assert len(tool_calls) == 3
+    assert tool_calls[0]["payload"]["tool"] == "read_file"
+
+
+# ---------------------------------------------------------------------------
+# Cline — CLI SQLite store
+# ---------------------------------------------------------------------------
+
+def test_scan_cline_cli_uses_aggregate_usage(tmp_path, monkeypatch):
+    cline_dir = tmp_path / ".cline"
+    monkeypatch.setattr(main, "CLINE_DIR", cline_dir)
+    monkeypatch.setattr(main, "CLINE_VSCODE_DIR", tmp_path / "missing-vscode")
+    db = cline_dir / "data" / "db" / "sessions.db"
+    _build_cline_cli_db(
+        db, "sess-agg", workspace_root=str(tmp_path / "proj"),
+        aggregate_usage={"inputTokens": 500, "outputTokens": 120, "cacheReadTokens": 30,
+                          "cacheWriteTokens": 0, "totalCost": 0.05},
+        total_cost=0.05,
+    )
+
+    out = main._scan_cline_sessions()
+    assert len(out) == 1
+    rec = out[0]
+    assert rec["agent"] == "cline"
+    assert rec["id"] == "sess-agg"
+    assert rec["project"] == str(tmp_path / "proj")
+    assert rec["tokens"]["input"] == 500
+    assert rec["tokens"]["output"] == 120
+    assert rec["tokens"]["cached"] == 30
+    assert rec["tokens"]["total"] == 620
+    assert rec["cost"] == pytest.approx(0.05)
+    assert rec["cline"]["source"] == "cli"
+    assert rec["cline"]["provider"] == "anthropic"
+
+
+def test_scan_cline_cli_falls_back_to_messages_metrics(tmp_path, monkeypatch):
+    """When aggregateUsage AND usage are both all-zero, sum metrics from the
+    messages_path transcript instead (verified fallback shape)."""
+    cline_dir = tmp_path / ".cline"
+    monkeypatch.setattr(main, "CLINE_DIR", cline_dir)
+    monkeypatch.setattr(main, "CLINE_VSCODE_DIR", tmp_path / "missing-vscode")
+
+    messages_path = tmp_path / "messages" / "sess-fallback.messages.json"
+    messages_path.parent.mkdir(parents=True, exist_ok=True)
+    messages_path.write_text(json.dumps({
+        "messages": [
+            {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+            {"role": "assistant", "content": [{"type": "text", "text": "ok"}],
+             "metrics": {"inputTokens": 200, "outputTokens": 50, "cacheReadTokens": 10}},
+            {"role": "assistant", "content": [{"type": "text", "text": "more"}],
+             "metrics": {"inputTokens": 20, "outputTokens": 5, "cacheReadTokens": 0}},
+        ]
+    }), encoding="utf-8")
+
+    db = cline_dir / "data" / "db" / "sessions.db"
+    zero_usage = {"inputTokens": 0, "outputTokens": 0, "cacheReadTokens": 0,
+                  "cacheWriteTokens": 0, "totalCost": 0}
+    _build_cline_cli_db(
+        db, "sess-fallback", workspace_root=str(tmp_path / "proj"),
+        aggregate_usage=zero_usage, usage=zero_usage, total_cost=0,
+        messages_path=messages_path,
+    )
+
+    out = main._scan_cline_sessions()
+    assert len(out) == 1
+    rec = out[0]
+    assert rec["tokens"]["input"] == 220
+    assert rec["tokens"]["output"] == 55
+    assert rec["tokens"]["cached"] == 10
+    # cost falls back to calculate_cost since metadata totalCost is 0.
+    expected_cost = main.calculate_cost("claude-sonnet-4-6", 220, 55, 10)
+    assert rec["cost"] == expected_cost
+
+
+def test_session_detail_cline_cli(tmp_path, monkeypatch):
+    cline_dir = tmp_path / ".cline"
+    monkeypatch.setattr(main, "CLINE_DIR", cline_dir)
+    monkeypatch.setattr(main, "CLINE_VSCODE_DIR", tmp_path / "missing-vscode")
+
+    messages_path = tmp_path / "sess-detail.messages.json"
+    messages_path.write_text(json.dumps({"messages": [
+        {"role": "user", "content": [{"type": "text", "text": "hello"}], "ts": 1},
+        {"role": "assistant", "content": [{"type": "text", "text": "hi there"}], "ts": 2},
+    ]}), encoding="utf-8")
+
+    db = cline_dir / "data" / "db" / "sessions.db"
+    _build_cline_cli_db(db, "sess-detail", workspace_root=str(tmp_path / "proj"),
+                         messages_path=messages_path)
+
+    result = asyncio.run(main.get_session_detail("sess-detail", "cline"))
+    assert isinstance(result, list)
+    assert result[0]["type"] == "user"
+    assert result[0]["payload"]["content"] == "hello"
+    assert result[1]["type"] == "assistant"
+    assert result[1]["payload"]["content"] == "hi there"
+
+
+# ---------------------------------------------------------------------------
+# Cline — VS Code extension store
+# ---------------------------------------------------------------------------
+
+def test_scan_cline_vscode_maps_and_dedupes_against_cli(tmp_path, monkeypatch):
+    cline_dir = tmp_path / ".cline"
+    vscode_dir = tmp_path / "vscode-cline"
+    monkeypatch.setattr(main, "CLINE_DIR", cline_dir)
+    monkeypatch.setattr(main, "CLINE_VSCODE_DIR", vscode_dir)
+
+    # CLI row for id "dup-id" — must win over the VS Code row with the same id.
+    db = cline_dir / "data" / "db" / "sessions.db"
+    _build_cline_cli_db(
+        db, "dup-id", workspace_root=str(tmp_path / "cli-proj"),
+        aggregate_usage={"inputTokens": 10, "outputTokens": 5, "cacheReadTokens": 0,
+                          "cacheWriteTokens": 0, "totalCost": 0.01},
+        total_cost=0.01,
+    )
+
+    state_dir = vscode_dir / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    history = [
+        {"id": "vsc-task-1", "ts": 1782882901945, "task": "Refactor the parser",
+         "tokensIn": 1000, "tokensOut": 300, "cacheWrites": 40, "cacheReads": 60,
+         "totalCost": 0.12, "size": 4096},
+        {"id": "dup-id", "ts": 1782882901945, "task": "Should be shadowed by the CLI row",
+         "tokensIn": 999999, "tokensOut": 999999, "cacheWrites": 0, "cacheReads": 0,
+         "totalCost": 99.0, "size": 1},
+    ]
+    (state_dir / "taskHistory.json").write_text(json.dumps(history), encoding="utf-8")
+
+    out = main._scan_cline_sessions()
+    by_id = {r["id"]: r for r in out}
+    assert set(by_id) == {"dup-id", "vsc-task-1"}
+
+    # CLI row wins for the duplicate id — VS Code's inflated numbers are dropped.
+    assert by_id["dup-id"]["cline"]["source"] == "cli"
+    assert by_id["dup-id"]["tokens"]["input"] == 10
+
+    vsc = by_id["vsc-task-1"]
+    assert vsc["agent"] == "cline"
+    assert vsc["cline"]["source"] == "vscode"
+    assert vsc["tokens"]["input"] == 1000
+    assert vsc["tokens"]["output"] == 300
+    assert vsc["tokens"]["cached"] == 60
+    assert vsc["cost"] == pytest.approx(0.12)
+    assert vsc["display"] == "Refactor the parser"
+
+
+def _build_cline_db_with_subagents(db_path, *, parent_id, child_id,
+                                   parent_usage, parent_aggregate, child_usage):
+    """Cline schema WITH the subagent columns (is_subagent, parent_session_id).
+
+    A parent that spawned a subagent: the child is its own row, and the
+    parent's aggregateUsage already SUMS the child in.
+    """
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE sessions (session_id TEXT, started_at TEXT, ended_at TEXT, "
+        "exit_code INTEGER, status TEXT, provider TEXT, model TEXT, cwd TEXT, "
+        "workspace_root TEXT, prompt TEXT, metadata_json TEXT, messages_path TEXT, "
+        "is_subagent INTEGER, parent_session_id TEXT, agent_id TEXT, team_name TEXT)"
+    )
+
+    def ins(sid, is_sub, parent, usage, aggregate):
+        meta = {"title": "t", "totalCost": 0, "usage": usage}
+        if aggregate is not None:
+            meta["aggregateUsage"] = aggregate
+        conn.execute(
+            "INSERT INTO sessions VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+            (sid, "2026-07-01T05:15:01.949Z", "2026-07-01T05:15:22.428Z", 0,
+             "completed", "anthropic", "claude-sonnet-4-6", "/w", "/w", "p",
+             json.dumps(meta), None, is_sub, parent, "agent-x", "team-1"),
+        )
+
+    ins(parent_id, 0, None, parent_usage, parent_aggregate)
+    ins(child_id, 1, parent_id, child_usage, child_usage)
+    conn.commit()
+    conn.close()
+
+
+def test_cline_subagent_no_double_count_and_links_parent(tmp_path, monkeypatch):
+    cline_dir = tmp_path / ".cline"
+    db = cline_dir / "data" / "db" / "sessions.db"
+    # Parent OWN usage 100/20; aggregate (parent+child) 150/30; child 50/10.
+    _build_cline_db_with_subagents(
+        db, parent_id="P", child_id="C",
+        parent_usage={"inputTokens": 100, "outputTokens": 20, "cacheReadTokens": 0},
+        parent_aggregate={"inputTokens": 150, "outputTokens": 30, "cacheReadTokens": 0},
+        child_usage={"inputTokens": 50, "outputTokens": 10, "cacheReadTokens": 0},
+    )
+    monkeypatch.setattr(main, "CLINE_DIR", cline_dir)
+    monkeypatch.setattr(main, "CLINE_VSCODE_DIR", tmp_path / "no-vscode")
+
+    recs = {r["id"]: r for r in main._scan_cline_sessions()}
+    assert set(recs) == {"P", "C"}
+
+    # Parent billed on its OWN usage, NOT the aggregate — otherwise the child
+    # (counted as its own row) would be double-counted.
+    assert recs["P"]["tokens"]["input"] == 100
+    assert recs["P"]["tokens"]["output"] == 20
+    assert recs["P"]["cline"]["spawned_children"] is True
+
+    # Child counted on its own usage and linked back to the parent.
+    assert recs["C"]["tokens"]["input"] == 50
+    assert recs["C"]["parent_session_id"] == "P"
+    assert recs["C"]["is_subagent"] is True
+
+    # Sum across the two rows equals the aggregate the parent reported (150/30).
+    assert sum(r["tokens"]["input"] for r in recs.values()) == 150
+    assert sum(r["tokens"]["output"] for r in recs.values()) == 30
+
+    assert "cline" in main._DELEGATION_CAPABLE_AGENTS
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/frontend/src/lib/agents.ts
+++ b/frontend/src/lib/agents.ts
@@ -1,6 +1,6 @@
 import {
   Terminal, Database, Sparkles, Orbit, Cpu, Zap, MousePointer2,
-  GitBranch, Code2, Server, type LucideIcon,
+  GitBranch, Code2, Server, Bot, Boxes, type LucideIcon,
 } from "lucide-react";
 import HermesIcon from "@/components/icons/HermesIcon";
 import GrokIcon from "@/components/icons/GrokIcon";
@@ -8,7 +8,7 @@ import GrokIcon from "@/components/icons/GrokIcon";
 export type AgentKey =
   | "claude" | "codex" | "gemini" | "antigravity"
   | "qwen" | "vibe" | "cursor" | "copilot" | "opencode" | "hermes" | "grok"
-  | "openai_compat";
+  | "openai_compat" | "cline" | "smallcode";
 
 export interface AgentMeta {
   key: AgentKey;
@@ -31,6 +31,8 @@ export const AGENTS: Record<AgentKey, AgentMeta> = {
   hermes:      { key: "hermes",      label: "Hermes Agent", hex: "#eab308", icon: HermesIcon },
   grok:        { key: "grok",        label: "Grok Build",  hex: "#d4d4d8", icon: GrokIcon },
   openai_compat: { key: "openai_compat", label: "OpenAI-compatible server", hex: "#14b8a6", icon: Server },
+  cline:       { key: "cline",       label: "Cline",       hex: "#7c3aed", icon: Bot },
+  smallcode:   { key: "smallcode",   label: "SmallCode",   hex: "#0d9488", icon: Boxes },
 };
 
 const FALLBACK: AgentMeta = {

--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -5,7 +5,7 @@ description: TokenTelemetry is a free, local-first observability dashboard for A
 
 ## What is TokenTelemetry?
 
-**TokenTelemetry** is a free, open-source, 100% local dashboard that reads the log files your AI coding agents already write and surfaces them in one unified place. It tracks token usage, LLM costs, tool calls, session traces, and reasoning steps across Claude Code, Codex, Gemini CLI, Cursor, Copilot, Qwen, OpenCode, Vibe, Antigravity, Grok Build, and Hermes Agent.
+**TokenTelemetry** is a free, open-source, 100% local dashboard that reads the log files your AI coding agents already write and surfaces them in one unified place. It tracks token usage, LLM costs, tool calls, session traces, and reasoning steps across Claude Code, Codex, Gemini CLI, Cursor, Copilot, Qwen, OpenCode, Vibe, Antigravity, Grok Build, Cline, SmallCode, and Hermes Agent.
 
 **No signup. No cloud. Your logs, prompts, and costs never leave your machine.** One command to start.
 

--- a/website/content/docs/supported-agents.mdx
+++ b/website/content/docs/supported-agents.mdx
@@ -1,6 +1,6 @@
 ---
 title: Supported Agents
-description: The 10 coding agents and Hermes autonomous agent that TokenTelemetry tracks, how each is detected, and what data each captures.
+description: The 12 coding agents and Hermes autonomous agent that TokenTelemetry tracks, how each is detected, and what data each captures.
 ---
 
 TokenTelemetry reads log files from the agents listed below. Detection is automatic — no configuration needed. Just run your agent as normal and TokenTelemetry picks up the sessions.
@@ -19,6 +19,8 @@ TokenTelemetry reads log files from the agents listed below. Detection is automa
 | **GitHub Copilot** | GitHub | VS Code `chatSessions/` | tokens, traces, cost |
 | **OpenCode** | OpenCode | `~/.local/share/opencode/` | tokens, traces |
 | **Grok Build** | xAI | `~/.grok/sessions/` | tokens, traces, reasoning, cost |
+| **Cline** | Cline (open source) | `~/.cline/data/db/sessions.db` + VS Code `taskHistory.json` | tokens in/out, cache read/write, cost, model, provider, cwd |
+| **SmallCode** | SmallCode (open source) | `<project>/.smallcode/traces/<id>.json` | prompt/completion tokens, model, tool-call steps, timing |
 
 ## Autonomous agents
 
@@ -57,6 +59,14 @@ Reads Copilot's chat session files from VS Code's `chatSessions/` directory (ins
 ### OpenCode
 
 Reads session data from `~/.local/share/opencode/`. Token counts and traces are captured; OpenCode children sessions are included in the relayed-session count (they are already counted in the parent session's token totals).
+
+### Cline
+
+TokenTelemetry reads both the Cline CLI SQLite store and the VS Code extension's JSON task history, de-duplicating sessions that appear in both.
+
+### SmallCode
+
+SmallCode writes traces into each project directory rather than a global home dir, so TokenTelemetry discovers them under the project paths it already tracks from other agents (and honors the `TT_SMALLCODE_ROOTS` env var for extra locations).
 
 ### Hermes Agent
 


### PR DESCRIPTION
Adds native session scanning for two more coding agents, closing the request in #118. Built on `main` so it excludes the in-progress workflows / resource-monitor work on the feature branch.

## What's tracked

Both agents' real on-disk formats were verified by installing them and running live sessions against local Ollama (the discussion's "plain JSON, no SQLite" description turned out not to match reality).

**Cline** — general agent runtime that spawns subagents/teams.
- CLI SQLite store `~/.cline/data/db/sessions.db` (tokens in `metadata_json.aggregateUsage`/`usage`, falling back to summing per-message `metrics` in the transcript).
- VS Code extension `saoudrizwan.claude-dev/state/taskHistory.json`.
- Sessions in both stores are de-duplicated by id (CLI wins).
- **Subagent-safe accounting:** a parent's `aggregateUsage` already sums its spawned children, and each child is its own row, so parents bill on their own `usage` to avoid double-counting; children link via `parent_session_id` and Cline is marked delegation-capable (same model as Grok/Codex/Antigravity).

**SmallCode** — purpose-built for small local models. Traces are project-local (`<project>/.smallcode/traces/<id>.json`), so they're discovered under the project roots TokenTelemetry already tracks, plus a `TT_SMALLCODE_ROOTS` override. No subagent handling needed — SmallCode's "escalation" is a single cloud-model fallback, not a spawn.

## Wiring
`_scan_cline_sessions()` / `_scan_smallcode_sessions()` modeled on `_scan_grok_sessions`, registered in `_scan_sessions_sync()`; `get_session_detail` branches for both; entries in `agent_retention`, `billing_mode`, `billing_route`; frontend `agents.ts` (Cline violet/Bot, SmallCode teal/Boxes); `supported-agents.mdx` + `index.mdx` docs.

## Tests
`backend/test_cline_smallcode.py` — 11 cases: SmallCode field mapping + root discovery, Cline CLI `aggregateUsage` mapping + messages-metrics fallback, VS Code mapping + dedup vs CLI, and a subagent parent/child double-count guard. All green; scanners verified against real captured sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)