### PR TITLE
fix: compute cache_hit_pct from cumulative cache reads, not the per-session high-water mark

### DIFF
--- a/backend/history_store.py
+++ b/backend/history_store.py
@@ -36,7 +36,7 @@ from tt_paths import data_dir
 
 _log = logging.getLogger("tokentelemetry.history")
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 # Sub-dicts folded into ``ecosystem_json`` and expanded back out on read. These
 # are the keys the analytics aggregation + delegation views consume beyond the
@@ -82,6 +82,7 @@ def _migrate(con: sqlite3.Connection) -> None:
                 input           INTEGER DEFAULT 0,
                 output          INTEGER DEFAULT 0,
                 cached          INTEGER DEFAULT 0,
+                cache_reads     INTEGER DEFAULT 0,
                 total           INTEGER DEFAULT 0,
                 cost            REAL    DEFAULT 0.0,
                 tok_per_sec     REAL,
@@ -115,6 +116,20 @@ def _migrate(con: sqlite3.Connection) -> None:
             );
             """
         )
+        con.execute(f"PRAGMA user_version={SCHEMA_VERSION}")
+        con.commit()
+    if ver < 2:
+        # v2 adds `cache_reads`: the CUMULATIVE cache-read sum per session
+        # (Claude-style scanners' `_cached_sum`). Distinct from `cached`, which
+        # is the per-session high-water mark. The analytics cache-hit metric
+        # needs cumulative reads; without persisting it, sessions served from
+        # this store fall back to the HWM and understate the rate (issue #126).
+        # ALTER always appends the column; ``ver < 1`` fresh DBs already have it
+        # from CREATE TABLE, so tolerate the duplicate-column error.
+        try:
+            con.execute("ALTER TABLE sessions ADD COLUMN cache_reads INTEGER DEFAULT 0")
+        except sqlite3.OperationalError:
+            pass
         con.execute(f"PRAGMA user_version={SCHEMA_VERSION}")
         con.commit()
 
@@ -165,14 +180,20 @@ def upsert_sessions(rows: Sequence[Dict[str, Any]]) -> int:
             for r in valid:
                 tok = r.get("tokens") or {}
                 ts = _to_utc_iso(r.get("timestamp"))
+                # Cumulative cache reads for the hit-rate metric. Prefer the
+                # scanner's `_cached_sum` (Claude-style); fall back to the HWM
+                # `cached` for scanners that don't track a sum, so their stored
+                # value equals today's. Explicit membership, not `or`, so a
+                # legitimately-zero `_cached_sum` is never masked by `cached`.
+                cache_reads = tok["_cached_sum"] if "_cached_sum" in tok else tok.get("cached", 0)
                 con.execute(
                     """
                     INSERT INTO sessions (
                         agent, id, project, model, provider, endpoint, billing_mode,
-                        first_ts, last_ts, input, output, cached, total, cost,
+                        first_ts, last_ts, input, output, cached, cache_reads, total, cost,
                         tok_per_sec, ecosystem_json, first_seen_at, last_seen_at,
                         source_present
-                    ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,1)
+                    ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,1)
                     ON CONFLICT(agent, id) DO UPDATE SET
                         project=excluded.project,
                         model=excluded.model,
@@ -184,6 +205,7 @@ def upsert_sessions(rows: Sequence[Dict[str, Any]]) -> int:
                         input=excluded.input,
                         output=excluded.output,
                         cached=excluded.cached,
+                        cache_reads=excluded.cache_reads,
                         total=excluded.total,
                         cost=excluded.cost,
                         tok_per_sec=excluded.tok_per_sec,
@@ -196,7 +218,8 @@ def upsert_sessions(rows: Sequence[Dict[str, Any]]) -> int:
                         r.get("provider"), r.get("endpoint"), r.get("billing_mode"),
                         ts, ts,
                         int(tok.get("input", 0) or 0), int(tok.get("output", 0) or 0),
-                        int(tok.get("cached", 0) or 0), int(tok.get("total", 0) or 0),
+                        int(tok.get("cached", 0) or 0), int(cache_reads or 0),
+                        int(tok.get("total", 0) or 0),
                         float(r.get("cost", 0.0) or 0.0),
                         r.get("tok_per_sec"),
                         _ecosystem_blob(r), now, now,
@@ -242,6 +265,11 @@ def _rehydrate(r: sqlite3.Row) -> Dict[str, Any]:
         ts = datetime.fromisoformat(r["last_ts"]) if r["last_ts"] else datetime.now(timezone.utc)
     except (ValueError, TypeError):
         ts = datetime.now(timezone.utc)
