### PR TITLE
feat: Second Brain tab — project wiki as an interactive graph

### DIFF
--- a/UPDATE.json
+++ b/UPDATE.json
@@ -1,6 +1,21 @@
 {
   "releases": [
     {
+      "tag": "2026-07-05",
+      "title": "Second Brain: your project wiki as a graph",
+      "highlights": [
+        {
+          "title": "Obsidian-style knowledge graph per project",
+          "description": "Projects with a compiled wiki (built by the tokentelemetry Claude Code plugin) get a Second Brain tab: an interactive force-directed graph of every page. Pages cluster by wiki section, hover lights up a page's neighborhood, and clicking opens the full page in a drawer with its links, tags, and a freshness check against the commit it was compiled from.",
+          "href": "/projects"
+        },
+        {
+          "title": "Import a brain you already built",
+          "description": "Already have a wiki or an Obsidian vault in the repo? The tab detects it and offers one-click import (a pointer in TokenTelemetry's own config; your repo is never written). Plain markdown vaults render as a graph too, including [[wikilinks]]."
+        }
+      ]
+    },
+    {
       "tag": "2026-06-24",
       "title": "Git worktrees, grouped under their project",
       "highlights": [

--- a/UPDATE.json
+++ b/UPDATE.json
@@ -11,7 +11,11 @@
         },
         {
           "title": "Import a brain you already built",
-          "description": "Already have a wiki or an Obsidian vault in the repo? The tab detects it and offers one-click import (a pointer in TokenTelemetry's own config; your repo is never written). Plain markdown vaults render as a graph too, including [[wikilinks]]."
+          "description": "Already have a wiki or an Obsidian vault? The tab detects in-repo candidates, and a folder browser lets you walk to a wiki anywhere on disk — no typing absolute paths. Import records a pointer in TokenTelemetry's own config; your repo is never written. Plain markdown vaults render as a graph too, including [[wikilinks]]."
+        },
+        {
+          "title": "See what the brain cost to build",
+          "description": "The tab shows the tokens spent by the /brain-init and /brain-compile sessions that built this project's wiki, including work delegated to subagents, so you can weigh the one-time build against the sessions it makes cheaper."
         }
       ]
     },

--- a/backend/main.py
+++ b/backend/main.py
@@ -7003,6 +7003,115 @@ async def get_brain_build_cost(project: Optional[str] = None):
     }
 
 
+import platform as _platform
+import shutil as _shutil
+import threading as _threading
+
+# One native dialog at a time: a second click while a dialog is up should not
+# stack another one behind it.
+_FOLDER_PICKER_LOCK = _threading.Lock()
+
+# How long the native dialog may sit open before we close it and give up.
+_FOLDER_PICKER_TIMEOUT_S = 300
+
+
+def _native_pick_folder_sync(start: Optional[str]) -> Dict[str, Any]:
+    """Open the OS folder dialog (Finder / Explorer / zenity) and return
+    {"path": ...} | {"canceled": True} | {"unsupported": True, "reason": ...}.
+
+    Runs in a worker thread; each branch shells out to the platform's dialog
+    tool so nothing here needs a GUI toolkit in-process. `start` is passed via
+    argv (never interpolated into a script) so a hostile path can't inject.
+    """
+    system = _platform.system()
+    try:
+        if system == "Darwin":
+            script = (
+                'on run argv\n'
+                '  if (count of argv) > 0 then\n'
+                '    return POSIX path of (choose folder with prompt '
+                '"Choose a wiki folder for TokenTelemetry" '
+                'default location (POSIX file (item 1 of argv)))\n'
+                '  else\n'
+                '    return POSIX path of (choose folder with prompt '
+                '"Choose a wiki folder for TokenTelemetry")\n'
+                '  end if\n'
+                'end run'
+            )
+            argv = [start] if start and Path(start).is_dir() else []
+            out = _subprocess.run(["osascript", "-e", script, *argv],
+                                  capture_output=True, text=True,
+                                  timeout=_FOLDER_PICKER_TIMEOUT_S)
+            if out.returncode == 0:
+                p = out.stdout.strip().rstrip("/")
+                return {"path": p} if p else {"canceled": True}
+            # -128 is AppleScript's "User canceled."; anything else means the
+            # dialog could not be shown (headless, no WindowServer session).
+            if "-128" in out.stderr or "canceled" in out.stderr.lower():
+                return {"canceled": True}
+            return {"unsupported": True, "reason": "could not open the macOS folder dialog"}
+        if system == "Windows":
+            ps = (
+                "Add-Type -AssemblyName System.Windows.Forms; "
+                "$f = New-Object System.Windows.Forms.FolderBrowserDialog; "
+                "$f.Description = 'Choose a wiki folder for TokenTelemetry'; "
+                "$f.ShowNewFolderButton = $false; "
+                "if ($f.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) "
+                "{ Write-Output $f.SelectedPath }"
+            )
+            out = _subprocess.run(
+                ["powershell", "-NoProfile", "-STA", "-Command", ps],
+                capture_output=True, text=True, timeout=_FOLDER_PICKER_TIMEOUT_S)
+            if out.returncode != 0:
+                return {"unsupported": True, "reason": "could not open the Explorer folder dialog"}
+            p = out.stdout.strip()
+            return {"path": p} if p else {"canceled": True}
+        # Linux: whichever of the two common dialog tools exists.
+        if _shutil.which("zenity"):
+            out = _subprocess.run(
+                ["zenity", "--file-selection", "--directory",
+                 "--title=Choose a wiki folder for TokenTelemetry"],
+                capture_output=True, text=True, timeout=_FOLDER_PICKER_TIMEOUT_S)
+            if out.returncode == 0 and out.stdout.strip():
+                return {"path": out.stdout.strip()}
+            return {"canceled": True}
+        if _shutil.which("kdialog"):
+            out = _subprocess.run(
+                ["kdialog", "--getexistingdirectory", start or str(Path.home())],
+                capture_output=True, text=True, timeout=_FOLDER_PICKER_TIMEOUT_S)
+            if out.returncode == 0 and out.stdout.strip():
+                return {"path": out.stdout.strip()}
+            return {"canceled": True}
+        return {"unsupported": True,
+                "reason": "no folder-dialog tool found (install zenity or kdialog)"}
+    except _subprocess.TimeoutExpired:
+        return {"canceled": True, "reason": "dialog timed out"}
+    except (OSError, ValueError) as e:
+        return {"unsupported": True, "reason": f"folder dialog failed: {e}"}
+
+
+@app.get("/brain/pick-folder")
+async def pick_brain_folder(request: Request, project: Optional[str] = None):
+    """Open the NATIVE OS folder picker on the machine running TokenTelemetry.
+
+    Loopback-only: for a remote (tailnet) viewer the dialog would open on the
+    host's screen, not theirs, so remote callers get `unsupported` and the UI
+    falls back to the in-app folder browser (/brain/browse).
+    """
+    client = request.client.host if request.client else ""
+    if client not in ("127.0.0.1", "::1", "localhost"):
+        return {"unsupported": True,
+                "reason": "native picker is only available on the machine running TokenTelemetry"}
+    proj = _brain_project(project)
+    start = str(proj) if proj else None
+    if not _FOLDER_PICKER_LOCK.acquire(blocking=False):
+        return {"busy": True}
+    try:
+        return await _asyncio.to_thread(_native_pick_folder_sync, start)
+    finally:
+        _FOLDER_PICKER_LOCK.release()
+
+
 class BrainRegisterPayload(BaseModel):
     project: str
     wiki_path: str

--- a/backend/main.py
+++ b/backend/main.py
@@ -6868,6 +6868,119 @@ async def get_config(project: Optional[str] = None):
     }
 
 # --------------------------------------------------------------------------- #
+# Second Brain (project wiki) — read-only; see backend/second_brain.py
+# --------------------------------------------------------------------------- #
+import second_brain as _second_brain
+
+
+def _brain_project(project: Optional[str]) -> Optional[Path]:
+    """Validate a ?project= param the same way /config does."""
+    if not project or not _project_within_safe_roots(project):
+        return None
+    p = Path(project)
+    return p if p.exists() and p.is_dir() else None
+
+
+def _brain_resolved(project: Optional[str]):
+    """(project_path, wiki_dir, kind, summary) or (None, None, None, error_dict)."""
+    proj = _brain_project(project)
+    if proj is None:
+        return None, None, None, {"exists": False, "kind": None, "source": "none",
+                                  "project_valid": False}
+    registered = _second_brain.load_brains().get(str(proj))
+    summary = _second_brain.wiki_summary(proj, registered)
+    summary["project_valid"] = True
+    if not summary["exists"]:
+        return proj, None, None, summary
+    return proj, Path(summary["wiki_path"]), summary["kind"], summary
+
+
+@app.get("/brain")
+async def get_brain(project: Optional[str] = None):
+    """Wiki detection summary for a project (drives the Second Brain tab states)."""
+    _, _, _, summary = _brain_resolved(project)
+    summary["project"] = project
+    return summary
+
+
+@app.get("/brain/graph")
+async def get_brain_graph(project: Optional[str] = None):
+    """Nodes/edges/clusters for the wiki graph view."""
+    proj, wiki_dir, kind, summary = _brain_resolved(project)
+    if wiki_dir is None:
+        return {"summary": summary, "nodes": [], "edges": [], "clusters": [], "types": {}}
+    graph = _second_brain.graph_cached(wiki_dir, kind)
+    return {"summary": summary, **graph}
+
+
+@app.get("/brain/page")
+async def get_brain_page(project: Optional[str] = None, id: Optional[str] = None):
+    """One wiki page: frontmatter, markdown body, in/out links, staleness."""
+    proj, wiki_dir, kind, summary = _brain_resolved(project)
+    if wiki_dir is None or not id:
+        raise HTTPException(status_code=404, detail="no wiki or page id")
+    graph = _second_brain.graph_cached(wiki_dir, kind)
+    detail = _second_brain.page_detail(
+        proj, wiki_dir, id, summary.get("compiled_from_sha"), graph)
+    if detail is None:
+        raise HTTPException(status_code=404, detail=f"page not found: {id}")
+    return detail
+
+
+@app.get("/brain/candidates")
+async def get_brain_candidates(project: Optional[str] = None):
+    """Importable wiki-shaped trees found inside the project directory."""
+    proj = _brain_project(project)
+    if proj is None:
+        return {"candidates": []}
+    return {"candidates": _second_brain.scan_candidates(proj)}
+
+
+class BrainRegisterPayload(BaseModel):
+    project: str
+    wiki_path: str
+
+
+@app.post("/brain/register")
+async def register_brain(payload: BrainRegisterPayload):
+    """Import an existing wiki: records a pointer in ~/.tokentelemetry only.
+
+    The project repo is never written; unregistering just deletes the pointer.
+    """
+    proj = _brain_project(payload.project)
+    if proj is None:
+        raise HTTPException(status_code=400, detail="invalid project path")
+    if not _project_within_safe_roots(payload.wiki_path):
+        raise HTTPException(status_code=400, detail="wiki path outside allowed roots")
+    kind = _second_brain.classify_wiki_dir(Path(payload.wiki_path))
+    if kind is None:
+        raise HTTPException(
+            status_code=422,
+            detail="not a recognizable wiki (no manifest, index+typed pages, "
+                   ".obsidian, or enough markdown files)")
+    brains = _second_brain.load_brains()
+    brains[str(proj)] = str(Path(payload.wiki_path).resolve())
+    _second_brain.save_brains(brains)
+    return {"ok": True, "kind": kind, "wiki_path": brains[str(proj)]}
+
+
+class BrainUnregisterPayload(BaseModel):
+    project: str
+
+
+@app.post("/brain/unregister")
+async def unregister_brain(payload: BrainUnregisterPayload):
+    proj = _brain_project(payload.project)
+    if proj is None:
+        raise HTTPException(status_code=400, detail="invalid project path")
+    brains = _second_brain.load_brains()
+    removed = brains.pop(str(proj), None)
+    if removed is not None:
+        _second_brain.save_brains(brains)
+    return {"ok": True, "removed": removed}
+
+
+# --------------------------------------------------------------------------- #
 # Trace summaries
 # --------------------------------------------------------------------------- #
 from fastapi import Body, HTTPException

--- a/backend/main.py
+++ b/backend/main.py
@@ -6936,6 +6936,73 @@ async def get_brain_candidates(project: Optional[str] = None):
     return {"candidates": _second_brain.scan_candidates(proj)}
 
 
+@app.get("/brain/browse")
+async def browse_brain_dirs(project: Optional[str] = None, path: Optional[str] = None):
+    """One directory level for the import folder picker.
+
+    Confined to the same safe roots as every other project-scoped endpoint;
+    `parent` is null at a root boundary so the UI can't walk above it.
+    """
+    proj = _brain_project(project)
+    if proj is None:
+        raise HTTPException(status_code=400, detail="invalid project path")
+    target = Path(path) if path else proj
+    try:
+        target = target.resolve()
+    except (OSError, RuntimeError):
+        raise HTTPException(status_code=400, detail="unreadable path")
+    if not _project_within_safe_roots(str(target)):
+        raise HTTPException(status_code=400, detail="path outside allowed roots")
+    if not target.is_dir():
+        raise HTTPException(status_code=404, detail="not a directory")
+    listing = _second_brain.browse_dir(target)
+    parent = target.parent
+    listing["parent"] = (
+        str(parent)
+        if parent != target and _project_within_safe_roots(str(parent))
+        else None
+    )
+    return listing
+
+
+@app.get("/brain/build-cost")
+async def get_brain_build_cost(project: Optional[str] = None):
+    """Tokens spent building this project's brain.
+
+    Derived from TT's own session scan: sessions in this project whose
+    skills_used include brain-init / brain-compile (bare or plugin-namespaced,
+    e.g. "tokentelemetry:brain-compile"). Includes delegated (subagent) tokens,
+    since brain-compile fans out most of its work to subagents.
+    """
+    proj = _brain_project(project)
+    if proj is None:
+        return {"available": False, "sessions": 0}
+    build_skills = {"brain-init", "brain-compile"}
+
+    def is_build_session(s: Dict[str, Any]) -> bool:
+        if s.get("project") != str(proj):
+            return False
+        return any(
+            (sk.get("name") or "").rsplit(":", 1)[-1] in build_skills
+            for sk in s.get("skills_used") or []
+        )
+
+    sessions = [s for s in await get_sessions_cached() if is_build_session(s)]
+    own = sum((s.get("tokens") or {}).get("total", 0) or 0 for s in sessions)
+    delegated = sum(
+        (s.get("delegation") or {}).get("delegated_total", 0) or 0 for s in sessions
+    )
+    cost = sum((s.get("cost") or 0) + (s.get("delegated_cost") or 0) for s in sessions)
+    return {
+        "available": True,
+        "sessions": len(sessions),
+        "tokens": own + delegated,
+        "own_tokens": own,
+        "delegated_tokens": delegated,
+        "cost": round(cost, 4),
+    }
+
+
 class BrainRegisterPayload(BaseModel):
     project: str
     wiki_path: str

--- a/backend/second_brain.py
+++ b/backend/second_brain.py
@@ -232,6 +232,58 @@ def scan_candidates(project: Path) -> List[dict]:
     return candidates
 
 
+def _wiki_hint(d: Path) -> Optional[str]:
+    """Cheap wiki-shape hint for the folder browser. Marker checks only — no
+    page iteration — so listing a directory of many children stays fast. The
+    authoritative check is still classify_wiki_dir() at register time."""
+    try:
+        if (d / "manifest.json").is_file() and (d / "BRAIN.md").is_file():
+            return "plugin_wiki"
+        if (d / ".obsidian").is_dir():
+            return "obsidian_vault"
+        md = 0
+        with os.scandir(d) as it:
+            for entry in it:
+                if entry.is_file() and entry.name.endswith(".md"):
+                    md += 1
+                    if md >= 3:
+                        return "markdown_wiki"
+    except OSError:
+        pass
+    return None
+
+
+def browse_dir(path: Path, limit: int = 200) -> dict:
+    """One level of the folder browser behind the import picker: immediate
+    subdirectories of `path` with a cheap wiki-shape hint each. Hidden
+    directories are skipped (vault config lives inside its parent, which is
+    what gets picked). Caller enforces the safe-roots boundary."""
+    dirs: List[dict] = []
+    truncated = False
+    try:
+        with os.scandir(path) as it:
+            children = sorted(
+                (e for e in it if e.is_dir(follow_symlinks=False) and not e.name.startswith(".")),
+                key=lambda e: e.name.lower())
+    except OSError:
+        children = []
+    for entry in children:
+        if len(dirs) >= limit:
+            truncated = True
+            break
+        dirs.append({
+            "name": entry.name,
+            "path": str(Path(path) / entry.name),
+            "hint": _wiki_hint(Path(entry.path)),
+        })
+    return {
+        "path": str(path),
+        "hint": _wiki_hint(path),
+        "dirs": dirs,
+        "truncated": truncated,
+    }
+
+
 # ---------------------------------------------------------------- graph
 
 def _mtime_fingerprint(wiki_dir: Path) -> float:

