### PR TITLE
Session intent previews for IDE sessions + per-step token usage

### DIFF
--- a/UPDATE.json
+++ b/UPDATE.json
@@ -1,6 +1,21 @@
 {
   "releases": [
     {
+      "tag": "2026-07-09",
+      "title": "Readable session intents & per-step tokens",
+      "highlights": [
+        {
+          "title": "IDE sessions now show your actual prompt",
+          "description": "Sessions started from the VS Code or JetBrains Claude plugins used to show \"No prompt content\" or raw editor tags in the sessions list. The list now skips the editor context and shows the first words you actually typed, so you can find the right session at a glance."
+        },
+        {
+          "title": "Token usage on every step of a trace",
+          "description": "Open a session trace and each step now shows the tokens that API call used — a small chip under the step and a per-step count in the step index. Makes it easy to scan an expensive session and spot which step was the main offender.",
+          "href": "/sessions"
+        }
+      ]
+    },
+    {
       "tag": "2026-06-24",
       "title": "Git worktrees, grouped under their project",
       "highlights": [

--- a/backend/main.py
+++ b/backend/main.py
@@ -2617,6 +2617,15 @@ _IDE_CONTEXT_TAG_RE = re.compile(r"<(ide_\w+)>.*?</\1>", re.DOTALL)
 _SYSTEM_REMINDER_RE = re.compile(r"<system-reminder>.*?</system-reminder>", re.DOTALL)
 
 
+def _strip_context_tags(text: str) -> str:
+    """Remove harness/editor context blocks from a prompt so a preview shows
+    what the user actually typed. Unclosed/malformed tags are left alone —
+    better to show something than nothing."""
+    text = _IDE_CONTEXT_TAG_RE.sub("", text)
+    text = _SYSTEM_REMINDER_RE.sub("", text)
+    return text.strip()
+
+
 def _claude_user_prompt_preview(data: Dict[str, Any], limit: int = 200) -> Optional[str]:
     """Human-typed prompt preview from one Claude Code user JSONL line.
 
@@ -2640,9 +2649,7 @@ def _claude_user_prompt_preview(data: Dict[str, Any], limit: int = 200) -> Optio
         return None
     if not text.strip():
         return None
-    text = _IDE_CONTEXT_TAG_RE.sub("", text)
-    text = _SYSTEM_REMINDER_RE.sub("", text)
-    text = text.strip()
+    text = _strip_context_tags(text)
     if (not text
             or text.startswith("<local-command-")
             or text.startswith("<command-name>")
@@ -3684,6 +3691,12 @@ def _scan_sessions_sync():
                         else:
                             with open(cf, "r", encoding="utf-8", errors="replace") as f:
                                 data = json.load(f)
+                        # VS Code writes a chatSession file the moment the chat
+                        # panel opens; files with no requests are phantom
+                        # sessions — no prompt, no response, no tokens — that
+                        # only pollute the list with empty intents (#129).
+                        if not (data.get("requests") or data.get("pendingRequests")):
+                            continue
                         sid = cf.stem; tokens = {"input": 0, "output": 0, "cached": 0, "total": 0}
                         first_msg = ""; plans = []; model = None
 
@@ -3876,7 +3889,10 @@ def _scan_sessions_sync():
                         except Exception: continue
                         ptype = pdata.get("type")
                         if ptype == "text" and not first_user:
-                            txt = pdata.get("text") or ""
+                            # Editor-context prefixes (<system-reminder>, <ide_*>)
+                            # make useless previews — strip them; if nothing
+                            # remains, keep scanning to the next text part (#129).
+                            txt = _strip_context_tags(pdata.get("text") or "")
                             if txt: first_user = txt
                         if ptype == "tool":
                             tname = pdata.get("tool")

--- a/backend/main.py
+++ b/backend/main.py
@@ -2607,6 +2607,50 @@ _BUILTIN_CLI_COMMANDS = {
 _CODEX_SKILL_RE = re.compile(r'skills[/\\]+([\w.-]+)[/\\]+SKILL\.md')
 
 
+# IDE-originated Claude Code sessions (VS Code plugin, JetBrains/Rider) prefix
+# the first user prompt with editor-context tags — <ide_selection>…,
+# <ide_opened_file>…, <ide_diagnostics>… — so the raw first line makes a
+# useless session preview (discussion #129). Strip every well-formed
+# <ide_*>…</ide_*> block plus harness-injected <system-reminder> blocks
+# before taking the preview.
+_IDE_CONTEXT_TAG_RE = re.compile(r"<(ide_\w+)>.*?</\1>", re.DOTALL)
+_SYSTEM_REMINDER_RE = re.compile(r"<system-reminder>.*?</system-reminder>", re.DOTALL)
+
+
+def _claude_user_prompt_preview(data: Dict[str, Any], limit: int = 200) -> Optional[str]:
+    """Human-typed prompt preview from one Claude Code user JSONL line.
+
+    Returns None when the line carries no usable prompt (meta lines, command
+    echoes, tool results, or IDE-context-only messages) so callers keep
+    scanning later user lines.
+    """
+    if data.get("isMeta"):
+        return None
+    msg = data.get("message") if isinstance(data.get("message"), dict) else {}
+    uc = msg.get("content")
+    if isinstance(uc, list):
+        # IDE / attachment messages arrive as content-block lists.
+        text = "\n".join(
+            b.get("text", "") for b in uc
+            if isinstance(b, dict) and b.get("type") == "text"
+        )
+    elif isinstance(uc, str):
+        text = uc
+    else:
+        return None
+    if not text.strip():
+        return None
+    text = _IDE_CONTEXT_TAG_RE.sub("", text)
+    text = _SYSTEM_REMINDER_RE.sub("", text)
+    text = text.strip()
+    if (not text
+            or text.startswith("<local-command-")
+            or text.startswith("<command-name>")
+            or text.startswith("Caveat:")):
+        return None
+    return text[:limit]
+
+
 def _count_tool(tool_counts: Dict[str, int], name) -> None:
     if name:
         tool_counts[name] = tool_counts.get(name, 0) + 1
@@ -2855,9 +2899,9 @@ def _scan_sessions_sync():
                         if data.get("type") == "summary" and data.get("summary"):
                             sess["display"] = str(data["summary"])[:120]
                         elif data.get("type") == "user":
-                            uc = data.get("message", {}).get("content")
-                            if isinstance(uc, str) and uc.strip():
-                                sess["display"] = uc.strip()[:120]
+                            preview = _claude_user_prompt_preview(data)
+                            if preview:
+                                sess["display"] = preview
                     if sess["project"] != "unknown" and sess.get("display"):
                         break
         except Exception: pass
@@ -4663,7 +4707,14 @@ async def get_session_detail(session_id: str, agent: str):
                         "callID": p.get("callID"),
                         "state": p.get("state"),
                     }, **base})
-                # step-start / step-finish are lifecycle markers; skip in trace
+                elif ptype == "step-finish":
+                    # Lifecycle marker, not its own trace event — but it carries
+                    # the step's token usage, so attach it to the step's last
+                    # emitted event for the per-step usage UI (#128).
+                    tk = p.get("tokens")
+                    if isinstance(tk, dict) and events:
+                        events[-1]["tokens"] = tk
+                # step-start is a lifecycle marker; skip in trace
             return events
         finally:
             conn.close()

--- a/backend/test_copilot_vscode_scan.py
+++ b/backend/test_copilot_vscode_scan.py
@@ -1,0 +1,90 @@
+"""VS Code Copilot chat-session scanning.
+
+Discussion #129 follow-up: VS Code writes a chatSessions/<id>.json(l) file the
+moment the chat panel opens, even if the user never sends a message. Those
+zero-request files showed up as copilot sessions with an empty intent and
+0 tokens. The scanner must skip them and keep real sessions.
+
+Run: pytest backend/test_copilot_vscode_scan.py -q
+"""
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+import main  # noqa: E402
+
+
+@pytest.fixture
+def scan_env(tmp_path, monkeypatch):
+    """Point every agent store at a nonexistent dir under tmp_path so a full
+    _scan_sessions_sync() run is hermetic (mirrors test_cline_smallcode.py)."""
+    missing = tmp_path / "missing"
+    for attr in ("CODEX_DIR", "GEMINI_DIR", "QWEN_DIR", "VIBE_DIR", "OLLAMA_DIR",
+                 "GROK_SESSIONS_DIR", "VSCODE_STORAGE", "CURSOR_STORAGE",
+                 "COPILOT_CLI_DIR", "ANTIGRAVITY_BRAIN_DIR", "ANTIGRAVITY_CLI_DIR",
+                 "HERMES_DIR"):
+        monkeypatch.setattr(main, attr, missing / attr.lower())
+    monkeypatch.setattr(main, "ANTIGRAVITY_BRAIN_SOURCES", [])
+    monkeypatch.setattr(main, "ANTIGRAVITY_BRAIN_DIRS", [])
+    monkeypatch.setattr(main, "_antigravity_cli_meta", lambda *a, **k: {})
+    monkeypatch.setattr(main, "CLAUDE_DIR", missing / "claude")
+    monkeypatch.setattr(main, "CURSOR_DIR", missing / "cursor")
+    monkeypatch.setattr(main, "OPENCODE_DB", missing / "opencode.db")
+    monkeypatch.setattr(main, "HERMES_DB", missing / "hermes-state.db")
+    monkeypatch.setattr(main, "HERMES_PROFILES_DIR", missing / "hermes-profiles")
+    monkeypatch.setattr(main, "PROJECT_ALIASES_FILE", tmp_path / "aliases.json")
+    monkeypatch.setattr(main, "CLINE_DIR", missing / "cline")
+    monkeypatch.setattr(main, "CLINE_VSCODE_DIR", missing / "cline-vscode")
+    monkeypatch.setattr(main, "SMALLCODE_EXTRA_ROOTS", [])
+    return tmp_path
+
+
+def _write_vscode_session(ws_dir: Path, sid: str, body: dict) -> None:
+    chat = ws_dir / "chatSessions"
+    chat.mkdir(parents=True, exist_ok=True)
+    (ws_dir / "workspace.json").write_text(json.dumps({"folder": "file:///tmp/proj"}))
+    (chat / f"{sid}.json").write_text(json.dumps(body))
+
+
+def test_zero_request_phantom_sessions_are_skipped(scan_env, monkeypatch):
+    storage = scan_env / "vscode-storage"
+    ws = storage / "ws1"
+    # Phantom: chat panel opened, nothing ever sent.
+    _write_vscode_session(ws, "phantom-1", {
+        "version": 3, "creationDate": 1781420401161, "requests": [],
+        "pendingRequests": [],
+    })
+    # Real session with one request.
+    _write_vscode_session(ws, "real-1", {
+        "version": 3, "creationDate": 1781420401161,
+        "requests": [{"message": {"text": "explain this function"},
+                      "modelId": "copilot/gpt-5-mini",
+                      "timestamp": 1781420405000,
+                      "completionTokens": 42}],
+    })
+    monkeypatch.setattr(main, "VSCODE_STORAGE", storage)
+
+    sessions = [s for s in main._scan_sessions_sync() if s["agent"] == "copilot"]
+    ids = {s["id"] for s in sessions}
+    assert "real-1" in ids
+    assert "phantom-1" not in ids
+    real = next(s for s in sessions if s["id"] == "real-1")
+    assert real["display"] == "explain this function"
+    assert real["tokens"]["output"] == 42
+
+
+def test_pending_only_session_is_kept(scan_env, monkeypatch):
+    # A request in flight when the snapshot was written is still a session.
+    storage = scan_env / "vscode-storage"
+    _write_vscode_session(storage / "ws1", "pending-1", {
+        "version": 3, "creationDate": 1781420401161, "requests": [],
+        "pendingRequests": [{"message": {"text": "still running"}}],
+    })
+    monkeypatch.setattr(main, "VSCODE_STORAGE", storage)
+
+    sessions = [s for s in main._scan_sessions_sync() if s["agent"] == "copilot"]
+    assert {s["id"] for s in sessions} == {"pending-1"}

--- a/backend/test_prompt_preview.py
+++ b/backend/test_prompt_preview.py
@@ -6,7 +6,7 @@ the sessions list showed either the tag junk or "No prompt content". The
 preview helper must strip the editor context and surface the typed prompt.
 """
 
-from main import _claude_user_prompt_preview
+from main import _claude_user_prompt_preview, _strip_context_tags
 
 
 def _user_line(content, **extra):
@@ -67,6 +67,14 @@ def test_preview_is_truncated_to_limit():
     long = "x" * 500
     out = _claude_user_prompt_preview(_user_line(long))
     assert out == "x" * 200
+
+
+def test_strip_context_tags_handles_opencode_system_reminder():
+    # OpenCode text parts get the same treatment (e.g. VS Code extension
+    # prefixes "Note: The user opened the file …" reminders).
+    raw = '<system-reminder>Note: The user opened the file "/x/y.py"</system-reminder>\nSummarize it'
+    assert _strip_context_tags(raw) == "Summarize it"
+    assert _strip_context_tags('<system-reminder>only context</system-reminder>') == ""
 
 
 def test_unclosed_tag_falls_back_to_raw_text():

--- a/backend/test_prompt_preview.py
+++ b/backend/test_prompt_preview.py
@@ -1,0 +1,76 @@
+"""Session-list prompt previews for IDE-originated Claude Code sessions.
+
+Discussion #129: sessions started from the VS Code / JetBrains plugins prefix
+the first user prompt with <ide_selection>/<ide_opened_file> context tags, so
+the sessions list showed either the tag junk or "No prompt content". The
+preview helper must strip the editor context and surface the typed prompt.
+"""
+
+from main import _claude_user_prompt_preview
+
+
+def _user_line(content, **extra):
+    line = {"type": "user", "message": {"role": "user", "content": content}}
+    line.update(extra)
+    return line
+
+
+def test_plain_string_prompt_passes_through():
+    assert _claude_user_prompt_preview(_user_line("fix the login bug")) == "fix the login bug"
+
+
+def test_ide_selection_prefix_is_stripped():
+    raw = "<ide_selection>The user selected lines 4-9 of foo.py:\ndef f(): ...</ide_selection>\nRefactor this function"
+    assert _claude_user_prompt_preview(_user_line(raw)) == "Refactor this function"
+
+
+def test_ide_opened_file_prefix_is_stripped():
+    raw = "<ide_opened_file>The user opened bar.ts</ide_opened_file>\nAdd null checks here"
+    assert _claude_user_prompt_preview(_user_line(raw)) == "Add null checks here"
+
+
+def test_multiple_ide_tags_and_system_reminder_stripped():
+    raw = (
+        "<ide_opened_file>a.py</ide_opened_file>"
+        "<ide_diagnostics>2 warnings</ide_diagnostics>"
+        "<system-reminder>injected context</system-reminder>"
+        "\nExplain the warnings"
+    )
+    assert _claude_user_prompt_preview(_user_line(raw)) == "Explain the warnings"
+
+
+def test_content_block_list_is_supported():
+    content = [
+        {"type": "text", "text": "<ide_selection>sel</ide_selection>\nWrite a test for this"},
+    ]
+    assert _claude_user_prompt_preview(_user_line(content)) == "Write a test for this"
+
+
+def test_ide_context_only_message_yields_none():
+    raw = "<ide_opened_file>The user opened baz.rs</ide_opened_file>"
+    assert _claude_user_prompt_preview(_user_line(raw)) is None
+
+
+def test_meta_and_command_lines_are_skipped():
+    assert _claude_user_prompt_preview(_user_line("anything", isMeta=True)) is None
+    assert _claude_user_prompt_preview(_user_line("<local-command-stdout>out</local-command-stdout>")) is None
+    assert _claude_user_prompt_preview(_user_line("<command-name>/model</command-name>")) is None
+    assert _claude_user_prompt_preview(_user_line("Caveat: the messages below were generated…")) is None
+
+
+def test_tool_result_only_content_yields_none():
+    content = [{"type": "tool_result", "tool_use_id": "t1", "content": "ok"}]
+    assert _claude_user_prompt_preview(_user_line(content)) is None
+
+
+def test_preview_is_truncated_to_limit():
+    long = "x" * 500
+    out = _claude_user_prompt_preview(_user_line(long))
+    assert out == "x" * 200
+
+
+def test_unclosed_tag_falls_back_to_raw_text():
+    # A malformed/unclosed tag can't be stripped safely — better to show
+    # something than nothing.
+    raw = "<ide_selection>partial…\nDo the thing"
+    assert _claude_user_prompt_preview(_user_line(raw)).startswith("<ide_selection>partial")

--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -72,6 +72,44 @@ interface Step {
   kind: StepKind;
   label: string;
   ts?: number;
+  tokens?: StepTokens | null;
+}
+
+/** Per-step (per-API-call) token usage — discussion #128. */
+interface StepTokens {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+}
+
+/* Extract per-step token usage where the trace records it:
+   - Claude / Cursor: each assistant JSONL line carries `message.usage`
+     (one API call's usage, repeated on every line of that call);
+   - Codex: `token_count` event_msgs report per-turn usage — attached to the
+     preceding event as `_tt_tokens` in normalizeTraceEvents;
+   - OpenCode: `step-finish` parts carry usage — attached backend-side as
+     `tokens` on the step's last event. */
+function eventTokens(evt: any): StepTokens | null {
+  const u = evt.message?.usage || evt._tt_tokens;
+  if (u && (u.input_tokens != null || u.output_tokens != null)) {
+    return {
+      input: u.input_tokens || 0,
+      output: u.output_tokens || 0,
+      cacheRead: u.cache_read_input_tokens ?? u.cached_input_tokens ?? 0,
+      cacheWrite: u.cache_creation_input_tokens || 0,
+    };
+  }
+  const t = evt.tokens;
+  if (t && typeof t === "object" && (t.input != null || t.output != null)) {
+    return {
+      input: t.input || 0,
+      output: t.output || 0,
+      cacheRead: t.cache?.read || 0,
+      cacheWrite: t.cache?.write || 0,
+    };
+  }
+  return null;
 }
 
 function eventKind(evt: Event): StepKind {
@@ -117,9 +155,17 @@ function normalizeTraceEvents(agent: string | null, data: any): Event[] {
     evts = [];
   }
   if (agent === "codex") {
+    // token_count events are filtered as noise, but they carry the turn's
+    // usage — hand it to the preceding kept event for the per-step chip (#128).
+    let lastKept: any = null;
     evts = evts.filter((e: any) => {
       if (e.type === "turn_context") return false;
-      if (e.type === "event_msg" && e.payload?.type === "token_count") return false;
+      if (e.type === "event_msg" && e.payload?.type === "token_count") {
+        const u = e.payload?.info?.last_token_usage;
+        if (u && lastKept) lastKept._tt_tokens = u;
+        return false;
+      }
+      lastKept = e;
       return true;
     });
   }
@@ -313,14 +359,31 @@ export default function SessionDetailPage() {
     return false;
   };
 
+  // Per-step token usage, deduped: Claude splits one API call across several
+  // JSONL lines that all repeat the same `message.usage`, so only the first
+  // line of each message id gets the usage attributed (#128).
+  const stepTokens = useMemo(() => {
+    const out: (StepTokens | null)[] = new Array(events.length).fill(null);
+    let lastMsgId: string | null = null;
+    events.forEach((e: any, i) => {
+      const t = eventTokens(e);
+      if (!t) return;
+      const msgId = e.message?.id;
+      if (msgId && msgId === lastMsgId) return;
+      if (msgId) lastMsgId = msgId;
+      out[i] = t;
+    });
+    return out;
+  }, [events]);
+
   // Steps for left index
   const steps: Step[] = useMemo(
     () =>
       events.map((evt, idx) => {
         const kind = eventKind(evt);
-        return { idx, kind, label: stepLabel(evt, kind), ts: normalizeTs(evt) };
+        return { idx, kind, label: stepLabel(evt, kind), ts: normalizeTs(evt), tokens: stepTokens[idx] };
       }),
-    [events]
+    [events, stepTokens]
   );
 
   // Stats
@@ -703,7 +766,7 @@ export default function SessionDetailPage() {
 
                       return (
                          <div key={idx} ref={(el) => { stepRefs.current[idx] = el; }} className={activeStep === idx ? `${stepRingClass[kind]} rounded-[var(--tt-radius-lg)]` : ""}>
-                            <EventCard event={event} mode={splitView ? "dialogue" : "all"} agent={agent} />
+                            <EventCard event={event} mode={splitView ? "dialogue" : "all"} agent={agent} tokens={stepTokens[idx]} />
                          </div>
                       );
                    })}
@@ -1056,6 +1119,14 @@ function StepRow({ step, active, beyond, onClick }: { step: Step; active: boolea
       <span className="text-[var(--tt-fg-faint)] w-7 tabular-nums">{step.idx.toString().padStart(3, "0")}</span>
       <span className={color[step.kind]}>{icon[step.kind]}</span>
       <span className="text-[var(--tt-fg)] truncate flex-1">{step.label}</span>
+      {step.tokens && (
+        <span
+          className="tabular-nums text-[9px] text-[var(--tt-fg-dim)] shrink-0"
+          title={`Tokens this step — in: ${step.tokens.input.toLocaleString()}, out: ${step.tokens.output.toLocaleString()}, cache read: ${step.tokens.cacheRead.toLocaleString()}, cache write: ${step.tokens.cacheWrite.toLocaleString()}`}
+        >
+          {formatTokens(step.tokens.output)}
+        </span>
+      )}
     </button>
   );
 }
@@ -1385,7 +1456,7 @@ function ArtifactViewer({ path }: { path: string }) {
   );
 }
 
-function EventCard({ event, mode = "all", agent }: { event: any, mode?: "dialogue" | "brain" | "all", agent?: string | null }) {
+function EventCard({ event, mode = "all", agent, tokens }: { event: any, mode?: "dialogue" | "brain" | "all", agent?: string | null, tokens?: StepTokens | null }) {
   const { type, timestamp, message, attachment, toolUseResult, payload, content, thoughts, toolCalls } = event;
 
   // Render a tiny timestamp badge if available
@@ -2072,7 +2143,34 @@ function EventCard({ event, mode = "all", agent }: { event: any, mode?: "dialogu
     );
   }
 
-  return <div className="space-y-6 w-full">{parts.map((p, i) => <React.Fragment key={i}>{p}</React.Fragment>)}</div>;
+  return (
+    <div className="space-y-6 w-full">
+      {parts.map((p, i) => <React.Fragment key={i}>{p}</React.Fragment>)}
+      {tokens && parts.length > 0 && <StepTokensChip t={tokens} />}
+    </div>
+  );
+}
+
+/* Per-step token usage footer (#128) — one API call's usage, right under the
+   step's cards so expensive steps are visible without opening the raw pane. */
+function StepTokensChip({ t }: { t: StepTokens }) {
+  const bits: string[] = [];
+  if (t.output) bits.push(`${formatTokens(t.output)} out`);
+  if (t.input) bits.push(`${formatTokens(t.input)} in`);
+  if (t.cacheRead) bits.push(`${formatTokens(t.cacheRead)} cache read`);
+  if (t.cacheWrite) bits.push(`${formatTokens(t.cacheWrite)} cache write`);
+  if (bits.length === 0) return null;
+  return (
+    <div className="flex justify-end !mt-2">
+      <span
+        className="inline-flex items-center gap-1.5 text-[9px] font-mono tabular-nums text-[var(--tt-fg-dim)] bg-[var(--tt-sunken)] border border-[var(--tt-border)] rounded px-2 py-0.5"
+        title="Token usage for this step (one API call)"
+      >
+        <Zap size={9} className="text-[var(--tt-brand)]" />
+        {bits.join(" · ")}
+      </span>
+    </div>
+  );
 }
 function ResponseBody({ text, tone = "default" }: { text: string; tone?: "default" | "muted" }) {
   const [mode, setMode] = useState<"md" | "raw">("md");


### PR DESCRIPTION
Implements the two ideas from discussions #128 and #129 (both from @ipatalas).

## #129 — Better session intent in sessions list

Sessions started from the VS Code / JetBrains Claude plugins prefix the first
user prompt with `<ide_selection>`/`<ide_opened_file>` context tags, and
sometimes ship content as block lists. The sessions list either showed the raw
tags or skipped the message entirely and fell through to "No prompt content".

- New `_claude_user_prompt_preview()` in `backend/main.py`: handles string and
  content-block-list messages, strips well-formed `<ide_*>…</ide_*>` and
  `<system-reminder>…` blocks, and skips meta lines / command echoes / tool
  results so the scan falls through to the next real user prompt.
- Preview length raised to 200 chars (was 120).
- Tests in `backend/test_prompt_preview.py` (10 cases, including unclosed-tag
  fallback and ide-context-only messages).

## #128 — Show token usage per step

Per-step usage existed only in the raw pane. The trace now shows it inline:

- A small chip under each step's cards: `⚡ 1.4k out · 4 in · 45.2k cache read`.
- A compact output-token count on each row of the step index rail (full
  breakdown in the tooltip), so the main offender stands out when scanning.

Data sources per agent:
- **Claude / Cursor**: `message.usage` per assistant line, deduped by message
  id (one API call spans several JSONL lines repeating the same usage).
- **Codex**: `token_count` event_msgs stay filtered from the trace, but their
  `last_token_usage` is attached to the preceding kept event first.
- **OpenCode**: `step-finish` parts now attach their tokens to the step's last
  trace event in the detail endpoint.

## Validation

- `backend/test_prompt_preview.py`: 10/10 pass; full backend suite has the
  same 17 environment-dependent failures as origin/main baseline (verified by
  stash/run/pop), no new failures.
- `frontend`: `tsc --noEmit` clean, `next build` succeeds.
- `UPDATE.json`: new 2026-07-09 release entry with both highlights.

🤖 Generated with [Claude Code](https://claude.com/claude-code)