+    # Cumulative cache reads (v2+). Rows persisted before v2 (or pruned before
+    # this ran) have 0 here; fall back to the HWM `cached` so the analytics
+    # cache-hit metric degrades to the old behavior for them rather than reading
+    # a spurious 0. Freshly-scanned sessions carry the real sum.
+    cache_reads = (r["cache_reads"] if "cache_reads" in r.keys() else 0) or r["cached"]
     out: Dict[str, Any] = {
         "id": r["id"],
         "agent": r["agent"],
@@ -254,6 +282,7 @@ def _rehydrate(r: sqlite3.Row) -> Dict[str, Any]:
         "tokens": {
             "input": r["input"], "output": r["output"],
             "cached": r["cached"], "total": r["total"],
+            "_cached_sum": cache_reads,
         },
         "cost": r["cost"],
         "tok_per_sec": r["tok_per_sec"],

--- a/backend/main.py
+++ b/backend/main.py
@@ -6002,7 +6002,13 @@ async def put_budgets(payload: Any = Body(...)):
 
 
 def _cache_hit_pct(input_tokens: int, cached_tokens: int) -> Optional[float]:
-    """Return cache hit ratio as 0-100, matching the Hermes overlay's scale."""
+    """Return cache hit ratio as 0-100, matching the Hermes overlay's scale.
+
+    `cached_tokens` must be the CUMULATIVE cache-read sum across turns
+    (`_cached_sum` for Claude-style scanners), never the per-session
+    high-water-mark `cached` field — HWM/(cumulative input) understates the
+    rate more the longer the session runs.
+    """
     denom = input_tokens + cached_tokens
     if denom <= 0:
         return None
@@ -6102,7 +6108,7 @@ async def get_analytics(
     for s in sessions:
         agent = s["agent"]
         if agent not in by_agent:
-            by_agent[agent] = {"input": 0, "output": 0, "cached": 0, "total": 0, "cost": 0.0,
+            by_agent[agent] = {"input": 0, "output": 0, "cached": 0, "cache_reads": 0, "total": 0, "cost": 0.0,
                                "energy_wh": 0.0, "savings_usd": 0.0, "co2_g": 0.0, "session_count": 0}
         st = s.get("tokens", {})
         scost = s.get("cost", 0.0)
@@ -6118,6 +6124,12 @@ async def get_analytics(
             savings = savings_vs_cloud(scost, cloud_cost)
             co2 = co2_for_session(st.get("output", 0), config=pc, tok_per_sec=tps)
         for k in ["input", "output", "cached", "total"]: by_agent[agent][k] += st.get(k, 0)
+        # Cumulative cache reads for the hit-rate metric. Claude-style scanners
+        # keep `cached` as a per-session high-water mark (unique prefix size) and
+        # the per-turn read sum in `_cached_sum`; mixing the HWM with cumulative
+        # `input` badly understates the hit rate on long sessions. Agents without
+        # `_cached_sum` fall back to `cached` (prior behavior).
+        by_agent[agent]["cache_reads"] += st.get("_cached_sum") or st.get("cached", 0) or 0
         by_agent[agent]["cost"] += scost
         by_agent[agent]["energy_wh"] += energy
         by_agent[agent]["savings_usd"] += savings
@@ -6145,7 +6157,7 @@ async def get_analytics(
         by_day[day]["savings_usd"] += savings
         by_day[day]["co2_g"] += co2
     for agent, row in by_agent.items():
-        row["cache_hit_pct"] = _cache_hit_pct(row["input"], row["cached"])
+        row["cache_hit_pct"] = _cache_hit_pct(row["input"], row["cache_reads"])
         # agg = quality_by_agent.get(agent)
         # if agg:
         #     row["quality"] = _quality_summary(agg["edit_turns"], agg["retry_turns"], agg["measured_sessions"])
@@ -6155,6 +6167,7 @@ async def get_analytics(
     total_input = sum(a["input"] for a in by_agent.values())
     total_output = sum(a["output"] for a in by_agent.values())
     total_cached = sum(a["cached"] for a in by_agent.values())
+    total_cache_reads = sum(a["cache_reads"] for a in by_agent.values())
 
     # Ecosystem usage: skills, MCP servers, subagent types. New keys only — the
     # existing by_agent/by_day/by_model/total stay byte-identical (no silent
@@ -6278,7 +6291,7 @@ async def get_analytics(
             "energy_wh": sum(a["energy_wh"] for a in by_agent.values()),
             "savings_usd": sum(a["savings_usd"] for a in by_agent.values()),
             "co2_g": sum(a["co2_g"] for a in by_agent.values()),
-            "cache_hit_pct": _cache_hit_pct(total_input, total_cached),
+            "cache_hit_pct": _cache_hit_pct(total_input, total_cache_reads),
         },
         "coverage": history_store.coverage(),
         "granularity": granularity,


### PR DESCRIPTION
Fixes #126.

## What

`/analytics` fed the per-session **high-water-mark** `cached` field (unique cached-prefix size) into `_cache_hit_pct()` alongside **cumulative** input, so the reported hit rate shrank as sessions grew longer. On a real Claude Code corpus this displayed ~70% for models whose true hit rate is ~99.9% (verified by recomputing from the session JSONLs directly — see the issue for numbers).

## How

- `by_agent` aggregation gains a `cache_reads` field: prefers the scanner's cumulative `_cached_sum`, falls back to `cached` — so agents whose scanners don't track `_cached_sum` (codex, gemini, antigravity, …) produce byte-identical output to today.
- Per-agent and overall `cache_hit_pct` now compute from `cache_reads`.
- `cached`, `total`, and all cost math are untouched — the HWM semantics stay load-bearing for footprint totals and pricing.
- `_cache_hit_pct()` docstring now states the cumulative-reads contract.

## Verification

Before/after on my live data (421 sessions): claude 69–76% → **99.9%**, overall → **99.7%**; codex/gemini/antigravity unchanged (91.9 / 28.2 / 45.0). The claude figure matches an independent recompute summing `cache_read_input_tokens` / `input_tokens` straight from the JSONL transcripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)