--- a/backend/second_brain.py
+++ b/backend/second_brain.py
@@ -1,0 +1,453 @@
+"""Second Brain (project wiki) read-side: detection, graph, page detail, registry.
+
+Serves the dashboard's Second Brain tab. Strictly read-only with respect to
+project repos: the ONLY write this module ever performs is to TT's own
+registry file (~/.tokentelemetry/brains.json), which maps a project path to a
+wiki directory the user explicitly imported. Wikis are produced and mutated by
+the tokentelemetry Claude Code plugin, never by the dashboard.
+
+Wiki format: an OKF v0.1 bundle (markdown pages with YAML frontmatter carrying
+`type`, plus index.md / log.md / manifest.json), but detection degrades
+gracefully: a plain markdown wiki or an Obsidian vault still renders as a
+graph (nodes = files, edges = links), just without types or staleness.
+"""
+
+import json
+import os
+import re
+import subprocess
+import threading
+import time
+from collections import Counter
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import yaml
+
+from tt_paths import data_dir
+
+# Files that are bundle plumbing, not concept pages. index.md links every page
+# by design; graphing it would star-connect the whole wiki and destroy the
+# real link structure, so reserved files are excluded from nodes AND edges.
+_RESERVED = {"index.md", "log.md", "BRAIN.md", "project-profile.md", "README.md"}
+
+# raw/ is the plugin's committed inbox of immutable source drops, .compile/ and
+# .obsidian/ are working state: none of them are pages.
+_SKIP_PARTS = ("raw",)
+
+_MD_LINK_RE = re.compile(r"\]\(([^)#\s]+\.md)(?:#[^)\s]*)?\)")
+_WIKILINK_RE = re.compile(r"\[\[([^\]|#]+)(?:#[^\]|]*)?(?:\|[^\]]*)?\]\]")
+_H1_RE = re.compile(r"^#\s+(.+)$", re.MULTILINE)
+
+_BRAINS_FILE = "brains.json"
+
+# Graph cache: wiki dirs are small (tens of pages) but the tab polls; a short
+# TTL plus a max-mtime fingerprint keeps rebuilds cheap and correct.
+_graph_cache: Dict[str, dict] = {}
+_graph_cache_lock = threading.Lock()
+_GRAPH_TTL_SEC = 10.0
+
+
+# ---------------------------------------------------------------- registry
+
+def _brains_path() -> Path:
+    return data_dir() / _BRAINS_FILE
+
+
+def load_brains() -> Dict[str, str]:
+    """project path -> imported wiki dir. Missing/malformed reads never raise."""
+    try:
+        data = json.loads(_brains_path().read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return {str(k): str(v) for k, v in data.items() if isinstance(v, str)}
+
+
+def save_brains(brains: Dict[str, str]) -> None:
+    d = data_dir()
+    d.mkdir(parents=True, exist_ok=True)
+    tmp = _brains_path().with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(brains, indent=2))
+    os.replace(tmp, _brains_path())
+
+
+# ---------------------------------------------------------------- parsing
+
+def _split_frontmatter(text: str) -> Tuple[dict, str]:
+    """Return (frontmatter dict, body). Tolerant: bad YAML -> ({}, full text)."""
+    if text.startswith("---"):
+        end = text.find("\n---", 3)
+        if end > 0:
+            try:
+                fm = yaml.safe_load(text[3:end])
+                if isinstance(fm, dict):
+                    return fm, text[end + 4:]
+            except Exception:
+                pass
+    return {}, text
+
+
+def _page_title(fm: dict, body: str, rel: str) -> str:
+    t = str(fm.get("title") or "").strip()
+    if t:
+        return t
+    m = _H1_RE.search(body)
+    if m:
+        return m.group(1).strip()
+    return Path(rel).stem.replace("-", " ").replace("_", " ")
+
+
+def _iter_pages(wiki_dir: Path):
+    """Yield (rel_posix, path) for concept pages only."""
+    for p in sorted(wiki_dir.rglob("*.md")):
+        rel = p.relative_to(wiki_dir).as_posix()
+        parts = Path(rel).parts
+        if any(part.startswith(".") for part in parts):
+            continue
+        if parts[0] in _SKIP_PARTS:
+            continue
+        if rel in _RESERVED:
+            continue
+        yield rel, p
+
+
+# ---------------------------------------------------------------- detection
+
+def _read_manifest(wiki_dir: Path) -> Optional[dict]:
+    try:
+        data = json.loads((wiki_dir / "manifest.json").read_text())
+        return data if isinstance(data, dict) else None
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _looks_typed(wiki_dir: Path, sample: int = 20) -> bool:
+    checked = 0
+    for _, p in _iter_pages(wiki_dir):
+        if checked >= sample:
+            break
+        checked += 1
+        try:
+            fm, _ = _split_frontmatter(p.read_text(errors="ignore"))
+        except OSError:
+            continue
+        if str(fm.get("type") or "").strip():
+            return True
+    return False
+
+
+def classify_wiki_dir(wiki_dir: Path) -> Optional[str]:
+    """Detection ladder for one directory. Returns kind or None.
+
+    plugin_wiki > okf_ish > obsidian_vault > markdown_wiki (same ladder the
+    plugin's profile_census.py uses, so both sides agree on what counts).
+    """
+    if not wiki_dir.is_dir():
+        return None
+    if (wiki_dir / "manifest.json").is_file():
+        return "plugin_wiki"
+    has_index = (wiki_dir / "index.md").is_file()
+    md_count = sum(1 for _ in _iter_pages(wiki_dir))
+    if md_count == 0 and not has_index:
+        return None
+    if has_index and _looks_typed(wiki_dir):
+        return "okf_ish"
+    if (wiki_dir / ".obsidian").is_dir():
+        return "obsidian_vault"
+    if md_count >= 2:
+        return "markdown_wiki"
+    return None
+
+
+def resolve_wiki(project: Path, registered: Optional[str]) -> Tuple[Optional[Path], Optional[str], str]:
+    """(wiki_dir, kind, source). Registered import wins over the default location."""
+    if registered:
+        kind = classify_wiki_dir(Path(registered))
+        if kind:
+            return Path(registered), kind, "registered"
+    default = project / "docs" / "wiki"
+    kind = classify_wiki_dir(default)
+    if kind:
+        return default, kind, "default"
+    # An Obsidian vault at the project root (no docs/wiki) still counts.
+    if (project / ".obsidian").is_dir():
+        return project, "obsidian_vault", "default"
+    return None, None, "none"
+
+
+def wiki_summary(project: Path, registered: Optional[str]) -> dict:
+    wiki_dir, kind, source = resolve_wiki(project, registered)
+    if wiki_dir is None:
+        return {"exists": False, "kind": None, "source": "none"}
+    manifest = _read_manifest(wiki_dir) or {}
+    page_count = sum(1 for _ in _iter_pages(wiki_dir))
+    return {
+        "exists": True,
+        "kind": kind,
+        "source": source,
+        "wiki_path": str(wiki_dir),
+        "page_count": page_count,
+        "status": manifest.get("status"),
+        "profile": manifest.get("profile"),
+        "batches_done": manifest.get("batches_done"),
+        "batches_total": manifest.get("batches_total"),
+        "updated": manifest.get("updated"),
+        "compiled_from_sha": manifest.get("compiled_from_sha"),
+    }
+
+
+def scan_candidates(project: Path) -> List[dict]:
+    """Shallow scan for importable wiki-shaped trees inside the project."""
+    candidates = []
+    seen = set()
+
+    def consider(d: Path):
+        key = str(d.resolve())
+        if key in seen:
+            return
+        seen.add(key)
+        kind = classify_wiki_dir(d)
+        if kind:
+            candidates.append({
+                "path": str(d),
+                "kind": kind,
+                "page_count": sum(1 for _ in _iter_pages(d)),
+            })
+
+    # decision: bare docs/ is deliberately absent; loose documentation folders
+    # classify as markdown_wiki too easily and the offer reads as noise.
+    for rel in ("docs/wiki", "wiki", "docs/kb", "kb", "notes"):
+        consider(project / rel)
+    # Obsidian vaults anywhere shallow (depth <= 2), including the root.
+    try:
+        if (project / ".obsidian").is_dir():
+            consider(project)
+        for child in sorted(project.iterdir()):
+            if child.is_dir() and not child.name.startswith(".") and (child / ".obsidian").is_dir():
+                consider(child)
+    except OSError:
+        pass
+    return candidates
+
+
+# ---------------------------------------------------------------- graph
+
+def _mtime_fingerprint(wiki_dir: Path) -> float:
+    latest = 0.0
+    try:
+        for _, p in _iter_pages(wiki_dir):
+            try:
+                latest = max(latest, p.stat().st_mtime)
+            except OSError:
+                continue
+        m = wiki_dir / "manifest.json"
+        if m.exists():
+            latest = max(latest, m.stat().st_mtime)
+    except OSError:
+        pass
+    return latest
+
+
+def _label_propagation(node_ids: List[str], neighbors: Dict[str, List[str]]) -> Dict[str, int]:
+    """Deterministic label propagation for community clustering.
+
+    Nodes iterate in sorted order adopting the most common label among their
+    neighbors (ties -> smallest label), for a bounded number of rounds. No
+    randomness: same wiki, same clusters, every request.
+    """
+    labels = {nid: i for i, nid in enumerate(sorted(node_ids))}
+    for _ in range(20):
+        changed = False
+        for nid in sorted(node_ids):
+            nbrs = neighbors.get(nid, [])
+            if not nbrs:
+                continue
+            counts = Counter(labels[n] for n in nbrs)
+            best = min(
+                (lab for lab, c in counts.items() if c == max(counts.values()))
+            )
+            if labels[nid] != best:
+                labels[nid] = best
+                changed = True
+        if not changed:
+            break
+    return labels
+
+
+def build_graph(wiki_dir: Path, kind: str) -> dict:
+    """Nodes (concept pages) + edges (resolved links) + clusters."""
+    pages: Dict[str, dict] = {}
+    raw_links: List[Tuple[str, str]] = []
+
+    name_index: Dict[str, str] = {}
+    for rel, p in _iter_pages(wiki_dir):
+        node_id = rel[:-3]  # strip .md
+        try:
+            text = p.read_text(errors="ignore")
+        except OSError:
+            continue
+        fm, body = _split_frontmatter(text)
+        pages[node_id] = {
+            "id": node_id,
+            "title": _page_title(fm, body, rel),
+            "type": str(fm.get("type") or "").strip() or None,
+            "description": str(fm.get("description") or "").strip() or None,
+            "tags": fm.get("tags") if isinstance(fm.get("tags"), list) else [],
+            "timestamp": str(fm.get("timestamp") or "") or None,
+            "resource": str(fm.get("resource") or "") or None,
+            "dir": Path(node_id).parts[0] if len(Path(node_id).parts) > 1 else "",
+        }
+        name_index[Path(node_id).name.lower()] = node_id
+
+        for target in _MD_LINK_RE.findall(text):
+            if target.startswith(("http://", "https://")):
+                continue
+            base = wiki_dir if target.startswith("/") else p.parent
+            try:
+                resolved = (base / target.lstrip("/")).resolve()
+                rel_t = resolved.relative_to(wiki_dir.resolve()).as_posix()
+            except (OSError, ValueError):
+                continue
+            raw_links.append((node_id, rel_t[:-3] if rel_t.endswith(".md") else rel_t))
+        if kind in ("obsidian_vault", "markdown_wiki"):
+            for target in _WIKILINK_RE.findall(text):
+                raw_links.append((node_id, "wikilink:" + target.strip().lower()))
+
+    # Resolve wikilinks by basename, dedupe, drop self-loops and dangling ends.
+    edge_set = set()
+    for src, dst in raw_links:
+        if dst.startswith("wikilink:"):
+            dst = name_index.get(dst[len("wikilink:"):].split("/")[-1], "")
+        if not dst or dst == src or dst not in pages or src not in pages:
+            continue
+        edge_set.add((src, dst))
+
+    neighbors: Dict[str, List[str]] = {nid: [] for nid in pages}
+    for src, dst in edge_set:
+        neighbors[src].append(dst)
+        neighbors[dst].append(src)
+    for nid in pages:
+        pages[nid]["degree"] = len(neighbors[nid])
+
+    # Clustering: directories ARE the semantic grouping in an OKF bundle
+    # (subsystems/, features/, ...), so use them when they exist; label
+    # propagation would just re-discover a coarser version of them on a dense
+    # wiki. Flat vaults (Obsidian, loose markdown) have no directory signal,
+    # so communities come from the link structure instead.
+    dirs = {p["dir"] for p in pages.values() if p["dir"]}
+    dir_coverage = sum(1 for p in pages.values() if p["dir"]) / max(len(pages), 1)
+    if len(dirs) >= 2 and dir_coverage >= 0.6:
+        group_of = {nid: (pages[nid]["dir"] or "core") for nid in pages}
+        label_for_group = {g: (g if g != "core" else "core") for g in set(group_of.values())}
+    else:
+        labels = _label_propagation(list(pages), neighbors)
+        group_of = {nid: f"c{labels[nid]}" for nid in pages}
+        # Name each community after its best-connected member.
+        label_for_group = {}
+        for g in set(group_of.values()):
+            members = [n for n in pages if group_of[n] == g]
+            top = max(members, key=lambda n: (pages[n]["degree"], n))
+            label_for_group[g] = pages[top]["title"]
+
+    clusters: List[dict] = []
+    cluster_idx: Dict[str, int] = {}
+    for g in sorted(set(group_of.values()), key=lambda g: (-sum(1 for n in group_of if group_of[n] == g), g)):
+        cluster_idx[g] = len(clusters)
+        clusters.append({
+            "id": len(clusters),
+            "label": label_for_group[g],
+            "size": sum(1 for n in group_of if group_of[n] == g),
+        })
+    for nid in pages:
+        pages[nid]["cluster"] = cluster_idx[group_of[nid]]
+
+    type_counts = Counter(p["type"] or "untyped" for p in pages.values())
+    return {
+        "nodes": list(pages.values()),
+        "edges": [{"source": s, "target": t} for s, t in sorted(edge_set)],
+        "clusters": clusters,
+        "types": dict(type_counts),
+    }
+
+
+def graph_cached(wiki_dir: Path, kind: str) -> dict:
+    key = str(wiki_dir.resolve())
+    now = time.time()
+    with _graph_cache_lock:
+        hit = _graph_cache.get(key)
+        if hit and now - hit["at"] < _GRAPH_TTL_SEC:
+            return hit["graph"]
+    fp = _mtime_fingerprint(wiki_dir)
+    with _graph_cache_lock:
+        hit = _graph_cache.get(key)
+        if hit and hit["fp"] == fp:
+            hit["at"] = now
+            return hit["graph"]
+    graph = build_graph(wiki_dir, kind)
+    with _graph_cache_lock:
+        _graph_cache[key] = {"graph": graph, "fp": fp, "at": now}
+    return graph
+
+
+# ---------------------------------------------------------------- page detail
+
+def _staleness(project: Path, compiled_sha: Optional[str], resource: Optional[str]) -> dict:
+    """Has the page's source changed since the wiki was compiled?
+
+    Local git call only (no network). Any failure -> status "unknown": an
+    honest shrug beats a wrong "fresh".
+    """
+    if not compiled_sha or not resource:
+        return {"status": "unknown", "reason": "no compiled SHA or resource on record"}
+    try:
+        proc = subprocess.run(
+            ["git", "diff", "--stat", compiled_sha, "--", resource],
+            cwd=str(project), capture_output=True, text=True, timeout=3,
+        )
+        if proc.returncode != 0:
+            return {"status": "unknown", "reason": (proc.stderr or "git error").strip()[:200]}
+        stat = proc.stdout.strip()
+        if not stat:
+            return {"status": "fresh"}
+        return {"status": "stale", "diffstat": stat.splitlines()[-1].strip()}
+    except (OSError, subprocess.TimeoutExpired):
+        return {"status": "unknown", "reason": "git unavailable"}
+
+
+def page_detail(project: Path, wiki_dir: Path, page_id: str,
+                compiled_sha: Optional[str], graph: dict) -> Optional[dict]:
+    # page_id comes from the client: re-resolve and confine it to the wiki dir.
+    try:
+        p = (wiki_dir / (page_id + ".md")).resolve()
+        p.relative_to(wiki_dir.resolve())
+    except (OSError, ValueError):
+        return None
+    if not p.is_file():
+        return None
+    try:
+        text = p.read_text(errors="ignore")
+    except OSError:
+        return None
+    fm, body = _split_frontmatter(text)
+
+    outbound = [e["target"] for e in graph["edges"] if e["source"] == page_id]
+    inbound = [e["source"] for e in graph["edges"] if e["target"] == page_id]
+    titles = {n["id"]: n["title"] for n in graph["nodes"]}
+    resource = str(fm.get("resource") or "") or None
+
+    return {
+        "id": page_id,
+        "title": _page_title(fm, body, page_id + ".md"),
+        "type": str(fm.get("type") or "").strip() or None,
+        "description": str(fm.get("description") or "").strip() or None,
+        "tags": fm.get("tags") if isinstance(fm.get("tags"), list) else [],
+        "timestamp": str(fm.get("timestamp") or "") or None,
+        "resource": resource,
+        "status": str(fm.get("status") or "") or None,
+        "body": body.strip(),
+        "outbound": [{"id": i, "title": titles.get(i, i)} for i in sorted(set(outbound))],
+        "inbound": [{"id": i, "title": titles.get(i, i)} for i in sorted(set(inbound))],
+        "staleness": _staleness(project, compiled_sha, resource),
+    }

--- a/backend/second_brain.py
+++ b/backend/second_brain.py
@@ -315,6 +315,40 @@ def build_graph(wiki_dir: Path, kind: str) -> dict:
             for target in _WIKILINK_RE.findall(text):
                 raw_links.append((node_id, "wikilink:" + target.strip().lower()))
 
+    # index.md is the hub: it links every page by design, so it joins the
+    # graph as a special center node whose edges are typed "index" (the
+    # frontend renders them faint and the physics treats them as loose ties).
+    # It stays OUT of degree counts and clustering, or it would star-connect
+    # everything into one community.
+    index_path = wiki_dir / "index.md"
+    has_index_node = False
+    if index_path.is_file():
+        try:
+            itext = index_path.read_text(errors="ignore")
+        except OSError:
+            itext = None
+        if itext is not None:
+            has_index_node = True
+            pages["index"] = {
+                "id": "index",
+                "title": "Index",
+                "type": "Index",
+                "description": "The wiki's grouped directory: every page, one line each.",
+                "tags": [],
+                "timestamp": None,
+                "resource": None,
+                "dir": "",
+            }
+            for target in _MD_LINK_RE.findall(itext):
+                if target.startswith(("http://", "https://")):
+                    continue
+                try:
+                    resolved = (wiki_dir / target.lstrip("/")).resolve()
+                    rel_t = resolved.relative_to(wiki_dir.resolve()).as_posix()
+                except (OSError, ValueError):
+                    continue
+                raw_links.append(("index", rel_t[:-3] if rel_t.endswith(".md") else rel_t))
+
     # Resolve wikilinks by basename, dedupe, drop self-loops and dangling ends.
     edge_set = set()
     for src, dst in raw_links:
@@ -324,30 +358,34 @@ def build_graph(wiki_dir: Path, kind: str) -> dict:
             continue
         edge_set.add((src, dst))
 
-    neighbors: Dict[str, List[str]] = {nid: [] for nid in pages}
-    for src, dst in edge_set:
+    real_edges = {(s, d) for s, d in edge_set if s != "index" and d != "index"}
+    concept_ids = [nid for nid in pages if nid != "index"]
+    neighbors: Dict[str, List[str]] = {nid: [] for nid in concept_ids}
+    for src, dst in real_edges:
         neighbors[src].append(dst)
         neighbors[dst].append(src)
-    for nid in pages:
+    for nid in concept_ids:
         pages[nid]["degree"] = len(neighbors[nid])
+    if has_index_node:
+        pages["index"]["degree"] = sum(1 for s, d in edge_set if s == "index" or d == "index")
 
     # Clustering: directories ARE the semantic grouping in an OKF bundle
     # (subsystems/, features/, ...), so use them when they exist; label
     # propagation would just re-discover a coarser version of them on a dense
     # wiki. Flat vaults (Obsidian, loose markdown) have no directory signal,
     # so communities come from the link structure instead.
-    dirs = {p["dir"] for p in pages.values() if p["dir"]}
-    dir_coverage = sum(1 for p in pages.values() if p["dir"]) / max(len(pages), 1)
+    dirs = {pages[n]["dir"] for n in concept_ids if pages[n]["dir"]}
+    dir_coverage = sum(1 for n in concept_ids if pages[n]["dir"]) / max(len(concept_ids), 1)
     if len(dirs) >= 2 and dir_coverage >= 0.6:
-        group_of = {nid: (pages[nid]["dir"] or "core") for nid in pages}
+        group_of = {nid: (pages[nid]["dir"] or "core") for nid in concept_ids}
         label_for_group = {g: (g if g != "core" else "core") for g in set(group_of.values())}
     else:
-        labels = _label_propagation(list(pages), neighbors)
-        group_of = {nid: f"c{labels[nid]}" for nid in pages}
+        labels = _label_propagation(concept_ids, neighbors)
+        group_of = {nid: f"c{labels[nid]}" for nid in concept_ids}
         # Name each community after its best-connected member.
         label_for_group = {}
         for g in set(group_of.values()):
-            members = [n for n in pages if group_of[n] == g]
+            members = [n for n in concept_ids if group_of[n] == g]
             top = max(members, key=lambda n: (pages[n]["degree"], n))
             label_for_group[g] = pages[top]["title"]
 
@@ -360,13 +398,19 @@ def build_graph(wiki_dir: Path, kind: str) -> dict:
             "label": label_for_group[g],
             "size": sum(1 for n in group_of if group_of[n] == g),
         })
-    for nid in pages:
+    for nid in concept_ids:
         pages[nid]["cluster"] = cluster_idx[group_of[nid]]
+    if has_index_node:
+        pages["index"]["cluster"] = -1  # hub: no hull, anchored to the center
 
