### PR TITLE
docs(wiki): second brain — OKF v0.1 bundle + /brain maintainer skill

### DIFF
--- a/.claude/skills/brain/SKILL.md
+++ b/.claude/skills/brain/SKILL.md
@@ -45,8 +45,14 @@ wiki compiles them, this file is the schema that keeps you disciplined.
 | Decision | `decisions/` | ADR (summary + consequence highlights, `resource:` the ADR) |
 | Playbook | `playbooks/` | recurring maintainer task (steps, files touched, traps) |
 | Convention | `conventions/` | project rule or invariant (the rule, why, enforcement) |
+| Analysis | `analyses/` | analysis produced in an agent chat worth keeping, implemented or not (extra frontmatter: `status: proposed \| adopted \| rejected \| superseded`) |
 
 New types are allowed when nothing fits; add them to this table in the same PR.
+
+Analysis pages differ from the rest: they are point-in-time snapshots of
+thinking, not compiled from repo sources. Their body is never rewritten after
+saving; later edits may only change `status` (with a one-line note and a link
+to what superseded or implemented them) and fix broken links.
 
 ## Workflows
 
@@ -68,6 +74,24 @@ After a PR merges to main, the ingest source is `git diff <before>..main`.
 1. Read `index.md`, follow links to the relevant pages, answer from the wiki.
 2. If the wiki couldn't answer and you had to read raw sources, file what you
    learned back into the wiki (same rules as ingest) so the next query hits.
+
+### save `<analysis from this chat>`
+
+For when a conversation produces an analysis worth keeping (a comparison, a
+design assessment, a recommendation) that may or may not ever be implemented.
+
+1. Distill the analysis from the conversation into one page under `analyses/`:
+   the question it answers, the reasoning, the conclusion, and any proposed
+   follow-ups. Keep the substance; drop the chat back-and-forth.
+2. Frontmatter: `type: Analysis`, `status: proposed` (or `adopted`/`rejected`
+   if the user already decided), plus the usual `title`, `description`,
+   `tags`, `timestamp`. Set `resource:` to the main artifact discussed, when
+   one exists.
+3. Cross-link related wiki pages; add the entry to `index.md` under
+   `## Analyses`; append a `log.md` **Creation** entry naming the chat context.
+4. Commit as `docs:`. When an analysis later gets implemented or overruled,
+   update only its `status` line and add the link; the body stays as written
+   (see the Analysis page-type rule above).
 
 ### lint
 

--- a/.claude/skills/brain/SKILL.md
+++ b/.claude/skills/brain/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: brain
+description: Maintain the project second brain at docs/wiki/ (an OKF v0.1 bundle). Use for /brain ingest <source>, /brain query <question>, /brain lint. Trigger whenever knowledge should be filed into or answered from the wiki.
+---
+
+# brain — TokenTelemetry second brain maintainer
+
+You are the maintainer of the project wiki at `docs/wiki/`. It is an
+[Open Knowledge Format v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
+bundle following Karpathy's llm-wiki pattern: raw sources stay immutable, the
+wiki compiles them, this file is the schema that keeps you disciplined.
+
+## Layers
+
+1. **Raw sources (never edit as part of wiki work):** code, `DESIGN.md`,
+   `docs/adr/`, `docs/design/`, `.claude/CLAUDE.md`, `CHANGELOG.md`,
+   `UPDATE.json`, `website/content/docs/`, GitHub issues/discussions/PRs.
+2. **Wiki (you own every file):** `docs/wiki/**`. Never hand-edited by humans;
+   humans edit sources, you recompile.
+3. **Schema:** this file.
+
+## Bundle rules (OKF v0.1)
+
+- Every concept page has YAML frontmatter. `type` is required; also set
+  `title`, `description` (one sentence), `tags`, `timestamp` (ISO 8601 date of
+  last meaningful change), and `resource` (repo-relative path or URL of the
+  primary source) when one exists.
+- Concept ID = path minus `.md` (e.g. `harnesses/claude-code`).
+- Links are normal markdown, relative within the bundle. Tolerate broken links
+  when reading; never create them when writing.
+- `index.md` (no frontmatter): grouped directory listing,
+  `* [Title](path.md) - description` per entry, descriptions mirroring each
+  page's frontmatter `description`. Regenerate whenever pages are added,
+  removed, or re-described.
+- `log.md`: newest-first `## YYYY-MM-DD` sections; prose entries starting with
+  a bold action word (**Creation**, **Update**, **Deprecation**, **Finding**).
+
+## Page types
+
+| type | directory | one page per |
+|------|-----------|--------------|
+| Harness | `harnesses/` | supported agent (data dirs, parsed signals, quirks) |
+| Subsystem | `subsystems/` | backend/frontend module (what it does, key files, invariants) |
+| Feature | `features/` | user-facing dashboard feature (behavior + gotchas, links to website docs) |
+| Decision | `decisions/` | ADR (summary + consequence highlights, `resource:` the ADR) |
+| Playbook | `playbooks/` | recurring maintainer task (steps, files touched, traps) |
+| Convention | `conventions/` | project rule or invariant (the rule, why, enforcement) |
+
+New types are allowed when nothing fits; add them to this table in the same PR.
+
+## Workflows
+
+### ingest `<diff | file | PR/issue/discussion ref>`
+
+1. Read the source fully.
+2. Decide which existing pages it touches (search the wiki first). Prefer
+   editing existing pages over creating new ones; create only when a distinct
+   concept has no home.
+3. Update pages: keep bodies short and factual, cite file paths as
+   `backend/main.py` style code spans, cross-link related pages.
+4. Bump `timestamp` on every touched page. Update `index.md` if the set or
+   descriptions changed. Append one `log.md` entry summarizing the ingest.
+
+After a PR merges to main, the ingest source is `git diff <before>..main`.
+
+### query `<question>`
+
+1. Read `index.md`, follow links to the relevant pages, answer from the wiki.
+2. If the wiki couldn't answer and you had to read raw sources, file what you
+   learned back into the wiki (same rules as ingest) so the next query hits.
+
+### lint
+
+Check and report; fix what's mechanical, list the rest:
+
+- frontmatter parses and `type` is non-empty on every non-reserved page
+- links resolve within the bundle
+- `index.md` matches the actual file set and descriptions
+- contradictions between pages, or between a page and its `resource` source
+- stale claims (page older than significant changes to its `resource`)
+- orphans (pages nothing links to and index barely explains)
+
+Record findings as **Finding** entries in `log.md`.
+
+## Hard rules
+
+- Facts must be grounded in a source; no invented behavior. When a source is
+  ambiguous, say so on the page rather than guessing.
+- Never restate whole source documents; summarize and point via `resource:`.
+- Wiki changes are `docs:` commits (no UPDATE.json needed).
+- Respect repo writing style: plain, terse, no hype, no em-dashes.

--- a/.claude/skills/brain/SKILL.md
+++ b/.claude/skills/brain/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: brain
-description: Maintain the project second brain at docs/wiki/ (an OKF v0.1 bundle). Use for /brain ingest <source>, /brain query <question>, /brain lint. Trigger whenever knowledge should be filed into or answered from the wiki.
+description: Maintain the project second brain at docs/wiki/ (an OKF v0.1 bundle). Use for /brain ingest <source>, /brain query <question>, /brain save <analysis>, /brain idea <rough idea>, /brain lint. Trigger whenever knowledge should be filed into or answered from the wiki.
 ---
 
 # brain — TokenTelemetry second brain maintainer
@@ -46,6 +46,7 @@ wiki compiles them, this file is the schema that keeps you disciplined.
 | Playbook | `playbooks/` | recurring maintainer task (steps, files touched, traps) |
 | Convention | `conventions/` | project rule or invariant (the rule, why, enforcement) |
 | Analysis | `analyses/` | analysis produced in an agent chat worth keeping, implemented or not (extra frontmatter: `status: proposed \| adopted \| rejected \| superseded`) |
+| Idea | `ideas/` | captured idea, clarified from a rough prompt, not yet assessed or implemented (extra frontmatter: `status: captured \| adopted \| dropped`) |
 
 New types are allowed when nothing fits; add them to this table in the same PR.
 
@@ -92,6 +93,34 @@ design assessment, a recommendation) that may or may not ever be implemented.
 4. Commit as `docs:`. When an analysis later gets implemented or overruled,
    update only its `status` line and add the link; the body stays as written
    (see the Analysis page-type rule above).
+
+### idea `<rough idea>`
+
+For when the user has a spark (a feature, an approach, a "what if") and wants
+it kept before it evaporates. The input is rough by nature; your job is to
+make it clear, then save it. Ideas are direction, not knowledge: a query must
+never present one as how TokenTelemetry works.
+
+1. **Clarify first.** Rewrite the prompt into plain prose: what the idea is,
+   the problem it addresses, how it might take shape. Keep the user's intent,
+   drop the rambling. If one load-bearing point is genuinely ambiguous, ask
+   one question; otherwise do not interrogate.
+2. **Confirm.** Show the cleaned-up version and get a quick yes before saving.
+   It is the user's idea; make sure clarifying did not distort it.
+3. **Dedupe.** Search `ideas/` before writing: a prompt that extends an
+   existing idea updates that page (append a dated refinement) instead of
+   creating a near-duplicate.
+4. One page under `ideas/`: the idea stated clearly, the motivation, a sketch
+   of the shape, open questions. Frontmatter: `type: Idea`,
+   `status: captured` (move to `adopted` / `dropped`, with a link to whatever
+   implemented or killed it, once its fate is known), plus the usual `title`,
+   `description`, `tags`, `timestamp`. Set `resource:` only when the idea
+   targets a specific existing artifact.
+5. Cross-link related pages, add the entry to `index.md` under `## Ideas`,
+   append a `log.md` **Creation** entry, commit as `docs:`.
+
+Unlike `save` snapshots, idea pages stay alive: refinements append with a
+date, and `status` changes as the idea is adopted or dropped.
 
 ### lint
 

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ tokentelemetry-cro-analysis.md
 pr.diff
 simulate.py
 .grok/
+
+# Obsidian vault config (docs/wiki opened as a vault for graph view)
+.obsidian/

--- a/docs/design/tokentelemetry-plugin.md
+++ b/docs/design/tokentelemetry-plugin.md
@@ -316,3 +316,30 @@ self-reported savings.
 - Runtime LLM calls or any new outbound network from the dashboard
   ([[local-first-no-user-network]]).
 - Causal "the wiki saved you X tokens" claims (§9).
+
+## 12. Addendum (2026-07-05, shipped in plugin v0.2.0): discovery, reuse, intake
+
+Three gaps found after the pcr-divergence dogfood, closed in the plugin repo:
+
+1. **Agent discovery.** A compiled wiki nobody's agents know about saves no
+   tokens. `scripts/agent_context.py` writes a stable pointer block (markers
+   `tokentelemetry-brain:start/end`) into `AGENTS.md` (created if missing) and
+   any existing `CLAUDE.md`; brain-compile's completion step offers it once the
+   manifest reaches `complete`. The block carries no counts or SHAs, so it
+   never churns between compiles (cache hygiene), and rewrites idempotently
+   between its markers only.
+2. **Prior-knowledge reuse.** `profile_census.py` now reports a
+   `prior_knowledge` list: graphify graphs (`graphify-out/graph.json`),
+   Obsidian vaults, ADR dirs, design docs, wiki-shaped trees. `/brain-init`
+   asks seed-or-ignore per source and records the choice in
+   `project-profile.md`; `/brain-compile` reads recorded seeds first (graph
+   clusters become queue topics and per-topic reader assignments). Seeds are a
+   map, not testimony: pages are still grounded by reading files. Honest
+   framing: seeding cuts discovery cost, it does not make compilation free.
+3. **Intake tray.** `docs/wiki/raw/` is the committed inbox for knowledge with
+   no repo home (external notes, pasted docs), completing the llm-wiki raw
+   layer for non-repo sources. `/brain ingest` sweeps it: distill into pages,
+   then move the file to `raw/processed/` (content immutable, moved not
+   edited). `okf_lint.py` exempts `raw/**` from page checks but warns on
+   unprocessed items; queries never read raw/ (pages stay the only query
+   surface, or the token savings leak).