-    type_counts = Counter(p["type"] or "untyped" for p in pages.values())
+    type_counts = Counter(pages[n]["type"] or "untyped" for n in concept_ids)
     return {
         "nodes": list(pages.values()),
-        "edges": [{"source": s, "target": t} for s, t in sorted(edge_set)],
+        "edges": [
+            {"source": s, "target": t,
+             "kind": "index" if "index" in (s, t) else "link"}
+            for s, t in sorted(edge_set)
+        ],
         "clusters": clusters,
         "types": dict(type_counts),
     }

--- a/backend/telemetry.py
+++ b/backend/telemetry.py
@@ -130,7 +130,8 @@ _EVENT_PROPS: Dict[str, set] = {
 _ENUMS: Dict[str, set] = {
     "route": {
         "dashboard", "analytics", "traces", "projects", "project-detail",
-        "hermes", "artifacts", "local-models", "settings", "sessions", "other",
+        "hermes", "artifacts", "local-models", "settings", "sessions", "brain",
+        "other",
     },
     "dimension": {"agent", "model", "local-only", "day", "other"},
     "outcome": {"ok", "error", "empty", "unavailable", "other"},
@@ -144,6 +145,10 @@ _ENUMS: Dict[str, set] = {
         # "budget-set" = saved a budget (the configuring action). No limit
         # value/cost ever rides along — only these two enum labels.
         "budgets", "budget-set",
+        # Second Brain: "brain-import" = registered an existing wiki (adoption
+        # of import), "brain-page-open" = opened a page drawer from the graph
+        # (engagement depth). Never the wiki path, page id, or project name.
+        "brain-import", "brain-page-open",
         "other",
     },
     "tier": {"full", "rollup", "other"},

--- a/docs/design/product-telemetry.md
+++ b/docs/design/product-telemetry.md
@@ -106,7 +106,7 @@ sent at most once per meaningful action.
 | `page.viewed` | a route is opened | `route` (enum: dashboard, analytics, traces, projects, hermes, artifacts, local-models, settings…) | **Which surfaces matter.** Is anyone using Hermes? Artifacts? |
 | `trace.summarized` | a trace summary is generated | `backend` (ollama/claude/…), `outcome` (ok/error-category) | Is the headline feature used? Which backend? Failure rate |
 | `analytics.filtered` | a filter is applied on Analytics | `dimension` (agent/model/local-only/day), no values | **Is local-model filtering used?** (your explicit question) |
-| `feature.used` | generic, for discrete features | `name` (plan-library, project-insights, delegation-view, power-cost, billing-mode, search…) | Long-tail feature adoption |
+| `feature.used` | generic, for discrete features | `name` (plan-library, project-insights, delegation-view, power-cost, billing-mode, search, brain-import, brain-page-open…) | Long-tail feature adoption |
 | `retention.opted_in` | user enables durable history | `tier` | Which power features convert |
 
 **Duration/outcome buckets, never raw values.** e.g. summary latency as

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,9 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@types/d3-force": "^3.0.10",
     "clsx": "^2.1.1",
+    "d3-force": "^3.0.0",
     "date-fns": "^4.1.0",
     "lucide-react": "^1.8.0",
     "next": "16.2.9",

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -222,3 +222,45 @@ body {
 .prose code { background: var(--tt-sunken); padding: 0.15em 0.4em; border-radius: 4px; font-family: var(--font-mono); font-size: 0.88em; border: 1px solid var(--tt-border); }
 .prose pre { background: var(--tt-sunken); padding: 1em; border-radius: var(--tt-radius); overflow-x: auto; border: 1px solid var(--tt-border); margin-bottom: 1.5em; }
 .prose blockquote { border-left: 3px solid var(--tt-success); padding-left: 1em; color: var(--tt-fg-dim); font-style: italic; }
+
+/* =========================================================================
+   Compact markdown scale (.tt-brain-md)
+   One notch down from .prose, which is sized for the full-width session
+   viewer. Used where markdown renders inside panels: the Second Brain page
+   drawer and the project Plans tab.
+   ========================================================================= */
+.tt-brain-md { font-size: 12.5px; line-height: 1.62; color: var(--tt-fg-muted); }
+.tt-brain-md h1, .tt-brain-md h2, .tt-brain-md h3, .tt-brain-md h4 {
+  color: var(--tt-fg); font-weight: 600; letter-spacing: -0.01em;
+  margin: 1.4em 0 0.45em;
+}
+.tt-brain-md > :first-child { margin-top: 0.2em; }
+.tt-brain-md h1 { font-size: 15px; padding-bottom: 0.3em; border-bottom: 1px solid var(--tt-border); }
+.tt-brain-md h2 { font-size: 13.5px; }
+.tt-brain-md h3, .tt-brain-md h4 { font-size: 12.5px; }
+.tt-brain-md p { margin: 0 0 0.8em; }
+.tt-brain-md ul, .tt-brain-md ol { margin: 0 0 0.8em; padding-left: 1.3em; }
+.tt-brain-md ul { list-style-type: disc; }
+.tt-brain-md ol { list-style-type: decimal; }
+.tt-brain-md li { margin-bottom: 0.3em; }
+.tt-brain-md code {
+  background: var(--tt-sunken); border: 1px solid var(--tt-border);
+  border-radius: 4px; padding: 0.1em 0.35em;
+  font-family: var(--font-mono); font-size: 0.92em;
+}
+.tt-brain-md pre {
+  background: var(--tt-sunken); border: 1px solid var(--tt-border);
+  border-radius: var(--tt-radius); padding: 0.75em 0.9em;
+  overflow-x: auto; margin: 0 0 1em; font-size: 11px; line-height: 1.55;
+}
+.tt-brain-md pre code { background: none; border: none; padding: 0; font-size: inherit; }
+.tt-brain-md blockquote {
+  border-left: 3px solid var(--tt-border-strong); padding-left: 0.9em;
+  margin: 0 0 0.8em; color: var(--tt-fg-dim); font-style: italic;
+}
+.tt-brain-md table { border-collapse: collapse; font-size: 11.5px; margin: 0 0 1em; display: block; overflow-x: auto; }
+.tt-brain-md th, .tt-brain-md td { border: 1px solid var(--tt-border); padding: 0.35em 0.6em; text-align: left; }
+.tt-brain-md th { background: var(--tt-sunken); color: var(--tt-fg); font-weight: 600; }
+.tt-brain-md a { color: var(--tt-brand); text-decoration: none; }
+.tt-brain-md a:hover { text-decoration: underline; }
+.tt-brain-md hr { border: none; border-top: 1px solid var(--tt-border); margin: 1.2em 0; }

--- a/frontend/src/app/projects/[path]/brain/_components/BrainGraph.tsx
+++ b/frontend/src/app/projects/[path]/brain/_components/BrainGraph.tsx
@@ -546,7 +546,7 @@ export default function BrainGraph({ nodes, edges, clusters, selectedId, onSelec
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder="Filter pages…"
-            className="bg-transparent outline-none text-[12px] text-[var(--tt-fg)] placeholder:text-[var(--tt-fg-faint)] w-[150px]"
+            className="bg-transparent outline-none focus-visible:outline-none text-[12px] text-[var(--tt-fg)] placeholder:text-[var(--tt-fg-faint)] w-[150px]"
           />
           {search && (
             <button onClick={() => setSearch("")} className="text-[var(--tt-fg-dim)] hover:text-[var(--tt-fg)]">

--- a/frontend/src/app/projects/[path]/brain/_components/BrainGraph.tsx
+++ b/frontend/src/app/projects/[path]/brain/_components/BrainGraph.tsx
@@ -1,0 +1,702 @@
+"use client";
+
+/* Obsidian-style force-directed graph of the project wiki.
+ *
+ * d3-force owns the physics; React owns the DOM. Positions stream into React
+ * state via requestAnimationFrame while the simulation is warm, so hover /
+ * filter / selection stay declarative. Wiki graphs are small (tens to a few
+ * hundred nodes), which keeps this comfortably within budget; beyond 300
+ * nodes the simulation is pre-run and rendered settled.
+ */
+
+import {
+  forceCenter, forceCollide, forceLink, forceManyBody, forceSimulation, forceX, forceY,
+  type Simulation, type SimulationNodeDatum,
+} from "d3-force";
+import {
+  Boxes, ChevronDown, Focus, Search, SlidersHorizontal, X,
+} from "lucide-react";
+import {
+  useCallback, useEffect, useMemo, useRef, useState,
+} from "react";
+
+import { cn } from "@/lib/cn";
+
+import { buildTypePalette, typeSlot, GRAY } from "./palette";
+import type { GraphCluster, GraphEdge, GraphNode } from "./types";
+
+/* ------------------------------------------------------------------ types */
+
+interface SimNode extends SimulationNodeDatum {
+  ref: GraphNode;
+  id: string;
+  r: number;
+}
+
+interface SimEdge {
+  source: SimNode;
+  target: SimNode;
+}
+
+interface Props {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  clusters: GraphCluster[];
+  selectedId: string | null;
+  onSelect: (id: string | null) => void;
+  height?: number;
+}
+
+interface Controls {
+  repel: number;       // many-body strength (positive slider, applied negative)
+  linkDist: number;
+  nodeScale: number;
+  labelZoom: number;   // zoom level at which labels fully appear
+  showHulls: boolean;
+  showOrphans: boolean;
+  focusDepth: 0 | 1 | 2; // 0 = whole graph
+}
+
+const DEFAULTS: Controls = {
+  repel: 300, linkDist: 90, nodeScale: 1, labelZoom: 1.25,
+  showHulls: true, showOrphans: true, focusDepth: 0,
+};
+
+/* ------------------------------------------------------------- component */
+
+export default function BrainGraph({ nodes, edges, clusters, selectedId, onSelect, height = 640 }: Props) {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const simRef = useRef<Simulation<SimNode, SimEdge> | null>(null);
+  const posCache = useRef<Map<string, { x: number; y: number }>>(new Map());
+  const [tick, setTick] = useState(0); // bumped per animation frame while warm
+  const [transform, setTransform] = useState({ x: 0, y: 0, k: 1 });
+  const [hoveredId, setHoveredId] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const [hiddenTypes, setHiddenTypes] = useState<Set<string>>(new Set());
+  const [ctl, setCtl] = useState<Controls>(DEFAULTS);
+  const [panelOpen, setPanelOpen] = useState(false);
+  const [dark, setDark] = useState(true);
+  const [size, setSize] = useState({ w: 1200, h: height });
+
+  /* theme: node fills are literal hex per mode (validated palette) */
+  useEffect(() => {
+    const el = document.documentElement;
+    const read = () => setDark(el.getAttribute("data-theme") !== "light");
+    read();
+    const obs = new MutationObserver(read);
+    obs.observe(el, { attributes: true, attributeFilter: ["data-theme"] });
+    return () => obs.disconnect();
+  }, []);
+
+  /* container size */
+  useEffect(() => {
+    const svg = svgRef.current;
+    if (!svg) return;
+    const ro = new ResizeObserver((entries) => {
+      const r = entries[0]?.contentRect;
+      if (r) setSize({ w: r.width, h: r.height });
+    });
+    ro.observe(svg);
+    return () => ro.disconnect();
+  }, []);
+
+  const palette = useMemo(
+    () => buildTypePalette(nodes.map((n) => n.type ?? "")),
+    [nodes],
+  );
+  const fillOf = useCallback(
+    (n: GraphNode) => (dark ? typeSlot(palette, n.type).dark : typeSlot(palette, n.type).light),
+    [palette, dark],
+  );
+
+  /* ---------------------------------------------------------- filtering */
+
+  const adjacency = useMemo(() => {
+    const adj = new Map<string, Set<string>>();
+    for (const n of nodes) adj.set(n.id, new Set());
+    for (const e of edges) {
+      adj.get(e.source)?.add(e.target);
+      adj.get(e.target)?.add(e.source);
+    }
+    return adj;
+  }, [nodes, edges]);
+
+  const visibleIds = useMemo(() => {
+    let ids = new Set(nodes.map((n) => n.id));
+    if (!ctl.showOrphans) {
+      ids = new Set([...ids].filter((id) => (adjacency.get(id)?.size ?? 0) > 0));
+    }
+    if (hiddenTypes.size > 0) {
+      const byId = new Map(nodes.map((n) => [n.id, n]));
+      ids = new Set([...ids].filter((id) => !hiddenTypes.has((byId.get(id)?.type ?? "untyped").toLowerCase())));
+    }
+    const q = search.trim().toLowerCase();
+    if (q) {
+      const byId = new Map(nodes.map((n) => [n.id, n]));
+      ids = new Set([...ids].filter((id) => {
+        const n = byId.get(id)!;
+        return n.title.toLowerCase().includes(q) || n.id.toLowerCase().includes(q)
+          || (n.tags ?? []).some((t) => String(t).toLowerCase().includes(q));
+      }));
+    }
+    if (ctl.focusDepth > 0 && selectedId && ids.has(selectedId)) {
+      const keep = new Set<string>([selectedId]);
+      let frontier = [selectedId];
+      for (let d = 0; d < ctl.focusDepth; d++) {
+        const next: string[] = [];
+        for (const id of frontier) {
+          for (const nb of adjacency.get(id) ?? []) {
+            if (!keep.has(nb) && ids.has(nb)) { keep.add(nb); next.push(nb); }
+          }
+        }
+        frontier = next;
+      }
+      ids = keep;
+    }
+    return ids;
+  }, [nodes, adjacency, ctl.showOrphans, ctl.focusDepth, hiddenTypes, search, selectedId]);
+
+  /* ------------------------------------------------------- simulation */
+
+  const simData = useMemo(() => {
+    const visNodes: SimNode[] = nodes
+      .filter((n) => visibleIds.has(n.id))
+      .map((n) => {
+        const cached = posCache.current.get(n.id);
+        return {
+          ref: n,
+          id: n.id,
+          r: (5 + Math.sqrt(n.degree) * 2.4) * ctl.nodeScale,
+          x: cached?.x, y: cached?.y,
+        } as SimNode;
+      });
+    const byId = new Map(visNodes.map((n) => [n.id, n]));
+    const visEdges: SimEdge[] = edges
+      .filter((e) => byId.has(e.source) && byId.has(e.target))
+      .map((e) => ({ source: byId.get(e.source)!, target: byId.get(e.target)! }));
+    return { visNodes, visEdges };
+  }, [nodes, edges, visibleIds, ctl.nodeScale]);
+
+  useEffect(() => {
+    const { visNodes, visEdges } = simData;
+    if (visNodes.length === 0) return;
+
+    // Cluster anchors on a ring: gives each community its own region so the
+    // hulls separate instead of interleaving.
+    const clusterIdxs = [...new Set(visNodes.map((n) => n.ref.cluster))].sort((a, b) => a - b);
+    const ring = Math.min(size.w, size.h) * 0.42 * (clusterIdxs.length > 1 ? 1 : 0);
+    const anchor = new Map<number, { x: number; y: number }>();
+    clusterIdxs.forEach((c, i) => {
+      const a = (2 * Math.PI * i) / clusterIdxs.length - Math.PI / 2;
+      anchor.set(c, { x: Math.cos(a) * ring, y: Math.sin(a) * ring });
+    });
+
+    const sim = forceSimulation<SimNode>(visNodes)
+      .force("link", forceLink<SimNode, SimEdge>(visEdges).distance(ctl.linkDist).strength(0.35))
+      .force("charge", forceManyBody().strength(-ctl.repel))
+      .force("center", forceCenter(0, 0).strength(0.04))
+      .force("collide", forceCollide<SimNode>().radius((d) => d.r + 6))
+      .force("cx", forceX<SimNode>((d) => anchor.get(d.ref.cluster)?.x ?? 0).strength(0.11))
+      .force("cy", forceY<SimNode>((d) => anchor.get(d.ref.cluster)?.y ?? 0).strength(0.11));
+    simRef.current = sim;
+    sim.stop();
+
+    // Pre-run most of the cooling synchronously (a few ms at wiki scale):
+    // the graph paints nearly settled and only a short organic drift remains.
+    // Also avoids minutes of slow-motion settling in throttled background tabs.
+    const preTicks = visNodes.length > 300 ? 300 : 140;
+    for (let i = 0; i < preTicks; i++) sim.tick();
+    for (const n of visNodes) posCache.current.set(n.id, { x: n.x!, y: n.y! });
+    setTick((t) => t + 1);
+    if (visNodes.length > 300) {
+      return () => { sim.stop(); simRef.current = null; };
+    }
+
+    let raf = 0;
+    const frame = () => {
+      sim.tick();
+      for (const n of visNodes) posCache.current.set(n.id, { x: n.x!, y: n.y! });
+      setTick((t) => t + 1);
+      if (sim.alpha() > 0.02) raf = requestAnimationFrame(frame);
+    };
+    raf = requestAnimationFrame(frame);
+    return () => { cancelAnimationFrame(raf); sim.stop(); simRef.current = null; };
+  }, [simData, ctl.linkDist, ctl.repel, size.w, size.h]);
+
+  /* --------------------------------------------------- pan / zoom / drag */
+
+  const dragState = useRef<{ mode: "pan" | "node"; id?: string; sx: number; sy: number; ox: number; oy: number; moved: boolean } | null>(null);
+
+  const toGraph = useCallback((clientX: number, clientY: number) => {
+    const rect = svgRef.current!.getBoundingClientRect();
+    return {
+      x: (clientX - rect.left - rect.width / 2 - transform.x) / transform.k,
+      y: (clientY - rect.top - rect.height / 2 - transform.y) / transform.k,
+    };
+  }, [transform]);
+
+  const onWheel = useCallback((e: React.WheelEvent) => {
+    e.preventDefault();
+    const rect = svgRef.current!.getBoundingClientRect();
+    const px = e.clientX - rect.left - rect.width / 2;
+    const py = e.clientY - rect.top - rect.height / 2;
+    setTransform((t) => {
+      const k = Math.min(4, Math.max(0.2, t.k * Math.exp(-e.deltaY * 0.0016)));
+      return { k, x: px - ((px - t.x) / t.k) * k, y: py - ((py - t.y) / t.k) * k };
+    });
+  }, []);
+
+  const onPointerDown = useCallback((e: React.PointerEvent, nodeId?: string) => {
+    (e.target as Element).setPointerCapture?.(e.pointerId);
+    if (nodeId) {
+      const n = simData.visNodes.find((x) => x.id === nodeId);
+      if (!n) return;
+      dragState.current = { mode: "node", id: nodeId, sx: e.clientX, sy: e.clientY, ox: n.x!, oy: n.y!, moved: false };
+    } else {
+      dragState.current = { mode: "pan", sx: e.clientX, sy: e.clientY, ox: transform.x, oy: transform.y, moved: false };
+    }
+    e.stopPropagation();
+  }, [simData, toGraph, transform]);
+
+  /* restart raf while dragging a node so physics feels alive */
+  const kickRef = useRef(0);
+  const kickSim = useCallback(() => {
+    cancelAnimationFrame(kickRef.current);
+    const step = () => {
+      const sim = simRef.current;
+      if (!sim) return;
+      sim.tick();
+      for (const n of simData.visNodes) posCache.current.set(n.id, { x: n.x!, y: n.y! });
+      setTick((t) => t + 1);
+      if (sim.alpha() > 0.02 || dragState.current?.mode === "node") kickRef.current = requestAnimationFrame(step);
+    };
+    kickRef.current = requestAnimationFrame(step);
+  }, [simData]);
+
+  const onPointerMove = useCallback((e: React.PointerEvent) => {
+    const d = dragState.current;
+    if (!d) return;
+    const dist = Math.hypot(e.clientX - d.sx, e.clientY - d.sy);
+    if (!d.moved && dist < 4) return; // click, not drag (yet)
+    if (!d.moved) {
+      d.moved = true;
+      if (d.mode === "node") kickSim(); // wake physics only once dragging is real
+    }
+    if (d.mode === "pan") {
+      setTransform((t) => ({ ...t, x: d.ox + (e.clientX - d.sx), y: d.oy + (e.clientY - d.sy) }));
+    } else if (d.id) {
+      const n = simData.visNodes.find((x) => x.id === d.id);
+      if (n) {
+        const p = toGraph(e.clientX, e.clientY);
+        n.fx = p.x; n.fy = p.y;
+        simRef.current?.alpha(Math.max(simRef.current.alpha(), 0.3));
+      }
+    }
+  }, [simData, toGraph]);
+
+  const onPointerUp = useCallback(() => {
+    const d = dragState.current;
+    dragState.current = null;
+    if (!d) return;
+    if (d.mode === "node" && d.id) {
+      if (!d.moved) {
+        onSelect(d.id); // a stationary press is a click: open the page
+      } else {
+        const n = simData.visNodes.find((x) => x.id === d.id);
+        if (n) { n.fx = null; n.fy = null; }
+        simRef.current?.alphaTarget(0);
+      }
+    } else if (d.mode === "pan" && !d.moved) {
+      onSelect(null); // background click clears selection
+    }
+  }, [simData, onSelect]);
+
+  /* center the view on a node (drawer navigation) */
+  useEffect(() => {
+    if (!selectedId) return;
+    const p = posCache.current.get(selectedId);
+    if (p) setTransform((t) => ({ ...t, x: -p.x * t.k, y: -p.y * t.k }));
+  }, [selectedId]);
+
+  /* -------------------------------------------------------- hulls */
+
+  const hulls = useMemo(() => {
+    if (!ctl.showHulls) return [];
+    void tick;
+    const byCluster = new Map<number, SimNode[]>();
+    for (const n of simData.visNodes) {
+      if (n.x == null) continue;
+      const arr = byCluster.get(n.ref.cluster) ?? [];
+      arr.push(n);
+      byCluster.set(n.ref.cluster, arr);
+    }
+    const out: { cluster: GraphCluster; path: string; labelX: number; labelY: number; color: string }[] = [];
+    for (const [cid, members] of byCluster) {
+      if (members.length < 2) continue;
+      const cluster = clusters.find((c) => c.id === cid);
+      if (!cluster) continue;
+      const pts = members.map((m) => [m.x!, m.y!] as [number, number]);
+      const hull = convexHull(pts);
+      const padded = padHull(hull, 30);
+      // dominant type color tints the hull
+      const typeCount = new Map<string, number>();
+      for (const m of members) {
+        const t = (m.ref.type ?? "untyped").toLowerCase();
+        typeCount.set(t, (typeCount.get(t) ?? 0) + 1);
+      }
+      const domType = [...typeCount.entries()].sort((a, b) => b[1] - a[1])[0][0];
+      const slot = domType === "untyped" ? GRAY : typeSlot(palette, domType);
+      const topmost = padded.reduce((a, b) => (b[1] < a[1] ? b : a));
+      out.push({
+        cluster,
+        path: smoothClosedPath(padded),
+        labelX: topmost[0],
+        labelY: topmost[1] - 10,
+        color: dark ? slot.dark : slot.light,
+      });
+    }
+    return out;
+  }, [ctl.showHulls, simData, clusters, palette, dark, tick]);
+
+  /* -------------------------------------------------------- highlight */
+
+  const activeId = hoveredId ?? selectedId;
+  const neighborSet = useMemo(() => {
+    if (!activeId) return null;
+    const s = new Set<string>([activeId]);
+    for (const nb of adjacency.get(activeId) ?? []) s.add(nb);
+    return s;
+  }, [activeId, adjacency]);
+
+  const labelOpacity = Math.max(0, Math.min(1, (transform.k - ctl.labelZoom + 0.35) / 0.35));
+  const hovered = hoveredId ? simData.visNodes.find((n) => n.id === hoveredId) : null;
+
+  const typeEntries = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const n of nodes) {
+      const t = (n.type ?? "untyped").toLowerCase();
+      counts.set(t, (counts.get(t) ?? 0) + 1);
+    }
+    return [...counts.entries()].sort((a, b) => b[1] - a[1]);
+  }, [nodes]);
+
+  void tick; // positions live in posCache; tick re-renders
+
+  /* ---------------------------------------------------------- render */
+
+  return (
+    <div className="relative rounded-[var(--tt-radius-lg)] border border-[var(--tt-border)] overflow-hidden bg-[var(--tt-panel)]" style={{ height }}>
+      {/* dot-grid backdrop, Obsidian-style */}
+      <div
+        aria-hidden
+        className="absolute inset-0 pointer-events-none opacity-60"
+        style={{
+          backgroundImage: "radial-gradient(color-mix(in oklab, var(--tt-fg) 7%, transparent) 1px, transparent 1px)",
+          backgroundSize: `${24 * transform.k}px ${24 * transform.k}px`,
+          backgroundPosition: `${transform.x + size.w / 2}px ${transform.y + size.h / 2}px`,
+        }}
+      />
+
+      <svg
+        ref={svgRef}
+        className="w-full h-full cursor-grab active:cursor-grabbing select-none touch-none"
+        onWheel={onWheel}
+        onPointerDown={(e) => onPointerDown(e)}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerLeave={onPointerUp}
+        role="img"
+        aria-label={`Wiki graph: ${simData.visNodes.length} pages, ${simData.visEdges.length} links`}
+      >
+        <g transform={`translate(${size.w / 2 + transform.x} ${size.h / 2 + transform.y}) scale(${transform.k})`}>
+          {/* cluster hulls */}
+          {hulls.map((h) => (
+            <g key={h.cluster.id} className="transition-opacity duration-200" opacity={neighborSet ? 0.5 : 1}>
+              <path d={h.path} fill={h.color} fillOpacity={0.055} stroke={h.color} strokeOpacity={0.16} strokeWidth={1.2} />
+              <text
+                x={h.labelX} y={h.labelY}
+                fontSize={11 / Math.sqrt(transform.k)}
+                fill={h.color} fillOpacity={0.75}
+                fontWeight={600} letterSpacing="0.08em"
+                style={{ textTransform: "uppercase" }}
+              >
+                {h.cluster.label}
+              </text>
+            </g>
+          ))}
+
+          {/* edges */}
+          {simData.visEdges.map((e, i) => {
+            const sp = posCache.current.get(e.source.id);
+            const tp = posCache.current.get(e.target.id);
+            if (!sp || !tp) return null;
+            const lit = neighborSet && activeId != null
+              && (e.source.id === activeId || e.target.id === activeId);
+            const dim = neighborSet && !lit;
+            return (
+              <line
+                key={i}
+                x1={sp.x} y1={sp.y} x2={tp.x} y2={tp.y}
+                stroke={lit ? "var(--tt-brand)" : "var(--tt-fg)"}
+                strokeOpacity={lit ? 0.65 : dim ? 0.04 : 0.13}
+                strokeWidth={(lit ? 1.8 : 1.1) / transform.k}
+                className="transition-[stroke-opacity] duration-150"
+              />
+            );
+          })}
+
+          {/* nodes */}
+          {simData.visNodes.map((n) => {
+            const p = posCache.current.get(n.id);
+            if (!p) return null;
+            const isActive = n.id === activeId;
+            const isNeighbor = neighborSet?.has(n.id) ?? false;
+            const dim = neighborSet ? !isNeighbor : false;
+            const isSelected = n.id === selectedId;
+            const showLabel = isActive || isSelected || isNeighbor || labelOpacity > 0.05;
+            const thisLabelOpacity = isActive || isSelected || isNeighbor ? 1 : labelOpacity;
+            return (
+              <g
+                key={n.id}
+                transform={`translate(${p.x} ${p.y})`}
+                className="cursor-pointer transition-opacity duration-150"
+                opacity={dim ? 0.15 : 1}
+                onPointerDown={(e) => onPointerDown(e, n.id)}
+                onPointerEnter={() => setHoveredId(n.id)}
+                onPointerLeave={() => setHoveredId(null)}
+              >
+                {isSelected && (
+                  <circle r={n.r + 5 / transform.k} fill="none" stroke="var(--tt-brand)" strokeWidth={1.5 / transform.k} strokeOpacity={0.8} strokeDasharray={`${4 / transform.k} ${3 / transform.k}`} />
+                )}
+                <circle
+                  r={n.r}
+                  fill={fillOf(n.ref)}
+                  stroke="var(--tt-panel)"
+                  strokeWidth={2}
+                  style={isActive ? { filter: `drop-shadow(0 0 ${8 / transform.k}px ${fillOf(n.ref)})` } : undefined}
+                />
+                {showLabel && (
+                  <text
+                    y={n.r + 12 / transform.k}
+                    textAnchor="middle"
+                    fontSize={11 / transform.k}
+                    fill="var(--tt-fg-muted)"
+                    opacity={thisLabelOpacity}
+                    style={{ paintOrder: "stroke", stroke: "var(--tt-panel)", strokeWidth: 3 / transform.k, strokeLinejoin: "round" }}
+                  >
+                    {n.ref.title}
+                  </text>
+                )}
+              </g>
+            );
+          })}
+        </g>
+      </svg>
+
+      {/* hover tooltip */}
+      {hovered && hovered.ref.description && (
+        <div
+          className="absolute z-10 max-w-[300px] px-3 py-2 rounded-[var(--tt-radius)] bg-[var(--tt-overlay)] border border-[var(--tt-border-strong)] shadow-[var(--tt-shadow-pop)] text-[11px] leading-snug text-[var(--tt-fg-muted)] pointer-events-none"
+          style={{
+            left: Math.min(size.w - 320, size.w / 2 + transform.x + (posCache.current.get(hovered.id)?.x ?? 0) * transform.k + 16),
+            top: size.h / 2 + transform.y + (posCache.current.get(hovered.id)?.y ?? 0) * transform.k + 16,
+          }}
+        >
+          <div className="text-[12px] font-semibold text-[var(--tt-fg)] mb-0.5">{hovered.ref.title}</div>
+          {hovered.ref.description}
+        </div>
+      )}
+
+      {/* search, top-left */}
+      <div className="absolute top-3 left-3 flex items-center gap-2">
+        <div className="flex items-center gap-1.5 h-8 px-2.5 rounded-[var(--tt-radius)] bg-[var(--tt-overlay)]/90 backdrop-blur border border-[var(--tt-border)] focus-within:border-[var(--tt-border-focus)]">
+          <Search size={13} className="text-[var(--tt-fg-dim)]" />
+          <input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Filter pages…"
+            className="bg-transparent outline-none text-[12px] text-[var(--tt-fg)] placeholder:text-[var(--tt-fg-faint)] w-[150px]"
+          />
+          {search && (
+            <button onClick={() => setSearch("")} className="text-[var(--tt-fg-dim)] hover:text-[var(--tt-fg)]">
+              <X size={12} />
+            </button>
+          )}
+        </div>
+        {selectedId && (
+          <button
+            onClick={() => setCtl((c) => ({ ...c, focusDepth: c.focusDepth === 0 ? 1 : c.focusDepth === 1 ? 2 : 0 }))}
+            className={cn(
+              "flex items-center gap-1.5 h-8 px-2.5 rounded-[var(--tt-radius)] border text-[11px] font-medium backdrop-blur transition-colors",
+              ctl.focusDepth > 0
+                ? "bg-[var(--tt-brand-glow)] border-[color:var(--tt-brand)]/40 text-[var(--tt-brand)]"
+                : "bg-[var(--tt-overlay)]/90 border-[var(--tt-border)] text-[var(--tt-fg-muted)] hover:text-[var(--tt-fg)]",
+            )}
+            title="Cycle local-graph depth: off / 1 / 2"
+          >
+            <Focus size={13} />
+            {ctl.focusDepth === 0 ? "Focus" : `Depth ${ctl.focusDepth}`}
+          </button>
+        )}
+      </div>
+
+      {/* controls panel, top-right */}
+      <div className="absolute top-3 right-3 flex flex-col items-end gap-2">
+        <button
+          onClick={() => setPanelOpen((o) => !o)}
+          className="flex items-center gap-1.5 h-8 px-2.5 rounded-[var(--tt-radius)] bg-[var(--tt-overlay)]/90 backdrop-blur border border-[var(--tt-border)] text-[11px] font-medium text-[var(--tt-fg-muted)] hover:text-[var(--tt-fg)]"
+        >
+          <SlidersHorizontal size={13} />
+          Controls
+          <ChevronDown size={12} className={cn("transition-transform", panelOpen && "rotate-180")} />
+        </button>
+        {panelOpen && (
+          <div className="w-[230px] p-3 rounded-[var(--tt-radius-lg)] bg-[var(--tt-overlay)]/95 backdrop-blur border border-[var(--tt-border-strong)] shadow-[var(--tt-shadow-pop)] space-y-3">
+            <PanelSection title="Display">
+              <Slider label="Node size" min={0.5} max={2} step={0.1} value={ctl.nodeScale} onChange={(v) => setCtl((c) => ({ ...c, nodeScale: v }))} />
+              <Slider label="Label fade" min={0.2} max={2.5} step={0.1} value={ctl.labelZoom} onChange={(v) => setCtl((c) => ({ ...c, labelZoom: v }))} />
+              <Toggle label="Cluster hulls" checked={ctl.showHulls} onChange={(v) => setCtl((c) => ({ ...c, showHulls: v }))} />
+              <Toggle label="Orphan pages" checked={ctl.showOrphans} onChange={(v) => setCtl((c) => ({ ...c, showOrphans: v }))} />
+            </PanelSection>
+            <PanelSection title="Forces">
+              <Slider label="Repel" min={40} max={500} step={10} value={ctl.repel} onChange={(v) => setCtl((c) => ({ ...c, repel: v }))} />
+              <Slider label="Link distance" min={25} max={200} step={5} value={ctl.linkDist} onChange={(v) => setCtl((c) => ({ ...c, linkDist: v }))} />
+            </PanelSection>
+            <button
+              onClick={() => { setCtl(DEFAULTS); setTransform({ x: 0, y: 0, k: 1 }); }}
+              className="w-full h-7 rounded-[var(--tt-radius-sm)] border border-[var(--tt-border)] text-[11px] text-[var(--tt-fg-dim)] hover:text-[var(--tt-fg)] hover:border-[var(--tt-border-strong)] transition-colors"
+            >
+              Reset view
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* legend, bottom-left: type identity is never color-alone (labels + counts) */}
+      <div className="absolute bottom-3 left-3 flex flex-wrap items-center gap-1.5 max-w-[70%]">
+        {typeEntries.map(([t, count]) => {
+          const hiddenT = hiddenTypes.has(t);
+          const slot = t === "untyped" ? GRAY : typeSlot(palette, t);
+          return (
+            <button
+              key={t}
+              onClick={() => setHiddenTypes((prev) => {
+                const next = new Set(prev);
+                if (next.has(t)) next.delete(t); else next.add(t);
+                return next;
+              })}
+              className={cn(
+                "flex items-center gap-1.5 h-6 px-2 rounded-full border text-[10.5px] font-medium backdrop-blur transition-all",
+                hiddenT
+                  ? "bg-transparent border-[var(--tt-border)] text-[var(--tt-fg-faint)] line-through"
+                  : "bg-[var(--tt-overlay)]/90 border-[var(--tt-border)] text-[var(--tt-fg-muted)] hover:border-[var(--tt-border-strong)]",
+              )}
+              title={hiddenT ? `Show ${t} pages` : `Hide ${t} pages`}
+            >
+              <span className="h-2 w-2 rounded-full" style={{ background: dark ? slot.dark : slot.light, opacity: hiddenT ? 0.3 : 1 }} />
+              {t} <span className="text-[var(--tt-fg-faint)] tabular">{count}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* graph stats, bottom-right */}
+      <div className="absolute bottom-3 right-3 flex items-center gap-1.5 text-[10.5px] text-[var(--tt-fg-dim)] px-2.5 h-6 rounded-full bg-[var(--tt-overlay)]/90 backdrop-blur border border-[var(--tt-border)]">
+        <Boxes size={11} />
+        {simData.visNodes.length} pages · {simData.visEdges.length} links · {hulls.length || clusters.length} clusters
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------ controls UI */
+
+function PanelSection({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <div className="text-[9px] font-semibold uppercase tracking-[0.18em] text-[var(--tt-fg-faint)] mb-1.5">{title}</div>
+      <div className="space-y-1.5">{children}</div>
+    </div>
+  );
+}
+
+function Slider({ label, min, max, step, value, onChange }: {
+  label: string; min: number; max: number; step: number; value: number; onChange: (v: number) => void;
+}) {
+  return (
+    <label className="flex items-center gap-2 text-[11px] text-[var(--tt-fg-muted)]">
+      <span className="w-[76px] shrink-0">{label}</span>
+      <input
+        type="range" min={min} max={max} step={step} value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="flex-1 h-1 accent-[var(--tt-brand)]"
+      />
+    </label>
+  );
+}
+
+function Toggle({ label, checked, onChange }: { label: string; checked: boolean; onChange: (v: boolean) => void }) {
+  return (
+    <label className="flex items-center justify-between gap-2 text-[11px] text-[var(--tt-fg-muted)] cursor-pointer">
+      {label}
+      <input type="checkbox" checked={checked} onChange={(e) => onChange(e.target.checked)} className="accent-[var(--tt-brand)]" />
+    </label>
+  );
+}
+
+/* --------------------------------------------------------------- geometry */
+
+/** Andrew's monotone chain convex hull. */
+function convexHull(points: [number, number][]): [number, number][] {
+  if (points.length <= 2) return points;
+  const pts = [...points].sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+  const cross = (o: number[], a: number[], b: number[]) =>
+    (a[0] - o[0]) * (b[1] - o[1]) - (a[1] - o[1]) * (b[0] - o[0]);
+  const lower: [number, number][] = [];
+  for (const p of pts) {
+    while (lower.length >= 2 && cross(lower[lower.length - 2], lower[lower.length - 1], p) <= 0) lower.pop();
+    lower.push(p);
+  }
+  const upper: [number, number][] = [];
+  for (const p of [...pts].reverse()) {
+    while (upper.length >= 2 && cross(upper[upper.length - 2], upper[upper.length - 1], p) <= 0) upper.pop();
+    upper.push(p);
+  }
+  return [...lower.slice(0, -1), ...upper.slice(0, -1)];
+}
+
+/** Push hull vertices outward from the centroid by `pad`. */
+function padHull(hull: [number, number][], pad: number): [number, number][] {
+  const cx = hull.reduce((s, p) => s + p[0], 0) / hull.length;
+  const cy = hull.reduce((s, p) => s + p[1], 0) / hull.length;
+  return hull.map(([x, y]) => {
+    const dx = x - cx, dy = y - cy;
+    const len = Math.sqrt(dx * dx + dy * dy) || 1;
+    return [x + (dx / len) * pad, y + (dy / len) * pad] as [number, number];
+  });
+}
+
+/** Closed Catmull-Rom spline through the hull points (soft blob look). */
+function smoothClosedPath(pts: [number, number][]): string {
+  if (pts.length < 3) {
+    if (pts.length === 2) {
+      const [a, b] = pts;
+      return `M ${a[0]} ${a[1]} L ${b[0]} ${b[1]}`;
+    }
+    return "";
+  }
+  const n = pts.length;
+  let d = `M ${pts[0][0]} ${pts[0][1]}`;
+  for (let i = 0; i < n; i++) {
+    const p0 = pts[(i - 1 + n) % n];
+    const p1 = pts[i];
+    const p2 = pts[(i + 1) % n];
+    const p3 = pts[(i + 2) % n];
+    const c1x = p1[0] + (p2[0] - p0[0]) / 6;
+    const c1y = p1[1] + (p2[1] - p0[1]) / 6;
+    const c2x = p2[0] - (p3[0] - p1[0]) / 6;
+    const c2y = p2[1] - (p3[1] - p1[1]) / 6;
+    d += ` C ${c1x} ${c1y}, ${c2x} ${c2y}, ${p2[0]} ${p2[1]}`;
+  }
+  return d + " Z";
+}

--- a/frontend/src/app/projects/[path]/brain/_components/BrainGraph.tsx
+++ b/frontend/src/app/projects/[path]/brain/_components/BrainGraph.tsx
@@ -14,7 +14,7 @@ import {
   type Simulation, type SimulationNodeDatum,
 } from "d3-force";
 import {
-  Boxes, ChevronDown, Focus, Search, SlidersHorizontal, X,
+  Boxes, ChevronDown, Focus, Maximize2, Minus, Plus, Search, SlidersHorizontal, X,
 } from "lucide-react";
 import {
   useCallback, useEffect, useMemo, useRef, useState,
@@ -36,6 +36,7 @@ interface SimNode extends SimulationNodeDatum {
 interface SimEdge {
   source: SimNode;
   target: SimNode;
+  kind: "link" | "index";
 }
 
 interface Props {
@@ -124,7 +125,10 @@ export default function BrainGraph({ nodes, edges, clusters, selectedId, onSelec
   const visibleIds = useMemo(() => {
     let ids = new Set(nodes.map((n) => n.id));
     if (!ctl.showOrphans) {
-      ids = new Set([...ids].filter((id) => (adjacency.get(id)?.size ?? 0) > 0));
+      // degree comes from the backend and excludes index-hub links, so a page
+      // only the index lists still counts as an orphan.
+      const degreeById = new Map(nodes.map((n) => [n.id, n.degree]));
+      ids = new Set([...ids].filter((id) => id === "index" || (degreeById.get(id) ?? 0) > 0));
     }
     if (hiddenTypes.size > 0) {
       const byId = new Map(nodes.map((n) => [n.id, n]));
@@ -166,14 +170,14 @@ export default function BrainGraph({ nodes, edges, clusters, selectedId, onSelec
         return {
           ref: n,
           id: n.id,
-          r: (5 + Math.sqrt(n.degree) * 2.4) * ctl.nodeScale,
+          r: (n.id === "index" ? 12 : 5 + Math.sqrt(n.degree) * 2.4) * ctl.nodeScale,
           x: cached?.x, y: cached?.y,
         } as SimNode;
       });
     const byId = new Map(visNodes.map((n) => [n.id, n]));
     const visEdges: SimEdge[] = edges
       .filter((e) => byId.has(e.source) && byId.has(e.target))
-      .map((e) => ({ source: byId.get(e.source)!, target: byId.get(e.target)! }));
+      .map((e) => ({ source: byId.get(e.source)!, target: byId.get(e.target)!, kind: e.kind ?? "link" }));
     return { visNodes, visEdges };
   }, [nodes, edges, visibleIds, ctl.nodeScale]);
 
@@ -182,22 +186,29 @@ export default function BrainGraph({ nodes, edges, clusters, selectedId, onSelec
     if (visNodes.length === 0) return;
 
     // Cluster anchors on a ring: gives each community its own region so the
-    // hulls separate instead of interleaving.
-    const clusterIdxs = [...new Set(visNodes.map((n) => n.ref.cluster))].sort((a, b) => a - b);
+    // hulls separate instead of interleaving. The index hub (cluster -1)
+    // anchors to the center: the glue that holds the map together.
+    const clusterIdxs = [...new Set(visNodes.map((n) => n.ref.cluster))]
+      .filter((c) => c >= 0).sort((a, b) => a - b);
     const ring = Math.min(size.w, size.h) * 0.42 * (clusterIdxs.length > 1 ? 1 : 0);
     const anchor = new Map<number, { x: number; y: number }>();
+    anchor.set(-1, { x: 0, y: 0 });
     clusterIdxs.forEach((c, i) => {
       const a = (2 * Math.PI * i) / clusterIdxs.length - Math.PI / 2;
       anchor.set(c, { x: Math.cos(a) * ring, y: Math.sin(a) * ring });
     });
 
     const sim = forceSimulation<SimNode>(visNodes)
-      .force("link", forceLink<SimNode, SimEdge>(visEdges).distance(ctl.linkDist).strength(0.35))
+      .force("link", forceLink<SimNode, SimEdge>(visEdges)
+        .distance((l) => (l.kind === "index" ? ctl.linkDist * 1.9 : ctl.linkDist))
+        .strength((l) => (l.kind === "index" ? 0.02 : 0.35)))
       .force("charge", forceManyBody().strength(-ctl.repel))
       .force("center", forceCenter(0, 0).strength(0.04))
       .force("collide", forceCollide<SimNode>().radius((d) => d.r + 6))
-      .force("cx", forceX<SimNode>((d) => anchor.get(d.ref.cluster)?.x ?? 0).strength(0.11))
-      .force("cy", forceY<SimNode>((d) => anchor.get(d.ref.cluster)?.y ?? 0).strength(0.11));
+      .force("cx", forceX<SimNode>((d) => anchor.get(d.ref.cluster)?.x ?? 0)
+        .strength((d) => (d.ref.cluster === -1 ? 0.4 : 0.11)))
+      .force("cy", forceY<SimNode>((d) => anchor.get(d.ref.cluster)?.y ?? 0)
+        .strength((d) => (d.ref.cluster === -1 ? 0.4 : 0.11)));
     simRef.current = sim;
     sim.stop();
 
@@ -235,16 +246,31 @@ export default function BrainGraph({ nodes, edges, clusters, selectedId, onSelec
     };
   }, [transform]);
 
-  const onWheel = useCallback((e: React.WheelEvent) => {
-    e.preventDefault();
-    const rect = svgRef.current!.getBoundingClientRect();
-    const px = e.clientX - rect.left - rect.width / 2;
-    const py = e.clientY - rect.top - rect.height / 2;
+  const zoomAt = useCallback((px: number, py: number, factor: number) => {
     setTransform((t) => {
-      const k = Math.min(4, Math.max(0.2, t.k * Math.exp(-e.deltaY * 0.0016)));
+      const k = Math.min(4, Math.max(0.2, t.k * factor));
       return { k, x: px - ((px - t.x) / t.k) * k, y: py - ((py - t.y) / t.k) * k };
     });
   }, []);
+
+  // Wheel/pinch must be a NATIVE non-passive listener: React attaches wheel
+  // handlers passively, so preventDefault() is ignored there and a trackpad
+  // pinch zooms the whole browser tab instead of the graph.
+  useEffect(() => {
+    const svg = svgRef.current;
+    if (!svg) return;
+    const onWheelNative = (e: WheelEvent) => {
+      e.preventDefault();
+      const rect = svg.getBoundingClientRect();
+      const px = e.clientX - rect.left - rect.width / 2;
+      const py = e.clientY - rect.top - rect.height / 2;
+      // ctrlKey marks a pinch gesture; its deltas are small, so scale harder.
+      const factor = Math.exp(-e.deltaY * (e.ctrlKey ? 0.01 : 0.0016));
+      zoomAt(px, py, factor);
+    };
+    svg.addEventListener("wheel", onWheelNative, { passive: false });
+    return () => svg.removeEventListener("wheel", onWheelNative);
+  }, [zoomAt]);
 
   const onPointerDown = useCallback((e: React.PointerEvent, nodeId?: string) => {
     (e.target as Element).setPointerCapture?.(e.pointerId);
@@ -400,7 +426,6 @@ export default function BrainGraph({ nodes, edges, clusters, selectedId, onSelec
       <svg
         ref={svgRef}
         className="w-full h-full cursor-grab active:cursor-grabbing select-none touch-none"
-        onWheel={onWheel}
         onPointerDown={(e) => onPointerDown(e)}
         onPointerMove={onPointerMove}
         onPointerUp={onPointerUp}
@@ -433,13 +458,15 @@ export default function BrainGraph({ nodes, edges, clusters, selectedId, onSelec
             const lit = neighborSet && activeId != null
               && (e.source.id === activeId || e.target.id === activeId);
             const dim = neighborSet && !lit;
+            const isHubTie = e.kind === "index";
             return (
               <line
                 key={i}
                 x1={sp.x} y1={sp.y} x2={tp.x} y2={tp.y}
                 stroke={lit ? "var(--tt-brand)" : "var(--tt-fg)"}
-                strokeOpacity={lit ? 0.65 : dim ? 0.04 : 0.13}
-                strokeWidth={(lit ? 1.8 : 1.1) / transform.k}
+                strokeOpacity={lit ? 0.6 : dim ? 0.03 : isHubTie ? 0.05 : 0.13}
+                strokeWidth={(lit ? 1.8 : isHubTie ? 0.9 : 1.1) / transform.k}
+                strokeDasharray={isHubTie ? `${3 / transform.k} ${4 / transform.k}` : undefined}
                 className="transition-[stroke-opacity] duration-150"
               />
             );
@@ -453,8 +480,9 @@ export default function BrainGraph({ nodes, edges, clusters, selectedId, onSelec
             const isNeighbor = neighborSet?.has(n.id) ?? false;
             const dim = neighborSet ? !isNeighbor : false;
             const isSelected = n.id === selectedId;
-            const showLabel = isActive || isSelected || isNeighbor || labelOpacity > 0.05;
-            const thisLabelOpacity = isActive || isSelected || isNeighbor ? 1 : labelOpacity;
+            const isHub = n.id === "index";
+            const showLabel = isActive || isSelected || isNeighbor || isHub || labelOpacity > 0.05;
+            const thisLabelOpacity = isActive || isSelected || isNeighbor || isHub ? 1 : labelOpacity;
             return (
               <g
                 key={n.id}
@@ -467,6 +495,9 @@ export default function BrainGraph({ nodes, edges, clusters, selectedId, onSelec
               >
                 {isSelected && (
                   <circle r={n.r + 5 / transform.k} fill="none" stroke="var(--tt-brand)" strokeWidth={1.5 / transform.k} strokeOpacity={0.8} strokeDasharray={`${4 / transform.k} ${3 / transform.k}`} />
+                )}
+                {isHub && !isSelected && (
+                  <circle r={n.r + 4 / transform.k} fill="none" stroke={fillOf(n.ref)} strokeWidth={1.2 / transform.k} strokeOpacity={0.45} />
                 )}
                 <circle
                   r={n.r}
@@ -600,16 +631,34 @@ export default function BrainGraph({ nodes, edges, clusters, selectedId, onSelec
         })}
       </div>
 
-      {/* graph stats, bottom-right */}
+      {/* zoom controls + graph stats, bottom-right */}
+      <div className="absolute bottom-12 right-3 flex flex-col rounded-[var(--tt-radius)] overflow-hidden border border-[var(--tt-border)] bg-[var(--tt-overlay)]/90 backdrop-blur">
+        <ZoomButton title="Zoom in" onClick={() => zoomAt(0, 0, 1.4)}><Plus size={13} /></ZoomButton>
+        <ZoomButton title="Zoom out" onClick={() => zoomAt(0, 0, 1 / 1.4)}><Minus size={13} /></ZoomButton>
+        <ZoomButton title="Reset view" onClick={() => setTransform({ x: 0, y: 0, k: 1 })}><Maximize2 size={12} /></ZoomButton>
+      </div>
       <div className="absolute bottom-3 right-3 flex items-center gap-1.5 text-[10.5px] text-[var(--tt-fg-dim)] px-2.5 h-6 rounded-full bg-[var(--tt-overlay)]/90 backdrop-blur border border-[var(--tt-border)]">
         <Boxes size={11} />
-        {simData.visNodes.length} pages · {simData.visEdges.length} links · {hulls.length || clusters.length} clusters
+        {simData.visNodes.filter((n) => n.id !== "index").length} pages · {simData.visEdges.length} links · {hulls.length || clusters.length} clusters
       </div>
     </div>
   );
 }
 
 /* ------------------------------------------------------------ controls UI */
+
+function ZoomButton({ title, onClick, children }: { title: string; onClick: () => void; children: React.ReactNode }) {
+  return (
+    <button
+      title={title}
+      aria-label={title}
+      onClick={onClick}
+      className="h-7 w-7 grid place-items-center text-[var(--tt-fg-dim)] hover:text-[var(--tt-fg)] hover:tt-tint-2 transition-colors border-b border-[var(--tt-border)] last:border-b-0"
+    >
+      {children}
+    </button>
+  );
+}
 
 function PanelSection({ title, children }: { title: string; children: React.ReactNode }) {
   return (

--- a/frontend/src/app/projects/[path]/brain/_components/Onboarding.tsx
+++ b/frontend/src/app/projects/[path]/brain/_components/Onboarding.tsx
@@ -35,6 +35,7 @@ export default function Onboarding({ project, onImported }: { project: string; o
   const [busyPath, setBusyPath] = useState<string | null>(null);
   const [importError, setImportError] = useState<string | null>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
+  const [picking, setPicking] = useState(false);
 
   const doImport = async (wikiPath: string): Promise<boolean> => {
     setBusyPath(wikiPath);
@@ -57,6 +58,30 @@ export default function Onboarding({ project, onImported }: { project: string; o
       return false;
     } finally {
       setBusyPath(null);
+    }
+  };
+
+  /** Native OS folder dialog (Finder / Explorer), served by the local backend.
+   * Remote viewers and headless hosts get `unsupported` and fall back to the
+   * in-app folder browser. */
+  const browseNative = async () => {
+    setImportError(null);
+    setPicking(true);
+    try {
+      const r = await api<{ path?: string; canceled?: boolean; busy?: boolean; unsupported?: boolean }>(
+        `/brain/pick-folder?project=${encodeURIComponent(project)}`,
+      );
+      if (r.path) {
+        setManualPath(r.path);
+        await doImport(r.path);
+        return;
+      }
+      if (r.canceled || r.busy) return;
+      setPickerOpen(true);
+    } catch {
+      setPickerOpen(true);
+    } finally {
+      setPicking(false);
     }
   };
 
@@ -152,12 +177,12 @@ export default function Onboarding({ project, onImported }: { project: string; o
 
           <div className="flex items-center gap-2">
             <button
-              onClick={() => setPickerOpen(true)}
-              disabled={busyPath !== null}
+              onClick={browseNative}
+              disabled={busyPath !== null || picking}
               className="flex items-center gap-1.5 h-8 px-3 rounded-[var(--tt-radius)] bg-[var(--tt-brand)] text-white text-[12px] font-medium hover:bg-[var(--tt-brand-strong)] disabled:opacity-50 transition-colors shrink-0"
             >
-              <FolderOpen size={13} />
-              Browse folders…
+              {picking ? <Loader2 size={13} className="animate-spin" /> : <FolderOpen size={13} />}
+              Choose folder…
             </button>
             <div className="flex items-center gap-1.5 flex-1 h-8 px-2.5 rounded-[var(--tt-radius)] bg-[var(--tt-sunken)] border border-[var(--tt-border)] focus-within:border-[var(--tt-border-focus)]">
               <input

--- a/frontend/src/app/projects/[path]/brain/_components/Onboarding.tsx
+++ b/frontend/src/app/projects/[path]/brain/_components/Onboarding.tsx
@@ -6,15 +6,17 @@
  * config; the dashboard never writes into the repo. */
 
 import {
-  Brain, Check, Copy, FolderOpen, Hammer, Import, Sparkles, TriangleAlert,
+  ArrowUp, Brain, Check, Copy, CornerDownLeft, Folder, FolderOpen, Hammer,
+  Import, Loader2, Sparkles, TriangleAlert, X,
 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
-import { apiFetch, useResource } from "@/lib/api";
+import { api, apiFetch, useResource } from "@/lib/api";
 import { cn } from "@/lib/cn";
+import { trackEvent } from "@/lib/telemetry";
 import { Badge, Card } from "@/components/ui";
 
-import type { WikiCandidate } from "./types";
+import type { BrowseListing, WikiCandidate } from "./types";
 
 const KIND_LABEL: Record<string, { label: string; tier: "full" | "partial" }> = {
   plugin_wiki: { label: "Plugin wiki", tier: "full" },
@@ -32,8 +34,9 @@ export default function Onboarding({ project, onImported }: { project: string; o
   const [manualPath, setManualPath] = useState("");
   const [busyPath, setBusyPath] = useState<string | null>(null);
   const [importError, setImportError] = useState<string | null>(null);
+  const [pickerOpen, setPickerOpen] = useState(false);
 
-  const doImport = async (wikiPath: string) => {
+  const doImport = async (wikiPath: string): Promise<boolean> => {
     setBusyPath(wikiPath);
     setImportError(null);
     try {
@@ -46,9 +49,12 @@ export default function Onboarding({ project, onImported }: { project: string; o
         const body = await res.json().catch(() => null);
         throw new Error(body?.detail ?? `import failed (${res.status})`);
       }
+      trackEvent("feature.used", { name: "brain-import" });
       onImported();
+      return true;
     } catch (e) {
       setImportError(String((e as Error)?.message ?? e));
+      return false;
     } finally {
       setBusyPath(null);
     }
@@ -145,13 +151,21 @@ export default function Onboarding({ project, onImported }: { project: string; o
           )}
 
           <div className="flex items-center gap-2">
+            <button
+              onClick={() => setPickerOpen(true)}
+              disabled={busyPath !== null}
+              className="flex items-center gap-1.5 h-8 px-3 rounded-[var(--tt-radius)] bg-[var(--tt-brand)] text-white text-[12px] font-medium hover:bg-[var(--tt-brand-strong)] disabled:opacity-50 transition-colors shrink-0"
+            >
+              <FolderOpen size={13} />
+              Browse folders…
+            </button>
             <div className="flex items-center gap-1.5 flex-1 h-8 px-2.5 rounded-[var(--tt-radius)] bg-[var(--tt-sunken)] border border-[var(--tt-border)] focus-within:border-[var(--tt-border-focus)]">
-              <FolderOpen size={13} className="text-[var(--tt-fg-dim)] shrink-0" />
               <input
                 value={manualPath}
                 onChange={(e) => setManualPath(e.target.value)}
-                placeholder="/absolute/path/to/wiki"
-                className="bg-transparent outline-none text-[12px] font-mono text-[var(--tt-fg)] placeholder:text-[var(--tt-fg-faint)] w-full"
+                onKeyDown={(e) => { if (e.key === "Enter" && manualPath.trim()) doImport(manualPath.trim()); }}
+                placeholder="or type /absolute/path/to/wiki"
+                className="bg-transparent outline-none focus-visible:outline-none text-[12px] font-mono text-[var(--tt-fg)] placeholder:text-[var(--tt-fg-faint)] w-full"
               />
             </div>
             <button
@@ -177,11 +191,171 @@ export default function Onboarding({ project, onImported }: { project: string; o
         </Card>
       </div>
 
+      {pickerOpen && (
+        <FolderPicker
+          project={project}
+          busy={busyPath !== null}
+          error={importError}
+          onImport={doImport}
+          onClose={() => setPickerOpen(false)}
+        />
+      )}
+
       {/* benefits strip */}
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
         <Benefit title="Cheaper sessions" text="Agents answer from short pages instead of re-reading the codebase; an AGENTS.md pointer makes it automatic." />
         <Benefit title="Bugs surface early" text="Compiles log contradictions as Findings; the first dogfood run caught a dead cache and stale tests." />
         <Benefit title="Humans can read it too" text="Onboarding, decisions, and playbooks live in one lint-checked place, with an inbox for new knowledge." />
+      </div>
+    </div>
+  );
+}
+
+const HINT_BADGE: Record<string, { label: string; variant: "success" | "warn" | "info" }> = {
+  plugin_wiki: { label: "Plugin wiki", variant: "success" },
+  obsidian_vault: { label: "Obsidian vault", variant: "warn" },
+  markdown_wiki: { label: "Markdown", variant: "info" },
+};
+
+/** Server-backed folder browser: browsers can't hand us an absolute path from a
+ * native picker, so the backend lists directories (inside the allowed roots)
+ * and the user walks to the wiki folder here. */
+function FolderPicker({ project, busy, error, onImport, onClose }: {
+  project: string;
+  busy: boolean;
+  error: string | null;
+  onImport: (path: string) => Promise<boolean>;
+  onClose: () => void;
+}) {
+  const [listing, setListing] = useState<BrowseListing | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const navigate = (path?: string) => {
+    setLoading(true);
+    setLoadError(null);
+    const qs = new URLSearchParams({ project });
+    if (path) qs.set("path", path);
+    api<BrowseListing>(`/brain/browse?${qs.toString()}`)
+      .then((l) => setListing(l))
+      .catch((e) => setLoadError(String((e as Error)?.message ?? e)))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    navigate();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [project]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const hint = listing?.hint ? HINT_BADGE[listing.hint] : null;
+
+  return (
+    <div role="dialog" aria-modal="true" aria-label="Choose a wiki folder" className="fixed inset-0 z-[100]">
+      <div className="absolute inset-0 bg-black/55 backdrop-blur-[2px]" onClick={onClose} />
+      <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[min(560px,calc(100vw-32px))] rounded-[var(--tt-radius-lg)] border border-[var(--tt-border-strong)] bg-[var(--tt-panel)] shadow-[var(--tt-shadow-pop)] flex flex-col max-h-[70vh]">
+        {/* header */}
+        <div className="shrink-0 flex items-center justify-between gap-3 px-4 pt-3.5 pb-3 border-b border-[var(--tt-border)]">
+          <div className="flex items-center gap-2 text-[13px] font-semibold text-[var(--tt-fg)]">
+            <FolderOpen size={14} className="text-[var(--tt-brand)]" />
+            Choose a wiki folder
+          </div>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="h-6 w-6 grid place-items-center rounded-[var(--tt-radius-sm)] text-[var(--tt-fg-dim)] hover:text-[var(--tt-fg)] hover:tt-tint-2 transition-colors"
+          >
+            <X size={13} />
+          </button>
+        </div>
+
+        {/* current path + up */}
+        <div className="shrink-0 flex items-center gap-2 px-4 py-2 border-b border-[var(--tt-border)]">
+          <button
+            onClick={() => listing?.parent && navigate(listing.parent)}
+            disabled={!listing?.parent || loading}
+            title="Up one level"
+            className="shrink-0 h-6 w-6 grid place-items-center rounded-[var(--tt-radius-sm)] border border-[var(--tt-border)] text-[var(--tt-fg-dim)] hover:text-[var(--tt-fg)] hover:border-[var(--tt-border-strong)] disabled:opacity-35 transition-colors"
+          >
+            <ArrowUp size={12} />
+          </button>
+          <span className="min-w-0 flex-1 font-mono text-[11px] text-[var(--tt-fg-muted)] truncate" title={listing?.path}>
+            {listing?.path ?? "…"}
+          </span>
+          {hint && <Badge variant={hint.variant} size="xs">{hint.label}</Badge>}
+        </div>
+
+        {/* directory list */}
+        <div className="flex-1 overflow-y-auto px-2 py-1.5 min-h-[180px]">
+          {loading && (
+            <div className="h-full grid place-items-center text-[var(--tt-fg-dim)]">
+              <Loader2 size={16} className="animate-spin" />
+            </div>
+          )}
+          {!loading && loadError && (
+            <p className="px-2 py-3 text-[11.5px] text-[var(--tt-danger-fg)]">{loadError}</p>
+          )}
+          {!loading && !loadError && listing && listing.dirs.length === 0 && (
+            <p className="px-2 py-3 text-[11.5px] text-[var(--tt-fg-dim)]">No subfolders here.</p>
+          )}
+          {!loading && !loadError && listing?.dirs.map((d) => {
+            const b = d.hint ? HINT_BADGE[d.hint] : null;
+            return (
+              <button
+                key={d.path}
+                onClick={() => navigate(d.path)}
+                className="w-full flex items-center gap-2 px-2 h-7 rounded-[var(--tt-radius-sm)] text-left text-[12px] text-[var(--tt-fg-muted)] hover:tt-tint-2 hover:text-[var(--tt-fg)] transition-colors"
+              >
+                <Folder size={12} className="shrink-0 text-[var(--tt-fg-dim)]" />
+                <span className="min-w-0 flex-1 truncate">{d.name}</span>
+                {b && <Badge variant={b.variant} size="xs">{b.label}</Badge>}
+              </button>
+            );
+          })}
+          {!loading && listing?.truncated && (
+            <p className="px-2 py-1.5 text-[10.5px] text-[var(--tt-fg-faint)]">List truncated; type the path directly if the folder is missing.</p>
+          )}
+        </div>
+
+        {/* footer */}
+        <div className="shrink-0 px-4 py-3 border-t border-[var(--tt-border)] space-y-2">
+          {error && (
+            <p className="text-[11.5px] text-[var(--tt-danger-fg)] flex items-start gap-1.5">
+              <TriangleAlert size={12} className="shrink-0 mt-0.5" />
+              {error}
+            </p>
+          )}
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-[10.5px] text-[var(--tt-fg-faint)]">
+              Pick the folder that holds the wiki pages, then import it.
+            </span>
+            <div className="flex items-center gap-2 shrink-0">
+              <button
+                onClick={onClose}
+                className="h-7 px-3 rounded-[var(--tt-radius-sm)] border border-[var(--tt-border)] text-[11.5px] text-[var(--tt-fg-dim)] hover:text-[var(--tt-fg)] transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={async () => {
+                  if (!listing) return;
+                  const ok = await onImport(listing.path);
+                  if (ok) onClose();
+                }}
+                disabled={!listing || busy || loading}
+                className="flex items-center gap-1.5 h-7 px-3 rounded-[var(--tt-radius-sm)] bg-[var(--tt-brand)] text-white text-[11.5px] font-medium hover:bg-[var(--tt-brand-strong)] disabled:opacity-50 transition-colors"
+              >
+                {busy ? <Loader2 size={11} className="animate-spin" /> : <CornerDownLeft size={11} />}
+                Import this folder
+              </button>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/app/projects/[path]/brain/_components/Onboarding.tsx
+++ b/frontend/src/app/projects/[path]/brain/_components/Onboarding.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+/* Shown when a project has no detected wiki: explain the plugin, offer the
+ * build-new commands, and offer import of an already-built brain (detected
+ * candidates or a manual path). Import only records a pointer in TT's own
+ * config; the dashboard never writes into the repo. */
+
+import {
+  Brain, Check, Copy, FolderOpen, Hammer, Import, Sparkles, TriangleAlert,
+} from "lucide-react";
+import { useMemo, useState } from "react";
+
+import { apiFetch, useResource } from "@/lib/api";
+import { cn } from "@/lib/cn";
+import { Badge, Card } from "@/components/ui";
+
+import type { WikiCandidate } from "./types";
+
+const KIND_LABEL: Record<string, { label: string; tier: "full" | "partial" }> = {
+  plugin_wiki: { label: "Plugin wiki", tier: "full" },
+  okf_ish: { label: "OKF wiki", tier: "full" },
+  obsidian_vault: { label: "Obsidian vault", tier: "partial" },
+  markdown_wiki: { label: "Markdown wiki", tier: "partial" },
+};
+
+export default function Onboarding({ project, onImported }: { project: string; onImported: () => void }) {
+  const { data: candData } = useResource<{ candidates: WikiCandidate[] }>(
+    `/brain/candidates?project=${encodeURIComponent(project)}`,
+    { initial: { candidates: [] } },
+  );
+  const candidates = useMemo(() => candData?.candidates ?? [], [candData]);
+  const [manualPath, setManualPath] = useState("");
+  const [busyPath, setBusyPath] = useState<string | null>(null);
+  const [importError, setImportError] = useState<string | null>(null);
+
+  const doImport = async (wikiPath: string) => {
+    setBusyPath(wikiPath);
+    setImportError(null);
+    try {
+      const res = await apiFetch("/brain/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ project, wiki_path: wikiPath }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.detail ?? `import failed (${res.status})`);
+      }
+      onImported();
+    } catch (e) {
+      setImportError(String((e as Error)?.message ?? e));
+    } finally {
+      setBusyPath(null);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* hero */}
+      <Card padding="lg">
+        <div className="flex flex-wrap items-center gap-6">
+          <div className="h-14 w-14 grid place-items-center rounded-[var(--tt-radius-lg)] bg-[var(--tt-brand-glow)] border border-[color:var(--tt-brand)]/25 text-[var(--tt-brand)] shrink-0">
+            <Brain size={26} />
+          </div>
+          <div className="min-w-[260px] flex-1">
+            <h2 className="text-[18px] font-semibold text-[var(--tt-fg)]">No second brain here yet</h2>
+            <p className="mt-1 text-[13px] leading-relaxed text-[var(--tt-fg-muted)] max-w-[560px]">
+              The tokentelemetry plugin compiles this project into a small wiki that coding
+              agents read instead of re-exploring the codebase. Once it exists, this tab
+              renders it as an interactive graph: clusters, links, and every page one click away.
+            </p>
+          </div>
+          <PreviewGraph />
+        </div>
+      </Card>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        {/* build new */}
+        <Card padding="lg">
+          <div className="flex items-center gap-2 mb-3">
+            <Hammer size={15} className="text-[var(--tt-brand)]" />
+            <h3 className="text-[14px] font-semibold text-[var(--tt-fg)]">Build a new brain</h3>
+          </div>
+          <p className="text-[12px] text-[var(--tt-fg-muted)] mb-3">
+            Run these in a Claude Code session inside this project. The compile is
+            resumable: batches checkpoint, and rerunning continues where it stopped.
+          </p>
+          <ol className="space-y-2">
+            <CommandStep n={1} cmd="/brain-init" note="detect the domain profile, scaffold docs/wiki/" />
+            <CommandStep n={2} cmd="/brain-compile" note="build pages in batches; rerun until complete" />
+            <CommandStep n={3} cmd="/skillsmith" note="optional: generate the per-project optimization skill" />
+          </ol>
+          <p className="mt-3 text-[11px] text-[var(--tt-fg-dim)] flex items-start gap-1.5">
+            <Sparkles size={12} className="shrink-0 mt-0.5 text-[var(--tt-brand)]" />
+            If the project already holds a graphify graph, ADRs, or an Obsidian vault,
+            /brain-init detects them and offers to seed the compile, so paid-for
+            knowledge is reused, not rebuilt.
+          </p>
+        </Card>
+
+        {/* import existing */}
+        <Card padding="lg">
+          <div className="flex items-center gap-2 mb-3">
+            <Import size={15} className="text-[var(--tt-brand)]" />
+            <h3 className="text-[14px] font-semibold text-[var(--tt-fg)]">Import an existing brain</h3>
+          </div>
+
+          {candidates.length > 0 ? (
+            <div className="space-y-2 mb-3">
+              {candidates.map((c) => {
+                const kind = KIND_LABEL[c.kind] ?? { label: c.kind, tier: "partial" as const };
+                return (
+                  <div
+                    key={c.path}
+                    className="flex items-center justify-between gap-3 px-3 py-2 rounded-[var(--tt-radius)] border border-[var(--tt-border)] bg-[var(--tt-sunken)]"
+                  >
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2">
+                        <span className="font-mono text-[11px] text-[var(--tt-fg)] truncate" title={c.path}>
+                          {c.path.replace(project + "/", "")}
+                        </span>
+                        <Badge variant={kind.tier === "full" ? "success" : "warn"} size="xs">{kind.label}</Badge>
+                      </div>
+                      <div className="text-[10.5px] text-[var(--tt-fg-dim)] mt-0.5">
+                        {c.page_count} pages
+                        {kind.tier === "partial" && " · renders untyped; run /brain adopt for the full experience"}
+                      </div>
+                    </div>
+                    <button
+                      onClick={() => doImport(c.path)}
+                      disabled={busyPath !== null}
+                      className="shrink-0 h-7 px-3 rounded-[var(--tt-radius-sm)] bg-[var(--tt-brand)] text-white text-[11px] font-medium hover:bg-[var(--tt-brand-strong)] disabled:opacity-50 transition-colors"
+                    >
+                      {busyPath === c.path ? "Importing…" : "Import"}
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <p className="text-[12px] text-[var(--tt-fg-muted)] mb-3">
+              No wiki-shaped folder was detected in this project. If a brain lives
+              somewhere unusual, point at it directly:
+            </p>
+          )}
+
+          <div className="flex items-center gap-2">
+            <div className="flex items-center gap-1.5 flex-1 h-8 px-2.5 rounded-[var(--tt-radius)] bg-[var(--tt-sunken)] border border-[var(--tt-border)] focus-within:border-[var(--tt-border-focus)]">
+              <FolderOpen size={13} className="text-[var(--tt-fg-dim)] shrink-0" />
+              <input
+                value={manualPath}
+                onChange={(e) => setManualPath(e.target.value)}
+                placeholder="/absolute/path/to/wiki"
+                className="bg-transparent outline-none text-[12px] font-mono text-[var(--tt-fg)] placeholder:text-[var(--tt-fg-faint)] w-full"
+              />
+            </div>
+            <button
+              onClick={() => manualPath.trim() && doImport(manualPath.trim())}
+              disabled={!manualPath.trim() || busyPath !== null}
+              className="h-8 px-3.5 rounded-[var(--tt-radius)] border border-[var(--tt-border-strong)] text-[12px] font-medium text-[var(--tt-fg)] hover:tt-tint-2 disabled:opacity-40 transition-colors"
+            >
+              Import
+            </button>
+          </div>
+
+          {importError && (
+            <p className="mt-2 text-[11.5px] text-[var(--tt-danger-fg)] flex items-start gap-1.5">
+              <TriangleAlert size={12} className="shrink-0 mt-0.5" />
+              {importError}
+            </p>
+          )}
+
+          <p className="mt-3 text-[11px] text-[var(--tt-fg-dim)]">
+            Importing records a pointer in ~/.tokentelemetry only. Nothing is copied
+            and this repo is never written; un-import any time.
+          </p>
+        </Card>
+      </div>
+
+      {/* benefits strip */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        <Benefit title="Cheaper sessions" text="Agents answer from short pages instead of re-reading the codebase; an AGENTS.md pointer makes it automatic." />
+        <Benefit title="Bugs surface early" text="Compiles log contradictions as Findings; the first dogfood run caught a dead cache and stale tests." />
+        <Benefit title="Humans can read it too" text="Onboarding, decisions, and playbooks live in one lint-checked place, with an inbox for new knowledge." />
+      </div>
+    </div>
+  );
+}
+
+function CommandStep({ n, cmd, note }: { n: number; cmd: string; note: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <li className="flex items-center gap-2.5">
+      <span className="h-5 w-5 grid place-items-center rounded-full tt-tint-2 text-[10px] font-semibold text-[var(--tt-fg-dim)] shrink-0">{n}</span>
+      <button
+        onClick={() => {
+          navigator.clipboard?.writeText(cmd);
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1200);
+        }}
+        className={cn(
+          "flex items-center gap-1.5 px-2 h-6 rounded-[var(--tt-radius-sm)] border font-mono text-[11.5px] transition-colors shrink-0",
+          copied
+            ? "border-[var(--tt-success-bd)] text-[var(--tt-success-fg)] bg-[var(--tt-success-bg)]"
+            : "border-[var(--tt-border)] bg-[var(--tt-sunken)] text-[var(--tt-brand)] hover:border-[var(--tt-border-strong)]",
+        )}
+        title="Copy command"
+      >
+        {cmd}
+        {copied ? <Check size={10} /> : <Copy size={10} className="text-[var(--tt-fg-faint)]" />}
+      </button>
+      <span className="text-[11px] text-[var(--tt-fg-dim)]">{note}</span>
+    </li>
+  );
+}
+
+function Benefit({ title, text }: { title: string; text: string }) {
+  return (
+    <div className="px-4 py-3 rounded-[var(--tt-radius)] border border-[var(--tt-border)] bg-[var(--tt-panel)]">
+      <div className="text-[12px] font-semibold text-[var(--tt-fg)] mb-1">{title}</div>
+      <div className="text-[11.5px] leading-relaxed text-[var(--tt-fg-dim)]">{text}</div>
+    </div>
+  );
+}
+
+/** Decorative static mini-graph so the payoff is visible before the work. */
+function PreviewGraph() {
+  const nodes = [
+    { x: 60, y: 34, r: 9, c: "#3987e5" },
+    { x: 26, y: 62, r: 6, c: "#199e70" },
+    { x: 94, y: 60, r: 6, c: "#199e70" },
+    { x: 60, y: 86, r: 5, c: "#c98500" },
+    { x: 110, y: 26, r: 4.5, c: "#9085e9" },
+    { x: 18, y: 24, r: 4.5, c: "#d55181" },
+  ];
+  const edges = [[0, 1], [0, 2], [0, 3], [1, 3], [2, 4], [0, 5]];
+  return (
+    <svg width={132} height={104} className="shrink-0 opacity-90" aria-hidden>
+      {edges.map(([a, b], i) => (
+        <line
+          key={i}
+          x1={nodes[a].x} y1={nodes[a].y} x2={nodes[b].x} y2={nodes[b].y}
+          stroke="var(--tt-fg)" strokeOpacity={0.16} strokeWidth={1.2}
+        />
+      ))}
+      {nodes.map((n, i) => (
+        <circle key={i} cx={n.x} cy={n.y} r={n.r} fill={n.c} stroke="var(--tt-panel)" strokeWidth={2} />
+      ))}
+    </svg>
+  );
+}

--- a/frontend/src/app/projects/[path]/brain/_components/PageDrawer.tsx
+++ b/frontend/src/app/projects/[path]/brain/_components/PageDrawer.tsx
@@ -72,45 +72,9 @@ export default function PageDrawer({ project, pageId, types, dark, onClose, onNa
         @media (prefers-reduced-motion: reduce) {
           .tt-brain-anim { animation: none !important }
         }
-        /* Drawer-scoped markdown scale. The global .prose is sized for the
-         * full-width session viewer; at 520px its headings read shouty, so
-         * everything steps down one notch here. */
-        .tt-brain-md { font-size: 12.5px; line-height: 1.62; color: var(--tt-fg-muted); }
-        .tt-brain-md h1, .tt-brain-md h2, .tt-brain-md h3, .tt-brain-md h4 {
-          color: var(--tt-fg); font-weight: 600; letter-spacing: -0.01em;
-          margin: 1.4em 0 0.45em;
-        }
-        .tt-brain-md > :first-child { margin-top: 0.2em; }
-        .tt-brain-md h1 { font-size: 15px; padding-bottom: 0.3em; border-bottom: 1px solid var(--tt-border); }
-        .tt-brain-md h2 { font-size: 13.5px; }
-        .tt-brain-md h3, .tt-brain-md h4 { font-size: 12.5px; }
-        .tt-brain-md p { margin: 0 0 0.8em; }
-        .tt-brain-md ul, .tt-brain-md ol { margin: 0 0 0.8em; padding-left: 1.3em; }
-        .tt-brain-md ul { list-style-type: disc; }
-        .tt-brain-md ol { list-style-type: decimal; }
-        .tt-brain-md li { margin-bottom: 0.3em; }
-        .tt-brain-md code {
-          background: var(--tt-sunken); border: 1px solid var(--tt-border);
-          border-radius: 4px; padding: 0.1em 0.35em;
-          font-family: var(--font-mono); font-size: 0.92em;
-        }
-        .tt-brain-md pre {
-          background: var(--tt-sunken); border: 1px solid var(--tt-border);
-          border-radius: var(--tt-radius); padding: 0.75em 0.9em;
-          overflow-x: auto; margin: 0 0 1em; font-size: 11px; line-height: 1.55;
-        }
-        .tt-brain-md pre code { background: none; border: none; padding: 0; font-size: inherit; }
-        .tt-brain-md blockquote {
-          border-left: 3px solid var(--tt-border-strong); padding-left: 0.9em;
-          margin: 0 0 0.8em; color: var(--tt-fg-dim); font-style: italic;
-        }
-        .tt-brain-md table { border-collapse: collapse; font-size: 11.5px; margin: 0 0 1em; display: block; overflow-x: auto; }
-        .tt-brain-md th, .tt-brain-md td { border: 1px solid var(--tt-border); padding: 0.35em 0.6em; text-align: left; }
-        .tt-brain-md th { background: var(--tt-sunken); color: var(--tt-fg); font-weight: 600; }
-        .tt-brain-md a { color: var(--tt-brand); text-decoration: none; }
-        .tt-brain-md a:hover { text-decoration: underline; }
-        .tt-brain-md hr { border: none; border-top: 1px solid var(--tt-border); margin: 1.2em 0; }
       `}</style>
+      {/* Markdown body uses the shared .tt-brain-md scale from globals.css
+        * (also used by the project Plans tab). */}
       <div
         className="tt-brain-anim absolute inset-0 bg-black/55 backdrop-blur-[2px] animate-[tt-brain-fade-in_120ms_ease-out]"
         onClick={onClose}

--- a/frontend/src/app/projects/[path]/brain/_components/PageDrawer.tsx
+++ b/frontend/src/app/projects/[path]/brain/_components/PageDrawer.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+/* Right-side drawer showing one wiki page: metadata, staleness, rendered
+ * markdown, and in/out links that navigate the graph. Follows the
+ * WhatsChangedDrawer pattern (backdrop, Esc, scroll lock, slide-in). */
+
+import {
+  ArrowDownLeft, ArrowUpRight, Check, Copy, FileText, GitCommitHorizontal, Tag, X,
+} from "lucide-react";
+import { useEffect, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+import { api } from "@/lib/api";
+import { cn } from "@/lib/cn";
+import { Badge, Skeleton } from "@/components/ui";
+
+import { buildTypePalette, typeSlot } from "./palette";
+import type { PageDetail } from "./types";
+
+interface Props {
+  project: string;
+  pageId: string | null;
+  types: string[];
+  dark: boolean;
+  onClose: () => void;
+  onNavigate: (id: string) => void;
+}
+
+export default function PageDrawer({ project, pageId, types, dark, onClose, onNavigate }: Props) {
+  const [detail, setDetail] = useState<PageDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const open = pageId !== null;
+
+  useEffect(() => {
+    if (!pageId) return;
+    let cancelled = false;
+    setDetail(null);
+    setError(null);
+    api<PageDetail>(`/brain/page?project=${encodeURIComponent(project)}&id=${encodeURIComponent(pageId)}`)
+      .then((d) => { if (!cancelled) setDetail(d); })
+      .catch((e) => { if (!cancelled) setError(String(e?.message ?? e)); });
+    return () => { cancelled = true; };
+  }, [project, pageId]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    window.addEventListener("keydown", onKey);
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prev;
+    };
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const palette = buildTypePalette(types);
+  const slot = typeSlot(palette, detail?.type ?? null);
+  const accent = dark ? slot.dark : slot.light;
+
+  return (
+    <div role="dialog" aria-modal="true" aria-labelledby="brain-drawer-title" className="fixed inset-0 z-[100]">
+      <style>{`
+        @keyframes tt-brain-fade-in { from { opacity: 0 } to { opacity: 1 } }
+        @keyframes tt-brain-slide-in { from { transform: translateX(8%); opacity: .4 } to { transform: none; opacity: 1 } }
+        @media (prefers-reduced-motion: reduce) {
+          .tt-brain-anim { animation: none !important }
+        }
+      `}</style>
+      <div
+        className="tt-brain-anim absolute inset-0 bg-black/55 backdrop-blur-[2px] animate-[tt-brain-fade-in_120ms_ease-out]"
+        onClick={onClose}
+      />
+      <aside className="tt-brain-anim absolute right-0 top-0 bottom-0 w-full max-w-[520px] bg-[var(--tt-panel)] border-l border-[var(--tt-border-strong)] shadow-[-24px_0_60px_-20px_rgba(0,0,0,0.6)] flex flex-col animate-[tt-brain-slide-in_180ms_ease-out]">
+        {/* header */}
+        <div className="shrink-0 px-5 pt-4 pb-3 border-b border-[var(--tt-border)]" style={{ boxShadow: `inset 3px 0 0 ${accent}` }}>
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <div className="flex items-center gap-2 mb-1">
+                <span className="h-2.5 w-2.5 rounded-full shrink-0" style={{ background: accent }} />
+                <span className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--tt-fg-dim)]">
+                  {detail?.type ?? "page"}
+                </span>
+                {detail?.status && (
+                  <Badge variant={detail.status === "adopted" ? "success" : detail.status === "rejected" ? "danger" : "info"} size="xs">
+                    {detail.status}
+                  </Badge>
+                )}
+              </div>
+              <h2 id="brain-drawer-title" className="text-[17px] font-semibold leading-snug text-[var(--tt-fg)]">
+                {detail?.title ?? pageId}
+              </h2>
+              <div className="mt-1 font-mono text-[10.5px] text-[var(--tt-fg-faint)] truncate" title={pageId ?? undefined}>
+                {pageId}.md
+              </div>
+            </div>
+            <button
+              onClick={onClose}
+              aria-label="Close"
+              className="shrink-0 h-7 w-7 grid place-items-center rounded-[var(--tt-radius-sm)] text-[var(--tt-fg-dim)] hover:text-[var(--tt-fg)] hover:tt-tint-2 transition-colors"
+            >
+              <X size={15} />
+            </button>
+          </div>
+        </div>
+
+        {/* body */}
+        <div className="flex-1 overflow-y-auto px-5 py-4 space-y-4">
+          {error && (
+            <div className="text-[12px] text-[var(--tt-danger-fg)] bg-[var(--tt-danger-bg)] border border-[var(--tt-danger-bd)] rounded-[var(--tt-radius)] px-3 py-2">
+              {error}
+            </div>
+          )}
+          {!detail && !error && (
+            <div className="space-y-3">
+              <Skeleton className="h-4 w-3/4" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-40 w-full" />
+            </div>
+          )}
+
+          {detail && (
+            <>
+              {detail.description && (
+                <p className="text-[13px] leading-relaxed text-[var(--tt-fg-muted)] italic">
+                  {detail.description}
+                </p>
+              )}
+
+              {/* meta grid */}
+              <div className="grid grid-cols-1 gap-1.5 text-[11.5px]">
+                {detail.timestamp && (
+                  <MetaRow label="Updated">{detail.timestamp}</MetaRow>
+                )}
+                {detail.resource && (
+                  <MetaRow label="Source">
+                    <span className="inline-flex items-center gap-1.5 min-w-0">
+                      <FileText size={11} className="shrink-0 text-[var(--tt-fg-dim)]" />
+                      <span className="font-mono truncate" title={detail.resource}>{detail.resource}</span>
+                      <button
+                        onClick={() => {
+                          navigator.clipboard?.writeText(detail.resource!);
+                          setCopied(true);
+                          setTimeout(() => setCopied(false), 1200);
+                        }}
+                        className="shrink-0 text-[var(--tt-fg-dim)] hover:text-[var(--tt-fg)]"
+                        title="Copy source path"
+                      >
+                        {copied ? <Check size={11} className="text-[var(--tt-success-fg)]" /> : <Copy size={11} />}
+                      </button>
+                    </span>
+                  </MetaRow>
+                )}
+                <MetaRow label="Freshness">
+                  <StalenessPill s={detail.staleness} />
+                </MetaRow>
+                {detail.tags.length > 0 && (
+                  <MetaRow label="Tags">
+                    <span className="flex flex-wrap gap-1">
+                      {detail.tags.map((t) => (
+                        <span key={String(t)} className="inline-flex items-center gap-1 px-1.5 h-5 rounded-full tt-tint-2 text-[10px] text-[var(--tt-fg-dim)]">
+                          <Tag size={9} />{String(t)}
+                        </span>
+                      ))}
+                    </span>
+                  </MetaRow>
+                )}
+              </div>
+
+              {/* markdown body */}
+              <div className="pt-2 border-t border-[var(--tt-border)]">
+                <div className="prose prose-sm max-w-none">
+                  <ReactMarkdown remarkPlugins={[remarkGfm]}>{detail.body}</ReactMarkdown>
+                </div>
+              </div>
+
+              {/* links */}
+              {(detail.outbound.length > 0 || detail.inbound.length > 0) && (
+                <div className="pt-3 border-t border-[var(--tt-border)] space-y-3">
+                  <LinkGroup
+                    icon={<ArrowUpRight size={12} />}
+                    label={`Links to (${detail.outbound.length})`}
+                    links={detail.outbound}
+                    onNavigate={onNavigate}
+                  />
+                  <LinkGroup
+                    icon={<ArrowDownLeft size={12} />}
+                    label={`Linked from (${detail.inbound.length})`}
+                    links={detail.inbound}
+                    onNavigate={onNavigate}
+                  />
+                </div>
+              )}
+            </>
+          )}
+        </div>
+
+        {/* footer */}
+        <div className="shrink-0 px-5 py-2.5 border-t border-[var(--tt-border)] flex items-center gap-1.5 text-[10.5px] text-[var(--tt-fg-faint)]">
+          <GitCommitHorizontal size={11} />
+          Maintained by the tokentelemetry plugin. Pages are a map, not testimony: confirm against the cited source before relying on one.
+        </div>
+      </aside>
+    </div>
+  );
+}
+
+function MetaRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-start gap-3">
+      <span className="w-[64px] shrink-0 text-[var(--tt-fg-faint)] uppercase tracking-wide text-[9.5px] font-semibold pt-0.5">{label}</span>
+      <span className="min-w-0 text-[var(--tt-fg-muted)]">{children}</span>
+    </div>
+  );
+}
+
+function StalenessPill({ s }: { s: PageDetail["staleness"] }) {
+  const cfg = {
+    fresh: { text: "Fresh", cls: "text-[var(--tt-success-fg)] bg-[var(--tt-success-bg)] border-[var(--tt-success-bd)]", hint: "Source unchanged since this page was compiled" },
+    stale: { text: "Source changed", cls: "text-[var(--tt-warn-fg)] bg-[var(--tt-warn-bg)] border-[var(--tt-warn-bd)]", hint: s.diffstat ?? "Source changed since compile; re-run /brain ingest" },
+    unknown: { text: "Unknown", cls: "text-[var(--tt-fg-dim)] tt-tint-1 border-[var(--tt-border)]", hint: s.reason ?? "No compile SHA on record" },
+  }[s.status];
+  return (
+    <span
+      className={cn("inline-flex items-center h-5 px-2 rounded-full border text-[10px] font-medium", cfg.cls)}
+      title={cfg.hint}
+    >
+      {cfg.text}
+    </span>
+  );
+}
+
+function LinkGroup({ icon, label, links, onNavigate }: {
+  icon: React.ReactNode; label: string; links: { id: string; title: string }[]; onNavigate: (id: string) => void;
+}) {
+  if (links.length === 0) return null;
+  return (
+    <div>
+      <div className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--tt-fg-faint)] mb-1.5">
+        {icon}{label}
+      </div>
+      <div className="flex flex-wrap gap-1.5">
+        {links.map((l) => (
+          <button
+            key={l.id}
+            onClick={() => onNavigate(l.id)}
+            className="px-2 h-6 rounded-full border border-[var(--tt-border)] bg-[var(--tt-sunken)] text-[11px] text-[var(--tt-fg-muted)] hover:text-[var(--tt-brand)] hover:border-[color:var(--tt-brand)]/40 transition-colors"
+            title={l.id}
+          >
+            {l.title}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/projects/[path]/brain/_components/PageDrawer.tsx
+++ b/frontend/src/app/projects/[path]/brain/_components/PageDrawer.tsx
@@ -13,6 +13,7 @@ import remarkGfm from "remark-gfm";
 
 import { api } from "@/lib/api";
 import { cn } from "@/lib/cn";
+import { trackEvent } from "@/lib/telemetry";
 import { Badge, Skeleton } from "@/components/ui";
 
 import { buildTypePalette, typeSlot } from "./palette";
@@ -38,6 +39,7 @@ export default function PageDrawer({ project, pageId, types, dark, onClose, onNa
     let cancelled = false;
     setDetail(null);
     setError(null);
+    trackEvent("feature.used", { name: "brain-page-open" });
     api<PageDetail>(`/brain/page?project=${encodeURIComponent(project)}&id=${encodeURIComponent(pageId)}`)
       .then((d) => { if (!cancelled) setDetail(d); })
       .catch((e) => { if (!cancelled) setError(String(e?.message ?? e)); });
@@ -70,6 +72,44 @@ export default function PageDrawer({ project, pageId, types, dark, onClose, onNa
         @media (prefers-reduced-motion: reduce) {
           .tt-brain-anim { animation: none !important }
         }
+        /* Drawer-scoped markdown scale. The global .prose is sized for the
+         * full-width session viewer; at 520px its headings read shouty, so
+         * everything steps down one notch here. */
+        .tt-brain-md { font-size: 12.5px; line-height: 1.62; color: var(--tt-fg-muted); }
+        .tt-brain-md h1, .tt-brain-md h2, .tt-brain-md h3, .tt-brain-md h4 {
+          color: var(--tt-fg); font-weight: 600; letter-spacing: -0.01em;
+          margin: 1.4em 0 0.45em;
+        }
+        .tt-brain-md > :first-child { margin-top: 0.2em; }
+        .tt-brain-md h1 { font-size: 15px; padding-bottom: 0.3em; border-bottom: 1px solid var(--tt-border); }
+        .tt-brain-md h2 { font-size: 13.5px; }
+        .tt-brain-md h3, .tt-brain-md h4 { font-size: 12.5px; }
+        .tt-brain-md p { margin: 0 0 0.8em; }
+        .tt-brain-md ul, .tt-brain-md ol { margin: 0 0 0.8em; padding-left: 1.3em; }
+        .tt-brain-md ul { list-style-type: disc; }
+        .tt-brain-md ol { list-style-type: decimal; }
+        .tt-brain-md li { margin-bottom: 0.3em; }
+        .tt-brain-md code {
+          background: var(--tt-sunken); border: 1px solid var(--tt-border);
+          border-radius: 4px; padding: 0.1em 0.35em;
+          font-family: var(--font-mono); font-size: 0.92em;
+        }
+        .tt-brain-md pre {
+          background: var(--tt-sunken); border: 1px solid var(--tt-border);
+          border-radius: var(--tt-radius); padding: 0.75em 0.9em;
+          overflow-x: auto; margin: 0 0 1em; font-size: 11px; line-height: 1.55;
+        }
+        .tt-brain-md pre code { background: none; border: none; padding: 0; font-size: inherit; }
+        .tt-brain-md blockquote {
+          border-left: 3px solid var(--tt-border-strong); padding-left: 0.9em;
+          margin: 0 0 0.8em; color: var(--tt-fg-dim); font-style: italic;
+        }
+        .tt-brain-md table { border-collapse: collapse; font-size: 11.5px; margin: 0 0 1em; display: block; overflow-x: auto; }
+        .tt-brain-md th, .tt-brain-md td { border: 1px solid var(--tt-border); padding: 0.35em 0.6em; text-align: left; }
+        .tt-brain-md th { background: var(--tt-sunken); color: var(--tt-fg); font-weight: 600; }
+        .tt-brain-md a { color: var(--tt-brand); text-decoration: none; }
+        .tt-brain-md a:hover { text-decoration: underline; }
+        .tt-brain-md hr { border: none; border-top: 1px solid var(--tt-border); margin: 1.2em 0; }
       `}</style>
       <div
         className="tt-brain-anim absolute inset-0 bg-black/55 backdrop-blur-[2px] animate-[tt-brain-fade-in_120ms_ease-out]"
@@ -173,8 +213,8 @@ export default function PageDrawer({ project, pageId, types, dark, onClose, onNa
 
               {/* markdown body */}
               <div className="pt-2 border-t border-[var(--tt-border)]">
-                <div className="prose prose-sm max-w-none">
-                  <ReactMarkdown remarkPlugins={[remarkGfm]}>{detail.body}</ReactMarkdown>
+                <div className="tt-brain-md max-w-none">
+                  <ReactMarkdown remarkPlugins={[remarkGfm]}>{stripDupTitle(detail.body, detail.title)}</ReactMarkdown>
                 </div>
               </div>
 
@@ -207,6 +247,15 @@ export default function PageDrawer({ project, pageId, types, dark, onClose, onNa
       </aside>
     </div>
   );
+}
+
+/** Drop a leading `# Heading` that just repeats the drawer's own title. */
+function stripDupTitle(body: string, title: string): string {
+  const m = body.match(/^\s*#\s+(.+?)\s*\n+/);
+  if (m && m[1].trim().toLowerCase() === title.trim().toLowerCase()) {
+    return body.slice((m.index ?? 0) + m[0].length);
+  }
+  return body;
 }
 
 function MetaRow({ label, children }: { label: string; children: React.ReactNode }) {

--- a/frontend/src/app/projects/[path]/brain/_components/palette.ts
+++ b/frontend/src/app/projects/[path]/brain/_components/palette.ts
@@ -1,0 +1,46 @@
+/* Node colors follow the page TYPE (identity encoding). The seven known OKF
+ * types take the dataviz reference categorical palette slots 1-7 in fixed
+ * order; the first unknown type (alphabetically) takes slot 8; any further
+ * unknown types fold into neutral gray rather than cycling hues. Both light
+ * and dark steps were validated (lightness band, chroma, CVD separation,
+ * contrast) against the app surfaces #fbfbfd / #11141a. */
+
+export interface TypeSlot {
+  light: string;
+  dark: string;
+}
+
+const SLOTS: TypeSlot[] = [
+  { light: "#2a78d6", dark: "#3987e5" }, // 1 blue
+  { light: "#1baf7a", dark: "#199e70" }, // 2 aqua
+  { light: "#eda100", dark: "#c98500" }, // 3 yellow
+  { light: "#008300", dark: "#008300" }, // 4 green
+  { light: "#4a3aa7", dark: "#9085e9" }, // 5 violet
+  { light: "#e34948", dark: "#e66767" }, // 6 red
+  { light: "#e87ba4", dark: "#d55181" }, // 7 magenta
+  { light: "#eb6834", dark: "#d95926" }, // 8 orange
+];
+
+export const GRAY: TypeSlot = { light: "#64748b", dark: "#64748b" };
+
+const KNOWN_ORDER = [
+  "overview", "subsystem", "feature", "decision", "convention", "playbook", "analysis",
+];
+
+/** Fixed type->slot assignment for a wiki's observed types. */
+export function buildTypePalette(types: string[]): Map<string, TypeSlot> {
+  const map = new Map<string, TypeSlot>();
+  for (let i = 0; i < KNOWN_ORDER.length; i++) map.set(KNOWN_ORDER[i], SLOTS[i]);
+  const unknown = types
+    .map((t) => t.toLowerCase())
+    .filter((t) => t && t !== "untyped" && !map.has(t))
+    .sort();
+  if (unknown.length > 0) map.set(unknown[0], SLOTS[7]);
+  for (const t of unknown.slice(1)) map.set(t, GRAY);
+  return map;
+}
+
+export function typeSlot(palette: Map<string, TypeSlot>, type: string | null): TypeSlot {
+  if (!type) return GRAY;
+  return palette.get(type.toLowerCase()) ?? GRAY;
+}

--- a/frontend/src/app/projects/[path]/brain/_components/palette.ts
+++ b/frontend/src/app/projects/[path]/brain/_components/palette.ts
@@ -31,6 +31,7 @@ const KNOWN_ORDER = [
 export function buildTypePalette(types: string[]): Map<string, TypeSlot> {
   const map = new Map<string, TypeSlot>();
   for (let i = 0; i < KNOWN_ORDER.length; i++) map.set(KNOWN_ORDER[i], SLOTS[i]);
+  map.set("index", SLOTS[0]); // hub node: same hue as Overview, never a new slot
   const unknown = types
     .map((t) => t.toLowerCase())
     .filter((t) => t && t !== "untyped" && !map.has(t))

--- a/frontend/src/app/projects/[path]/brain/_components/types.ts
+++ b/frontend/src/app/projects/[path]/brain/_components/types.ts
@@ -1,0 +1,72 @@
+export interface BrainSummary {
+  exists: boolean;
+  kind: "plugin_wiki" | "okf_ish" | "obsidian_vault" | "markdown_wiki" | null;
+  source: "default" | "registered" | "none";
+  project_valid?: boolean;
+  wiki_path?: string;
+  page_count?: number;
+  status?: "compiling" | "complete" | null;
+  profile?: string | null;
+  batches_done?: number | null;
+  batches_total?: number | null;
+  updated?: string | null;
+  compiled_from_sha?: string | null;
+}
+
+export interface GraphNode {
+  id: string;
+  title: string;
+  type: string | null;
+  description: string | null;
+  tags: string[];
+  timestamp: string | null;
+  resource: string | null;
+  dir: string;
+  degree: number;
+  cluster: number;
+}
+
+export interface GraphEdge {
+  source: string;
+  target: string;
+}
+
+export interface GraphCluster {
+  id: number;
+  label: string;
+  size: number;
+}
+
+export interface BrainGraphData {
+  summary: BrainSummary;
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  clusters: GraphCluster[];
+  types: Record<string, number>;
+}
+
+export interface PageLink {
+  id: string;
+  title: string;
+}
+
+export interface PageDetail {
+  id: string;
+  title: string;
+  type: string | null;
+  description: string | null;
+  tags: string[];
+  timestamp: string | null;
+  resource: string | null;
+  status: string | null;
+  body: string;
+  outbound: PageLink[];
+  inbound: PageLink[];
+  staleness: { status: "fresh" | "stale" | "unknown"; reason?: string; diffstat?: string };
+}
+
+export interface WikiCandidate {
+  path: string;
+  kind: string;
+  page_count: number;
+}

--- a/frontend/src/app/projects/[path]/brain/_components/types.ts
+++ b/frontend/src/app/projects/[path]/brain/_components/types.ts
@@ -71,3 +71,17 @@ export interface WikiCandidate {
   kind: string;
   page_count: number;
 }
+
+export interface BrowseEntry {
+  name: string;
+  path: string;
+  hint: string | null;
+}
+
+export interface BrowseListing {
+  path: string;
+  parent: string | null;
+  hint: string | null;
+  dirs: BrowseEntry[];
+  truncated: boolean;
+}

--- a/frontend/src/app/projects/[path]/brain/_components/types.ts
+++ b/frontend/src/app/projects/[path]/brain/_components/types.ts
@@ -29,6 +29,7 @@ export interface GraphNode {
 export interface GraphEdge {
   source: string;
   target: string;
+  kind?: "link" | "index";
 }
 
 export interface GraphCluster {

--- a/frontend/src/app/projects/[path]/brain/page.tsx
+++ b/frontend/src/app/projects/[path]/brain/page.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { Brain, Loader2, RefreshCw, TriangleAlert, Unplug } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+
+import { apiFetch, useResource } from "@/lib/api";
+import { Badge, Card, EmptyState, Skeleton } from "@/components/ui";
+
+import { useProject } from "../_lib/project-context";
+import BrainGraph from "./_components/BrainGraph";
+import Onboarding from "./_components/Onboarding";
+import PageDrawer from "./_components/PageDrawer";
+import type { BrainGraphData } from "./_components/types";
+
+const KIND_LABEL: Record<string, string> = {
+  plugin_wiki: "plugin wiki",
+  okf_ish: "OKF wiki",
+  obsidian_vault: "Obsidian vault",
+  markdown_wiki: "markdown wiki",
+};
+
+function useDarkTheme() {
+  const [dark, setDark] = useState(true);
+  useEffect(() => {
+    const el = document.documentElement;
+    const read = () => setDark(el.getAttribute("data-theme") !== "light");
+    read();
+    const obs = new MutationObserver(read);
+    obs.observe(el, { attributes: true, attributeFilter: ["data-theme"] });
+    return () => obs.disconnect();
+  }, []);
+  return dark;
+}
+
+export default function BrainTab() {
+  const { decodedPath } = useProject();
+  const dark = useDarkTheme();
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [drawerId, setDrawerId] = useState<string | null>(null);
+
+  const q = `project=${encodeURIComponent(decodedPath)}`;
+  const { data, loading, refetch } = useResource<BrainGraphData>(
+    decodedPath ? `/brain/graph?${q}` : null,
+    { initial: undefined },
+  );
+
+  const onSelect = useCallback((id: string | null) => {
+    setSelectedId(id);
+    setDrawerId(id);
+  }, []);
+
+  const onNavigate = useCallback((id: string) => {
+    setSelectedId(id);
+    setDrawerId(id);
+  }, []);
+
+  const unregister = useCallback(async () => {
+    await apiFetch("/brain/unregister", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ project: decodedPath }),
+    }).catch(() => null);
+    refetch();
+  }, [decodedPath, refetch]);
+
+  if (loading && !data) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-[560px] w-full" />
+      </div>
+    );
+  }
+
+  const summary = data?.summary;
+  if (!summary || !summary.exists) {
+    if (summary && summary.project_valid === false) {
+      return (
+        <Card>
+          <EmptyState
+            icon={<TriangleAlert size={20} />}
+            title="Project folder not reachable"
+            description="This project path no longer exists on disk (or sits outside the allowed roots), so its wiki cannot be read."
+          />
+        </Card>
+      );
+    }
+    return <Onboarding project={decodedPath} onImported={refetch} />;
+  }
+
+  const compiling = summary.status === "compiling";
+  const types = data ? Object.keys(data.types) : [];
+
+  return (
+    <div className="space-y-3">
+      {/* status strip */}
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="flex items-center gap-2 text-[13px] font-semibold text-[var(--tt-fg)]">
+          <Brain size={15} className="text-[var(--tt-brand)]" />
+          Second brain
+        </div>
+        <Badge variant="outline" size="xs">{KIND_LABEL[summary.kind ?? ""] ?? summary.kind}</Badge>
+        {summary.profile && <Badge variant="info" size="xs">{summary.profile}</Badge>}
+        {summary.status === "complete" && <Badge variant="success" size="xs">complete</Badge>}
+        {compiling && (
+          <Badge variant="warn" size="xs">
+            compiling {summary.batches_done ?? 0}/{summary.batches_total ?? "?"}
+          </Badge>
+        )}
+        {summary.compiled_from_sha && (
+          <span className="font-mono text-[10px] text-[var(--tt-fg-faint)]" title="Commit the wiki was compiled from">
+            @{summary.compiled_from_sha.slice(0, 7)}
+          </span>
+        )}
+        <span className="flex-1" />
+        {summary.source === "registered" && (
+          <button
+            onClick={unregister}
+            className="flex items-center gap-1.5 h-7 px-2.5 rounded-[var(--tt-radius-sm)] border border-[var(--tt-border)] text-[11px] text-[var(--tt-fg-dim)] hover:text-[var(--tt-fg)] hover:border-[var(--tt-border-strong)] transition-colors"
+            title={`Imported from ${summary.wiki_path}. Click to un-import (removes the pointer only).`}
+          >
+            <Unplug size={12} />
+            imported · un-import
+          </button>
+        )}
+        <button
+          onClick={refetch}
+          className="flex items-center gap-1.5 h-7 px-2.5 rounded-[var(--tt-radius-sm)] border border-[var(--tt-border)] text-[11px] text-[var(--tt-fg-dim)] hover:text-[var(--tt-fg)] hover:border-[var(--tt-border-strong)] transition-colors"
+          title="Re-read the wiki from disk"
+        >
+          {loading ? <Loader2 size={12} className="animate-spin" /> : <RefreshCw size={12} />}
+          Refresh
+        </button>
+      </div>
+
+      {/* honest-status banners */}
+      {compiling && (
+        <div className="flex items-start gap-2 px-3.5 py-2.5 rounded-[var(--tt-radius)] border border-[var(--tt-warn-bd)] bg-[var(--tt-warn-bg)] text-[12px] text-[var(--tt-warn-fg)]">
+          <TriangleAlert size={14} className="shrink-0 mt-0.5" />
+          <span>
+            This wiki is partially compiled ({summary.batches_done ?? 0} of {summary.batches_total ?? "?"} batches).
+            The graph shows what exists so far; rerun <code className="font-mono">/brain-compile</code> in the project to finish.
+          </span>
+        </div>
+      )}
+      {(summary.kind === "obsidian_vault" || summary.kind === "markdown_wiki") && (
+        <div className="flex items-start gap-2 px-3.5 py-2.5 rounded-[var(--tt-radius)] border border-[var(--tt-border)] bg-[var(--tt-panel)] text-[12px] text-[var(--tt-fg-dim)]">
+          <Brain size={14} className="shrink-0 mt-0.5 text-[var(--tt-brand)]" />
+          <span>
+            Rendered from a {KIND_LABEL[summary.kind]}: pages are untyped, so nodes are
+            uncolored and staleness is unavailable. Run <code className="font-mono">/brain adopt</code> to
+            formalize it into an OKF bundle.
+          </span>
+        </div>
+      )}
+
+      {/* the graph */}
+      {data && data.nodes.length > 0 ? (
+        <BrainGraph
+          nodes={data.nodes}
+          edges={data.edges}
+          clusters={data.clusters}
+          selectedId={selectedId}
+          onSelect={onSelect}
+          height={Math.max(560, typeof window !== "undefined" ? window.innerHeight - 420 : 640)}
+        />
+      ) : (
+        <Card>
+          <EmptyState
+            icon={<Brain size={20} />}
+            title="Wiki detected, but no concept pages yet"
+            description="The bundle exists but holds no pages to graph. Run /brain-compile in the project to build the first batch."
+          />
+        </Card>
+      )}
+
+      <p className="text-[10.5px] text-[var(--tt-fg-faint)]">
+        Hover a node to light up its neighborhood; click to open the page; drag nodes,
+        scroll to zoom, drag the canvas to pan. Clusters group pages by wiki section
+        (or by link communities for flat vaults).
+      </p>
+
+      <PageDrawer
+        project={decodedPath}
+        pageId={drawerId}
+        types={types}
+        dark={dark}
+        onClose={() => setDrawerId(null)}
+        onNavigate={onNavigate}
+      />
+    </div>
+  );
+}

--- a/frontend/src/app/projects/[path]/brain/page.tsx
+++ b/frontend/src/app/projects/[path]/brain/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { Brain, Loader2, RefreshCw, TriangleAlert, Unplug } from "lucide-react";
+import { Brain, Coins, Loader2, RefreshCw, TriangleAlert, Unplug } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 
 import { apiFetch, useResource } from "@/lib/api";
+import { formatCost, formatTokens } from "@/lib/format";
 import { Badge, Card, EmptyState, Skeleton } from "@/components/ui";
 
 import { useProject } from "../_lib/project-context";
@@ -18,6 +19,15 @@ const KIND_LABEL: Record<string, string> = {
   obsidian_vault: "Obsidian vault",
   markdown_wiki: "markdown wiki",
 };
+
+interface BuildCost {
+  available: boolean;
+  sessions: number;
+  tokens: number;
+  own_tokens: number;
+  delegated_tokens: number;
+  cost: number;
+}
 
 function useDarkTheme() {
   const [dark, setDark] = useState(true);
@@ -41,6 +51,12 @@ export default function BrainTab() {
   const q = `project=${encodeURIComponent(decodedPath)}`;
   const { data, loading, refetch } = useResource<BrainGraphData>(
     decodedPath ? `/brain/graph?${q}` : null,
+    { initial: undefined },
+  );
+  // Tokens spent on /brain-init + /brain-compile sessions in this project,
+  // from TT's own session scan (includes delegated subagent work).
+  const { data: buildCost } = useResource<BuildCost>(
+    decodedPath ? `/brain/build-cost?${q}` : null,
     { initial: undefined },
   );
 
@@ -110,6 +126,15 @@ export default function BrainTab() {
         {summary.compiled_from_sha && (
           <span className="font-mono text-[10px] text-[var(--tt-fg-faint)]" title="Commit the wiki was compiled from">
             @{summary.compiled_from_sha.slice(0, 7)}
+          </span>
+        )}
+        {buildCost?.available && buildCost.sessions > 0 && (
+          <span
+            className="inline-flex items-center gap-1 h-5 px-2 rounded-full border border-[var(--tt-border)] bg-[var(--tt-sunken)] text-[10.5px] text-[var(--tt-fg-dim)]"
+            title={`Tokens spent by /brain-init + /brain-compile sessions here: ${buildCost.own_tokens.toLocaleString()} in-session + ${buildCost.delegated_tokens.toLocaleString()} delegated to subagents across ${buildCost.sessions} session${buildCost.sessions === 1 ? "" : "s"} (${formatCost(buildCost.cost)})`}
+          >
+            <Coins size={10} className="text-[var(--tt-brand)]" />
+            built with {formatTokens(buildCost.tokens)} tok
           </span>
         )}
         <span className="flex-1" />

--- a/frontend/src/app/projects/[path]/layout.tsx
+++ b/frontend/src/app/projects/[path]/layout.tsx
@@ -5,7 +5,7 @@ import { useParams, usePathname } from "next/navigation";
 import { useMemo } from "react";
 import {
   ChevronRight, Folder, Activity, Sparkles, ClipboardList, Settings2,
-  Clock, Users, Zap, GitBranch, Wallet,
+  Clock, Users, Zap, GitBranch, Wallet, Brain,
 } from "lucide-react";
 
 import { useResource } from "@/lib/api";
@@ -16,10 +16,11 @@ import { type BudgetStatus, budgetTone } from "@/lib/budgets";
 import { ProjectProvider, type ProjectData, type SessionRow } from "./_lib/project-context";
 
 const TABS = [
-  { key: "activity", label: "Activity",  icon: Activity,      href: "activity"  },
-  { key: "insights", label: "Insights",  icon: Sparkles,      href: "insights"  },
-  { key: "plans",    label: "Plans",     icon: ClipboardList, href: "plans"     },
-  { key: "config",   label: "Config",    icon: Settings2,     href: "config"    },
+  { key: "activity", label: "Activity",     icon: Activity,      href: "activity" },
+  { key: "insights", label: "Insights",     icon: Sparkles,      href: "insights" },
+  { key: "plans",    label: "Plans",        icon: ClipboardList, href: "plans"    },
+  { key: "brain",    label: "Second Brain", icon: Brain,         href: "brain"    },
+  { key: "config",   label: "Config",       icon: Settings2,     href: "config"   },
 ];
 
 export default function ProjectShellLayout({ children }: { children: React.ReactNode }) {

--- a/frontend/src/app/projects/[path]/plans/page.tsx
+++ b/frontend/src/app/projects/[path]/plans/page.tsx
@@ -43,7 +43,9 @@ export default function PlansTab() {
             </span>
           </div>
 
-          <div className="p-6 prose prose-sm max-w-none">
+          {/* .tt-brain-md: shared compact markdown scale (globals.css), same
+            * treatment as the Second Brain page drawer. */}
+          <div className="p-6 tt-brain-md max-w-none">
             <ReactMarkdown remarkPlugins={[remarkGfm]}>{plan.content}</ReactMarkdown>
           </div>
 

--- a/frontend/src/lib/telemetry.ts
+++ b/frontend/src/lib/telemetry.ts
@@ -71,6 +71,7 @@ export function routeOf(pathname: string): string {
   if (p.startsWith("/analytics")) return "analytics";
   if (p.startsWith("/local-models")) return "local-models";
   if (p.startsWith("/sessions")) return "traces";
+  if (/^\/projects\/[^/]+\/brain$/.test(p)) return "brain";
   if (p.startsWith("/projects")) return p === "/projects" ? "projects" : "project-detail";
   if (p.startsWith("/hermes")) return "hermes";
   if (p.startsWith("/settings")) return "settings";


### PR DESCRIPTION
## What

A new **Second Brain** tab on the project page that renders the project's compiled wiki (`docs/wiki`, built by the tokentelemetry Claude Code plugin) as an Obsidian-style interactive graph, with an import path for brains built elsewhere.

## Graph view
- Force-directed layout (d3-force, the only new dependency) with **cluster hulls**: pages group by wiki section (subsystems/, features/, ...), or by link communities for flat vaults; each hull is a padded smoothed convex hull tinted by its dominant page type.
- Hover lights up a page's neighborhood and shows a description tooltip; everything else fades.
- Click opens a **page drawer**: type, tags, timestamps, rendered markdown, inbound/outbound link chips that navigate the graph, and a **freshness pill** (`git diff --stat <compiled_from_sha> -- <resource>`, honest "unknown" when there's no manifest).
- Drag nodes, pan, scroll-zoom (labels fade in with zoom), search, per-type legend toggles, orphan toggle, focus mode (selected node ± depth 1-2), force/display sliders, reset.
- Node colors: categorical palette validated for both themes (lightness band, chroma, CVD separation, contrast vs app surfaces); types beyond the 8th fold to gray rather than cycling hues; identity is never color-alone (labels + legend).

## States
- **No wiki** → onboarding: what the plugin does, copyable `/brain-init` → `/brain-compile` steps, and **Import an existing brain** (auto-detected candidates with honest tier labels, or a manual path). Import records a pointer in `~/.tokentelemetry/brains.json` only; the repo is never written. Un-import is one click.
- **Compiling** → amber partial-wiki banner (status contract: a half wiki is never presented as whole).
- **Obsidian/markdown vault** → renders (incl. `[[wikilinks]]`) with a banner suggesting `/brain adopt`.

## Backend
`backend/second_brain.py` + 6 read-only endpoints (`/brain`, `/brain/graph`, `/brain/page`, `/brain/candidates`, `/brain/register`, `/brain/unregister`), placed next to `/config` and reusing its safe-roots path validation. Graph parse is mtime+TTL cached. Clustering is deterministic (directory-based for OKF bundles, label propagation for flat vaults).

## Verification
- Node/edge counts cross-checked against `okf_lint.py --json` on two real wikis: this repo's 45-page wiki (45 nodes / 79 links / 8 clusters) and pcr-divergence's 11-page one (11 / 57).
- Import round-trip via API: register → summary flips to `source: registered` → graph renders → non-wiki path rejected 422 → unregister leaves `brains.json` empty.
- Clicked through in the browser (dark + light): hover highlight, drawer, link navigation, theme flip, onboarding with a detected candidate.
- `tsc --noEmit` clean, `npm run build` passes with the new route, backend module imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)