--- a/docs/design/tokentelemetry-plugin.md
+++ b/docs/design/tokentelemetry-plugin.md
@@ -1,0 +1,318 @@
+# Design: the TokenTelemetry plugin (per-project second brains + generated optimization skills)
+
+**Status:** PROPOSED · **Author:** analysis (3-agent debate, 2026-07-03/04) · **Date:** 2026-07-04
+**Related:** `docs/wiki/` + `.claude/skills/brain/SKILL.md` (the proven seed, PR #121) ·
+[[local-first-no-user-network]] · [[second-brain-wiki]] · the "master prompt v2"
+resumable-compile design (Verizon/BQ project) · token-efficiency panel analysis
+(session 2026-07-04)
+
+---
+
+## 1. Problem and thesis
+
+Generic token optimizers (ponytail, caveman, headroom; see §2) all optimize *within*
+a turn: less code out, terser prose out, smaller payloads in. None of them touch the
+largest residual sink in agentic work: **cross-session re-derivation**. Every fresh
+session rebuilds the agent's mental model with 10-20 exploratory tool calls, re-carries
+that context on every later turn, and repeats wrong turns it has already taken. Prompt
+caching does not cross sessions. For non-coding projects (data analysis, legal,
+learning) the generic tools do nothing at all: there is no code for a decision ladder
+or tree-sitter to act on.
+
+Thesis: ship a **Claude Code plugin** ("tokentelemetry") that
+
+1. compiles a per-project llm-wiki / Google OKF v0.1 knowledge bundle ("second brain")
+   from project files and git history, with domain-aware profiles, and
+2. generates a per-project optimization skill on top of the wiki, applying
+   ponytail/caveman/headroom principles instantiated with project nouns, and
+3. closes the loop with the TT dashboard, which detects the wiki and shows honest
+   before/after token metrics per project.
+
+The dashboard stays read-only. Everything that writes into a user's repo is a plugin
+command the user invokes in their own agent. This split is load-bearing: TT's brand is
+the trustworthy local meter, and the plugin must not spend that trust.
+
+The moat is (3). Every optimizer in this space asserts its savings; headroom, with
+full request interception, can still only estimate counterfactuals with confidence
+intervals. TT observes real longitudinal per-project data on both sides of wiki
+adoption. We can prove or falsify the savings claim, including showing zero.
+
+## 2. Prior art (source: maintainer-supplied research, 2026-07)
+
+- **ponytail** (DietrichGebert): prompt-injected "lazy senior dev" persona with a
+  7-rung decision ladder (YAGNI → reuse codebase → stdlib → platform-native →
+  installed deps → one-liner → minimal code). ~54% less generated code. Two lessons we
+  inherit as hard requirements: naive "prefer less" prompts strip validation, so
+  explicit negative constraints are mandatory; and deliberate shortcuts get annotated
+  with an upgrade path.
+- **caveman** (JuliusBrussee): telegraphic output style, ~65-75% output prose cut,
+  code byte-exact, no invented abbreviations (BPE-aware). Lesson we inherit:
+  **auto-clarity**, full prose is forced for security warnings, irreversible actions,
+  and deliverables. Also `caveman-compress`: permanent telegraphic rewrite of memory
+  files (~46% baseline input cut).
+- **headroom** (headroomlabs-ai): input-side compression middleware with type-routed
+  compressors and lossless cache-and-retrieve pointers. Lessons we inherit: the
+  `learn` module (mine past sessions for waste loops, write guardrails to memory) and
+  the CacheAligner warning (rewriting history breaks provider KV-cache discounts;
+  keep stable prefixes stable).
+
+The wiki composes with all three rather than competing: it removes turns, they
+compress the turns that remain.
+
+## 3. Decisions (summary)
+
+| # | Decision | Why |
+|---|----------|-----|
+| D1 | Generation lives in a plugin, not the dashboard | TT stays read-only; blast radius and trust |
+| D2 | Session mining extracts **structural signals only**, never transcript content | Content mining is a laundering pipeline from gitignored logs into committed pages; semantic leaks are unredactable at solo-maintainer confidence |
+| D3 | Ship 2 proven domain profiles (fullstack-app, research-data) + a generic fallback + a profile-authoring guide | Legal/learning profiles would ship untested by construction; confident garbage pages are structurally privileged over ground truth |
+| D4 | The resumable compile machinery (disk-backed queue, batches, checkpoints) is v1 scope | The BQ compile proved the job does not fit one session; a one-shot skill dies mid-compile |
+| D5 | Generated skills carry lint-enforced anti-compounding invariants (§7) | Stale wiki + wiki-first routing + laziness + terseness each suppress the correction mechanism the previous layer needed |
+| D6 | Dashboard "import" = detection + registration in `~/.tokentelemetry`; conversion/adoption is a plugin command | Read-only rule; see scenario matrix §8 |
+| D7 | Loose coupling via `docs/wiki/manifest.json` | Either product works without the other |
+
+## 4. Plugin anatomy
+
+Marketplace repo `tokentelemetry-plugin`. Four skills, four subagents, four
+stdlib-Python scripts, no hooks in v1 (nothing may tax every session of every
+project; all opt-in).
+
+```
+tokentelemetry-plugin/
+├── .claude-plugin/plugin.json
+├── skills/
+│   ├── brain/SKILL.md            # ingest | query | lint | adopt (reads project BRAIN.md)
+│   ├── brain-init/
+│   │   ├── SKILL.md              # Phase 0: census → profile proposal → scaffold
+│   │   └── templates/            # BRAIN.md.tmpl, project-profile.md.tmpl, wiki skeleton
+│   ├── brain-compile/SKILL.md    # resumable compile loop (master prompt v2, generalized)
+│   └── skillsmith/
+│       ├── SKILL.md              # drafts the per-project optimization skill
+│       └── seeds/                # ponytail-ladder.md, caveman-style.md, headroom-guardrails.md
+├── agents/
+│   ├── source-reader.md          # files → condensed facts (fixed schema, word cap)
+│   ├── session-miner.md          # one session's slim event stream → structural signals
+│   ├── git-historian.md          # decision-shaped commits, per-file churn → topics
+│   └── wiki-auditor.md           # semantic lint (contradictions, staleness)
+├── profiles/
+│   ├── fullstack-app.yaml
+│   ├── research-data.yaml
+│   ├── generic.yaml
+│   └── AUTHORING.md              # third parties own the risk of their own domains
+└── scripts/
+    ├── okf_lint.py               # deterministic OKF checks (port of the existing lint)
+    ├── profile_census.py         # extension histogram, framework markers → JSON
+    ├── session_scan.py           # harness log locator + slim parsers (structural only)
+    └── wiki_manifest.py          # writes/updates docs/wiki/manifest.json
+```
+
+Project-side state (written by the plugin, committed in the user's repo):
+`docs/wiki/{BRAIN.md, project-profile.md, manifest.json, index.md, log.md, <pages>}`
+plus working state in `docs/wiki/.compile/{compile-queue.md, mining/}`.
+
+Key generalization: the current `.claude/skills/brain/SKILL.md` hardcodes TT's schema.
+In the plugin, per-project schema (page types, extraction rules, conventions) moves to
+a generated `docs/wiki/BRAIN.md` in each project; the plugin skills read it. Step 1 of
+the build is porting `/brain` to this form and verifying it reproduces today's
+behavior on the TT repo exactly.
+
+## 5. Domain profiles (data, not prompts)
+
+One compile skill consumes `profiles/*.yaml`. Each profile defines:
+
+- `detect`: census signals (`package.json + backend/*.py` → fullstack-app;
+  high `.sql`/`.ipynb` density → research-data; `.md`/`.pdf` dominant, no build
+  files → generic).
+- `page_types`: `{type, directory, one_page_per}` rows; becomes the generated
+  BRAIN.md schema table.
+- `extraction`: per-filetype rules (`{glob, extract, ignore}`).
+- `source_priority`: which sources seed the queue first (ADRs > CLAUDE.md > code
+  for apps; docs > SQL > notebooks for research).
+- `escalation`: the ladder (too big → subagent; ambiguous → queue-mark
+  `needs-human`, never guess; contradiction → Finding in log.md).
+- `redaction`: hard rules. research-data carries "knowledge never data" verbatim:
+  schemas, meanings, aggregate conclusions yes; row values, PII, anything
+  subscriber- or site-identifying never.
+
+Reference instantiations: **TokenTelemetry** → fullstack-app (page types
+harness/subsystem/feature/decision/playbook/convention, i.e. exactly today's wiki).
+**BQ research project** → research-data (dataset-table/metric/analysis/query-pattern/
+decision/gotcha; `.sql` → intent + lineage + joins, BQ metadata → schema +
+partitioning, `.csv` → column semantics only, `.ipynb` → conclusions not cell
+outputs).
+
+Phase 0 (`/brain-init`) always proposes and the user confirms; detection is a
+proposal, not a verdict. The confirmed result is saved to `project-profile.md` so it
+never re-asks.
+
+## 6. The compile loop and session mining
+
+`/brain-compile` adapts the proven master-prompt-v2 design:
+
+1. **Seed** `compile-queue.md` from profile source-priority census, git-historian
+   topics, session-mining aggregation, and (optionally) the TT dashboard's top
+   re-read files. Items: `- [ ] path|topic | kind | gist | priority`.
+2. **Per batch** (3-6 pages by topic): fan out source-readers per extraction rules;
+   write/update pages against BRAIN.md; regenerate index.md; append log.md; run
+   `okf_lint.py`; commit (`docs:` prefix); check off queue items with the commit hash.
+3. **Wiki-as-context after batch 1**: later batches read index.md + adjacent pages
+   first; update rather than duplicate.
+4. **Checkpoint rule**: on context pressure, stop cleanly at a batch boundary and
+   tell the user to rerun `/brain-compile`. Resume = read queue, continue at first
+   unchecked batch. Survives context exhaustion, session death, multi-day gaps.
+5. The manifest records `status: compiling|complete` and batch progress. Generated
+   skills refuse wiki-first routing while status is `compiling` (a half wiki must
+   never be silently trusted as complete).
+
+**Session mining (structural signals only, D2).** Past sessions are mined for:
+file-read frequencies (page priority signals), repeated error-loop signatures and
+retry patterns (guardrail candidates), file co-occurrence (topic clustering), tool
+call mix. `session_scan.py` locates this project's logs (Claude Code JSONLs
+first-class; other harnesses later and behind a flag), emits slim event streams;
+session-miner subagents return fixed-schema notes, hard-capped, extract-and-discard.
+**Never extracted:** transcript prose, user messages, tool outputs, data values.
+If content-shaped mining ever ships, output goes to a gitignored scratch file the
+user promotes by hand; nothing content-derived flows directly into committed pages.
+
+## 7. Generated optimization skills (/skillsmith)
+
+A generated skill is one SKILL.md derived deterministically from wiki + profile +
+mined waste evidence. Its value is entirely in project-noun specificity; every rule
+names a real artifact (a page path, a helper module, a validated query). Sections:
+
+1. Frontmatter + trigger, modes lite/full/ultra.
+2. **Knowledge routing (wiki-first)**: question class → page path, plus the negative
+   form ("never re-derive what a page answers; stale page → flag for `/brain
+   ingest`, do not silently re-explore").
+3. **Decision ladder**, 5-9 rungs, domain-adapted; the unit of reuse differs
+   (helper functions vs validated queries vs templates).
+4. **Cost model**: what is being optimized, in priority order. For research-data,
+   BigQuery bytes billed can dominate LLM tokens, so the ladder reorders around
+   dry-run gating. The framework generalizes to any metered resource.
+5. **Output style + auto-clarity boundaries**: telegraphic defaults with an
+   enumerated, project-specific full-prose list (TT: auth changes, UPDATE.json copy;
+   BQ: analysis writeups, statistical claims, cost-incurring confirmations).
+6. **Learned guardrails** (headroom-learn style, behavior only, never data values).
+7. **Cache hygiene**: stable prefixes, no mid-session CLAUDE.md churn.
+8. **Hard negative constraints + escape hatch**.
+
+Abbreviated reference sketches (full versions in the analysis session):
+
+```markdown
+# tt-optimize (fullstack-app)
+Routing: orientation → docs/wiki/index.md; harness formats → harnesses/<x>.md
+(never re-open ~/.claude fixtures); internals → subsystems/; process → playbooks/.
+Ladder: needed at all? → existing scanner helper? → stdlib/framework? → installed
+dep (NO new deps without asking; issue #91)? → minimal code, honest n/a over
+estimates. Full prose required: RemoteAuthMiddleware/CORS changes, UPDATE.json copy,
+error-hint text. Guardrails: day buckets are LOCAL days; confirm fresh .next before
+validating. Never optimize away: trust-boundary validation, middleware ordering,
+the 3-layer error-category rule.
+```
+
+```markdown
+# bq-research-optimize (research-data)
+Cost model: BigQuery bytes billed FIRST, LLM tokens second.
+Routing: table questions → wiki/tables/<t>.md (never run a discovery query a page
+answers); prior computations → wiki/queries/ validated snippets; definitions →
+wiki/metrics/.
+Ladder: validated snippet exists? → INFORMATION_SCHEMA/table page instead of
+scanning? → dry-run FIRST, report est. bytes, stop over cap (default 10 GB) →
+always partition filter, never SELECT *, LIMIT does not cut cost → shape in Python,
+not re-queries.
+Redaction: pages and this skill state shapes/schemas/distributions, NEVER row
+values, PII, sample records, or query results.
+Full prose required: analysis writeups, caveats, significance claims.
+```
+
+**Anti-compounding invariants (lint-enforced; generation fails without them):**
+
+- The wiki is a **map, not testimony**: use it to find sources; cite only sources
+  for anything user-visible.
+- Every page carries the git SHA it was compiled from; pages whose `resource:`
+  sources changed since compile are untrusted (cheap `git diff --stat <sha>` check).
+- Distrust triggers: wiki-vs-file contradiction, user correction, failing check →
+  raw-source mode for that topic.
+- Domain verify-floors that laziness cannot override: numbers get recomputed
+  (the repo's "verify before reporting done" rule, exported); nothing ships on wiki
+  authority alone.
+- ponytail's negative-constraint section and caveman's auto-clarity floor are fixed
+  template blocks, never removable.
+- Diff-before-install: a skill is prompt injection into every future session;
+  silent install is unacceptable.
+- Regenerable, never hand-tuned: generated-by header with wiki SHA + profile
+  version; the fix path is edit wiki/profile → regenerate.
+- "When this skill is wrong" escape note, always present.
+- Size budget ~1.5k tokens (lite): the skill is overhead paid every session.
+
+## 8. Wiki lifecycle in the TT dashboard: detection, import, scenarios
+
+The dashboard's per-project section gains a **Knowledge** card. TT never writes into
+the user's repo: "import" means *detect + validate + register*, with registration
+state in `~/.tokentelemetry` (config/history.db), like an Obsidian vault registry.
+Anything that converts or writes is a plugin command the card only tells you to run.
+
+Detection (scanner-side, reusing the existing project-dir walk that already powers
+skills scanning): `docs/wiki/manifest.json` (first-class), OKF-ish signals
+(index.md + log.md + frontmatter `type:` fields), Obsidian markers (`.obsidian/`),
+generic markdown-wiki shapes. Docs *sites* (mkdocs/docusaurus/API docs) are
+recognized and excluded: a rendered docs site is not a second brain.
+
+Validation tiers:
+
+| Tier | Signals | What it unlocks |
+|------|---------|-----------------|
+| Full OKF | manifest + frontmatter + index | Health card, staleness checks, before/after measurement, /skillsmith |
+| Partial | markdown wiki, links resolve, no/partial frontmatter | Registration + measurement only; card suggests `/brain adopt` to unlock routing skills |
+| Not a wiki | docs site, auto-generated API docs | Not offered |
+
+Scenario matrix:
+
+| # | Scenario | Dashboard behavior | Plugin action offered |
+|---|----------|--------------------|-----------------------|
+| S1 | No wiki exists | Knowledge card shows the project's waste metrics (top re-read files, exploration share) + "Build a second brain" CTA | `/brain-init` (the waste metrics seed the compile queue) |
+| S2 | Plugin-built wiki (manifest present) | Auto-registered. Health card: page count by type, last updated, staleness badge, before/after token trend split at `manifest.created` | `/brain ingest` on staleness |
+| S3 | Hand-built OKF-ish wiki, no manifest (e.g. TT's own docs/wiki today) | "Detected knowledge base at docs/wiki. Register it?" → user confirms → registered (Partial or Full tier) | `/brain adopt`: generate manifest, fill frontmatter gaps, rebuild index; shown as a diff |
+| S4 | Obsidian vault inside the repo (`.obsidian/` present) | Same as S3, plus link-style caveat: `[[wikilinks]]` don't resolve for plain-markdown agents | `/brain adopt` converts wikilinks → relative links (or emits an alias map); suggests gitignoring `.obsidian/` |
+| S5 | External wiki/vault outside the repo | User supplies the path; registered as external; measurement works | Generated skill routes via absolute path; card recommends moving/symlinking into the repo for portability. TT never copies content |
+| S6 | Multiple candidates (docs/wiki + a vault) | Picker; exactly one primary per project | Others can be registered as secondary (measured, not routed to) |
+| S7 | Compile in progress (queue has unchecked items / manifest `status: compiling`) | Progress: "4 of 9 batches, last commit <sha>", resume command shown | `/brain-compile` to continue; generated skills refuse wiki-first mode until complete |
+| S8 | Stale wiki (manifest SHA far behind HEAD; resource files changed) | Staleness badge with the count of affected pages | `/brain ingest` (or recompile if drift is large) |
+| S9 | Registered path disappeared (moved/deleted) | Marked unlinked; historical before/after boundary retained; asks user to re-point or forget | Re-register or `/brain-init` fresh |
+| S10 | User declines ("this project doesn't need one") | Choice recorded; card collapses to metrics only, never re-prompts | n/a |
+
+Monorepos: registration is per TT-project (per scanned cwd); a shared root wiki may
+be registered by several projects, and per-package wikis win over a root wiki when
+both exist (closest-ancestor rule, mirroring the profile confirmation step).
+
+## 9. Measurement loop (the honest part)
+
+With a registration date (S2/S3) or manifest.created, TT splits per-project metrics
+into before/after: input tokens/session, cache-hit ratio, exploration-tool share,
+top re-read files (once the scanner extracts file paths), cost/week. Framing is
+**observational trend, never causal claim**, with a visible confound disclosure
+(model switches, segment by `models_used`; harness updates; task-mix change; pricing
+changes; excluded estimated-input harnesses). Showing a zero or negative delta is a
+feature: it is the honesty that differentiates this loop from every optimizer's
+self-reported savings.
+
+## 10. Build order
+
+| Step | What | Notes |
+|------|------|-------|
+| 1 | Port `/brain` to plugin form; TT-specifics → generated BRAIN.md | Must reproduce today's behavior on this repo exactly |
+| 2 | `okf_lint.py`, `profile_census.py`, profiles, `/brain-init` | Test detection on TT and the BQ repo |
+| 3 | `/brain-compile` (files + git only) | Dogfood: full compile of a third, wiki-less project |
+| 4 | Structural session mining (Claude Code JSONLs first) | TT's scanner code is the parsing reference |
+| 5 | `wiki_manifest.py` + TT-side detection + Knowledge card (S1-S10) | Separate TT PR; enables before/after |
+| 6 | `/skillsmith` | Last: needs a mature wiki + mining evidence to beat generic advice |
+
+## 11. Explicitly cut (the never list)
+
+- TT-the-dashboard writing wikis or skills into user repos, ever.
+- Transcript-content mining into committed pages (D2).
+- Untested domain profiles shipped as first-class (D3).
+- One-shot in-session compilation without the queue (D4).
+- Runtime LLM calls or any new outbound network from the dashboard
+  ([[local-first-no-user-network]]).
+- Causal "the wiki saved you X tokens" claims (§9).

--- a/docs/wiki/analyses/brain-savings-approaches.md
+++ b/docs/wiki/analyses/brain-savings-approaches.md
@@ -1,0 +1,138 @@
+---
+type: Analysis
+status: proposed
+title: How to prove the brain saves tokens, ranked approaches
+description: Depth-and-breadth assessment of eight measurement approaches, grounded in a real 2-arm pilot on education_video and a 51-session trace audit; adherence, not wiki quality, is the current bottleneck.
+tags: [plugin, benchmarks, token-savings, adherence, methodology]
+timestamp: 2026-07-06
+resource: docs/wiki/ideas/prove-brain-token-savings.md
+---
+
+# How to prove the brain saves tokens, ranked approaches
+
+Analysis saved from the 2026-07-06 research session that assessed
+[Prove the brain saves tokens](../ideas/prove-brain-token-savings.md).
+Eight candidate approaches were enumerated, a real pilot experiment and a
+historical trace audit were run, and two adversarial reviews (experimental
+methodology; product honesty) attacked the draft ranking. Body is a snapshot;
+only `status` may change.
+
+## Evidence gathered
+
+**Pilot A/B (education_video, 2026-07-06).** Two identical copies of the
+repo (~4.8MB source), one with its compiled 18-page wiki plus the
+CLAUDE.md/AGENTS.md pointer block, one stripped. Six questions (four
+wiki-covered, one partial, one uncovered), headless sonnet sessions,
+`--max-turns 25`; replicate 2 partially killed by plan session limits
+(16 valid sessions, ~$5).
+
+| q | plain $ / turns | wiki $ / turns | wiki reads | delta |
+|---|---|---|---|---|
+| q1 playbook | .405 / 6 | .416 / 9 | 0 | wiki worse (both reps) |
+| q2 decision | .364 / 10 | .452 / 14 | 0 | wiki worse (both reps) |
+| q3 subsystem | .283 / 7 | .237 / 8 | 2 | wiki better |
+| q4 convention | .404 / 15 | .223 / 9 | 3 | wiki halves cost, cache reads -62% |
+| q5 partial | .218 / 7 | .201 / 5 | 0 | noise |
+| q6 uncovered | .351 / 6 | .303 / 6 | 0 | noise |
+
+Both arms answered all six questions correctly (scored against
+independently read ground truth), so correctness could not discriminate.
+
+Findings that survive small n (existence proofs, not effect sizes):
+
+- **Adherence is the bottleneck.** 4 of 6 questions never consulted the wiki
+  despite the pointer block and direct page coverage. Where ignored, the
+  wiki arm was consistently equal-or-worse (pointer overhead without
+  benefit); where consulted, it won both times, once halving cost
+  (turns 15 to 9).
+- **The saving mechanism is avoided turns, not avoided file bytes.** The
+  whole wiki is ~13.5k tokens (median page ~560); q4's win came from six
+  fewer turns, each avoided turn skipping a re-read of the growing context
+  (446k fewer cache-read tokens). Savings therefore scale with context and
+  repo size; a small repo is the wrong regime to benchmark in.
+- **Dollar cost is not a usable primary metric.** Same-condition replicates
+  varied 3x on prompt-cache state alone. Turns, tool calls, and cache-read
+  volume are steadier (a credible effect needs ~15-20 paired replicates per
+  question on turns; 100+ on dollars).
+- **Verification tax.** One wiki session re-verified pages against code per
+  the map-not-testimony rule, nearly erasing its win. Correct behavior, but
+  it caps savings on small repos and must be priced into expectations.
+
+**Trace audit (51 historical sessions, this repo + education_video).**
+Zero sessions ever consulted a wiki (the TT wiki lives on an unmerged
+branch), so observational metrics have no data yet. Exploration is 40-57%
+of tool calls once Bash-carried searching is counted; the corpus contains
+zero Grep/Glob tool calls, so wiki-read detection must parse Bash command
+strings. `backend/main.py` was read 119 times across 16 sessions, the
+single clearest re-read-waste signal. Raw JSONLs get pruned (education_video
+kept one file), so tool-level classification must persist at scan time;
+durable history already keeps the aggregates.
+
+## The ranked approaches
+
+No single approach answers everything, but one thing beats all in
+sequence: fix and measure routing before measuring savings. Measuring
+savings of a wiki agents do not open measures a discovery bug and will
+"prove" zero.
+
+1. **Adherence experiment (run first).** Manipulate the routing mechanism —
+   pointer-block wording/placement, index-in-pointer, and the skillsmith
+   skill's wiki-first section as its own arm — with a binary outcome:
+   did the session consult the wiki on a covered question. Binary outcomes
+   are cheap (~20-25 runs per arm detects 30% to 70%); this also answers
+   the idea's skillsmith doubt. Gate: no savings benchmark until a variant
+   reaches roughly 4-of-6 adherence.
+2. **Scanner-side session classification, then the honest in-product
+   panel.** Persist per-session wiki-touch flag, exploration share, and top
+   re-read files into the durable history at scan time (parsing Bash
+   commands, not just Read paths). On top of it ship only §9-legal copy:
+   build cost (already shipped), "N of M sessions read the wiki since
+   build", within-period wiki-touch vs non-touch comparison with the
+   selection-bias disclosure, and past-spend re-read facts ("you spent X
+   tokens re-reading these files"). Never a payback number:
+   `build_cost / saving` is a causal claim in arithmetic clothing and §11
+   bans it; zero and negative deltas render identically.
+3. **One controlled benchmark campaign (after routing works).** Large repo
+   (this one, where the 119x re-read lives), 2x2 pointer-x-wiki factorial
+   plus a wiki+skill arm; questions sampled from historical session prompts
+   (not curated against the wiki); intention-to-treat pre-registered;
+   primary metrics turns/tool calls/cache-read volume with cold-cache
+   control; 3+ replicates; checkpoint-and-resume harness (plan limits kill
+   long runs). One published campaign with method, rerun only when routing
+   mechanics change, never per release. The causal payback number may exist
+   exactly once, here, clearly labeled benchmark-measured.
+4. **Re-read waste card (pre-build, observational).** The §8 S1 Knowledge
+   card powered by the same scanner data: past spend only, named files,
+   no counterfactual ("could save you") phrasing. Doubles as compile-queue
+   prioritization input.
+5. **Maintainer-only query suite (compiler-regression cadence).** Fixed
+   question sets with ground truth on 1-2 reference repos, run when the
+   compiler or profiles change, never per compile and never on user
+   machines. Its uncoverable-question output is the evidence for the
+   domain-profile doubt; the profile ablation experiment is deferred until
+   a real census visibly straddles profiles.
+
+Deferred: stale-wiki harm arm (meaningless while adherence is low; the
+staleness badge and untrusted-page rule ship without it), profile ablation
+(see 5), any live per-session wiki-hiding on user machines (hostile, never).
+
+## Consequences for existing plans
+
+- Build-order step 6 (skillsmith last) inverts: skillsmith is the routing
+  hypothesis under test in approach 1.
+- The idea page's "compare against comparable pre-brain sessions" is
+  unimplementable as written (before-population tool detail is pruned;
+  zero historical wiki reads); the shipped comparison is within-period
+  wiki-touch vs non-touch with disclosure.
+- Add to the never list: no benchmark LLM sessions launched on user
+  machines; no auto-tuning of pointer/skill text from measured adherence;
+  no marketing savings claim until the published campaign exists.
+
+## Related
+
+- [Prove the brain saves tokens](../ideas/prove-brain-token-savings.md):
+  the idea this analysis assesses.
+- [Delegation and ecosystem telemetry](../subsystems/delegation-telemetry.md):
+  the scanner capabilities approach 2 extends.
+- Design doc §9/§11 (`resource:` on the idea page) supply the honesty
+  constraints the ranking enforces.

--- a/docs/wiki/analyses/graphify-vs-tt-plugin.md
+++ b/docs/wiki/analyses/graphify-vs-tt-plugin.md
@@ -1,0 +1,73 @@
+---
+type: Analysis
+title: graphify vs the tokentelemetry plugin
+description: "Comparison of the graphify knowledge-graph skill and the tokentelemetry second-brain plugin: cousins, not twins; a map vs a field guide, and how they compose."
+resource: docs/design/tokentelemetry-plugin.md
+tags: [analysis, knowledge-base, graphify, plugin, token-optimization]
+timestamp: 2026-07-05
+status: proposed
+---
+
+# graphify vs the tokentelemetry plugin
+
+Question: is graphify (the `/graphify` skill installed on this machine) the
+same thing as the tokentelemetry plugin's second-brain workflow, and should
+they interact?
+
+## What each builds
+
+**graphify** extracts a knowledge graph automatically: thousands of small
+nodes (functions, concepts, papers, images) and typed edges (calls, cites,
+semantically-similar-to), via AST parsing for code plus parallel subagent
+extraction for docs. It clusters the graph into communities, labels them, and
+outputs an interactive HTML map, a report, and query commands (BFS/DFS
+traversal, shortest path). Bottom-up: structure emerges from clustering. Its
+special trick is surprise, connections between files nobody thought to ask
+about.
+
+**The tokentelemetry plugin** compiles a knowledge wiki: a few dozen curated
+prose pages (subsystems, decisions, gotchas, playbooks) with typed OKF
+frontmatter, an index, and a log. Top-down: a domain profile decides the page
+types, and structural session mining decides which pages to write first (in
+this repo, `backend/main.py` re-read 71 times across 9 sessions is the page
+priority signal). On top, `/skillsmith` generates a per-project skill that
+routes the agent to pages instead of re-exploring, and the TT dashboard
+measures before/after token use.
+
+## Real overlaps
+
+Both are Karpathy-lineage (graphify cites the /raw folder workflow, ours the
+llm-wiki pattern). Both fan out subagents to read the corpus. Both keep
+resumable, incremental state on disk. Both carry honesty rules (graphify tags
+every edge EXTRACTED/INFERRED/AMBIGUOUS; the wiki requires every fact grounded
+in a named source). Both target token reduction. graphify even has a `--wiki`
+flag, but it auto-generates one article per cluster rather than curated typed
+pages.
+
+## Key differences
+
+| | graphify | tokentelemetry plugin |
+|---|---|---|
+| Knowledge shape | graph: 1000s of nodes and edges | wiki: ~40 curated typed pages |
+| Structure decided by | clustering algorithm | domain profile + maintainer |
+| Best at answering | "what connects to what?" | "what does this mean, what did we decide, what bit us before?" |
+| Uses past chat sessions | no | yes (structural signals set page priorities) |
+| Generates an optimization skill | no (a CLAUDE.md note at most) | yes: ladder, guardrails, staleness checks |
+| Proves savings | one-shot benchmark estimate | dashboard before/after on real sessions |
+| Dependencies | pip package (networkx, whisper, ...) | stdlib scripts + prompts |
+
+## Conclusion
+
+A map vs a field guide. The map shows every road and where they cross; the
+field guide says which roads matter, why, and where the potholes are. They
+compose rather than compete.
+
+Proposed follow-ups (not implemented):
+
+1. Run graphify on a new codebase for orientation, then `/brain-init` +
+   `/brain-compile` for the durable second brain.
+2. Feed graphify's god nodes into the `/brain-compile` queue as page
+   candidates (a third seeding signal next to git history and session
+   mining).
+3. Optionally point graphify at `docs/wiki/` itself to visualize the wiki's
+   link structure beyond what Obsidian shows.

--- a/docs/wiki/analyses/multi-harness-session-mining.md
+++ b/docs/wiki/analyses/multi-harness-session-mining.md
@@ -1,0 +1,110 @@
+---
+type: Analysis
+status: proposed
+title: Multi-harness session mining for the plugin
+description: How to extend the plugin's session_scan beyond Claude Code to every harness TokenTelemetry parses, with a per-harness feasibility matrix and three build options.
+tags: [plugin, session-scan, harnesses, brain-compile, session-miner]
+timestamp: 2026-07-06
+resource: backend/main.py
+---
+
+# Multi-harness session mining for the plugin
+
+Saved from a maintainer chat, 2026-07-06. The plugin's `session_scan.py` only
+mines Claude Code sessions, while TokenTelemetry itself parses ~13 agent
+sources. This analysis maps the gap and ranks the ways to close it.
+
+## Current state
+
+`tokentelemetry-plugin/scripts/session_scan.py` is Claude-only by
+construction: the projects root is hardcoded to `~/.claude/projects`, the
+event shape assumed is Claude's JSONL (`message.content[].tool_use`,
+`message.usage`), and `--harness` literally rejects any value but `claude`
+("other harnesses are behind a future flag per design"). Its consumers are
+the `session-miner` subagent (brain-compile topic seeding) and skillsmith's
+structural mining. Its privacy boundary: structural signals only — tool
+counts, file paths from tool inputs, error flags, loop signatures, token
+totals; never message text, never Bash command strings.
+
+## What TokenTelemetry already knows (backend/main.py)
+
+All parsing lives in `_scan_sessions_sync` (~1,300 lines) plus per-agent
+detail parsers (~900 lines). Per harness, the three facts that decide
+minability: where sessions live, how a session is tied to a project, and
+whether the log carries tool-level file paths.
+
+| harness | store | project attribution | mineable signals |
+|---|---|---|---|
+| claude | `~/.claude/projects/<enc>/*.jsonl` | encoded dir + `cwd` | full (done today) |
+| codex | `~/.codex/sessions/**/rollout-*.jsonl` | `cwd` in rollout meta | tokens + tool mix; path signals sparse (tools are shell commands, whose strings the privacy rule excludes) |
+| qwen | `~/.qwen/projects/**/chats/*.jsonl` | per-project tree | tool calls present; layout closest to Claude's |
+| opencode | SQLite `session`/`message`/`part` | `session.directory` column | full (`part` rows typed `tool`) |
+| antigravity | `~/.gemini/antigravity/brain/` + `antigravity-cli/conversations/<id>.db` | brain metadata / CLI db | full via the CLI SQLite (richer than brain markdown) |
+| cline | `~/.cline/data/db/sessions.db` + VS Code globalStorage JSON | db fields | tool calls present |
+| smallcode | `<project>/.smallcode/traces/*.json` | project-local by definition | full (`steps[]` with `tool_call`) |
+| copilot-cli | `~/.copilot/session-state/<id>/events.jsonl` | session-state metadata | tool events (`toolInvocation`) |
+| grok | `~/.grok/sessions/<id>/` (events + chat history) | session metadata | `tool_calls` in chat history |
+| vibe | `~/.vibe/logs/session/*.json` | file metadata | messages with roles; moderate |
+| hermes | `~/.hermes` SQLite (pre-aggregated tokens) | db fields | tokens reliable; `tool_calls` JSON in messages |
+| cursor | `~/.cursor/projects/**/agent-transcripts/<sid>/<sid>.jsonl` | per-project tree | transcripts exist but no usage data; paths-only at best |
+| gemini | `~/.gemini/tmp/<sha256(cwd)>/chats/*.json` | sha256 reverse map | legacy — CLI discontinued 2026-06-18; skip |
+
+Omnigent is planned for TT but not yet in `main.py`; when it lands, the same
+question recurs (read-only `~/.omnigent/chat.db` scan).
+
+## Constraint that shapes everything
+
+The privacy boundary must hold per adapter, and it bites differently per
+harness. Claude's file tools put paths in structured inputs; Codex's tool
+stream is mostly shell strings, which the rule forbids reading, so a Codex
+adapter honestly yields tokens and tool mix but few path signals. Signals
+must degrade gracefully rather than tempt an adapter into parsing command
+text.
+
+## Options
+
+1. **A — adapter registry inside `session_scan.py`.** One locate+parse
+   adapter per harness, capability-tagged (`full` / `tokens-only` /
+   `paths-only`), `--harness all` as the new default, aggregate keyed by
+   harness. Stdlib-only holds (`sqlite3` is stdlib; every store is a file or
+   SQLite db). Cost: re-states parsing knowledge TT's backend already has,
+   and format drift must now be caught twice.
+2. **B — ask the TT backend.** New `/sessions/signals?project=` endpoint
+   computing the same signal shape with the existing parsers; the plugin
+   queries it and falls back to the local Claude scan. No duplication, but
+   brain-compile then needs a running backend, and the plugin's scripts stop
+   being self-contained.
+3. **C — shared parser library.** Extract per-harness session reading from
+   `main.py` into a package both the backend and the plugin use. Cleanest
+   end state; largest refactor of a monolith a solo maintainer ships from.
+
+## Recommendation
+
+A now, C later, B never as a dependency (fine as a bonus fast-path). Mining
+runs once per compile and offline; a compile-time server dependency is the
+wrong trade. Build A in evidence-value order — codex, opencode,
+antigravity-cli, qwen, cline, smallcode — then copilot-cli, grok, vibe,
+hermes (tokens-only); cursor paths-only if at all; gemini skipped as legacy.
+Each adapter ships with a sanitized fixture log and a conformance test so
+format drift surfaces in CI, not in a silent empty scan.
+
+Add a new-agent playbook to the plugin docs: when TT gains an agent source,
+the adapter checklist is (1) store path + env override, (2) project
+attribution rule, (3) tool stream location and whether paths are structured
+inputs or strings, (4) token fields, (5) fixture + test. That makes "new
+coding agent added, scan its sessions too" a bounded task instead of a
+re-exploration.
+
+## Follow-ups
+
+- Decide option (maintainer call), then implement adapters in priority order.
+- Fold the harness matrix above into the plugin's AUTHORING docs as the
+  playbook seed.
+- Revisit when Omnigent lands in TT.
+
+## Related
+
+- [Prove the brain saves tokens](../ideas/prove-brain-token-savings.md):
+  session evidence quality directly feeds brain-compile topic seeding.
+- The plugin design doc (`docs/design/tokentelemetry-plugin.md`) fixed the
+  structural-only privacy rule this analysis keeps load-bearing.

--- a/docs/wiki/analyses/multi-harness-session-mining.md
+++ b/docs/wiki/analyses/multi-harness-session-mining.md
@@ -1,6 +1,6 @@
 ---
 type: Analysis
-status: proposed
+status: adopted
 title: Multi-harness session mining for the plugin
 description: How to extend the plugin's session_scan beyond Claude Code to every harness TokenTelemetry parses, with a per-harness feasibility matrix and three build options.
 tags: [plugin, session-scan, harnesses, brain-compile, session-miner]
@@ -9,6 +9,11 @@ resource: backend/main.py
 ---
 
 # Multi-harness session mining for the plugin
+
+Status 2026-07-06: adopted. The maintainer picked option A (with codex
+shell-string path extraction approved); implemented as the plugin's
+`scripts/harness_adapters.py` registry, commit `09762fe` (plugin v0.4.0,
+11 adapters, per-adapter fixtures in `tests/`).
 
 Saved from a maintainer chat, 2026-07-06. The plugin's `session_scan.py` only
 mines Claude Code sessions, while TokenTelemetry itself parses ~13 agent

--- a/docs/wiki/analyses/next-token-optimization-techniques.md
+++ b/docs/wiki/analyses/next-token-optimization-techniques.md
@@ -1,0 +1,120 @@
+---
+type: Analysis
+status: proposed
+title: Four token-optimization techniques beyond the current seeds
+description: Data-mined candidates attacking conversation shape (turn batching, tool-result diet, scout delegation, checkpoint-restart), the waste pools ponytail, caveman, headroom and the wiki do not touch.
+tags: [plugin, token-savings, skillsmith, batching, delegation, methodology]
+timestamp: 2026-07-06
+resource: docs/wiki/analyses/brain-savings-approaches.md
+---
+
+# Four token-optimization techniques beyond the current seeds
+
+Saved from the 2026-07-06 research session. The existing techniques attack
+output volume (ponytail ladder), prose (caveman style), input slices, cache
+hygiene and learned guardrails (headroom), and orientation knowledge
+(llm-wiki/OKF). None attack conversation shape: turn count, context growth,
+delegation topology, session lifecycle. This session's experiments showed
+that is where the money is (cost tracked turns times context size, not file
+bytes). Three independent sources fed this list: architectural reasoning, a
+105-transcript waste-pool measurement, and an independent Codex session
+whose proposals converged on the same shapes.
+
+## Measured waste pools (105 transcripts, this repo + experiment copies)
+
+- Parallel tool batching is nearly absent: 1.5% of tool-using turns issue
+  more than one call; 278 consecutive read-only turns were collapsible,
+  carrying ~26M replayed cache-read tokens (upper bound; cached replays
+  bill at ~0.1x).
+- Tool-result bloat is concentrated: 1.7% of tool results carry 24.8% of
+  all result bytes; whole-file Reads are the top offender (44% of Reads
+  pass no window).
+- Context grows ~1.5-2k tokens per turn; the final third of a long
+  session's turns costs 37% of its cache-read spend (33% would be flat).
+  Real but modest in this corpus.
+- Delegation is rare (16% of sessions) and shallow: even delegating
+  sessions keep 13x more input-side tokens in the parent than in children.
+
+## T1. Turn batching (bundle-and-fence)
+
+Mechanism: every assistant turn replays the whole context; K independent
+read-only calls issued as one message pay one replay instead of K. The
+adherence experiment's 11-to-4 turn drop halving cost is the same lever.
+Rule form: plan reads upfront; issue independent Read/Grep/Glob in a single
+message; never alternate think-read-think-read for enumerable reads.
+Evidence: 1.5% batching rate today; largest measured pool.
+Experiment: fixed task set, arm with a batching rule in CLAUDE.md vs
+without; primary metric turns and cache-read volume, correctness gate.
+Risk: over-batching fetches wrong files (loses adaptivity); ceiling where
+the next read genuinely depends on the previous result.
+
+## T2. Tool-result diet (windowed reads, fat-tail caps)
+
+Mechanism: a large tool result is paid once when produced, then re-paid in
+every later turn. The waste is in the tail: cap the 1.7% of results that
+carry a quarter of the bytes. Extends headroom's grep-before-read from
+advice to enforcement (a PreToolUse hook can warn on whole-file reads of
+large files; slim output flags on Bash).
+Evidence: result sizes p50 328 chars vs p99 13k; Read is the top offender.
+Experiment: tasks over large files with and without a windowed-read rule;
+measure context size at end, re-read rate (windowing that misses context
+forces re-reads, the failure mode to watch), correctness.
+Risk: missing imports/distant definitions causes wrong edits or re-reads
+that erase the saving.
+
+## T3. Scout delegation (thin parent, disposable children)
+
+Mechanism: exploration noise kept in the parent is re-paid every subsequent
+turn; a subagent's context is paid once and discarded, returning
+conclusions only. Moves the quadratic term to a throwaway.
+Rule form: exploration expected to exceed ~N tool calls or produce dumps
+goes to a scout subagent; the parent receives verdict plus evidence
+pointers, never raw output.
+Evidence: delegation used in 16% of sessions, parent spend still dominates
+13:1, so the pattern exists but barely offloads; TT's delegation telemetry
+already measures the split, so this is cheap to evaluate on real usage.
+Experiment: search-heavy tasks inline vs scouted; measure parent context at
+end, total tokens (parent plus child), correctness. Model tiering (haiku
+scouts) is a follow-on multiplier, not part of the base test.
+Risk: lossy summaries force the parent to reopen the search; child
+cold-start overhead exceeds the saving on small explorations.
+
+## T4. Checkpoint-restart (capped context, cheap re-entry)
+
+Mechanism: the only technique that caps growth instead of slowing it: at a
+milestone, write a small state capsule (decisions, open files, next steps)
+and restart the session from it. Compounds with the second brain: the
+index-in-pointer experiment showed re-orientation costs ~2-4 turns when a
+wiki exists, which is what makes restarts cheap enough to consider.
+Evidence: the corpus long-session tax is modest (37% vs 33%), so this ranks
+last here despite an independent reviewer ranking it first structurally;
+it should pay mainly on very long sessions and harnesses without good
+compaction.
+Experiment: multi-milestone tasks, one continuous session vs
+restart-at-milestone with capsule plus wiki; total tokens and rework rate.
+Find the break-even context size from the growth curve before promoting it.
+Risk: the capsule omits a latent constraint and causes silent rework;
+built-in compaction already approximates this, so the marginal win may be
+small.
+
+## Rejected or deferred
+
+- Delta-only output (diffs over whole files): already mostly enforced by
+  the Edit tool and covered by ponytail/caveman's volume rules.
+- Model tiering: a multiplier on T3, not independent; test after T3 stands.
+- Windowed subtask fanout (parallel candidate solutions): coordination
+  overhead likely exceeds savings at this project's scale.
+
+## Adoption path
+
+Each surviving technique becomes a skillsmith seed (like ponytail, caveman,
+headroom) only after its experiment shows a real effect; the adherence
+lesson applies to these too: a rule agents do not follow saves nothing, so
+each experiment must measure adherence to the rule, not just the outcome.
+
+## Related
+
+- [How to prove the brain saves tokens, ranked approaches](brain-savings-approaches.md):
+  the measurement methodology these experiments should follow.
+- [Prove the brain saves tokens](../ideas/prove-brain-token-savings.md):
+  the idea thread this extends.

--- a/docs/wiki/analyses/wiki-staleness-failure-modes.md
+++ b/docs/wiki/analyses/wiki-staleness-failure-modes.md
@@ -1,6 +1,6 @@
 ---
 type: Analysis
-status: proposed
+status: adopted
 title: Wiki staleness failure modes and the update-nudge design
 description: Eleven-agent simulation of how a compiled wiki fails after code drift, what can go catastrophically wrong, and a harness-agnostic design for suggesting (never auto-running) ingest.
 tags: [plugin, staleness, ingest, nudge, multi-harness, security, simulation]
@@ -9,6 +9,13 @@ resource: docs/design/tokentelemetry-plugin.md
 ---
 
 # Wiki staleness failure modes and the update-nudge design
+
+Status 2026-07-06: adopted, with the maintainer's refinement that stale
+pages FALL BACK to source (wiki-as-cache) instead of demanding updates.
+Shipped as plugin v0.5.0 commit `060b674`: `wiki_manifest.py stamp`
+(content-hash provenance) + self-contained `docs/wiki/status.py`
+(FRESH/STALE/TAMPERED/UNVERIFIABLE, --note refresh queue), hardened by a
+4-role agent review; rolled out to this wiki and education_video.
 
 Saved from a maintainer chat, 2026-07-06. Trigger: a real incident — the
 maintainer merged code changes, forgot `/brain ingest`, and later got a

--- a/docs/wiki/analyses/wiki-staleness-failure-modes.md
+++ b/docs/wiki/analyses/wiki-staleness-failure-modes.md
@@ -1,0 +1,149 @@
+---
+type: Analysis
+status: proposed
+title: Wiki staleness failure modes and the update-nudge design
+description: Eleven-agent simulation of how a compiled wiki fails after code drift, what can go catastrophically wrong, and a harness-agnostic design for suggesting (never auto-running) ingest.
+tags: [plugin, staleness, ingest, nudge, multi-harness, security, simulation]
+timestamp: 2026-07-06
+resource: docs/design/tokentelemetry-plugin.md
+---
+
+# Wiki staleness failure modes and the update-nudge design
+
+Saved from a maintainer chat, 2026-07-06. Trigger: a real incident — the
+maintainer merged code changes, forgot `/brain ingest`, and later got a
+confidently stale answer with no warning anywhere. The ask: design a dynamic
+suggestion (never an auto-ingest) that works in any harness, and stress-test
+the whole approach for what can go wrong and what can go crazy-high.
+
+## Method
+
+A workflow ran 6 persona simulations (forgetful maintainer, Codex-only user,
+new collaborator on a 3-month-stale wiki, unattended cron bot following a
+playbook, heavy trusting querier, and a counterfactual world where ingest IS
+auto-run) followed by 5 adversarial critics (staleness/correctness, cost
+runaway, nudge UX, security/injection, multi-harness reality). 11 agents,
+~66 findings; agents verified claims against the real bundle.
+
+## Verified today, in this repo's own wiki
+
+- `docs/wiki` has **no manifest.json**, so the pointer block's only trust
+  gate ("trust while manifest status: complete") evaluates to nothing.
+- **Zero pages carry `compiled_from_sha`** (the adopted bundle predates it),
+  so no sha-based staleness check has anything to key on.
+- **6/6 playbooks and 3/5 conventions have no `resource:`** — the
+  "confirm the page's resource file" rule is structurally inapplicable to
+  exactly the pages agents execute.
+- Three pages share `resource: backend/main.py` (~7k lines), so honest
+  verification costs ~70k tokens and file-level staleness cries wolf.
+
+## Top failure modes (converged across agents)
+
+1. **Stale wiki is worse than no wiki: agents revert code to match it.**
+   The pointer block makes the wiki primary evidence; a stale page outranks
+   fresh code, so the agent "fixes" the port back, recreates a renamed
+   module, or resurrects a moved config file at its old path (silent no-op
+   edits on pricing). Phantom-debug loops cost ~100x the original question,
+   sometimes across multiple harnesses chasing the same ghost.
+2. **The trust gate never flips on drift.** `status: complete` means
+   "compile finished", not "still true"; a 3-month-stale bundle passes every
+   check the system defines. Staleness detection exists only in the
+   dashboard, which nobody opens mid-session.
+3. **Drift is created where the repair path doesn't exist.** Code changes
+   happen in Codex/Cursor/OpenCode sessions; `/brain ingest` is a Claude
+   Code skill. Detection in those harnesses dead-ends, so users hand-edit
+   pages, which forges provenance and permanently masks the staleness.
+4. **Executed pages are the blind spot.** Playbooks (followed verbatim,
+   including by unattended bots) carry no provenance at all. Worst case
+   simulated: a cron bot follows a stale playbook whose flag semantics
+   changed and force-publishes unreviewed HEAD at 2am.
+5. **The wiki is a cross-harness prompt-injection channel.** The pointer
+   block grants pages instruction-level trust in every harness; one poisoned
+   or hand-edited page becomes persistent, repo-committed injection.
+   Provenance is self-asserted frontmatter, so a forged
+   `compiled_from_sha` is undetectable without a content hash.
+6. **Cost runaways.** Deferred catch-up ingest of a 30-merge backlog is a
+   non-resumable token furnace; staleness nudges convert into reflexive
+   full recompiles (2-8M tokens/month steady state); ingest bumps
+   `timestamp` but never re-stamps `compiled_from_sha`, so a sha-keyed
+   nudge would nag forever after a successful ingest.
+7. **Auto-ingest (the rejected design) is confirmed bad.** Simulated week:
+   vendored-diff token furnace, a briefly-committed secret laundered into
+   permanent wiki prose, mid-refactor states distilled as truth with fresh
+   stamps (undetectable staleness), commit spam re-triggering push gates,
+   manifest races across harnesses, and a self-triggering ingest loop on
+   its own docs(wiki) commits.
+
+## Nudge anti-requirements (what the critics killed)
+
+- **Not session-start wallpaper**: with 13 pages keyed to `main.py`, "N
+  files changed" fires on every merge and becomes noise before the first
+  real incident. Fire at point of use, per page.
+- **Not model-rendered**: an instruction asking each agent to compute sha
+  distance is skipped under exactly the economic pressure the wiki creates.
+  The computation must be a script whose output lands in the transcript.
+- **Not commit-sha-keyed**: squash-merges, rebases, 21 worktrees, and gc
+  invalidate `compiled_from_sha` comparisons. Key on content hashes of
+  resource blobs.
+- **Not a writable ledger**: a pending-ingest file forks per branch and
+  races across concurrent harness sessions. Recompute statelessly; the only
+  committed marker is CI-written on main (single writer).
+- **Not git hooks as the trigger**: merges happen on GitHub's servers;
+  fetch has no hook. Local post-merge hooks fire approximately never in
+  this workflow.
+- **Silence must not certify freshness**: the check's output must always
+  enumerate its blind spots ("9 pages have no provenance and cannot be
+  checked").
+
+## Recommended design (suggestion, never auto-run)
+
+1. **Fix the data model first** (prerequisite, cheap): `resource:`
+   mandatory on every page type including playbooks (multiple resources
+   allowed; narrow anchors like `file#symbol` for giant files);
+   `/brain lint` fails without it; manifest records per-page
+   `sha256(resource blob)` and `sha256(page body)` written only by /brain
+   workflows; ingest re-stamps provenance on every touched page.
+2. **One committed, stateless, stdlib check script** (e.g.
+   `docs/wiki/status.py`, installed by compile): recomputes per-page
+   freshness from content hashes, flags hand-edits (page-hash mismatch =
+   tamper), always prints blind spots, and ends with one copy-pasteable
+   next step. Works identically in every harness that can run shell.
+3. **Pointer block carries one stable indirection**: "before answering
+   from or acting on a wiki page, run `python3 docs/wiki/status.py
+   [page]`" — all volatile logic lives in the script, so the nudge itself
+   cannot go stale.
+4. **Point-of-use trust demotion**: a page listed as suspect flips the
+   evidence hierarchy — code is authoritative, never edit code to match a
+   suspect page; pages tagged `security` are always verified regardless of
+   freshness; pages get reference trust, never instruction trust.
+5. **A legal escape hatch for non-Claude harnesses**: never hand-edit;
+   drop a one-line note into `docs/wiki/raw/` (the inbox that already
+   exists and ingest already sweeps): "STALE: <page> contradicts
+   <resource> at <sha>". Detection becomes durable without a new write
+   channel.
+6. **CI marker on main**: a GitHub Action on push-to-main runs the same
+   script and commits a small STALENESS marker, catching the drift that
+   arrives by remote merge, with exactly one writer.
+7. **Ingest catch-up mode**: no-argument `/brain ingest` derives the
+   backlog per page (resource hash mismatch), presents a ranked per-page
+   repair list with token estimates, and processes it as a resumable
+   queue — the anti-recompile.
+
+## Follow-ups
+
+- Implement 1-3 in the plugin (lint rules, status.py, template pointer
+  line); 5 is a pointer-block text change; 6 is a workflow file the
+  installer offers.
+- TT's own wiki needs the data-model backfill (manifest + provenance) via
+  a /brain maintenance pass before any of this can protect it.
+- Skillsmith relation: the routing win (page map in pointer) stays; the
+  status.py line becomes the second fixed line of the pointer block.
+
+## Related
+
+- [Multi-harness session mining for the plugin](multi-harness-session-mining.md):
+  same multi-harness constraint, solved with adapters; the nudge reuses its
+  "committed text + plain files are the only universal transports" lesson.
+- [Prove the brain saves tokens](../ideas/prove-brain-token-savings.md):
+  the measured 12/12 adherence is what makes staleness dangerous — agents
+  now actually read the wiki.

--- a/docs/wiki/conventions/count-once-invariant.md
+++ b/docs/wiki/conventions/count-once-invariant.md
@@ -1,0 +1,26 @@
+---
+type: Convention
+title: Count-once invariant and honest n/a
+description: Every token appears in aggregates exactly once, and signals a harness does not record render as "not recorded", never zero or estimated.
+tags: [convention, telemetry, trust]
+timestamp: 2026-07-02
+---
+
+# Count-once invariant, honest n/a
+
+Two trust rules from `DESIGN.md` that govern all telemetry work:
+
+1. **Count once.** Every token is in project/analytics aggregates exactly
+   once. Where children are already sessions (opencode, hermes, grok, codex,
+   antigravity), parent-side delegated sums are display-only. Where subagent
+   usage was counted nowhere (claude-code), it joins aggregates as a separate
+   `delegated` bucket, and the totals increase is announced in
+   [UPDATE.json](update-json-feed.md), never discovered.
+2. **Honest n/a.** If an agent's logs don't record a signal, render
+   "not recorded by <agent>". No fake zeros, no estimates (cursor subagent
+   tokens are the canonical case). Cache figures follow source semantics:
+   `cached` = high-water-mark of `cache_read_input_tokens` per transcript.
+
+Corollaries: no silent historical changes, model-correct pricing (cost each
+file by its own model), existing aggregate keys stay byte-identical when new
+buckets are added.

--- a/docs/wiki/conventions/error-handling.md
+++ b/docs/wiki/conventions/error-handling.md
@@ -1,0 +1,26 @@
+---
+type: Convention
+title: Classify errors, never dump them
+description: Any summarizer-backend failure must pass through classify() into a titled card with a plain message and actionable hint; raw text only behind a disclosure.
+tags: [convention, errors, ux]
+timestamp: 2026-07-02
+---
+
+# Classify errors, never dump them
+
+A user must never see a bare stack trace, `HTTP 4xx ...`, or a provider JSON
+blob as an error message.
+
+**Why:** raw provider errors are unreadable to the target user and erode the
+polished-local-tool feel.
+
+**How to apply:** adapters raise `SummarizerError` preserving detail;
+`backend/summarizers/errors.py::classify()` buckets it (ordered patterns,
+first match wins); the frontend renders the resulting `error_info` as
+`SummaryErrorCard`. Hints say what to DO (switch model, check
+`ollama serve`, set an env var), not what failed. Prefer graceful
+degradation over erroring (openai_compat's clean-payload retry). Adding a
+category touches three layers; follow the
+[playbook](../playbooks/add-summarizer-error-category.md).
+
+Mechanics: [summarizers subsystem](../subsystems/summarizers.md).

--- a/docs/wiki/conventions/local-first.md
+++ b/docs/wiki/conventions/local-first.md
@@ -1,0 +1,23 @@
+---
+type: Convention
+title: Local-first, no user-machine network calls
+description: No new outbound calls from user machines; data that needs refreshing is refreshed at build/CI time and shipped in releases.
+tags: [convention, privacy, local-first]
+timestamp: 2026-07-02
+---
+
+# Local-first
+
+The brand promise: logs, prompts, tokens, and costs never leave the user's
+machine. Enforced as a design rule, not just marketing.
+
+**Why:** privacy is the product's main differentiator against cloud
+observability tools.
+
+**How to apply:** never add outbound network calls that run on user
+machines. Data that goes stale ([pricing](../subsystems/pricing.md)) is
+refreshed in CI and ships as committed files through normal updates. The
+one deliberate exception is opt-out anonymous, content-free usage stats
+(`backend/telemetry.py`, `DO_NOT_TRACK=1`, redaction tested in
+`test_telemetry_redaction.py`); any future product telemetry must be
+off-by-default (`docs/design/product-telemetry.md`).

--- a/docs/wiki/conventions/pre-push-gates.md
+++ b/docs/wiki/conventions/pre-push-gates.md
@@ -1,0 +1,34 @@
+---
+type: Convention
+title: Pre-push and pre-merge gates
+description: "Three automated gates; UPDATE.json enforcement on feat: pushes, a local Claude review of the branch diff, and a CI npm-audit on package.json changes."
+resource: /.claude/hooks
+tags: [convention, ci, security, hooks]
+timestamp: 2026-07-02
+---
+
+# Pre-push and pre-merge gates
+
+Solo-maintainer substitute for human review, hardened after issue #91
+(vulnerable + unused deps merged un-reviewed).
+
+1. **`enforce-update-json.py`** (PreToolUse hook on Bash): a push/PR from a
+   non-main branch containing at least one `feat:` commit must include an
+   [UPDATE.json](update-json-feed.md) change in the diff vs `origin/main`.
+   Pure fix/chore/docs branches pass silently. Detects pushes via proper
+   shell tokenization, not substring match.
+2. **`prepush-claude-review.py`** (PreToolUse hook on Bash): sends the
+   branch diff to the local `claude` CLI for a focused review (dependency
+   hygiene, remote-exposure/auth-bypass regressions, secrets, injection).
+   Denies only on an explicit high-confidence `block`; **fails open** on any
+   reviewer flakiness. Skips docs/asset-only pushes. Imports the
+   push-detection helpers from gate 1.
+3. **`.github/workflows/security-audit.yml`** (CI, deterministic):
+   `npm audit --omit=dev --audit-level=high` across root/frontend/website on
+   PRs touching a `package.json`. Catches contributor PRs the local hooks
+   can't see. Lockfiles are gitignored, so CI uses
+   `npm install --package-lock-only`; pins + `overrides` live in the
+   committed `package.json`.
+
+Last-resort bypass: `claude --no-hooks` (if needed often, the rule is
+mis-tuned).

--- a/docs/wiki/conventions/update-json-feed.md
+++ b/docs/wiki/conventions/update-json-feed.md
@@ -1,0 +1,31 @@
+---
+type: Convention
+title: UPDATE.json is a curated feature feed
+description: "Committed release feed rendered as the in-app update drawer; every feat: push must update it, fixes and chores must not pollute it."
+resource: /UPDATE.json
+tags: [convention, releases]
+timestamp: 2026-07-02
+---
+
+# UPDATE.json
+
+Committed at the repo root (source code, not generated). Rendered as the
+in-app update drawer (up to 6 newest releases, 1-5 highlights each).
+
+**Why curated:** the banner is only valuable when it announces things users
+care about. Forcing entries for every fix/chore would train users to ignore
+it; forgetting entries for real features means users on old versions never
+hear about them.
+
+**Schema:** `releases[]` newest-first with `tag` (ISO date), `title`
+(<=50 chars), `highlights[]` of `{title, description, href?}`; internal
+`href` renders as an in-app `<Link>`, external opens a new tab.
+Descriptions explain why a non-technical user should care.
+
+**Enforcement:** `.claude/hooks/enforce-update-json.py` denies any push
+containing a `feat:` commit whose branch diff doesn't touch UPDATE.json;
+see [pre-push gates](pre-push-gates.md) and the
+[ship-a-feature playbook](../playbooks/ship-a-feature.md).
+
+Test pollution note: clear `~/.tokentelemetry/.update-check.json` after
+manually seeding it.

--- a/docs/wiki/decisions/adr-0001-record-decisions.md
+++ b/docs/wiki/decisions/adr-0001-record-decisions.md
@@ -1,0 +1,16 @@
+---
+type: Decision
+title: ADR-0001 Record architecture decisions
+description: Architecture decisions are recorded as ADRs in docs/adr/, one per decision, committed in the feature PR.
+resource: /docs/adr/0001-record-architecture-decisions.md
+tags: [decision, process]
+timestamp: 2026-07-02
+---
+
+# ADR-0001: Record architecture decisions
+
+Decisions live in `docs/adr/` (template: `docs/adr/0000-template.md`), the
+*why* counterpart to `docs/design/` (*what and how*) and the GitHub Projects
+board #1 (*tracking*). Each substantial feature ships its ADR and design doc
+inside the feature PR. Playbook:
+[record a decision](../playbooks/record-a-decision.md).

--- a/docs/wiki/decisions/adr-0002-durable-history.md
+++ b/docs/wiki/decisions/adr-0002-durable-history.md
@@ -1,0 +1,22 @@
+---
+type: Decision
+title: ADR-0002 Durable SQLite rollup for analytics history
+description: Accepted 2026-06-13; own SQLite store of raw facts merged with live scans, tiered retention, because agents prune their own transcripts.
+resource: /docs/adr/0002-durable-history-rollup.md
+tags: [decision, analytics, sqlite]
+timestamp: 2026-07-02
+---
+
+# ADR-0002: Durable SQLite rollup
+
+**Accepted** 2026-06-13 (issue #83, discussion #27). Long date ranges were
+structurally impossible from live scans because agents prune transcripts
+(~30 days). Chosen: local SQLite of **raw facts** (not derived insights, so
+config changes apply retroactively), merged with the live scan at read,
+tiered retention (core rollup always; transcripts opt-in; summaries persist).
+
+Rejected: live-scan only (feature impossible), archive-everything default
+(disk-heavy, un-asked-for copying), storing derived insights (freezes power
+config), per-request Python filtering (latency).
+
+Consequences and limits on the [history store page](../subsystems/history-store.md).

--- a/docs/wiki/decisions/adr-0003-docs-site-fumadocs.md
+++ b/docs/wiki/decisions/adr-0003-docs-site-fumadocs.md
@@ -1,0 +1,22 @@
+---
+type: Decision
+title: ADR-0003 Docs and resources site with Fumadocs
+description: Docs built with Fumadocs inside the existing website/ Next.js app, statically exported to tokentelemetry.com/docs on GitHub Pages.
+resource: /docs/adr/0003-docs-site-fumadocs.md
+tags: [decision, docs, website]
+timestamp: 2026-07-02
+---
+
+# ADR-0003: Docs site with Fumadocs
+
+Docs and community resources live as a Fumadocs route group inside the
+existing `website/` Next.js app (Tailwind v4, App Router), served from
+GitHub Pages at `tokentelemetry.com/docs` and `/resources` (subdirectory,
+not subdomain, for SEO and one toolchain). Content is MDX, one file per
+feature under `website/content/docs/`; search is a prebuilt Orama static
+index; videos are embeds, not committed files. The local app links out to
+the docs (Docs nav link + per-page help icons).
+
+Constraints that drove it: solo maintainer, static-export-only hosting,
+local-first ethos (no hosted SaaS), existing Next.js investment. Design doc:
+`docs/design/documentation-site.md`.

--- a/docs/wiki/features/analytics.md
+++ b/docs/wiki/features/analytics.md
@@ -1,0 +1,24 @@
+---
+type: Feature
+title: Analytics
+description: Cross-agent token/cost analytics with date-range filters served from durable history merged with the live scan.
+resource: /website/content/docs/features/analytics.mdx
+tags: [feature, analytics]
+timestamp: 2026-07-02
+---
+
+# Analytics
+
+`/analytics` in the app. Aggregates tokens, cost, models, and agents over
+time.
+
+- Date ranges beyond each agent's own transcript retention work because reads
+  come from the [history store](../subsystems/history-store.md) merged with
+  the live scan (historical-only windows skip scanning entirely).
+- Start-from-now caveat: only sessions on disk at first install are captured;
+  the UI states this.
+- Ecosystem buckets from [delegation telemetry](../subsystems/delegation-telemetry.md):
+  `by_skill`, `by_mcp_server`, `by_subagent_type`, plus a `delegation` totals
+  bucket. Delegated usage is exposed separately, never silently merged.
+- Energy/CO2/savings figures recompute at read time from
+  [power config](../subsystems/power-cost.md).

--- a/docs/wiki/features/artifacts.md
+++ b/docs/wiki/features/artifacts.md
@@ -1,0 +1,43 @@
+---
+type: Feature
+title: Artifacts
+description: Deliverable artifacts per project and per session; Claude Code published pages and Antigravity task/plan/walkthrough docs, with local previews and a Cards/List toggle.
+resource: /website/content/docs/features/artifacts.mdx
+tags: [feature, artifacts, projects, sessions]
+timestamp: 2026-07-22
+---
+
+# Artifacts
+
+Shipped in PR #193 (2026-07-22). Surfaces the deliverables agents produce
+beyond code, in two places: an Artifacts tab per project workspace and the
+artifacts panel inside a [session trace](traces.md).
+
+Two kinds, one `published_artifacts` list per session:
+
+- **kind `page`:** a hosted claude.ai page published by Claude Code's
+  `Artifact` tool. Extraction pairs the tool_use (file_path, title,
+  description, favicon) with its tool_result, which carries the URL.
+  Deduped by URL across redeploys: later publish wins, metadata a redeploy
+  omitted is kept. The local source `path` is retained for previews. See
+  [Claude Code](../harnesses/claude-code.md).
+- **kind `document`:** Antigravity's per-session `task.md` /
+  `implementation_plan.md` / `walkthrough.md`, with title from the doc's
+  first heading and description from its `.metadata.json` sidecar summary.
+  Sidecar `userFacing: false` docs are excluded. See
+  [Antigravity](../harnesses/antigravity.md).
+
+Behavior:
+
+- `/projects` aggregates entries per card (`artifacts`); worktree publishes
+  merge onto the repo-root card, identity url-or-path.
+- Cards view previews artifacts locally: a sandboxed no-script iframe of the
+  page's local HTML source (only while the file exists and sits under a
+  served agent root; the hosted page is never fetched, per
+  [local-first](../conventions/local-first.md)) and an expandable markdown
+  preview for documents. List view is a compact row table; the toggle
+  persists in localStorage. `/artifacts` answers HEAD for the existence
+  check.
+- Claude entries persist in the [history store](../subsystems/history-store.md)
+  ecosystem blob, so links outlive transcript pruning.
+- Tests: `backend/test_published_artifacts.py`.

--- a/docs/wiki/features/hermes-dashboard.md
+++ b/docs/wiki/features/hermes-dashboard.md
@@ -1,0 +1,21 @@
+---
+type: Feature
+title: Hermes dashboard
+description: Dedicated /hermes surface; sources, skills, memory, cron health, gateway health, cost anomalies.
+resource: /website/content/docs/features/hermes.mdx
+tags: [feature, hermes, autonomous-agent]
+timestamp: 2026-07-02
+---
+
+# Hermes dashboard
+
+`/hermes` in the app; the shape-specific surface for
+[Hermes Agent](../harnesses/hermes.md), which runs across 38 platforms
+rather than a terminal. Surfaces: overview with per-API-call latency and
+cache-hit %, inline `delegate_task` subagent cards, skills page (90+ skills
+with platform conditions), memory page (`MEMORY.md` / `USER.md` with
+char-limit bars), cron-health tile, gateway-health pill, cost anomaly
+detection.
+
+A launcher plugin also embeds TT links inside Hermes's own dashboard (port
+9119); details on the [harness page](../harnesses/hermes.md).

--- a/docs/wiki/features/local-models.md
+++ b/docs/wiki/features/local-models.md
@@ -1,0 +1,16 @@
+---
+type: Feature
+title: Local models
+description: Inventory of local models from Ollama and Hugging Face caches, with electricity-cost context.
+resource: /website/content/docs/configuration/local-models.mdx
+tags: [feature, local-models, power]
+timestamp: 2026-07-02
+---
+
+# Local models
+
+`/local-models` lists models found in `~/.ollama` and
+`~/.cache/huggingface` (`OLLAMA_DIR`, `HF_DIR` in `backend/main.py`) and
+ties into [power costing](../subsystems/power-cost.md): local inference is
+priced by electricity (watts x latency) instead of API rates, enabling
+API-vs-local savings comparisons.

--- a/docs/wiki/features/projects.md
+++ b/docs/wiki/features/projects.md
@@ -1,0 +1,15 @@
+---
+type: Feature
+title: Projects
+description: Groups sessions by working directory/project across agents, with per-project totals.
+resource: /website/content/docs/features/projects.mdx
+tags: [feature, projects]
+timestamp: 2026-07-02
+---
+
+# Projects
+
+`/projects` groups sessions from all harnesses by project (working
+directory), answering "what did this repo cost me across agents".
+Per-project aggregates follow the same
+[count-once rules](../conventions/count-once-invariant.md) as analytics.

--- a/docs/wiki/features/projects.md
+++ b/docs/wiki/features/projects.md
@@ -4,7 +4,7 @@ title: Projects
 description: Groups sessions by working directory/project across agents, with per-project totals.
 resource: /website/content/docs/features/projects.mdx
 tags: [feature, projects]
-timestamp: 2026-07-02
+timestamp: 2026-07-22
 ---
 
 # Projects
@@ -13,3 +13,6 @@ timestamp: 2026-07-02
 directory), answering "what did this repo cost me across agents".
 Per-project aggregates follow the same
 [count-once rules](../conventions/count-once-invariant.md) as analytics.
+
+Workspace tabs: Activity, Insights, Plans, [Artifacts](artifacts.md)
+(added PR #193, with count badge), Config.

--- a/docs/wiki/features/schedules.md
+++ b/docs/wiki/features/schedules.md
@@ -1,0 +1,17 @@
+---
+type: Feature
+title: Schedules (read-only)
+description: Scheduled-job visibility; the CRUD UI exists but is intentionally disabled behind DISABLED-MUTATIONS markers.
+resource: /backend/main.py
+tags: [feature, schedules, cron]
+timestamp: 2026-07-02
+---
+
+# Schedules
+
+Scheduled-job (cron) health is shown read-only (most visibly the Hermes
+cron-health tile flagging at-risk schedules).
+
+**The schedules page is read-only by decision.** Mutation endpoints and CRUD
+UI were built but are commented out under `# DISABLED-MUTATIONS:` markers in
+`backend/main.py`. To re-enable, uncomment those blocks; do not reimplement.

--- a/docs/wiki/features/summarization.md
+++ b/docs/wiki/features/summarization.md
@@ -1,0 +1,23 @@
+---
+type: Feature
+title: AI session summaries
+description: One-click session summaries via a user-picked backend (installed CLIs, Ollama, or any OpenAI-compatible endpoint) with classified errors.
+resource: /website/content/docs/features/summarization.mdx
+tags: [feature, summarization]
+timestamp: 2026-07-02
+---
+
+# AI session summaries
+
+Configured in Settings (backend picker + test-connection); generated from
+session detail. Backends and the error pipeline live in the
+[summarizers subsystem](../subsystems/summarizers.md).
+
+- Backend options: installed agent CLIs (claude, codex, gemini, qwen,
+  antigravity), local Ollama, or any OpenAI-compatible endpoint.
+- Failures always render as a classified card (title, plain message,
+  actionable hint, raw behind a disclosure), never a stack trace
+  ([error handling](../conventions/error-handling.md)).
+- Summaries persist in the [history store](../subsystems/history-store.md)
+  even after the agent prunes the underlying transcript.
+- Docs: `website/content/docs/configuration/configure-summarizer.mdx`.

--- a/docs/wiki/features/traces.md
+++ b/docs/wiki/features/traces.md
@@ -1,0 +1,23 @@
+---
+type: Feature
+title: Session traces
+description: Per-session drill-in; tool calls, reasoning steps, artifacts, delegated-work cards, skills and MCP usage.
+resource: /website/content/docs/features/traces.mdx
+tags: [feature, sessions, traces]
+timestamp: 2026-07-02
+---
+
+# Session traces
+
+`/sessions` list and `/sessions/[id]` detail.
+
+- Detail shows the event trace: tool calls (direct vs MCP grouped by
+  server), reasoning steps, and artifacts (images/files; loaded with
+  `?token=` under [remote auth](../subsystems/remote-auth.md)).
+- Delegated-work card links subagent spawns to the spawning `Agent`/`Task`
+  tool call; tokens shown per subagent where the harness records them
+  ([delegation telemetry](../subsystems/delegation-telemetry.md)).
+- Sessions whose transcript the agent already pruned appear in aggregates but
+  without drill-in (summary-only rows,
+  [history store](../subsystems/history-store.md)).
+- AI summaries per session via [summarization](summarization.md).

--- a/docs/wiki/features/traces.md
+++ b/docs/wiki/features/traces.md
@@ -4,7 +4,7 @@ title: Session traces
 description: Per-session drill-in; tool calls, reasoning steps, artifacts, delegated-work cards, skills and MCP usage.
 resource: /website/content/docs/features/traces.mdx
 tags: [feature, sessions, traces]
-timestamp: 2026-07-02
+timestamp: 2026-07-22
 ---
 
 # Session traces
@@ -13,7 +13,10 @@ timestamp: 2026-07-02
 
 - Detail shows the event trace: tool calls (direct vs MCP grouped by
   server), reasoning steps, and artifacts (images/files; loaded with
-  `?token=` under [remote auth](../subsystems/remote-auth.md)).
+  `?token=` under [remote auth](../subsystems/remote-auth.md)). The
+  artifacts panel also lists Published Pages: url-bearing
+  [published artifacts](artifacts.md) only, since document-kind entries
+  already appear as local files (PR #193).
 - Delegated-work card links subagent spawns to the spawning `Agent`/`Task`
   tool call; tokens shown per subagent where the harness records them
   ([delegation telemetry](../subsystems/delegation-telemetry.md)).

--- a/docs/wiki/harnesses/antigravity.md
+++ b/docs/wiki/harnesses/antigravity.md
@@ -1,0 +1,27 @@
+---
+type: Harness
+title: Antigravity (Google)
+description: Gemini CLI's successor; brain transcripts under ~/.gemini/antigravity, CLI data under ~/.gemini/antigravity-cli, subagents linked via INVOKE_SUBAGENT.
+resource: /backend/main.py
+tags: [harness, coding-agent, delegation, google]
+timestamp: 2026-07-02
+---
+
+# Antigravity
+
+Google's live agent after the [Gemini CLI](gemini-cli.md) sunset
+(2026-06-18). Two surfaces share `~/.gemini`:
+
+- **IDE/brain:** `~/.gemini/antigravity/brain` (`ANTIGRAVITY_BRAIN_DIR`),
+  transcripts at `brain/<id>/.system_generated/logs/transcript.jsonl`.
+  Extensions inventory at `~/.antigravity/extensions`.
+- **CLI (`agy`):** `~/.gemini/antigravity-cli` (`ANTIGRAVITY_CLI_DIR`);
+  tests in `backend/test_antigravity_cli.py`. Also a summarizer backend
+  (`backend/summarizers/antigravity.py`).
+
+**Delegation:** spawns create full sibling conversations. The parent brain
+transcript records an `INVOKE_SUBAGENT` step whose content embeds the child
+`conversationId` (JSON-escaped); children link back via `send_message` to the
+parent id. Children are sessions in their own right, so linkage is
+annotation-only. Verified with agy 1.0.7; retroactive local linkage found 7
+parents / 10 children (`DESIGN.md`).

--- a/docs/wiki/harnesses/antigravity.md
+++ b/docs/wiki/harnesses/antigravity.md
@@ -4,7 +4,7 @@ title: Antigravity (Google)
 description: Gemini CLI's successor; brain transcripts under ~/.gemini/antigravity, CLI data under ~/.gemini/antigravity-cli, subagents linked via INVOKE_SUBAGENT.
 resource: /backend/main.py
 tags: [harness, coding-agent, delegation, google]
-timestamp: 2026-07-02
+timestamp: 2026-07-22
 ---
 
 # Antigravity
@@ -18,6 +18,14 @@ Google's live agent after the [Gemini CLI](gemini-cli.md) sunset
 - **CLI (`agy`):** `~/.gemini/antigravity-cli` (`ANTIGRAVITY_CLI_DIR`);
   tests in `backend/test_antigravity_cli.py`. Also a summarizer backend
   (`backend/summarizers/antigravity.py`).
+
+**Artifacts:** each brain session writes `task.md`,
+`implementation_plan.md`, `walkthrough.md` with `.metadata.json` sidecars
+(summary, updatedAt, userFacing). User-facing ones become document-kind
+[published artifacts](../features/artifacts.md); title from the doc's first
+heading, description from the sidecar summary (PR #193). Only sessions
+discovered via the brain path get these; chat-path sessions (real tokens,
+first-discovery-wins dedup) do not.
 
 **Delegation:** spawns create full sibling conversations. The parent brain
 transcript records an `INVOKE_SUBAGENT` step whose content embeds the child

--- a/docs/wiki/harnesses/claude-code.md
+++ b/docs/wiki/harnesses/claude-code.md
@@ -1,0 +1,31 @@
+---
+type: Harness
+title: Claude Code
+description: Richest-signal harness; JSONL transcripts under ~/.claude/projects with full cache fields, subagent rollup, skill and MCP usage.
+resource: /backend/main.py
+tags: [harness, coding-agent, delegation, anthropic]
+timestamp: 2026-07-02
+---
+
+# Claude Code
+
+- **Data:** `~/.claude/projects/<encoded-project>/<sessionId>.jsonl`
+  (`CLAUDE_DIR` in `backend/main.py`). Subagents live at
+  `<sessionId>/subagents/agent-<agentId>.jsonl` + `.meta.json`; the sibling
+  `tool-results/` dir is ignored.
+- **Signals:** input/output tokens, cache fields
+  (`cache_read_input_tokens`, `cache_creation_input_tokens`, 1h ephemeral),
+  model per line, tool calls, reasoning steps, skills
+  (`Skill` tool_use + `<command-name>` tags, built-in CLI commands filtered),
+  MCP usage from `mcp__<server>__<tool>` names.
+- **Delegation:** full token rollup, the only harness with one. Subagent files
+  are not sessions; their usage goes into a separate `delegated` bucket that IS
+  included in aggregates. Cost each subagent file by its own `message.model`
+  (subagent models routinely differ from the parent's; parent-model costing
+  would be wrong). Parent link: dir name, with the `sessionId` field inside
+  subagent lines as authoritative fallback. Spawning tool_use is `Agent`
+  (older versions: `Task`). See [delegation telemetry](../subsystems/delegation-telemetry.md).
+- **Quirks:** skip `<synthetic>` model lines; `cached` = high-water-mark of
+  `cache_read_input_tokens` per transcript ([count-once](../conventions/count-once-invariant.md));
+  transcripts pruned after `cleanupPeriodDays` (default 30), which is why the
+  [history store](../subsystems/history-store.md) exists.

--- a/docs/wiki/harnesses/claude-code.md
+++ b/docs/wiki/harnesses/claude-code.md
@@ -4,7 +4,7 @@ title: Claude Code
 description: Richest-signal harness; JSONL transcripts under ~/.claude/projects with full cache fields, subagent rollup, skill and MCP usage.
 resource: /backend/main.py
 tags: [harness, coding-agent, delegation, anthropic]
-timestamp: 2026-07-02
+timestamp: 2026-07-22
 ---
 
 # Claude Code
@@ -17,7 +17,11 @@ timestamp: 2026-07-02
   (`cache_read_input_tokens`, `cache_creation_input_tokens`, 1h ephemeral),
   model per line, tool calls, reasoning steps, skills
   (`Skill` tool_use + `<command-name>` tags, built-in CLI commands filtered),
-  MCP usage from `mcp__<server>__<tool>` names.
+  MCP usage from `mcp__<server>__<tool>` names. Published
+  [artifacts](../features/artifacts.md): an `Artifact` tool_use paired by
+  tool_use_id with its tool_result, which carries the hosted
+  `claude.ai/code/artifact/<uuid>` URL; `action: "list"` calls and
+  URL-less (failed) results are skipped (PR #193).
 - **Delegation:** full token rollup, the only harness with one. Subagent files
   are not sessions; their usage goes into a separate `delegated` bucket that IS
   included in aggregates. Cost each subagent file by its own `message.model`

--- a/docs/wiki/harnesses/cline.md
+++ b/docs/wiki/harnesses/cline.md
@@ -1,0 +1,22 @@
+---
+type: Harness
+title: Cline
+description: Two stores; a CLI SQLite db at ~/.cline/data/db/sessions.db and the VS Code extension's taskHistory.json. Added in PR #120.
+resource: /backend/test_cline_smallcode.py
+tags: [harness, coding-agent, sqlite, vscode]
+timestamp: 2026-07-02
+---
+
+# Cline
+
+Added in PR #120 (commit 90f7ad0). Two independent stores:
+
+- **CLI:** `~/.cline/data/db/sessions.db` (`CLINE_DIR`, overridable with
+  `TT_CLINE_DIR`). Shape verified against real data
+  (`backend/testdata/cline_smallcode/cline_cli/`).
+- **VS Code extension:** globalStorage
+  `saoudrizwan.claude-dev/state/taskHistory.json` (`CLINE_VSCODE_DIR`). Not
+  installed on the dev machine when written, so the parser sticks to the
+  documented HistoryItem shape only; treat as lower-confidence.
+
+Tests: `backend/test_cline_smallcode.py`. No delegation signal.

--- a/docs/wiki/harnesses/codex.md
+++ b/docs/wiki/harnesses/codex.md
@@ -1,0 +1,24 @@
+---
+type: Harness
+title: OpenAI Codex CLI
+description: Rollout-file transcripts under ~/.codex; subagent threads detected via thread_source markers; session index is unreliable.
+resource: /backend/main.py
+tags: [harness, coding-agent, delegation, openai]
+timestamp: 2026-07-02
+---
+
+# OpenAI Codex CLI
+
+- **Data:** `~/.codex` (`CODEX_DIR`), one rollout file per thread.
+- **Signals:** tokens, model, tool counts; also a summarizer backend
+  (`backend/summarizers/codex.py`).
+- **Delegation:** subagent threads are separate rollout files whose
+  `session_meta.payload` carries `thread_source: "subagent"`,
+  `forked_from_id`, and `source.subagent.thread_spawn`
+  (`parent_thread_id`, `depth`, `agent_nickname`, `agent_role`). Plain
+  `forked_from_id` also fires on user `codex fork`, so require the subagent
+  markers before linking.
+- **Quirks:** Codex stopped maintaining `session_index.jsonl` (observed frozen
+  2026-04-23; 10 indexed vs 36 actual sessions), so the scanner globs rollout
+  files directly and uses the index only for legacy thread names. Verified
+  against codex 0.136.0 (`DESIGN.md`).

--- a/docs/wiki/harnesses/copilot.md
+++ b/docs/wiki/harnesses/copilot.md
@@ -1,0 +1,16 @@
+---
+type: Harness
+title: GitHub Copilot CLI
+description: Session state under ~/.copilot/session-state; basic token/session signals, no delegation or per-call tool signal.
+resource: /backend/main.py
+tags: [harness, coding-agent, github]
+timestamp: 2026-07-02
+---
+
+# GitHub Copilot CLI
+
+- **Data:** `~/.copilot/session-state` (`COPILOT_CLI_DIR`).
+- **Signals:** sessions and token usage.
+- **Delegation:** no subagent signal; UI renders "not recorded by copilot".
+- **Quirks:** no per-call tool signal either, so `tool_counts` / `mcp_usage`
+  keys are simply absent for Copilot sessions (`DESIGN.md` Phase 2).

--- a/docs/wiki/harnesses/cursor.md
+++ b/docs/wiki/harnesses/cursor.md
@@ -1,0 +1,19 @@
+---
+type: Harness
+title: Cursor
+description: Agent transcripts under ~/.cursor/projects; subagent spawns are detectable but carry no token usage at all.
+resource: /backend/main.py
+tags: [harness, coding-agent, delegation]
+timestamp: 2026-07-02
+---
+
+# Cursor
+
+- **Data:** `~/.cursor/projects/<slug>/agent-transcripts/<sessionId>/`
+  (`CURSOR_DIR`), subagents under `.../subagents/<uuid>.jsonl`.
+- **Signals:** session transcripts and tool counts.
+- **Delegation:** spawn detection only. Subagent files contain plain
+  `{role, message}` lines with no usage fields, no model, no meta.json
+  (verified in `DESIGN.md`). TokenTelemetry reports spawn count and shows
+  tokens/cost as "not recorded by Cursor". Never estimate
+  ([honest n/a](../conventions/count-once-invariant.md)).

--- a/docs/wiki/harnesses/gemini-cli.md
+++ b/docs/wiki/harnesses/gemini-cli.md
@@ -1,0 +1,22 @@
+---
+type: Harness
+title: Gemini CLI (legacy)
+description: Google's discontinued CLI agent; still scanned from ~/.gemini but treated as legacy, superseded by Antigravity.
+resource: /backend/main.py
+tags: [harness, coding-agent, legacy, google]
+timestamp: 2026-07-02
+---
+
+# Gemini CLI
+
+- **Data:** `~/.gemini` (`GEMINI_DIR`). Note the same directory also hosts
+  Antigravity data (`antigravity/brain`, `antigravity-cli`); see
+  [Antigravity](antigravity.md).
+- **Signals:** tokens, model, tool counts; also a summarizer backend
+  (`backend/summarizers/gemini.py`).
+- **Delegation:** no subagent signal in its logs; the UI renders
+  "not recorded by gemini", never 0.
+- **Status:** Google discontinued Gemini CLI on 2026-06-18 in favor of the
+  closed-source Antigravity CLI. Keep parsing existing local data (users keep
+  history), but treat the harness as legacy: no new feature work, prune
+  default was 30 days so most installs age out on their own.

--- a/docs/wiki/harnesses/grok-build.md
+++ b/docs/wiki/harnesses/grok-build.md
@@ -1,0 +1,22 @@
+---
+type: Harness
+title: Grok Build (xAI)
+description: Sessions under ~/.grok/sessions; subagents on by default with rich meta.json spawn records, children are sibling sessions.
+resource: /backend/main.py
+tags: [harness, coding-agent, delegation, xai]
+timestamp: 2026-07-02
+---
+
+# Grok Build
+
+- **Data:** `~/.grok/sessions` (`GROK_SESSIONS_DIR`). Per-session
+  `signals.json` carries `contextTokensUsed`.
+- **Delegation:** subagents ON by default (`--no-subagents` to disable). The
+  parent writes `<session>/subagents/<spawn-id>/meta.json` with
+  `{subagent_type, description, prompt, status, duration_ms, tool_calls,
+  turns, effective_model_id, parent_session_id, child_session_id}`. The child
+  is a full sibling session dir, already counted; linkage is annotation-only
+  ([count-once](../conventions/count-once-invariant.md)).
+  `spawn_subagent` / `get_command_or_subagent_output` show up in
+  `events.jsonl`. Verified with grok 0.2.39 (`DESIGN.md`).
+- **Quirks:** no per-call tool signal beyond events; `tool_counts` absent.

--- a/docs/wiki/harnesses/hermes.md
+++ b/docs/wiki/harnesses/hermes.md
@@ -1,0 +1,33 @@
+---
+type: Harness
+title: Hermes Agent (Nous Research)
+description: Autonomous agent with a dedicated /hermes dashboard; state.db + agent.log under ~/.hermes, 38 source platforms, cron and gateway health.
+resource: /llms.txt
+tags: [harness, autonomous-agent, delegation, sqlite, nous]
+timestamp: 2026-07-02
+---
+
+# Hermes Agent
+
+The one autonomous (non-coding) agent, with its own dashboard at `/hermes`.
+TokenTelemetry is the only third-party observability tool supporting it.
+
+- **Data:** `~/.hermes` (`HERMES_DIR`, honors `HERMES_HOME`);
+  `state.db` (sessions, `sessions.source` = 38 platforms: CLI, Telegram,
+  Discord, Slack, cron, webhooks, email, SMS, ...), `logs/agent.log`
+  (per-API-call latency, cache-hit %), profiles under `profiles/`, prompt
+  snapshot for the skills page, `MEMORY.md` / `USER.md` for the memory page.
+- **Dashboard surfaces:** delegate_task subagent cards, 90+ skills with
+  platform conditions, memory char-limit bars, cron-health tile (at-risk
+  schedules), gateway-health pill, cost anomaly detection (silent
+  reasoning-token waste, e.g. MiMo thinking mode), provider-aware pricing
+  (same model priced per aggregator: direct / OpenRouter / Together /
+  Fireworks). See [Hermes dashboard](../features/hermes-dashboard.md).
+- **Delegation:** children are sessions linked by
+  `sessions.parent_session_id`; already counted, annotation-only
+  ([count-once](../conventions/count-once-invariant.md)). Locally verified:
+  12 of 21 sessions were children (`DESIGN.md`).
+- **Plugin:** a launcher plugin for Hermes's own dashboard (port 9119) deep-
+  links into TT pages; install via
+  `hermes plugins install VasiHemanth/tokentelemetry-hermes-plugin` or
+  `scripts/install-hermes-plugin.sh`. It is a launcher, not the engine.

--- a/docs/wiki/harnesses/opencode.md
+++ b/docs/wiki/harnesses/opencode.md
@@ -1,0 +1,19 @@
+---
+type: Harness
+title: OpenCode
+description: SQLite-backed sessions; child sessions are first-class rows linked by session.parent_id, so delegated usage is already counted.
+resource: /backend/main.py
+tags: [harness, coding-agent, delegation, sqlite]
+timestamp: 2026-07-02
+---
+
+# OpenCode
+
+- **Data:** SQLite state (sessions table with `parent_id`).
+- **Signals:** tokens, model, tool counts.
+- **Delegation:** children ARE sessions and already appear in aggregates.
+  TokenTelemetry only annotates the hierarchy: `parent_session_id` on
+  children, `child_session_ids` plus display-only delegated sums on parents.
+  Never fold child sums into totals; that double-counts
+  ([count-once](../conventions/count-once-invariant.md)). Locally verified:
+  5 of 12 sessions were children (`DESIGN.md`).

--- a/docs/wiki/harnesses/qwen.md
+++ b/docs/wiki/harnesses/qwen.md
@@ -1,0 +1,16 @@
+---
+type: Harness
+title: Qwen CLI
+description: Alibaba's coding agent; scanned from ~/.qwen, also usable as a summarizer backend. No delegation signal.
+resource: /backend/main.py
+tags: [harness, coding-agent, alibaba]
+timestamp: 2026-07-02
+---
+
+# Qwen CLI
+
+- **Data:** `~/.qwen` (`QWEN_DIR`); extensions inventory at
+  `~/.qwen/extensions`.
+- **Signals:** tokens, model, tool counts; also a summarizer backend
+  (`backend/summarizers/qwen.py`, auth via `qwen auth` / `DASHSCOPE_API_KEY`).
+- **Delegation:** no subagent signal; UI renders "not recorded by qwen".

--- a/docs/wiki/harnesses/smallcode.md
+++ b/docs/wiki/harnesses/smallcode.md
@@ -1,0 +1,19 @@
+---
+type: Harness
+title: SmallCode
+description: Project-local traces at <project>/.smallcode/traces/<id>.json; the only harness whose data lives in the repo, not the home dir. Added in PR #120.
+resource: /backend/test_cline_smallcode.py
+tags: [harness, coding-agent, project-local]
+timestamp: 2026-07-02
+---
+
+# SmallCode
+
+Added in PR #120 (commit 90f7ad0).
+
+- **Data:** PROJECT-LOCAL: `<project>/.smallcode/traces/<id>.json`. Unlike
+  every other harness there is no home-dir store, so discovery depends on
+  knowing project roots. Verified shape:
+  `backend/testdata/cline_smallcode/smallcode/8fadca50.json`.
+- **Signals:** per-trace token counts (e.g. `prompt_tokens`).
+- Tests: `backend/test_cline_smallcode.py`. No delegation signal.

--- a/docs/wiki/harnesses/vibe.md
+++ b/docs/wiki/harnesses/vibe.md
@@ -1,0 +1,15 @@
+---
+type: Harness
+title: Vibe
+description: Scanned from ~/.vibe; sessions and tokens only, no delegation or per-call tool signal.
+resource: /backend/main.py
+tags: [harness, coding-agent]
+timestamp: 2026-07-02
+---
+
+# Vibe
+
+- **Data:** `~/.vibe` (`VIBE_DIR`).
+- **Signals:** sessions and token usage.
+- **Delegation:** no subagent signal; UI renders "not recorded by vibe".
+  No per-call tool signal, so `tool_counts` / `mcp_usage` are absent.

--- a/docs/wiki/ideas/prove-brain-token-savings.md
+++ b/docs/wiki/ideas/prove-brain-token-savings.md
@@ -115,6 +115,27 @@ Testable with the existing harness: compile education_video under a forced
 `generic` profile vs a census-driven schema, run the same question set,
 compare adherence, turns, correctness.
 
+## Refinement 2026-07-06 (round 2): A/B on the census-schema wiki ran
+
+The A/B benchmark sketched in Doubt 2 was executed against the regenerated
+education_video wiki (28 pages, census-derived schema, page-map pointer
+block): 2 arms (wiki + pointer vs no wiki, pointer stripped) x 7 questions
+(round-1 set plus one targeting the new Domain pages) x 2 replicates, 28
+sessions, all valid, all correct on source-verified key facts in both arms.
+
+Results by coverage class: where the wiki actually answers the question
+(3 of 7), brain halved both turns (4.0 vs 8.2 mean) and cost ($0.14 vs
+$0.28); where the details live in CLAUDE.md that both arms read anyway, no
+advantage; on the one uncovered code-path question the wiki cost ~2 extra
+turns (the wiki tax is real but small); overall cost -18% ($3.03 vs $3.70).
+Adherence of the shipped pointer block: 12/14, and 12/12 on questions that
+do not name a source file (both misses were the question naming
+`scripts/research.js`, where going straight to the file is rational). The
+new schema's pages earned their place: the tracker-database data-store page
+flipped last round's partially-covered DB question to a 3-turn half-cost
+answer. Correctness never degraded; brain answers still verified against
+source and were deeper on one question (found the posting CLI mismatch).
+
 ## Related
 
 - [How to prove the brain saves tokens, ranked approaches](../analyses/brain-savings-approaches.md):

--- a/docs/wiki/ideas/prove-brain-token-savings.md
+++ b/docs/wiki/ideas/prove-brain-token-savings.md
@@ -56,8 +56,21 @@ Sketch of the fix, in three parts:
 - Staleness risk: a wrong wiki can cost more than no wiki. The benchmark
   should include a stale-wiki arm.
 
+## Refinement 2026-07-06
+
+A research pass ran a real pilot (education_video, 2 arms, 16 sessions) and
+a 51-session trace audit, then ranked the measurement approaches:
+[How to prove the brain saves tokens, ranked approaches](../analyses/brain-savings-approaches.md).
+Headline: adherence, not wiki quality, is the current bottleneck (agents
+ignored the wiki on 4 of 6 covered questions; when they read it, one answer
+halved in cost). Sequencing changes: routing experiment first, savings
+benchmark after; the payback number as sketched here is §11-banned in
+product and survives only as a published benchmark result.
+
 ## Related
 
+- [How to prove the brain saves tokens, ranked approaches](../analyses/brain-savings-approaches.md):
+  the 2026-07-06 assessment of this idea's measurement sketch.
 - [Graphify vs the TokenTelemetry plugin](../analyses/graphify-vs-tt-plugin.md):
   earlier analysis of prior-knowledge overlap.
 - The plugin design doc (`resource:` above) sketches a before/after metrics

--- a/docs/wiki/ideas/prove-brain-token-savings.md
+++ b/docs/wiki/ideas/prove-brain-token-savings.md
@@ -1,0 +1,64 @@
+---
+type: Idea
+status: captured
+title: Prove the brain saves tokens
+description: Benchmark the brain-init/compile/skillsmith pipeline and surface a payback metric; loosen domain profiles from boxes to starting kits.
+tags: [plugin, benchmarks, token-savings, domain-profiles, skillsmith]
+timestamp: 2026-07-06
+resource: docs/design/tokentelemetry-plugin.md
+---
+
+# Prove the brain saves tokens
+
+Captured from a maintainer prompt, 2026-07-06.
+
+## The pipeline being questioned
+
+`/brain-init` picks one domain profile (fullstack-app, research-data,
+generic), `/brain-compile` builds the OKF wiki, a pointer block lands in
+CLAUDE.md/AGENTS.md, and `/skillsmith` generates the per-project skill. The
+whole chain rests on an unproven claim: that agents reading the wiki spend
+fewer tokens than agents re-exploring the codebase.
+
+## Doubt 1: domain profiles are too restrictive
+
+One profile chosen up front fixes the entire page-type table. Real projects
+straddle domains; a fullstack app with a research pipeline gets squeezed into
+whichever profile was picked.
+
+Sketch: treat profiles as starting kits, not boxes. `/brain-init` composes the
+page-type table from the project census, mixing rows across profiles or
+proposing new ones, instead of forcing one choice.
+
+## Doubt 2: savings are asserted, never shown
+
+Sketch of the fix, in three parts:
+
+1. **A/B benchmark.** A fixed task suite per repo, run with the brain vs
+   without, and separately brain + skillsmith skill vs neither. Compare total
+   tokens, wall time, correctness. Publish method and results so the claim is
+   verifiable.
+2. **In-product payback metric.** The Second Brain tab already shows the build
+   cost ("built with N tok"). Add the other side: compare wiki-consulting
+   sessions against comparable pre-brain sessions in the same project.
+   TokenTelemetry already has per-session tokens and skill attribution
+   (see [Delegation and ecosystem telemetry](../subsystems/delegation-telemetry.md))
+   to tell the two populations apart.
+3. **Skillsmith in the matrix.** Measure whether the generated skill, the
+   wiki, or the combination carries the savings.
+
+## Open questions
+
+- What task suite is fair? Repo-specific tasks favor the wiki; generic tasks
+  may never touch it.
+- How to attribute savings in sessions that mix wiki reads with raw
+  exploration.
+- Staleness risk: a wrong wiki can cost more than no wiki. The benchmark
+  should include a stale-wiki arm.
+
+## Related
+
+- [Graphify vs the TokenTelemetry plugin](../analyses/graphify-vs-tt-plugin.md):
+  earlier analysis of prior-knowledge overlap.
+- The plugin design doc (`resource:` above) sketches a before/after metrics
+  panel in §9; this idea asks for the rigor behind that panel.

--- a/docs/wiki/ideas/prove-brain-token-savings.md
+++ b/docs/wiki/ideas/prove-brain-token-savings.md
@@ -2,7 +2,7 @@
 type: Idea
 status: captured
 title: Prove the brain saves tokens
-description: Benchmark the brain-init/compile/skillsmith pipeline and surface a payback metric; loosen domain profiles from boxes to starting kits.
+description: Benchmark the brain-init/compile/skillsmith pipeline and surface a payback metric; replace the domain-profile menu with a census-driven dynamic schema.
 tags: [plugin, benchmarks, token-savings, domain-profiles, skillsmith]
 timestamp: 2026-07-06
 resource: docs/design/tokentelemetry-plugin.md
@@ -80,6 +80,40 @@ arm vs baseline do not overlap (3-8 vs 9-12). Direction for the plugin:
 embed the index (or a distilled page map) in the pointer block, and rethink
 skillsmith's role; a skill described as optimization advice never fires on
 ordinary questions, so routing cannot live there.
+
+## Refinement 2026-07-06 (later still): drop the profile menu entirely
+
+Doubt 1 sharpened from "starting kits, not boxes" to removing the
+three-profile menu altogether. The maintainer's call: the supplied context
+(raw sources, census) stays as is, but wiki generation should derive the
+page-type table and folder structure dynamically instead of picking from
+fullstack-app / research-data / generic.
+
+Evidence since the original capture supports it: TT itself, the reference
+project for `fullstack-app`, needed a `harness` type the profile did not
+ship (BRAIN.md was the escape hatch, so the schema is already per-project
+in practice); and the proven routing win (index-in-pointer, 8/8 adherence)
+is schema-agnostic, so a dynamic taxonomy does not threaten it.
+
+Agreed shape (option B of three discussed):
+
+- A universal skeleton every project gets with no LLM discretion:
+  `Overview`, `Decision`, `Playbook`, `Convention`, index/log/manifest,
+  OKF rules, and a non-negotiable redaction core copied verbatim into
+  every generated BRAIN.md. Redaction is never LLM-derived.
+- `profile_census.py` changes job: its facts (extension histogram,
+  framework markers, tree, doc inventory) feed an LLM proposal of 3-8
+  domain-specific page types, each with a directory, `one_page_per`
+  granularity, and evidence of at least 2-3 expected pages.
+- The AskUserQuestion gate stays, showing the proposed table instead of a
+  three-item menu. BRAIN.md remains the durable contract: only
+  `/brain-init` derives; compiles and ingests never re-derive.
+- The three profile YAMLs demote to few-shot exemplars in the brain-init
+  prompt; explicit custom profiles stay supported as overrides.
+
+Testable with the existing harness: compile education_video under a forced
+`generic` profile vs a census-driven schema, run the same question set,
+compare adherence, turns, correctness.
 
 ## Related
 

--- a/docs/wiki/ideas/prove-brain-token-savings.md
+++ b/docs/wiki/ideas/prove-brain-token-savings.md
@@ -67,6 +67,20 @@ halved in cost). Sequencing changes: routing experiment first, savings
 benchmark after; the payback number as sketched here is §11-banned in
 product and survives only as a published benchmark result.
 
+## Refinement 2026-07-06 (later): adherence experiment ran
+
+The routing experiment the analysis ranked first was executed the same day
+(3 arms x 4 covered questions x 2 replicates, 24 sessions, education_video
+copies): current pointer block 5/8 runs consulted the wiki (median 11 turns,
+mean $0.30); pointer with the wiki index embedded 8/8 (median 4 turns, mean
+$0.14, answers still correct and still verifying against source); pointer
+plus a skillsmith-generated skill 2/8, with the skill invoked in 0 of 8 runs
+despite being loaded (verified available). Turn distributions for the index
+arm vs baseline do not overlap (3-8 vs 9-12). Direction for the plugin:
+embed the index (or a distilled page map) in the pointer block, and rethink
+skillsmith's role; a skill described as optimization advice never fires on
+ordinary questions, so routing cannot live there.
+
 ## Related
 
 - [How to prove the brain saves tokens, ranked approaches](../analyses/brain-savings-approaches.md):

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -70,7 +70,7 @@ Humans edit sources; the wiki is recompiled from them. History in
 
 ## Ideas
 
-* [Prove the brain saves tokens](ideas/prove-brain-token-savings.md) - Benchmark the brain-init/compile/skillsmith pipeline and surface a payback metric; loosen domain profiles from boxes to starting kits.
+* [Prove the brain saves tokens](ideas/prove-brain-token-savings.md) - Benchmark the brain-init/compile/skillsmith pipeline and surface a payback metric; replace the domain-profile menu with a census-driven dynamic schema.
 
 ## Conventions
 

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -62,6 +62,10 @@ Humans edit sources; the wiki is recompiled from them. History in
 * [Run TokenTelemetry locally](playbooks/run-locally.md) - Start backend and frontend for development; default ports 8000/3000, data dir override, common env vars.
 * [Record a decision (ADR)](playbooks/record-a-decision.md) - When and how to write an ADR; copy the template, number it, link issue/discussion/design doc, ship it in the feature PR.
 
+## Analyses
+
+* [graphify vs the tokentelemetry plugin](analyses/graphify-vs-tt-plugin.md) - Comparison of the graphify knowledge-graph skill and the tokentelemetry second-brain plugin: cousins, not twins; a map vs a field guide, and how they compose.
+
 ## Conventions
 
 * [Local-first, no user-machine network calls](conventions/local-first.md) - No new outbound calls from user machines; data that needs refreshing is refreshed at build/CI time and shipped in releases.

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -66,6 +66,10 @@ Humans edit sources; the wiki is recompiled from them. History in
 
 * [graphify vs the tokentelemetry plugin](analyses/graphify-vs-tt-plugin.md) - Comparison of the graphify knowledge-graph skill and the tokentelemetry second-brain plugin: cousins, not twins; a map vs a field guide, and how they compose.
 
+## Ideas
+
+* [Prove the brain saves tokens](ideas/prove-brain-token-savings.md) - Benchmark the brain-init/compile/skillsmith pipeline and surface a payback metric; loosen domain profiles from boxes to starting kits.
+
 ## Conventions
 
 * [Local-first, no user-machine network calls](conventions/local-first.md) - No new outbound calls from user machines; data that needs refreshing is refreshed at build/CI time and shipped in releases.

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -65,6 +65,7 @@ Humans edit sources; the wiki is recompiled from them. History in
 ## Analyses
 
 * [graphify vs the tokentelemetry plugin](analyses/graphify-vs-tt-plugin.md) - Comparison of the graphify knowledge-graph skill and the tokentelemetry second-brain plugin: cousins, not twins; a map vs a field guide, and how they compose.
+* [How to prove the brain saves tokens, ranked approaches](analyses/brain-savings-approaches.md) - Depth-and-breadth assessment of eight measurement approaches, grounded in a real 2-arm pilot on education_video and a 51-session trace audit; adherence, not wiki quality, is the current bottleneck.
 
 ## Ideas
 

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -1,0 +1,71 @@
+# TokenTelemetry wiki
+
+Second brain for the project: an [OKF v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
+bundle maintained by the `/brain` skill (`.claude/skills/brain/SKILL.md`).
+Humans edit sources; the wiki is recompiled from them. History in
+[log.md](log.md).
+
+## Start here
+
+* [TokenTelemetry](overview.md) - Local-first observability dashboard for AI coding agents and autonomous agents; reads session logs from disk, no SDK or cloud.
+
+## Harnesses
+
+* [Claude Code](harnesses/claude-code.md) - Richest-signal harness; JSONL transcripts under ~/.claude/projects with full cache fields, subagent rollup, skill and MCP usage.
+* [OpenAI Codex CLI](harnesses/codex.md) - Rollout-file transcripts under ~/.codex; subagent threads detected via thread_source markers; session index is unreliable.
+* [Cursor](harnesses/cursor.md) - Agent transcripts under ~/.cursor/projects; subagent spawns are detectable but carry no token usage at all.
+* [GitHub Copilot CLI](harnesses/copilot.md) - Session state under ~/.copilot/session-state; basic token/session signals, no delegation or per-call tool signal.
+* [Qwen CLI](harnesses/qwen.md) - Alibaba's coding agent; scanned from ~/.qwen, also usable as a summarizer backend. No delegation signal.
+* [OpenCode](harnesses/opencode.md) - SQLite-backed sessions; child sessions are first-class rows linked by session.parent_id, so delegated usage is already counted.
+* [Vibe](harnesses/vibe.md) - Scanned from ~/.vibe; sessions and tokens only, no delegation or per-call tool signal.
+* [Antigravity (Google)](harnesses/antigravity.md) - Gemini CLI's successor; brain transcripts under ~/.gemini/antigravity, CLI data under ~/.gemini/antigravity-cli, subagents linked via INVOKE_SUBAGENT.
+* [Gemini CLI (legacy)](harnesses/gemini-cli.md) - Google's discontinued CLI agent; still scanned from ~/.gemini but treated as legacy, superseded by Antigravity.
+* [Grok Build (xAI)](harnesses/grok-build.md) - Sessions under ~/.grok/sessions; subagents on by default with rich meta.json spawn records, children are sibling sessions.
+* [Cline](harnesses/cline.md) - Two stores; a CLI SQLite db at ~/.cline/data/db/sessions.db and the VS Code extension's taskHistory.json. Added in PR #120.
+* [SmallCode](harnesses/smallcode.md) - Project-local traces at <project>/.smallcode/traces/<id>.json; the only harness whose data lives in the repo, not the home dir. Added in PR #120.
+* [Hermes Agent (Nous Research)](harnesses/hermes.md) - Autonomous agent with a dedicated /hermes dashboard; state.db + agent.log under ~/.hermes, 38 source platforms, cron and gateway health.
+
+## Subsystems
+
+* [Session scanner](subsystems/scanner.md) - The core pipeline in backend/main.py; live-scans every harness's on-disk logs into a unified session list with a 30s cache and 100-session cap.
+* [Durable history store](subsystems/history-store.md) - SQLite rollup at ~/.tokentelemetry/history.db so analytics survive each agent's transcript pruning; raw facts stored, insights recomputed at read.
+* [Pricing](subsystems/pricing.md) - Costing from a bundled, committed pricing_data.json; refreshed by a CI-only models.dev sync that opens a review PR. Zero runtime network.
+* [Summarizers](subsystems/summarizers.md) - Pluggable session-summary backends (claude, codex, gemini, qwen, antigravity, ollama, openai_compat) with a strict classify-don't-dump error pipeline.
+* [Remote access auth](subsystems/remote-auth.md) - Token gate for non-loopback access; RemoteAuthMiddleware requires a bearer token on remote requests, loopback always exempt, CORS is not the boundary.
+* [Power, energy and CO2 costing](subsystems/power-cost.md) - Local-electricity and subscription costing; energy = configured watts x session latency, recomputed at read time from stored raw facts.
+* [Delegation and ecosystem telemetry](subsystems/delegation-telemetry.md) - Per-session subagent, skill, and MCP attribution; capability varies by harness, tokens are never invented, aggregates never double-count.
+* [CLI launcher](subsystems/cli.md) - bin/cli.js starts backend (default port 8000) and frontend (3000); flags for ports, host, origins, auth token, data dir.
+* [Frontend dashboard](subsystems/frontend.md) - Next.js 16 App Router app in frontend/; routes for dashboard, analytics, sessions, projects, hermes, local-models, settings.
+
+## Features
+
+* [Analytics](features/analytics.md) - Cross-agent token/cost analytics with date-range filters served from durable history merged with the live scan.
+* [Session traces](features/traces.md) - Per-session drill-in; tool calls, reasoning steps, artifacts, delegated-work cards, skills and MCP usage.
+* [Projects](features/projects.md) - Groups sessions by working directory/project across agents, with per-project totals.
+* [Hermes dashboard](features/hermes-dashboard.md) - Dedicated /hermes surface; sources, skills, memory, cron health, gateway health, cost anomalies.
+* [AI session summaries](features/summarization.md) - One-click session summaries via a user-picked backend (installed CLIs, Ollama, or any OpenAI-compatible endpoint) with classified errors.
+* [Local models](features/local-models.md) - Inventory of local models from Ollama and Hugging Face caches, with electricity-cost context.
+* [Schedules (read-only)](features/schedules.md) - Scheduled-job visibility; the CRUD UI exists but is intentionally disabled behind DISABLED-MUTATIONS markers.
+
+## Decisions
+
+* [ADR-0001 Record architecture decisions](decisions/adr-0001-record-decisions.md) - Architecture decisions are recorded as ADRs in docs/adr/, one per decision, committed in the feature PR.
+* [ADR-0002 Durable SQLite rollup for analytics history](decisions/adr-0002-durable-history.md) - Accepted 2026-06-13; own SQLite store of raw facts merged with live scans, tiered retention, because agents prune their own transcripts.
+* [ADR-0003 Docs and resources site with Fumadocs](decisions/adr-0003-docs-site-fumadocs.md) - Docs built with Fumadocs inside the existing website/ Next.js app, statically exported to tokentelemetry.com/docs on GitHub Pages.
+
+## Playbooks
+
+* [Add a new harness](playbooks/add-a-harness.md) - Steps to support a new agent; verify real data shapes first, add scanner constants and parser, fixture tests, honest capability flags, docs.
+* [Add a summarizer error category](playbooks/add-summarizer-error-category.md) - Three files must change together; errors.py pattern + copy, the TS category union, and the ERROR_ICONS record.
+* [Ship a feature to main](playbooks/ship-a-feature.md) - The maintainer loop; branch, ADR/design doc in the PR, UPDATE.json entry for feat: commits, pass the pre-push gates, PR, board card.
+* [Write scanner tests](playbooks/write-scanner-tests.md) - Fixture pattern for backend tests; monkeypatch the module-level dir constants and build a tmp tree mirroring the harness's real layout.
+* [Run TokenTelemetry locally](playbooks/run-locally.md) - Start backend and frontend for development; default ports 8000/3000, data dir override, common env vars.
+* [Record a decision (ADR)](playbooks/record-a-decision.md) - When and how to write an ADR; copy the template, number it, link issue/discussion/design doc, ship it in the feature PR.
+
+## Conventions
+
+* [Local-first, no user-machine network calls](conventions/local-first.md) - No new outbound calls from user machines; data that needs refreshing is refreshed at build/CI time and shipped in releases.
+* [Count-once invariant and honest n/a](conventions/count-once-invariant.md) - Every token appears in aggregates exactly once, and signals a harness does not record render as "not recorded", never zero or estimated.
+* [UPDATE.json is a curated feature feed](conventions/update-json-feed.md) - Committed release feed rendered as the in-app update drawer; every feat: push must update it, fixes and chores must not pollute it.
+* [Pre-push and pre-merge gates](conventions/pre-push-gates.md) - Three automated gates; UPDATE.json enforcement on feat: pushes, a local Claude review of the branch diff, and a CI npm-audit on package.json changes.
+* [Classify errors, never dump them](conventions/error-handling.md) - Any summarizer-backend failure must pass through classify() into a titled card with a plain message and actionable hint; raw text only behind a disclosure.

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -67,6 +67,7 @@ Humans edit sources; the wiki is recompiled from them. History in
 * [graphify vs the tokentelemetry plugin](analyses/graphify-vs-tt-plugin.md) - Comparison of the graphify knowledge-graph skill and the tokentelemetry second-brain plugin: cousins, not twins; a map vs a field guide, and how they compose.
 * [How to prove the brain saves tokens, ranked approaches](analyses/brain-savings-approaches.md) - Depth-and-breadth assessment of eight measurement approaches, grounded in a real 2-arm pilot on education_video and a 51-session trace audit; adherence, not wiki quality, is the current bottleneck.
 * [Four token-optimization techniques beyond the current seeds](analyses/next-token-optimization-techniques.md) - Data-mined candidates attacking conversation shape (turn batching, tool-result diet, scout delegation, checkpoint-restart), the waste pools ponytail, caveman, headroom and the wiki do not touch.
+* [Multi-harness session mining for the plugin](analyses/multi-harness-session-mining.md) - How to extend the plugin's session_scan beyond Claude Code to every harness TokenTelemetry parses, with a per-harness feasibility matrix and three build options.
 
 ## Ideas
 

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -68,6 +68,7 @@ Humans edit sources; the wiki is recompiled from them. History in
 * [How to prove the brain saves tokens, ranked approaches](analyses/brain-savings-approaches.md) - Depth-and-breadth assessment of eight measurement approaches, grounded in a real 2-arm pilot on education_video and a 51-session trace audit; adherence, not wiki quality, is the current bottleneck.
 * [Four token-optimization techniques beyond the current seeds](analyses/next-token-optimization-techniques.md) - Data-mined candidates attacking conversation shape (turn batching, tool-result diet, scout delegation, checkpoint-restart), the waste pools ponytail, caveman, headroom and the wiki do not touch.
 * [Multi-harness session mining for the plugin](analyses/multi-harness-session-mining.md) - How to extend the plugin's session_scan beyond Claude Code to every harness TokenTelemetry parses, with a per-harness feasibility matrix and three build options.
+* [Wiki staleness failure modes and the update-nudge design](analyses/wiki-staleness-failure-modes.md) - Eleven-agent simulation of how a compiled wiki fails after code drift, what can go catastrophically wrong, and a harness-agnostic design for suggesting (never auto-running) ingest.
 
 ## Ideas
 

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -66,6 +66,7 @@ Humans edit sources; the wiki is recompiled from them. History in
 
 * [graphify vs the tokentelemetry plugin](analyses/graphify-vs-tt-plugin.md) - Comparison of the graphify knowledge-graph skill and the tokentelemetry second-brain plugin: cousins, not twins; a map vs a field guide, and how they compose.
 * [How to prove the brain saves tokens, ranked approaches](analyses/brain-savings-approaches.md) - Depth-and-breadth assessment of eight measurement approaches, grounded in a real 2-arm pilot on education_video and a 51-session trace audit; adherence, not wiki quality, is the current bottleneck.
+* [Four token-optimization techniques beyond the current seeds](analyses/next-token-optimization-techniques.md) - Data-mined candidates attacking conversation shape (turn batching, tool-result diet, scout delegation, checkpoint-restart), the waste pools ponytail, caveman, headroom and the wiki do not touch.
 
 ## Ideas
 

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -42,6 +42,7 @@ Humans edit sources; the wiki is recompiled from them. History in
 * [Analytics](features/analytics.md) - Cross-agent token/cost analytics with date-range filters served from durable history merged with the live scan.
 * [Session traces](features/traces.md) - Per-session drill-in; tool calls, reasoning steps, artifacts, delegated-work cards, skills and MCP usage.
 * [Projects](features/projects.md) - Groups sessions by working directory/project across agents, with per-project totals.
+* [Artifacts](features/artifacts.md) - Deliverable artifacts per project and per session; Claude Code published pages and Antigravity task/plan/walkthrough docs, with local previews and a Cards/List toggle.
 * [Hermes dashboard](features/hermes-dashboard.md) - Dedicated /hermes surface; sources, skills, memory, cron health, gateway health, cost anomalies.
 * [AI session summaries](features/summarization.md) - One-click session summaries via a user-picked backend (installed CLIs, Ollama, or any OpenAI-compatible endpoint) with classified errors.
 * [Local models](features/local-models.md) - Inventory of local models from Ollama and Hugging Face caches, with electricity-cost context.

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -2,6 +2,14 @@
 
 ## 2026-07-06
 
+**Update** `ideas/prove-brain-token-savings.md` gained a third dated
+refinement: Doubt 1 sharpened from "starting kits, not boxes" to dropping
+the three-profile menu entirely. Wiki generation should derive the
+page-type table dynamically from the census, on top of a fixed universal
+skeleton (Overview/Decision/Playbook/Convention plus a never-LLM-derived
+redaction core); the three profile YAMLs demote to few-shot exemplars.
+Plugin-side brain-init changes drafted separately in the plugin repo.
+
 **Creation** Analysis page
 `analyses/next-token-optimization-techniques.md`: four candidate
 techniques (turn batching, tool-result diet, scout delegation,

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -2,6 +2,14 @@
 
 ## 2026-07-06
 
+**Creation** Analysis page `analyses/brain-savings-approaches.md`, saved from
+the research session that assessed `ideas/prove-brain-token-savings.md`.
+Evidence: a 2-arm pilot on education_video (16 headless sessions) and a
+51-session trace audit, plus two adversarial reviews. Ranked five approaches;
+headline finding is that agent adherence to the wiki, not wiki quality, is
+the current bottleneck. The idea page gained a dated refinement pointing at
+the analysis. Status: proposed.
+
 **Creation** First `Idea` page via the new `/brain idea` workflow:
 `ideas/prove-brain-token-savings.md`. Captured from a maintainer prompt:
 domain profiles may be too restrictive (starting kits, not boxes), and the

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -2,6 +2,17 @@
 
 ## 2026-07-06
 
+**Update** `analyses/wiki-staleness-failure-modes.md` moved to
+status: adopted, refined per the maintainer: stale pages fall back to
+reading source (wiki-as-cache, code authoritative) rather than nudging
+for updates. Implemented in the plugin (v0.5.0, commit 060b674): stamp
+writes content-hash provenance and installs a self-contained status.py
+per wiki; verdicts FRESH/STALE/TAMPERED/UNVERIFIABLE; refresh notes
+queue in raw/stale-notes.md for the next ingest. A 100-case validation
+set (10 agents) and a 4-role hardening review (red-team, tests,
+integration, docs) preceded the ship; this wiki and education_video are
+stamped and carry status.py.
+
 **Creation** Analysis page `analyses/wiki-staleness-failure-modes.md`,
 saved from a maintainer chat after a real forgotten-ingest incident
 produced a stale answer. An 11-agent simulation (6 personas, 5

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -2,6 +2,16 @@
 
 ## 2026-07-06
 
+**Creation** Analysis page
+`analyses/next-token-optimization-techniques.md`: four candidate
+techniques (turn batching, tool-result diet, scout delegation,
+checkpoint-restart) attacking conversation-shape waste pools the existing
+seeds do not cover. Grounded in a 105-transcript waste-pool measurement
+(1.5% batching rate, 26M replayed tokens in collapsible turns, 1.7% of tool
+results carrying 24.8% of bytes) plus an independent Codex session that
+converged on the same shapes. Status: proposed; each becomes a skillsmith
+seed only after its experiment shows an effect.
+
 **Finding** The adherence experiment proposed by
 `analyses/brain-savings-approaches.md` ran the same day (24 sessions, 3
 routing arms on education_video copies). Index-in-pointer routing reached

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -1,5 +1,13 @@
 # Log
 
+## 2026-07-06
+
+**Creation** First `Idea` page via the new `/brain idea` workflow:
+`ideas/prove-brain-token-savings.md`. Captured from a maintainer prompt:
+domain profiles may be too restrictive (starting kits, not boxes), and the
+token-savings claim behind the plugin pipeline needs benchmarks plus an
+in-product payback metric next to the build-cost badge. Status: captured.
+
 ## 2026-07-05
 
 **Creation** New page type `Analysis` (`analyses/`, snapshot pages saved from

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -2,6 +2,16 @@
 
 ## 2026-07-06
 
+**Finding** The adherence experiment proposed by
+`analyses/brain-savings-approaches.md` ran the same day (24 sessions, 3
+routing arms on education_video copies). Index-in-pointer routing reached
+8/8 wiki consultation at a third of the turns and half the cost of the
+current pointer block (5/8); a skillsmith-generated skill never fired (0/8
+invocations while loaded). Recorded as a dated refinement on
+`ideas/prove-brain-token-savings.md`; plugin-side changes (pointer block
+gains an embedded page map, skillsmith routing role rethought) are direction,
+not yet implemented.
+
 **Creation** Analysis page `analyses/brain-savings-approaches.md`, saved from
 the research session that assessed `ideas/prove-brain-token-savings.md`.
 Evidence: a 2-arm pilot on education_video (16 headless sessions) and a

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -2,6 +2,15 @@
 
 ## 2026-07-06
 
+**Creation** Analysis page `analyses/multi-harness-session-mining.md`, saved
+from a maintainer chat. The plugin's `session_scan.py` mines only Claude
+Code sessions while TokenTelemetry parses ~13 agent sources; the page maps
+each harness's store, project attribution, and signal richness, and ranks
+three options (adapter registry in the plugin, backend signals endpoint,
+shared parser library). Recommendation: adapter registry now with
+per-adapter fixtures, shared library later; gemini skipped as legacy.
+Status: proposed, awaiting the maintainer's option pick.
+
 **Update** `ideas/prove-brain-token-savings.md` gained a fourth dated
 refinement: the A/B benchmark from Doubt 2 ran against the regenerated
 census-schema education_video wiki (2 arms x 7 questions x 2 replicates,

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -2,6 +2,15 @@
 
 ## 2026-07-06
 
+**Update** `ideas/prove-brain-token-savings.md` gained a fourth dated
+refinement: the A/B benchmark from Doubt 2 ran against the regenerated
+census-schema education_video wiki (2 arms x 7 questions x 2 replicates,
+28 sessions). Where the wiki answers the question, turns and cost halve;
+overall cost -18%; adherence of the shipped page-map pointer block 12/14
+(12/12 on questions not naming a source file); correctness equal in both
+arms. The new data-store page flipped the previously partially-covered
+tracker-DB question to a 3-turn half-cost answer.
+
 **Update** `ideas/prove-brain-token-savings.md` gained a third dated
 refinement: Doubt 1 sharpened from "starting kits, not boxes" to dropping
 the three-profile menu entirely. Wiki generation should derive the

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -2,6 +2,18 @@
 
 ## 2026-07-06
 
+**Creation** Analysis page `analyses/wiki-staleness-failure-modes.md`,
+saved from a maintainer chat after a real forgotten-ingest incident
+produced a stale answer. An 11-agent simulation (6 personas, 5
+adversarial critics, ~66 findings) mapped staleness failure modes; the
+critics also verified live gaps in this repo's own bundle (no
+manifest.json, no compiled_from_sha anywhere, 6/6 playbooks without
+resource:). Recommendation: content-hash provenance, a committed
+stateless status.py check script referenced by one stable pointer-block
+line, point-of-use trust demotion, a raw/ inbox escape hatch for
+non-Claude harnesses, and a CI staleness marker; auto-ingest stays
+rejected. Status: proposed.
+
 **Update** `analyses/multi-harness-session-mining.md` moved to
 status: adopted. The maintainer picked option A the same day, approving
 codex shell-string path extraction (in-memory tokenization, only path

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -1,0 +1,17 @@
+# Log
+
+## 2026-07-02
+
+**Creation** Initial compile of the bundle: overview, 13 harness pages, 9
+subsystem pages, 7 feature pages, 3 decision pages, 6 playbooks, 5
+conventions. Sources: repo at 8215d60 (`DESIGN.md`, `docs/adr/`,
+`docs/design/`, `.claude/CLAUDE.md`, `llms.txt`, `backend/`, `bin/cli.js`,
+`website/content/docs/`).
+
+**Finding** `llms.txt` and `README.md` still list 10 coding agents; Cline and
+SmallCode landed in PR #120 (commit 90f7ad0), so the real count is 12. The
+source files need the update, not the wiki.
+
+**Finding** ADR-0004 (resource-history sampling) and the
+`docs/design/resource-history.md` design doc exist only on an unmerged branch;
+the bundle documents main only and will pick them up on merge.

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -2,6 +2,12 @@
 
 ## 2026-07-06
 
+**Update** `analyses/multi-harness-session-mining.md` moved to
+status: adopted. The maintainer picked option A the same day, approving
+codex shell-string path extraction (in-memory tokenization, only path
+tokens emitted); shipped as the plugin's harness_adapters registry
+(11 adapters, 16 fixture tests), plugin commit 09762fe / v0.4.0.
+
 **Creation** Analysis page `analyses/multi-harness-session-mining.md`, saved
 from a maintainer chat. The plugin's `session_scan.py` mines only Claude
 Code sessions while TokenTelemetry parses ~13 agent sources; the page maps

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -1,5 +1,14 @@
 # Log
 
+## 2026-07-05
+
+**Creation** New page type `Analysis` (`analyses/`, snapshot pages saved from
+agent chats via the new `/brain save` workflow; body immutable after save,
+only `status` may change). First page:
+`analyses/graphify-vs-tt-plugin.md`, comparing the graphify knowledge-graph
+skill with the tokentelemetry second-brain plugin, saved from the 2026-07-05
+chat session, status proposed.
+
 ## 2026-07-02
 
 **Creation** Initial compile of the bundle: overview, 13 harness pages, 9

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -1,5 +1,18 @@
 # Log
 
+## 2026-07-22
+
+**Creation** `features/artifacts.md` from the merged PR #193 diff
+(fb41faf): per-project Artifacts tab and session Published Pages;
+Claude Code hosted-page extraction (kind page) and Antigravity
+task/plan/walkthrough docs (kind document), local-only previews,
+Cards/List toggle. Updated `features/projects.md` (workspace tabs),
+`features/traces.md` (Published Pages), `harnesses/claude-code.md`
+(Artifact tool extraction), `harnesses/antigravity.md` (doc artifacts,
+brain-path-only caveat), `subsystems/scanner.md` (sidecar scan cache,
+CACHE_VERSION now v5), `subsystems/history-store.md`
+(published_artifacts in the ecosystem blob).
+
 ## 2026-07-06
 
 **Update** `analyses/wiki-staleness-failure-modes.md` moved to

--- a/docs/wiki/manifest.json
+++ b/docs/wiki/manifest.json
@@ -1,0 +1,387 @@
+{
+  "okf": "0.1",
+  "profile": "generic",
+  "created": "2026-07-07",
+  "updated": "2026-07-07",
+  "status": "complete",
+  "batches_done": 0,
+  "batches_total": 0,
+  "page_count": 50,
+  "page_types": {
+    "Analysis": 5,
+    "Convention": 5,
+    "Decision": 3,
+    "Feature": 7,
+    "Harness": 13,
+    "Idea": 1,
+    "Overview": 1,
+    "Playbook": 6,
+    "Subsystem": 9
+  },
+  "compiled_from_sha": "422d0a95a075b21296f6ea536bd1e946be0015d2",
+  "plugin_version": "0.5.0",
+  "provenance": {
+    "analyses/brain-savings-approaches": {
+      "resources": {
+        "backend/main.py": "8e0dd470a9de"
+      },
+      "page_sha": "13fa09cde345"
+    },
+    "analyses/graphify-vs-tt-plugin": {
+      "resources": {
+        "docs/design/tokentelemetry-plugin.md": "413e28691c69",
+        "backend/main.py": "8e0dd470a9de"
+      },
+      "page_sha": "963bd54a41af"
+    },
+    "analyses/multi-harness-session-mining": {
+      "resources": {
+        "backend/main.py": "8e0dd470a9de",
+        "docs/design/tokentelemetry-plugin.md": "413e28691c69"
+      },
+      "page_sha": "ace25d740218"
+    },
+    "analyses/next-token-optimization-techniques": {
+      "resources": {},
+      "page_sha": "15bf5487011c"
+    },
+    "analyses/wiki-staleness-failure-modes": {
+      "resources": {
+        "docs/design/tokentelemetry-plugin.md": "413e28691c69"
+      },
+      "page_sha": "d81e0413d5e8"
+    },
+    "conventions/count-once-invariant": {
+      "resources": {
+        "DESIGN.md": "a4d991aa3a82"
+      },
+      "page_sha": "188585db4a34"
+    },
+    "conventions/error-handling": {
+      "resources": {},
+      "page_sha": "35af3d274202"
+    },
+    "conventions/local-first": {
+      "resources": {
+        "backend/telemetry.py": "5cae82d67eb4",
+        "docs/design/product-telemetry.md": "330dc75a8ce6"
+      },
+      "page_sha": "6f5f2e3f6443"
+    },
+    "conventions/pre-push-gates": {
+      "resources": {
+        ".claude/hooks": "cd12867e57c3",
+        ".github/workflows/security-audit.yml": "0380f6de0e45",
+        "package.json": "1ef388d4ea7d"
+      },
+      "page_sha": "27c3b327e04f"
+    },
+    "conventions/update-json-feed": {
+      "resources": {
+        "UPDATE.json": "5e22e7247d56",
+        ".claude/hooks/enforce-update-json.py": "90d9e15c8a67"
+      },
+      "page_sha": "13f181c5e2b7"
+    },
+    "decisions/adr-0001-record-decisions": {
+      "resources": {
+        "docs/adr/0001-record-architecture-decisions.md": "9b3e2b3d8915",
+        "docs/adr/0000-template.md": "9b9be070a9f4"
+      },
+      "page_sha": "313f8f82e5a3"
+    },
+    "decisions/adr-0002-durable-history": {
+      "resources": {
+        "docs/adr/0002-durable-history-rollup.md": "91537b269515"
+      },
+      "page_sha": "1fc31c77d92e"
+    },
+    "decisions/adr-0003-docs-site-fumadocs": {
+      "resources": {
+        "docs/adr/0003-docs-site-fumadocs.md": "74fd2b176ee1",
+        "docs/design/documentation-site.md": "ab49fb16e733"
+      },
+      "page_sha": "290f6003a2fb"
+    },
+    "features/analytics": {
+      "resources": {
+        "website/content/docs/features/analytics.mdx": "220d91676db6"
+      },
+      "page_sha": "a93fef816637"
+    },
+    "features/hermes-dashboard": {
+      "resources": {
+        "website/content/docs/features/hermes.mdx": "ab33fb0c9073"
+      },
+      "page_sha": "c570524912c0"
+    },
+    "features/local-models": {
+      "resources": {
+        "website/content/docs/configuration/local-models.mdx": "93ff4308e341",
+        "backend/main.py": "8e0dd470a9de"
+      },
+      "page_sha": "4ec78c5d3e17"
+    },
+    "features/projects": {
+      "resources": {
+        "website/content/docs/features/projects.mdx": "4853d319d015"
+      },
+      "page_sha": "0ddc7ce1c0fb"
+    },
+    "features/schedules": {
+      "resources": {
+        "backend/main.py": "8e0dd470a9de"
+      },
+      "page_sha": "1ec53bc3573b"
+    },
+    "features/summarization": {
+      "resources": {
+        "website/content/docs/features/summarization.mdx": "8e2ab2a51b05",
+        "website/content/docs/configuration/configure-summarizer.mdx": "c0154f720b5b"
+      },
+      "page_sha": "436a4dca94a4"
+    },
+    "features/traces": {
+      "resources": {
+        "website/content/docs/features/traces.mdx": "98eb7c88a1c3"
+      },
+      "page_sha": "9eebb56ff3ef"
+    },
+    "harnesses/antigravity": {
+      "resources": {
+        "backend/main.py": "8e0dd470a9de",
+        "backend/test_antigravity_cli.py": "e445e1bb6b11",
+        "backend/summarizers/antigravity.py": "4d9aa5586c1c",
+        "DESIGN.md": "a4d991aa3a82"
+      },
+      "page_sha": "930eabeedf0b"
+    },
+    "harnesses/claude-code": {
+      "resources": {
+        "backend/main.py": "8e0dd470a9de"
+      },
+      "page_sha": "2c216069cd5a"
+    },
+    "harnesses/cline": {
+      "resources": {
+        "backend/test_cline_smallcode.py": "e08c33615b50"
+      },
+      "page_sha": "a04f0df4e716"
+    },
+    "harnesses/codex": {
+      "resources": {
+        "backend/main.py": "8e0dd470a9de",
+        "backend/summarizers/codex.py": "e22e52d9186d",
+        "DESIGN.md": "a4d991aa3a82"
+      },
+      "page_sha": "b143125a5545"
+    },
+    "harnesses/copilot": {
+      "resources": {
+        "backend/main.py": "8e0dd470a9de",
+        "DESIGN.md": "a4d991aa3a82"
+      },
+      "page_sha": "fd3eb65b1ddf"
+    },
+    "harnesses/cursor": {
+      "resources": {
+        "backend/main.py": "8e0dd470a9de",
+        "DESIGN.md": "a4d991aa3a82"
+      },
+      "page_sha": "41abb014f52b"
+    },
+    "harnesses/gemini-cli": {
+      "resources": {
+        "backend/main.py": "8e0dd470a9de",
+        "backend/summarizers/gemini.py": "00dcad893c0c"
+      },
+      "page_sha": "dc9fb5857463"
+    },
+    "harnesses/grok-build": {
+      "resources": {
+        "backend/main.py": "8e0dd470a9de",
+        "DESIGN.md": "a4d991aa3a82"
+      },
+      "page_sha": "7c8e23148b11"
+    },
+    "harnesses/hermes": {
+      "resources": {
+        "llms.txt": "000be374c343",
+        "DESIGN.md": "a4d991aa3a82",
+        "scripts/install-hermes-plugin.sh": "b99357121ef3"
+      },
+      "page_sha": "1305b3a21b2d"
+    },
+    "harnesses/opencode": {
+      "resources": {
+        "backend/main.py": "8e0dd470a9de",
+        "DESIGN.md": "a4d991aa3a82"
+      },
+      "page_sha": "32660f6a7dbb"
+    },
+    "harnesses/qwen": {
+      "resources": {
+        "backend/main.py": "8e0dd470a9de",
+        "backend/summarizers/qwen.py": "804b5cd76e2d"
+      },
+      "page_sha": "c749cb2f3db5"
+    },
+    "harnesses/smallcode": {
+      "resources": {
+        "backend/test_cline_smallcode.py": "e08c33615b50"
+      },
+      "page_sha": "3379249d17c6"
+    },
+    "harnesses/vibe": {
+      "resources": {
+        "backend/main.py": "8e0dd470a9de"
+      },
+      "page_sha": "6fb98fae671d"
+    },
+    "ideas/prove-brain-token-savings": {
+      "resources": {
+        "docs/design/tokentelemetry-plugin.md": "413e28691c69"
+      },
+      "page_sha": "e44062ecb80c"
+    },
+    "overview": {
+      "resources": {
+        "README.md": "bababfc991eb",
+        "bin/cli.js": "8d71c5e79981"
+      },
+      "page_sha": "1f143a898018"
+    },
+    "playbooks/add-a-harness": {
+      "resources": {
+        "DESIGN.md": "a4d991aa3a82",
+        "backend/main.py": "8e0dd470a9de",
+        "backend/pricing_data.json": "3c7b4d2d4342",
+        "frontend/src/lib/agents.ts": "b193ba6fc1c8",
+        "llms.txt": "000be374c343",
+        "website/content/docs/supported-agents.mdx": "8a0e8da319c8"
+      },
+      "page_sha": "35a4d7cb489f"
+    },
+    "playbooks/add-summarizer-error-category": {
+      "resources": {
+        "backend/summarizers/errors.py": "592d89974e72",
+        "frontend/src/lib/summarizer.ts": "2f17b2887f24"
+      },
+      "page_sha": "f45907b9f28d"
+    },
+    "playbooks/record-a-decision": {
+      "resources": {
+        "docs/adr/README.md": "58f3b66b8ecd",
+        "docs/adr/0000-template.md": "9b9be070a9f4",
+        "docs/design/README.md": "0be8156b26ba"
+      },
+      "page_sha": "c7f40d5cf539"
+    },
+    "playbooks/run-locally": {
+      "resources": {
+        "start.sh": "4d5e10bfcb0a",
+        "start.bat": "40f026c31bcd",
+        "bin/cli.js": "8d71c5e79981",
+        "backend/requirements.txt": "8802a907c88a"
+      },
+      "page_sha": "395d9e4598b6"
+    },
+    "playbooks/ship-a-feature": {
+      "resources": {
+        "package.json": "1ef388d4ea7d"
+      },
+      "page_sha": "a7b8a40fc1ca"
+    },
+    "playbooks/write-scanner-tests": {
+      "resources": {
+        "backend/main.py": "8e0dd470a9de",
+        "backend/test_delegation.py": "257569ece81e",
+        "backend/test_cline_smallcode.py": "e08c33615b50",
+        "backend/test_tt_paths.py": "288419373978",
+        "backend/requirements.txt": "8802a907c88a"
+      },
+      "page_sha": "7635ed701509"
+    },
+    "subsystems/cli": {
+      "resources": {
+        "bin/cli.js": "8d71c5e79981",
+        "install.sh": "feca80435159",
+        "install.ps1": "537f1f458b8a",
+        "start.sh": "4d5e10bfcb0a",
+        "start.bat": "40f026c31bcd",
+        "backend/tt_paths.py": "db6aa0a1f1af"
+      },
+      "page_sha": "44156256820f"
+    },
+    "subsystems/delegation-telemetry": {
+      "resources": {
+        "DESIGN.md": "a4d991aa3a82",
+        "backend/main.py": "8e0dd470a9de",
+        "backend/test_delegation.py": "257569ece81e"
+      },
+      "page_sha": "ea90f59cfbd8"
+    },
+    "subsystems/frontend": {
+      "resources": {
+        "frontend/src/app": "7e8d442f1177"
+      },
+      "page_sha": "891110dd0350"
+    },
+    "subsystems/history-store": {
+      "resources": {
+        "backend/history_store.py": "699133c3edba",
+        "docs/design/durable-history.md": "d6a5fd7b520a",
+        "backend/agent_retention.py": "9bf7333d5eff"
+      },
+      "page_sha": "a9b2e328bf16"
+    },
+    "subsystems/power-cost": {
+      "resources": {
+        "backend/power_meter.py": "56abb1079848",
+        "backend/power_config.py": "16b29824d0bb",
+        "backend/billing_mode.py": "e035e26b4bcb",
+        "backend/billing_route.py": "38c90538d879",
+        "backend/insights.py": "1b715e553e7e"
+      },
+      "page_sha": "e29b1829952d"
+    },
+    "subsystems/pricing": {
+      "resources": {
+        "backend/pricing.py": "c756bb833671",
+        "backend/pricing_data.json": "3c7b4d2d4342",
+        "backend/pricing_sync.py": "8c014b8ad5b1",
+        ".github/workflows/pricing-sync.yml": "e286a7c238b2",
+        "backend/test_pricing.py": "0c90af890adb",
+        "backend/test_pricing_data.py": "464dbf675f33"
+      },
+      "page_sha": "e7f0aa14adbc"
+    },
+    "subsystems/remote-auth": {
+      "resources": {
+        "backend/main.py": "8e0dd470a9de",
+        "frontend/src/lib/api.ts": "67893809aa1b",
+        "backend/test_remote_auth.py": "6cde91f67191"
+      },
+      "page_sha": "e3ebbdb4e8d9"
+    },
+    "subsystems/scanner": {
+      "resources": {
+        "backend/main.py": "8e0dd470a9de"
+      },
+      "page_sha": "5e8c7477d86c"
+    },
+    "subsystems/summarizers": {
+      "resources": {
+        "backend/summarizers": "e2991c4d1b44",
+        "backend/summaries.py": "b58d4370d345",
+        "frontend/src/lib/summarizer.ts": "2f17b2887f24"
+      },
+      "page_sha": "5c9ed61baca0"
+    }
+  },
+  "provenance_stamped": "2026-07-07",
+  "source_tree": {
+    "count": 352,
+    "sha": "548f42cb4551"
+  }
+}

--- a/docs/wiki/manifest.json
+++ b/docs/wiki/manifest.json
@@ -2,23 +2,23 @@
   "okf": "0.1",
   "profile": "generic",
   "created": "2026-07-07",
-  "updated": "2026-07-07",
+  "updated": "2026-07-25",
   "status": "complete",
   "batches_done": 0,
   "batches_total": 0,
-  "page_count": 50,
+  "page_count": 51,
   "page_types": {
     "Analysis": 5,
     "Convention": 5,
     "Decision": 3,
-    "Feature": 7,
+    "Feature": 8,
     "Harness": 13,
     "Idea": 1,
     "Overview": 1,
     "Playbook": 6,
     "Subsystem": 9
   },
-  "compiled_from_sha": "422d0a95a075b21296f6ea536bd1e946be0015d2",
+  "compiled_from_sha": "2a67ce4bc55c0b8d62f243a1a1edb33aeaf1dc66",
   "plugin_version": "0.5.0",
   "provenance": {
     "analyses/brain-savings-approaches": {
@@ -109,6 +109,12 @@
       },
       "page_sha": "a93fef816637"
     },
+    "features/artifacts": {
+      "resources": {
+        "website/content/docs/features/artifacts.mdx": "ab7760ba8c5a"
+      },
+      "page_sha": "09dc69ef20d4"
+    },
     "features/hermes-dashboard": {
       "resources": {
         "website/content/docs/features/hermes.mdx": "ab33fb0c9073"
@@ -126,7 +132,7 @@
       "resources": {
         "website/content/docs/features/projects.mdx": "4853d319d015"
       },
-      "page_sha": "0ddc7ce1c0fb"
+      "page_sha": "157c68324899"
     },
     "features/schedules": {
       "resources": {
@@ -145,7 +151,7 @@
       "resources": {
         "website/content/docs/features/traces.mdx": "98eb7c88a1c3"
       },
-      "page_sha": "9eebb56ff3ef"
+      "page_sha": "d603e3ec7a39"
     },
     "harnesses/antigravity": {
       "resources": {
@@ -154,13 +160,13 @@
         "backend/summarizers/antigravity.py": "4d9aa5586c1c",
         "DESIGN.md": "a4d991aa3a82"
       },
-      "page_sha": "930eabeedf0b"
+      "page_sha": "e5a6e6708ffe"
     },
     "harnesses/claude-code": {
       "resources": {
         "backend/main.py": "8e0dd470a9de"
       },
-      "page_sha": "2c216069cd5a"
+      "page_sha": "524a89b38bba"
     },
     "harnesses/cline": {
       "resources": {
@@ -333,7 +339,7 @@
         "docs/design/durable-history.md": "d6a5fd7b520a",
         "backend/agent_retention.py": "9bf7333d5eff"
       },
-      "page_sha": "a9b2e328bf16"
+      "page_sha": "8a4fffce5704"
     },
     "subsystems/power-cost": {
       "resources": {
@@ -368,7 +374,7 @@
       "resources": {
         "backend/main.py": "8e0dd470a9de"
       },
-      "page_sha": "5e8c7477d86c"
+      "page_sha": "fcf447dbb51f"
     },
     "subsystems/summarizers": {
       "resources": {
@@ -379,9 +385,9 @@
       "page_sha": "5c9ed61baca0"
     }
   },
-  "provenance_stamped": "2026-07-07",
+  "provenance_stamped": "2026-07-25",
   "source_tree": {
-    "count": 352,
-    "sha": "548f42cb4551"
+    "count": 354,
+    "sha": "9b0ac95195f1"
   }
 }

--- a/docs/wiki/overview.md
+++ b/docs/wiki/overview.md
@@ -1,0 +1,32 @@
+---
+type: Overview
+title: TokenTelemetry
+description: Local-first observability dashboard for AI coding agents and autonomous agents; reads session logs from disk, no SDK or cloud.
+resource: /README.md
+tags: [overview]
+timestamp: 2026-07-02
+---
+
+# TokenTelemetry
+
+Free, MIT-licensed dashboard that tracks token usage, LLM costs, tool calls,
+session traces, reasoning steps, subagent delegations, cron health, and
+gateway health across 12 coding agents and Hermes Agent (Nous Research). It
+reads each agent's session logs and SQLite state straight from the filesystem
+(no SDK, no instrumentation) and serves a local web UI at
+`http://localhost:3000`.
+
+- Stack: Next.js 16 frontend (`frontend/`), FastAPI backend (`backend/`),
+  Node launcher (`bin/cli.js`), marketing + docs site (`website/`, static
+  export to tokentelemetry.com).
+- Privacy: logs never leave the machine ([local-first](conventions/local-first.md)).
+  Anonymous content-free usage stats are on by default, opt-out in Settings or
+  `DO_NOT_TRACK=1`.
+- Solo-maintained by Hemanth Vasi; tracked on GitHub Projects board #1 with
+  ADRs and design docs in-repo ([recording decisions](decisions/adr-0001-record-decisions.md)).
+
+Start here:
+
+- [Supported harnesses](index.md) under `harnesses/`
+- [Scanner](subsystems/scanner.md), the core pipeline
+- [Ship a feature](playbooks/ship-a-feature.md), the maintainer loop

--- a/docs/wiki/playbooks/add-a-harness.md
+++ b/docs/wiki/playbooks/add-a-harness.md
@@ -1,0 +1,34 @@
+---
+type: Playbook
+title: Add a new harness
+description: Steps to support a new agent; verify real data shapes first, add scanner constants and parser, fixture tests, honest capability flags, docs.
+tags: [playbook, harness, scanner]
+timestamp: 2026-07-02
+---
+
+# Add a new harness
+
+Reference examples: PR #120 (Cline + SmallCode), `DESIGN.md` probe notes.
+
+1. **Verify the real data shape first.** Run the agent locally (headless
+   probes work; see DESIGN.md's grok/codex/agy method), find its store
+   (JSONL, JSON, or SQLite), and commit a small verified sample under
+   `backend/testdata/<harness>/`. Don't code against documentation alone;
+   when forced to (Cline's VS Code store), say so in comments and tests.
+2. **Scanner:** add the data-dir as a module-level constant in
+   `backend/main.py` (env-overridable if users relocate it, like
+   `TT_CLINE_DIR` / `HERMES_HOME`), plus the parse into the unified session
+   shape. Tolerant per-line parsing; skip usage-less lines.
+3. **Capability flags:** only claim signals the logs actually record.
+   Delegation support goes in `_DELEGATION_CAPABLE_AGENTS`; anything absent
+   renders "not recorded by <agent>"
+   ([count-once / honest n/a](../conventions/count-once-invariant.md)).
+4. **Tests:** fixture tests monkeypatching the dir constants
+   ([scanner tests](write-scanner-tests.md)).
+5. **Pricing:** ensure the models it emits exist in
+   `backend/pricing_data.json` ([pricing](../subsystems/pricing.md)).
+6. **Frontend:** register the agent in `frontend/src/lib/agents.ts`.
+7. **Docs + ship:** update README + `llms.txt` agent lists and counts,
+   `website/content/docs/supported-agents.mdx`, a `harnesses/` wiki page,
+   and follow [ship-a-feature](ship-a-feature.md) (a new harness is a
+   `feat:`, so UPDATE.json).

--- a/docs/wiki/playbooks/add-summarizer-error-category.md
+++ b/docs/wiki/playbooks/add-summarizer-error-category.md
@@ -1,0 +1,23 @@
+---
+type: Playbook
+title: Add a summarizer error category
+description: Three files must change together; errors.py pattern + copy, the TS category union, and the ERROR_ICONS record.
+tags: [playbook, summarization, errors]
+timestamp: 2026-07-02
+---
+
+# Add a summarizer error category
+
+All three layers or it won't compile / won't render:
+
+1. `backend/summarizers/errors.py`: add the pattern tuple to `_PATTERNS`
+   (order matters, first match wins; put more specific wording before
+   broader, e.g. `too_large` sits before `quota`) and the
+   `title`/`message`/`hint` branch. Hints must say what to DO.
+2. `frontend/src/lib/summarizer.ts`: add the category to the
+   `SummaryErrorInfo["category"]` union.
+3. `SummaryPanel.tsx`: add an icon to `ERROR_ICONS` (total `Record`; TS
+   fails the build if missing, which is the safety net).
+
+Context: [error-handling convention](../conventions/error-handling.md),
+[summarizers subsystem](../subsystems/summarizers.md).

--- a/docs/wiki/playbooks/record-a-decision.md
+++ b/docs/wiki/playbooks/record-a-decision.md
@@ -1,0 +1,26 @@
+---
+type: Playbook
+title: Record a decision (ADR)
+description: When and how to write an ADR; copy the template, number it, link issue/discussion/design doc, ship it in the feature PR.
+tags: [playbook, process, adr]
+timestamp: 2026-07-02
+---
+
+# Record a decision
+
+Write an ADR for any decision that shapes architecture, storage, security
+posture, or process (see `docs/adr/README.md`).
+
+1. Copy `docs/adr/0000-template.md` to the next number:
+   `docs/adr/000N-short-slug.md`.
+2. Fill Status (Proposed/Accepted), Date, Deciders, and Related links
+   (issue, discussion, `docs/design/` doc).
+3. Context = the forces, including rejected alternatives and why. Decision =
+   one paragraph. Consequences = the honest list, including the negative
+   ones and how to undo.
+4. Commit it in the feature PR, add the design doc to the
+   `docs/design/README.md` index, and add a `decisions/` page here.
+
+Existing: [0001](../decisions/adr-0001-record-decisions.md),
+[0002](../decisions/adr-0002-durable-history.md),
+[0003](../decisions/adr-0003-docs-site-fumadocs.md).

--- a/docs/wiki/playbooks/run-locally.md
+++ b/docs/wiki/playbooks/run-locally.md
@@ -1,0 +1,25 @@
+---
+type: Playbook
+title: Run TokenTelemetry locally
+description: Start backend and frontend for development; default ports 8000/3000, data dir override, common env vars.
+tags: [playbook, dev]
+timestamp: 2026-07-02
+---
+
+# Run locally
+
+- **Users:** `curl -fsSL https://tokentelemetry.com/install.sh | bash`, or
+  `start.sh` / `start.bat` from a clone. Everything is fronted by
+  [`bin/cli.js`](../subsystems/cli.md): backend on 8000, frontend on 3000.
+- **Dev:** run the FastAPI backend from `backend/` (deps in
+  `backend/requirements.txt`) and `frontend/` with the usual Next.js dev
+  server. Non-default API port needs only `--api-port` (frontend derives the
+  base at runtime).
+- Useful envs: `TOKENTELEMETRY_DATA_DIR` (isolate `history.db` while
+  testing), `TT_CLINE_DIR` / `HERMES_HOME` (relocated agent stores),
+  `DO_NOT_TRACK=1`, `TT_<BACKEND>_TIMEOUT` (summarizers).
+- Cleanup traps: remove `~/.tokentelemetry/.update-check.json` if you seeded
+  it; never point a test run's data dir at your real one when exercising
+  retention/deletion paths.
+- Backend tests: `pytest backend -q`. Frontend type-checks via
+  `npm run build` in `frontend/`.

--- a/docs/wiki/playbooks/ship-a-feature.md
+++ b/docs/wiki/playbooks/ship-a-feature.md
@@ -1,0 +1,28 @@
+---
+type: Playbook
+title: Ship a feature to main
+description: "The maintainer loop; branch, ADR/design doc in the PR, UPDATE.json entry for feat: commits, pass the pre-push gates, PR, board card."
+tags: [playbook, process, releases]
+timestamp: 2026-07-02
+---
+
+# Ship a feature to main
+
+1. Branch from main. For anything non-trivial, write the ADR
+   ([record a decision](record-a-decision.md)) and/or a design doc in
+   `docs/design/`, committed in the same PR.
+2. Implement with tests. Follow the standing conventions:
+   [local-first](../conventions/local-first.md),
+   [count-once](../conventions/count-once-invariant.md),
+   [error handling](../conventions/error-handling.md).
+3. If any commit is `feat:`, add a release entry to the top of
+   [UPDATE.json](../conventions/update-json-feed.md) (user-benefit wording;
+   the pre-push hook blocks you otherwise). Mixed branches: one entry for
+   the feature, fixes ride free. Mis-labeled non-user-visible `feat:`:
+   re-label to `refactor:`/`chore:` instead.
+4. Push; the [gates](../conventions/pre-push-gates.md) run (UPDATE.json
+   check + local Claude diff review; CI npm-audit if a `package.json`
+   changed).
+5. PR to main; track on GitHub Projects board #1. If totals or historical
+   numbers change meaning, the UPDATE.json entry must say so explicitly.
+6. After merge: `/brain ingest` the merged diff so this wiki stays current.

--- a/docs/wiki/playbooks/write-scanner-tests.md
+++ b/docs/wiki/playbooks/write-scanner-tests.md
@@ -1,0 +1,23 @@
+---
+type: Playbook
+title: Write scanner tests
+description: Fixture pattern for backend tests; monkeypatch the module-level dir constants and build a tmp tree mirroring the harness's real layout.
+tags: [playbook, testing, backend]
+timestamp: 2026-07-02
+---
+
+# Write scanner tests
+
+Scanner paths are module-level constants (`CLAUDE_DIR = HOME / ".claude"`
+etc. in `backend/main.py`), so fixtures must **monkeypatch the constant**
+and build a tmp tree that mirrors the harness's real layout (parent
+transcript + `subagents/` subdir, SQLite db file, etc.).
+
+- Copy the pattern from an existing test: `backend/test_delegation.py`
+  (JSONL trees), `backend/test_cline_smallcode.py` (SQLite + JSON stores,
+  builder helpers), `backend/test_tt_paths.py` (data-dir resolution).
+- Base fixtures on verified real shapes committed under `backend/testdata/`.
+- Cover the tolerant-parse edges: partial trailing line, usage-less lines,
+  `<synthetic>` model, missing/corrupt meta.json (falls back to
+  `agent_type: "unknown"` but still sums usage).
+- Run: `pytest backend/<file> -q` (deps: `backend/requirements.txt`).

--- a/docs/wiki/status.py
+++ b/docs/wiki/status.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+# STATUS_PY_VERSION: 2
+"""status.py — freshness checker for this compiled wiki. Self-contained,
+Python 3.9+ stdlib only, no plugin required: anyone who clones the repo can
+run it, in any coding harness that can run a shell command.
+
+The wiki is a CACHE of the codebase. This script is the cache-validity
+check. It compares content hashes recorded in manifest.json (written by the
+tokentelemetry plugin's stamp step at compile/ingest time) against the
+repository's files RIGHT NOW. Content hashes, not git shas: results are
+identical across worktrees, squash-merges, rebases, and tarballs.
+
+Usage:
+  python3 docs/wiki/status.py                 whole-wiki report
+  python3 docs/wiki/status.py <page-id>       one page (e.g. subsystems/scanner)
+  python3 docs/wiki/status.py <page-id> --note  also queue a refresh note in raw/
+  python3 docs/wiki/status.py --json          machine-readable full report
+
+Verdicts per page:
+  FRESH        at least one recorded source verified byte-identical to
+               compile time, none changed, and the page itself is
+               untouched. Safe to answer from.
+  STALE        a source changed (or moved/vanished). Do NOT trust the page
+               body. Read the listed source files and answer from CODE; the
+               page still tells you which files matter.
+  TAMPERED     the page file was edited outside /brain workflows. Trust the
+               listed sources, not the page.
+  UNVERIFIABLE nothing checkable: no provenance recorded, no repo files
+               cited, or every cited source is unhashable (too large,
+               missing at stamp time). Treat as hints; verify before
+               relying. An unhashable source is NEVER reported fresh.
+
+Honest limits (read once):
+- FRESH means "no drift since compile", not "cannot be forged": an editor
+  with repo write access who updates both a page and manifest.json will not
+  be detected. TAMPERED catches accidents and naive edits only.
+- Many pages STALE at once usually means one shared source file changed,
+  not that the wiki rotted; the report groups by changed file.
+- A fact that moved to a file NO page cites is invisible per page; the
+  repo-fingerprint advisory at the bottom of the report is the only signal.
+
+The protocol for agents (also in the CLAUDE.md/AGENTS.md pointer block):
+fresh -> use the page; stale/tampered -> read sources, answer from code,
+re-run with --note; unverifiable -> verify first. Code is ALWAYS
+authoritative over the wiki. Never edit wiki pages by hand; never "fix"
+code to match a wiki page. Refreshing the wiki (/brain ingest, in Claude
+Code) is optional batched maintenance, never required to keep working.
+
+Exit codes: 0 fresh/ok, 1 stale or tampered pages found, 2 error,
+3 nothing checkable (whole-wiki report where no page could be verified —
+automation must not read this as a green light).
+"""
+
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+WIKI = Path(__file__).resolve().parent
+NOTES = WIKI / "raw" / "stale-notes.md"
+NOTES_HEADER = ("# Pending wiki refresh notes\n\nAppended by status.py --note; "
+                "swept and cleared by the next /brain ingest. One line per "
+                "stale page.\n\n")
+DIR_HASH_FILE_CAP = 200
+SENTINELS = {"missing", "unhashable"}
+SAFE_ID_RE = re.compile(r"[^\w/.-]")
+
+
+def sha12(data):
+    return hashlib.sha256(data).hexdigest()[:12]
+
+
+def self_cmd():
+    """How to invoke this script from the caller's cwd (footer suggestions
+    must be copy-pasteable, not just the bare filename)."""
+    try:
+        return os.path.relpath(Path(__file__).resolve())
+    except ValueError:
+        return str(Path(__file__).resolve())
+
+
+def repo_root():
+    try:
+        top = subprocess.run(["git", "rev-parse", "--show-toplevel"],
+                             cwd=WIKI, capture_output=True, text=True, check=True
+                             ).stdout.strip()
+        if top:
+            return Path(top)
+    except Exception:
+        pass
+    return WIKI.parent.parent
+
+
+def hash_resource(root, rel):
+    p = (root / rel.lstrip("/")).resolve()
+    try:
+        p.relative_to(root.resolve())
+    except ValueError:
+        return "unhashable"
+    if p.is_file():
+        try:
+            return sha12(p.read_bytes())
+        except OSError:
+            return "unhashable"
+    if p.is_dir():
+        files = sorted(f for f in p.rglob("*") if f.is_file()
+                       and not any(part.startswith(".") for part in f.relative_to(p).parts))
+        if len(files) > DIR_HASH_FILE_CAP:
+            return "unhashable"
+        h = hashlib.sha256()
+        for f in files:
+            try:
+                h.update(str(f.relative_to(p)).encode())
+                h.update(sha12(f.read_bytes()).encode())
+            except OSError:
+                return "unhashable"
+        return h.hexdigest()[:12]
+    return "missing"
+
+
+def check_page(root, prov, page_id):
+    """Return (verdict, changed_resources, sources, why). Precedence:
+    TAMPERED > STALE > UNVERIFIABLE > FRESH. A sentinel recorded hash
+    ("missing"/"unhashable") never counts as verification: comparing
+    unhashable to unhashable proves nothing, so a page with only sentinel
+    resources is UNVERIFIABLE, not FRESH."""
+    entry = prov.get(page_id)
+    page_file = WIKI / (page_id + ".md")
+    if entry is None:
+        return "UNVERIFIABLE", [], [], "no provenance recorded for this page"
+    resources = entry.get("resources") or {}
+    sources = sorted(resources)
+    if not page_file.exists():
+        return "STALE", [], sources, "page file missing (deleted or moved)"
+    if sha12(page_file.read_bytes()) != entry.get("page_sha"):
+        return ("TAMPERED", [], sources,
+                "page body changed outside /brain workflows")
+    if not resources:
+        return ("UNVERIFIABLE", [], [],
+                "page cites no repo files; nothing to check")
+    changed, verified, unhashable = [], 0, 0
+    for rel, recorded in resources.items():
+        now = hash_resource(root, rel)
+        if now != recorded:
+            changed.append(f"{rel} ({recorded} -> {now})")
+        elif recorded in SENTINELS:
+            unhashable += 1
+        else:
+            verified += 1
+    if changed:
+        return "STALE", changed, sources, "source changed since this page was compiled"
+    if verified == 0:
+        return ("UNVERIFIABLE", [], sources,
+                f"all {unhashable} cited source(s) unhashable or missing; "
+                f"freshness cannot be proven")
+    why = "all verifiable sources byte-identical to compile time"
+    if unhashable:
+        why += f" ({unhashable} source(s) unhashable, not counted)"
+    return "FRESH", [], sources, why
+
+
+def load():
+    mpath = WIKI / "manifest.json"
+    if not mpath.exists():
+        print("error: no manifest.json next to status.py; this wiki has no "
+              "provenance. Run the plugin's stamp step (wiki_manifest.py "
+              "<wiki-dir> stamp) from Claude Code first.", file=sys.stderr)
+        sys.exit(2)
+    try:
+        manifest = json.loads(mpath.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"error: cannot parse manifest.json: {e}", file=sys.stderr)
+        sys.exit(2)
+    prov = manifest.get("provenance")
+    if not isinstance(prov, dict) or not prov:
+        print("error: manifest.json has no provenance block; run the stamp "
+              "step (wiki_manifest.py <wiki-dir> stamp) first.", file=sys.stderr)
+        sys.exit(2)
+    return manifest, prov
+
+
+def pending_notes():
+    if not NOTES.exists():
+        return 0
+    try:
+        return sum(1 for l in NOTES.read_text(encoding="utf-8").splitlines()
+                   if l.startswith("- STALE:"))
+    except OSError:
+        return 0
+
+
+def append_note(page_id, changed):
+    # page ids come from filenames, which an attacker (or accident) can fill
+    # with instruction-looking text; sanitize so raw/stale-notes.md only ever
+    # carries [word/.-] ids and known-charset paths, never free text
+    safe_id = SAFE_ID_RE.sub("_", page_id)
+    files = ", ".join(SAFE_ID_RE.sub("_", c.split(" ")[0]) for c in changed)
+    line = f"- STALE: `{safe_id}` — changed: {files or 'page/sources'}"
+    NOTES.parent.mkdir(parents=True, exist_ok=True)
+    existing = NOTES.read_text(encoding="utf-8") if NOTES.exists() else ""
+    if f"- STALE: `{safe_id}`" in existing:
+        return False  # already queued; one note per page until the next ingest
+    with open(NOTES, "a", encoding="utf-8") as f:
+        if not existing:
+            f.write(NOTES_HEADER)
+        f.write(line + "\n")
+    return True
+
+
+def protocol_line(verdict):
+    return {
+        "FRESH": "OK to answer from this page.",
+        "STALE": "Do NOT trust the page body. Read the changed source files "
+                 "listed above and answer from CODE. The rest of the page's "
+                 "file map is still useful for finding things.",
+        "TAMPERED": "Page was hand-edited; do not trust its body. Answer from "
+                    "the recorded source files listed above. Mention the "
+                    "tamper to the user.",
+        "UNVERIFIABLE": "Treat the page as hints only; verify claims against "
+                        "the files it mentions before relying on them.",
+    }[verdict]
+
+
+def main(argv):
+    as_json = "--json" in argv
+    note = "--note" in argv
+    args = [a for a in argv if not a.startswith("--")]
+    manifest, prov = load()
+    root = repo_root()
+
+    if args:  # single page
+        page_id = args[0]
+        if page_id.endswith(".md"):
+            page_id = page_id[:-3]
+        page_id = page_id.strip("/")
+        # never let a page id escape the wiki dir
+        try:
+            (WIKI / (page_id + ".md")).resolve().relative_to(WIKI)
+        except ValueError:
+            print(f"error: not a wiki page id: {page_id}", file=sys.stderr)
+            return 2
+        if page_id not in prov and not (WIKI / (page_id + ".md")).exists():
+            print(f"error: no such page: {page_id}", file=sys.stderr)
+            return 2
+        verdict, changed, sources, why = check_page(root, prov, page_id)
+        if as_json:
+            print(json.dumps({"page": page_id, "verdict": verdict,
+                              "changed": changed, "sources": sources,
+                              "why": why}))
+        else:
+            print(f"{verdict}: {page_id} — {why}")
+            for c in changed:
+                print(f"  changed: {c}")
+            if verdict in ("TAMPERED", "UNVERIFIABLE") and sources:
+                print(f"  recorded sources: {', '.join(sources)}")
+            print(f"  -> {protocol_line(verdict)}")
+        if note and verdict in ("STALE", "TAMPERED"):
+            added = append_note(page_id, changed)
+            if not as_json:
+                print("  note queued in raw/stale-notes.md" if added
+                      else "  note already queued")
+        return 1 if verdict in ("STALE", "TAMPERED") else 0
+
+    # whole wiki
+    rows = []
+    for page_id in sorted(prov):
+        verdict, changed, sources, why = check_page(root, prov, page_id)
+        rows.append({"page": page_id, "verdict": verdict,
+                     "changed": changed, "why": why})
+    # pages on disk that were never stamped are unverifiable too
+    for p in sorted(WIKI.rglob("*.md")):
+        rel = p.relative_to(WIKI)
+        if rel.name in ("index.md", "log.md", "BRAIN.md", "project-profile.md") and len(rel.parts) == 1:
+            continue
+        if any(part.startswith(".") for part in rel.parts) or rel.parts[0] == "raw":
+            continue
+        pid = str(rel)[:-3]
+        if pid not in prov:
+            rows.append({"page": pid, "verdict": "UNVERIFIABLE",
+                         "changed": [], "why": "created after last stamp"})
+
+    counts = {}
+    for r in rows:
+        counts[r["verdict"]] = counts.get(r["verdict"], 0) + 1
+    bad = [r for r in rows if r["verdict"] in ("STALE", "TAMPERED")]
+    checkable = counts.get("FRESH", 0) + len(bad)
+    queued = pending_notes()
+
+    # repo-fingerprint advisory: files added/removed since stamp may carry
+    # facts no page cites (the per-page check cannot see those)
+    tree_note = None
+    recorded_tree = manifest.get("source_tree")
+    if isinstance(recorded_tree, dict) and recorded_tree.get("sha"):
+        # recompute the same way stamp did (git list, pruned-walk fallback)
+        try:
+            out = subprocess.run(["git", "ls-files"], cwd=root, capture_output=True,
+                                 text=True, check=True).stdout
+            files = sorted(l for l in out.splitlines() if l)
+        except (subprocess.CalledProcessError, OSError):
+            skip = {"node_modules", "__pycache__", ".git", "output", "dist", "build"}
+            files = sorted(
+                str(f.relative_to(root)) for f in root.rglob("*")
+                if f.is_file() and not any(
+                    part in skip or part.startswith(".")
+                    for part in f.relative_to(root).parts))
+        now_sha = hashlib.sha256("\n".join(files).encode()).hexdigest()[:12]
+        if now_sha != recorded_tree["sha"]:
+            tree_note = (f"repo file set changed since stamp "
+                         f"({recorded_tree.get('count')} -> {len(files)} files): "
+                         f"new files may hold facts no page cites yet.")
+
+    if as_json:
+        print(json.dumps({"stamped": manifest.get("provenance_stamped"),
+                          "counts": counts, "checkable": checkable,
+                          "pending_notes": queued, "tree_changed": bool(tree_note),
+                          "pages": rows}))
+        return 1 if bad else (3 if checkable == 0 else 0)
+
+    print(f"wiki status (stamped {manifest.get('provenance_stamped')}): "
+          + ", ".join(f"{v} {k}" for k, v in sorted(counts.items())))
+    for r in bad:
+        print(f"  {r['verdict']}: {r['page']}"
+              + (f" — {r['changed'][0]}" + (f" (+{len(r['changed'])-1} more)" if len(r['changed']) > 1 else "")
+                 if r["changed"] else ""))
+    unv = counts.get("UNVERIFIABLE", 0)
+    if unv:
+        print(f"  blind spot: {unv} page(s) have no checkable provenance and "
+              f"CANNOT be verified — treat them as hints, not facts.")
+    if queued:
+        print(f"  pending: raw/stale-notes.md has {queued} queued note(s); "
+              f"the next /brain ingest sweeps them.")
+    if tree_note:
+        print(f"  advisory: {tree_note}")
+    if bad:
+        print(f"  -> stale/tampered pages: answer from their source files, not "
+              f"the page body. Queue refreshes with: python3 {self_cmd()} "
+              f"<page> --note. Catch up anytime with /brain ingest "
+              f"(Claude Code; optional).")
+    if checkable == 0:
+        print("  -> NOTHING here could be verified; this report is not a "
+              "green light. Run the stamp step to establish provenance.")
+        return 3
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/docs/wiki/subsystems/cli.md
+++ b/docs/wiki/subsystems/cli.md
@@ -1,0 +1,28 @@
+---
+type: Subsystem
+title: CLI launcher
+description: bin/cli.js starts backend (default port 8000) and frontend (3000); flags for ports, host, origins, auth token, data dir.
+resource: /bin/cli.js
+tags: [subsystem, cli]
+timestamp: 2026-07-02
+---
+
+# CLI launcher
+
+`bin/cli.js` starts the FastAPI backend (default port **8000**) and the
+Next.js frontend (port 3000). Install via `install.sh` / `install.ps1` or
+`start.sh` / `start.bat` from a clone.
+
+- **Flags:** `--port`, `--api-port`, `--host`, `--allowed-origins`,
+  `--auth-token`, `--insecure-no-auth`, `--data-dir`, `--quiet`, `--flag`,
+  `--help`.
+- The frontend derives its API base from `window.location` +
+  `NEXT_PUBLIC_API_PORT` at runtime (set by `bin/cli.js` from `--api-port`),
+  so non-default ports work automatically. `NEXT_PUBLIC_API_BASE` remains an
+  explicit override to pin a fixed host, but is not needed just to change
+  ports.
+- Remote access (`--host` non-loopback) turns on the token gate; see
+  [remote auth](remote-auth.md). Envs: `TT_HOST`, `TT_ALLOWED_ORIGINS`,
+  `TT_AUTH_TOKEN`.
+- Data dir override: `--data-dir` / `TOKENTELEMETRY_DATA_DIR` (used by the
+  [history store](history-store.md); path logic in `backend/tt_paths.py`).

--- a/docs/wiki/subsystems/delegation-telemetry.md
+++ b/docs/wiki/subsystems/delegation-telemetry.md
@@ -1,0 +1,37 @@
+---
+type: Subsystem
+title: Delegation and ecosystem telemetry
+description: Per-session subagent, skill, and MCP attribution; capability varies by harness, tokens are never invented, aggregates never double-count.
+resource: /DESIGN.md
+tags: [subsystem, backend, delegation, analytics]
+timestamp: 2026-07-02
+---
+
+# Delegation and ecosystem telemetry
+
+Design of record: `DESIGN.md` (pre-ADR, data shapes verified against real
+local data 2026-06-10). Implementation `backend/main.py`
+(`_claude_subagent_usage()`, `session_delegation()`), tests
+`backend/test_delegation.py`.
+
+- Every session carries a `delegation` marker. Capability is per-agent
+  (`_DELEGATION_CAPABLE_AGENTS = {claude, cursor, opencode, hermes}`);
+  everything else gets `{"supported": false}` and the UI renders
+  "not recorded by <agent>", never 0.
+- Modes by harness: full token rollup
+  ([claude-code](../harnesses/claude-code.md)), spawn-count only
+  ([cursor](../harnesses/cursor.md)), parent/child annotation
+  ([opencode](../harnesses/opencode.md), [hermes](../harnesses/hermes.md);
+  [grok-build](../harnesses/grok-build.md), [codex](../harnesses/codex.md),
+  [antigravity](../harnesses/antigravity.md) verified capable, per DESIGN.md
+  probes).
+- Rich per-session breakdown is a separate overlay endpoint,
+  `GET /sessions/{session_id}/delegation?agent=...` (follows the
+  hermes-overlay precedent).
+- Phase 2 adds `skills_used`, `tool_counts`, `mcp_usage` per session and
+  `by_skill` / `by_mcp_server` / `by_subagent_type` + `delegation` buckets to
+  `/analytics`; existing aggregate keys stay byte-identical.
+- Governing rule: [count-once invariant](../conventions/count-once-invariant.md).
+  Claude delegated tokens ARE added to aggregates (they were counted nowhere);
+  opencode/hermes children already are sessions, so parent sums are
+  display-only.

--- a/docs/wiki/subsystems/frontend.md
+++ b/docs/wiki/subsystems/frontend.md
@@ -1,0 +1,27 @@
+---
+type: Subsystem
+title: Frontend dashboard
+description: Next.js 16 App Router app in frontend/; routes for dashboard, analytics, sessions, projects, hermes, local-models, settings.
+resource: /frontend/src/app
+tags: [subsystem, frontend, nextjs]
+timestamp: 2026-07-02
+---
+
+# Frontend dashboard
+
+`frontend/` (Next.js 16, App Router, served at `localhost:3000`).
+
+- **Routes** (`frontend/src/app/`): `/` dashboard, `/analytics`,
+  `/sessions` + `/sessions/[id]`, `/projects`, `/hermes`, `/local-models`,
+  `/settings`.
+- **Key lib files:** `src/lib/api.ts` (API base derivation + bearer token),
+  `src/lib/agents.ts` (agent registry/branding), `src/lib/summarizer.ts`
+  (error category union). `TokenGate.tsx` handles the
+  [remote auth](remote-auth.md) token prompt.
+- Error rendering rule: summarizer failures go through `SummaryErrorCard` in
+  `SummaryPanel.tsx`, never raw ([error handling](../conventions/error-handling.md)).
+- Honest-signal rule: missing per-harness data renders as
+  "not recorded by <agent>", never zero
+  ([count-once](../conventions/count-once-invariant.md)).
+- This is the product UI; the separate `website/` app is marketing + docs
+  ([docs site decision](../decisions/adr-0003-docs-site-fumadocs.md)).

--- a/docs/wiki/subsystems/history-store.md
+++ b/docs/wiki/subsystems/history-store.md
@@ -1,0 +1,32 @@
+---
+type: Subsystem
+title: Durable history store
+description: SQLite rollup at ~/.tokentelemetry/history.db so analytics survive each agent's transcript pruning; raw facts stored, insights recomputed at read.
+resource: /backend/history_store.py
+tags: [subsystem, backend, sqlite, analytics]
+timestamp: 2026-07-02
+---
+
+# Durable history store
+
+Decision: [ADR-0002](../decisions/adr-0002-durable-history.md); design:
+`docs/design/durable-history.md`; code `backend/history_store.py`,
+retention in `backend/agent_retention.py`.
+
+- **Why:** agents prune their own transcripts (Claude Code and Gemini CLI
+  default 30 days), so "this month/year" analytics were structurally
+  impossible from live scans alone (issue #83, discussion #27).
+- **What:** SQLite at `~/.tokentelemetry/history.db` (honors
+  `TOKENTELEMETRY_DATA_DIR`), upserted on every scan from a background
+  thread. Analytics = SQL-filtered history merged with the live scan; live
+  wins for in-flight sessions.
+- **Raw facts only** (tokens, cost, model, tok/s, timestamps, small
+  ecosystem JSON); energy/savings/CO2 recomputed at read so
+  [power-config](power-cost.md) changes apply retroactively.
+- **Tiered retention:** tiny core rollup always kept; full transcript
+  archival opt-in per agent and deletable; summaries persist past transcript
+  deletion.
+- **Limits:** start-from-now (pre-install history is unrecoverable, UI says
+  so); summary-only rows have no drill-in; transcript archival resolves paths
+  for claude/codex only (`_resolve_transcript_path`).
+- Undo: delete `history.db`; agent data is never modified.

--- a/docs/wiki/subsystems/history-store.md
+++ b/docs/wiki/subsystems/history-store.md
@@ -4,7 +4,7 @@ title: Durable history store
 description: SQLite rollup at ~/.tokentelemetry/history.db so analytics survive each agent's transcript pruning; raw facts stored, insights recomputed at read.
 resource: /backend/history_store.py
 tags: [subsystem, backend, sqlite, analytics]
-timestamp: 2026-07-02
+timestamp: 2026-07-22
 ---
 
 # Durable history store
@@ -22,7 +22,10 @@ retention in `backend/agent_retention.py`.
   wins for in-flight sessions.
 - **Raw facts only** (tokens, cost, model, tok/s, timestamps, small
   ecosystem JSON); energy/savings/CO2 recomputed at read so
-  [power-config](power-cost.md) changes apply retroactively.
+  [power-config](power-cost.md) changes apply retroactively. The ecosystem
+  blob (`_ECOSYSTEM_KEYS`) carries skills/MCP/delegation/loop plus
+  `published_artifacts` since PR #193, so
+  [artifact](../features/artifacts.md) links survive transcript pruning.
 - **Tiered retention:** tiny core rollup always kept; full transcript
   archival opt-in per agent and deletable; summaries persist past transcript
   deletion.

--- a/docs/wiki/subsystems/power-cost.md
+++ b/docs/wiki/subsystems/power-cost.md
@@ -1,0 +1,28 @@
+---
+type: Subsystem
+title: Power, energy and CO2 costing
+description: Local-electricity and subscription costing; energy = configured watts x session latency, recomputed at read time from stored raw facts.
+resource: /backend/power_meter.py
+tags: [subsystem, backend, power, co2]
+timestamp: 2026-07-02
+---
+
+# Power, energy and CO2 costing
+
+Shipped from discussion #49. Code: `backend/power_config.py`,
+`backend/power_meter.py`, billing in `backend/billing_mode.py` +
+`backend/billing_route.py`; insights in `backend/insights.py`.
+
+- **Model:** measured tok/s already reflects total session latency, so
+  energy = configured watts x session latency. CO2 derives from energy.
+- Insights are recomputed at read time from raw facts in the
+  [history store](history-store.md), so changing wattage or tariff
+  re-prices old sessions retroactively.
+- Local model inventories come from `~/.ollama` (`OLLAMA_DIR`) and
+  `~/.cache/huggingface` (`HF_DIR`); surfaced on the
+  [/local-models page](../features/local-models.md).
+- Billing modes cover API pay-per-token vs subscription plans; re-check
+  provider billing formats before touching this code
+  ([pricing](pricing.md) has the same rule).
+- Tests: `test_power_config.py`, `test_power_meter.py`, `test_local_power.py`,
+  `test_co2.py`, `test_billing_mode.py`, `test_billing_route.py`.

--- a/docs/wiki/subsystems/pricing.md
+++ b/docs/wiki/subsystems/pricing.md
@@ -1,0 +1,26 @@
+---
+type: Subsystem
+title: Pricing
+description: Costing from a bundled, committed pricing_data.json; refreshed by a CI-only models.dev sync that opens a review PR. Zero runtime network.
+resource: /backend/pricing.py
+tags: [subsystem, backend, pricing, local-first]
+timestamp: 2026-07-02
+---
+
+# Pricing
+
+- `backend/pricing.py` reads only the committed `backend/pricing_data.json`.
+  No network I/O at import or runtime; users get fresh prices through normal
+  version updates ([local-first](../conventions/local-first.md)).
+- `backend/pricing_sync.py` is the ONLY place with outbound pricing I/O:
+  dev/CI-only, fetches models.dev, regenerates the JSON. Runs on a schedule
+  via `.github/workflows/pricing-sync.yml`, which opens a PR so the diff is
+  reviewed before shipping (latest sync: PR #117).
+- Cost is computed per line/file by that line's own model, never the parent
+  session's (subagent models differ; see
+  [Claude Code](../harnesses/claude-code.md)).
+- Hermes gets provider-aware pricing: the same model priced per aggregator
+  (direct API / OpenRouter / Together / Fireworks).
+- Before touching billing/subscription/drain logic, re-search current
+  provider billing formats; they change often.
+- Tests: `backend/test_pricing.py`, `backend/test_pricing_data.py`.

--- a/docs/wiki/subsystems/remote-auth.md
+++ b/docs/wiki/subsystems/remote-auth.md
@@ -1,0 +1,29 @@
+---
+type: Subsystem
+title: Remote access auth
+description: Token gate for non-loopback access; RemoteAuthMiddleware requires a bearer token on remote requests, loopback always exempt, CORS is not the boundary.
+resource: /backend/main.py
+tags: [subsystem, backend, security]
+timestamp: 2026-07-02
+---
+
+# Remote access auth
+
+Default is loopback-only. For tailnet/remote use (`--host` /
+`--allowed-origins`, envs `TT_HOST` / `TT_ALLOWED_ORIGINS`):
+
+- A non-loopback `--host` auto-generates `TT_AUTH_TOKEN` (printed once at
+  startup). `RemoteAuthMiddleware` in `backend/main.py` then requires it on
+  every remote request; loopback is always exempt, so the local experience is
+  unchanged.
+- **CORS is not the security boundary** (it only restrains browsers); the
+  token is. The middleware registers BEFORE CORS so CORS stays outermost
+  (answers OPTIONS preflight, decorates the 401). Keep that order.
+- Frontend carries the token via `Authorization: Bearer`, and `?token=` for
+  artifact `<img>`/`<a>` loads: `frontend/src/lib/api.ts` +
+  `TokenGate.tsx`.
+- Overrides: `--auth-token` to pin, `--insecure-no-auth` for a trusted
+  tailnet.
+- History: hardened after issue #91, which also produced the
+  [pre-push gates](../conventions/pre-push-gates.md).
+- Tests: `backend/test_remote_auth.py`.

--- a/docs/wiki/subsystems/scanner.md
+++ b/docs/wiki/subsystems/scanner.md
@@ -1,0 +1,31 @@
+---
+type: Subsystem
+title: Session scanner
+description: The core pipeline in backend/main.py; live-scans every harness's on-disk logs into a unified session list with a 30s cache and 100-session cap.
+resource: /backend/main.py
+tags: [subsystem, backend]
+timestamp: 2026-07-02
+---
+
+# Session scanner
+
+`backend/main.py` (~7k lines) live-scans each harness's data directory into a
+unified session shape served by `/sessions` and `/analytics`.
+
+- **Agent roots are module-level constants** (`CLAUDE_DIR`, `CODEX_DIR`,
+  `GEMINI_DIR`, `QWEN_DIR`, `VIBE_DIR`, `CURSOR_DIR`, `HERMES_DIR`,
+  `GROK_SESSIONS_DIR`, `COPILOT_CLI_DIR`, `ANTIGRAVITY_*_DIR`, `CLINE_DIR`,
+  ...) around line 253+. Tests monkeypatch these constants; see
+  [scanner tests playbook](../playbooks/write-scanner-tests.md).
+- **Caching:** `get_sessions_cached` holds results in RAM for 30s
+  (`SESSIONS_TTL_SEC`); list endpoints work over the top-100 sessions.
+  Expensive per-session detail lives on separate endpoints (e.g. the
+  [delegation overlay](delegation-telemetry.md)).
+- **Parsing is tolerant:** per-line JSON parse, partial trailing lines
+  skipped (sessions may still be mid-write), usage-less and `<synthetic>`
+  lines skipped for cost.
+- Durability on top of the live scan comes from the
+  [history store](history-store.md); the scan alone dies with each agent's
+  own transcript pruning.
+
+Per-harness specifics live on the `harnesses/` pages.

--- a/docs/wiki/subsystems/scanner.md
+++ b/docs/wiki/subsystems/scanner.md
@@ -4,7 +4,7 @@ title: Session scanner
 description: The core pipeline in backend/main.py; live-scans every harness's on-disk logs into a unified session list with a 30s cache and 100-session cap.
 resource: /backend/main.py
 tags: [subsystem, backend]
-timestamp: 2026-07-02
+timestamp: 2026-07-22
 ---
 
 # Session scanner
@@ -20,7 +20,12 @@ unified session shape served by `/sessions` and `/analytics`.
 - **Caching:** `get_sessions_cached` holds results in RAM for 30s
   (`SESSIONS_TTL_SEC`); list endpoints work over the top-100 sessions.
   Expensive per-session detail lives on separate endpoints (e.g. the
-  [delegation overlay](delegation-telemetry.md)).
+  [delegation overlay](delegation-telemetry.md)). Claude and Codex sessions
+  also have a per-session sidecar cache (`backend/scan_cache.py`), keyed on
+  source mtime and `CACHE_VERSION`; bump the version whenever cached payload
+  shape or semantics change (v5 as of PR #193, which added
+  `published_artifacts` and page source paths). A version mismatch is a
+  miss, so stale entries reparse transparently.
 - **Parsing is tolerant:** per-line JSON parse, partial trailing lines
   skipped (sessions may still be mid-write), usage-less and `<synthetic>`
   lines skipped for cost.

--- a/docs/wiki/subsystems/summarizers.md
+++ b/docs/wiki/subsystems/summarizers.md
@@ -1,0 +1,37 @@
+---
+type: Subsystem
+title: Summarizers
+description: Pluggable session-summary backends (claude, codex, gemini, qwen, antigravity, ollama, openai_compat) with a strict classify-don't-dump error pipeline.
+resource: /backend/summarizers
+tags: [subsystem, backend, summarization, errors]
+timestamp: 2026-07-02
+---
+
+# Summarizers
+
+Adapters in `backend/summarizers/`: `claude.py`, `codex.py`, `gemini.py`,
+`qwen.py`, `antigravity.py`, `ollama.py`, `openai_compat.py`, base class in
+`base.py`. Endpoint plumbing in `backend/summaries.py`.
+
+## Error pipeline (never dump raw errors in the UI)
+
+Rule of record: [summarizer error handling](../conventions/error-handling.md).
+Three layers, all of which must change together when adding a category:
+
+1. Adapters raise `SummarizerError` keeping status + provider body in the
+   message so the classifier can match.
+2. `errors.py::classify()` buckets via ordered `_PATTERNS` (first match wins;
+   `too_large` before `quota` because token-budget 413s carry rate-limit
+   wording) into categories: `auth`, `too_large`, `quota`, `model`,
+   `timeout`, `network`, `no_output`. Returns
+   `{category, title, message, hint, raw}` with per-backend hints
+   (e.g. ollama network hint: "Is `ollama serve` running?"; timeouts:
+   `TT_<BACKEND>_TIMEOUT` override).
+3. Frontend renders `error_info` via `SummaryErrorCard`
+   (`SummaryPanel.tsx`); `ERROR_ICONS` is a total Record so TS fails the
+   build on a missing category. Category union lives in
+   `frontend/src/lib/summarizer.ts`.
+
+Prefer graceful degradation: `openai_compat` retries once with a clean
+OpenAI-only payload when a strict gateway 400s on a non-standard field.
+Playbook: [add an error category](../playbooks/add-summarizer-error-category.md).


### PR DESCRIPTION
## What

A project second brain at `docs/wiki/`: the repo's scattered knowledge (DESIGN.md, ADRs, design docs, CLAUDE.md conventions, llms.txt, scanner internals) compiled into a [Google OKF v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) bundle, maintained per Karpathy's [llm-wiki pattern](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f): humans edit sources, the wiki is recompiled by an LLM under a fixed schema.

## Contents

- **44 concept pages**, each with OKF frontmatter (`type` required; `title`/`description`/`resource`/`tags`/`timestamp`):
  - `harnesses/` (13) — per-agent data dirs, parsed signals, delegation support, quirks (incl. Cline + SmallCode from #120)
  - `subsystems/` (9) — scanner, history store, pricing, summarizers, remote auth, power/CO2, delegation telemetry, CLI, frontend
  - `features/` (7), `decisions/` (3 ADR summaries), `playbooks/` (6), `conventions/` (5)
- **Reserved files** per spec: `index.md` (grouped listing for progressive disclosure) and `log.md` (newest-first history; already carries two lint findings, e.g. llms.txt/README still say 10 coding agents post-#120)
- **`.claude/skills/brain/SKILL.md`** — the schema: page types, frontmatter rules, and the `/brain ingest | query | lint` workflows

## Validation

Linted as an OKF bundle (frontmatter parses, non-empty `type` on all 44 pages, all internal links resolve, index matches the file set). Docs-only change; no UPDATE.json entry needed.

## Maintenance loop

After a PR merges: `/brain ingest` the diff. `/brain query` answers from the wiki and files back what it had to learn. `/brain lint` catches drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)