### PR TITLE
fix(scan): remove 100-session cap, fix timestamp/cache correctness for Claude & Codex

### DIFF
--- a/UPDATE.json
+++ b/UPDATE.json
@@ -6,7 +6,7 @@
       "highlights": [
         {
           "title": "Full session history — not just the last 100",
-          "description": "Claude Code and Codex used to stop tracking real usage once you passed 100 sessions; anything older sat frozen as a blank, zero-token row. Every session is now fully scanned, with a local cache keeping repeat scans fast, so your full history — and its true token/cost totals — stays accurate no matter how many sessions you've run.",
+          "description": "Claude Code and Codex used to stop tracking real usage once you passed 100 sessions; anything older sat frozen as a blank, zero-token row. Every session is now fully scanned, with a local cache keeping repeat scans fast, so your full history — and its true token/cost totals — stays accurate no matter how many sessions you've run. Thanks to mariadb-KyleHutchinson for reporting and fixing this (PR #131).",
           "href": "/sessions"
         },
         {

--- a/UPDATE.json
+++ b/UPDATE.json
@@ -1,6 +1,22 @@
 {
   "releases": [
     {
+      "tag": "2026-07-09",
+      "title": "Every session tracked, correctly dated",
+      "highlights": [
+        {
+          "title": "Full session history — not just the last 100",
+          "description": "Claude Code and Codex used to stop tracking real usage once you passed 100 sessions; anything older sat frozen as a blank, zero-token row. Every session is now fully scanned, with a local cache keeping repeat scans fast, so your full history — and its true token/cost totals — stays accurate no matter how many sessions you've run.",
+          "href": "/sessions"
+        },
+        {
+          "title": "Reopening an old session no longer misdates it",
+          "description": "Opening an old Claude session (e.g. from VS Code's history sidebar) used to bump its reported date to today, scattering old work into the wrong day on Analytics and sometimes tripping a false \"recent activity\" alert. Sessions are now dated by when the conversation actually happened.",
+          "href": "/analytics"
+        }
+      ]
+    },
+    {
       "tag": "2026-06-24",
       "title": "Git worktrees, grouped under their project",
       "highlights": [

--- a/backend/history_store.py
+++ b/backend/history_store.py
@@ -186,32 +186,49 @@ def upsert_sessions(rows: Sequence[Dict[str, Any]]) -> int:
                 # value equals today's. Explicit membership, not `or`, so a
                 # legitimately-zero `_cached_sum` is never masked by `cached`.
                 cache_reads = tok["_cached_sum"] if "_cached_sum" in tok else tok.get("cached", 0)
-                con.execute(
+                # A stub row is a session we discovered on disk but did NOT fully
+                # parse this scan (e.g. its sidecar cache was cold and we chose
+                # not to reparse, or it's brand-new and unseen). Its zero-value
+                # rollup must never overwrite a previously-persisted real one, so
+                # its DO UPDATE SET touches only liveness columns. INSERT is
+                # identical to the real path, so a genuinely-new stub still lands
+                # as a zero-value row rather than being dropped.
+                if r.get("stub", False):
+                    conflict_clause = """
+                        ON CONFLICT(agent, id) DO UPDATE SET
+                            last_seen_at=excluded.last_seen_at,
+                            source_present=1
                     """
+                else:
+                    conflict_clause = """
+                        ON CONFLICT(agent, id) DO UPDATE SET
+                            project=excluded.project,
+                            model=excluded.model,
+                            provider=excluded.provider,
+                            endpoint=excluded.endpoint,
+                            billing_mode=excluded.billing_mode,
+                            first_ts=MIN(sessions.first_ts, excluded.first_ts),
+                            last_ts=MAX(sessions.last_ts, excluded.last_ts),
+                            input=excluded.input,
+                            output=excluded.output,
+                            cached=excluded.cached,
+                            cache_reads=excluded.cache_reads,
+                            total=excluded.total,
+                            cost=excluded.cost,
+                            tok_per_sec=excluded.tok_per_sec,
+                            ecosystem_json=excluded.ecosystem_json,
+                            last_seen_at=excluded.last_seen_at,
+                            source_present=1
+                    """
+                con.execute(
+                    f"""
                     INSERT INTO sessions (
                         agent, id, project, model, provider, endpoint, billing_mode,
                         first_ts, last_ts, input, output, cached, cache_reads, total, cost,
                         tok_per_sec, ecosystem_json, first_seen_at, last_seen_at,
                         source_present
                     ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,1)
-                    ON CONFLICT(agent, id) DO UPDATE SET
-                        project=excluded.project,
-                        model=excluded.model,
-                        provider=excluded.provider,
-                        endpoint=excluded.endpoint,
-                        billing_mode=excluded.billing_mode,
-                        first_ts=MIN(sessions.first_ts, excluded.first_ts),
-                        last_ts=MAX(sessions.last_ts, excluded.last_ts),
-                        input=excluded.input,
-                        output=excluded.output,
-                        cached=excluded.cached,
-                        cache_reads=excluded.cache_reads,
-                        total=excluded.total,
-                        cost=excluded.cost,
-                        tok_per_sec=excluded.tok_per_sec,
-                        ecosystem_json=excluded.ecosystem_json,
-                        last_seen_at=excluded.last_seen_at,
-                        source_present=1
+                    {conflict_clause}
                     """,
                     (
                         r.get("agent"), r.get("id"), r.get("project"), r.get("model"),

--- a/backend/main.py
+++ b/backend/main.py
@@ -2769,7 +2769,7 @@ def _claude_subagent_usage(session_file: Path, sid: str) -> Optional[Dict[str, A
 
 _CLAUDE_CACHE_FIELDS = (
     "tokens", "model", "cost", "mcp_tools", "has_plan", "plans",
-    "delegation", "delegated_cost",
+    "delegation", "delegated_cost", "tool_counts", "mcp_usage", "skills_used",
 )
 
 
@@ -2779,10 +2779,10 @@ def _claude_cache_payload(sess: Dict[str, Any]) -> Dict[str, Any]:
     `artifacts` (always recomputed fresh — `project` so project-alias edits
     apply retroactively, `artifacts` so Claude Project Memory files added or
     removed after the last full parse are still reflected) and `id`/`agent`
-    (known from the cache key already)."""
-    payload = {k: sess.get(k) for k in _CLAUDE_CACHE_FIELDS}
-    if "delegated_cost" not in sess:
-        payload.pop("delegated_cost", None)
+    (known from the cache key already). Only-if-present (not `.get()`)
+    so sessions with no MCP/skill/delegation signal keep lacking those keys
+    on a cache hit, same as a fresh parse — see `_attach_tool_usage`."""
+    payload = {k: sess[k] for k in _CLAUDE_CACHE_FIELDS if k in sess}
     ts = sess.get("timestamp")
     payload["timestamp"] = ts.isoformat() if isinstance(ts, datetime) else ts
     payload["plans"] = [

--- a/backend/main.py
+++ b/backend/main.py
@@ -2812,7 +2812,7 @@ def _apply_claude_cache_hit(sess: Dict[str, Any], cached: Dict[str, Any]) -> Non
 _CODEX_CACHE_FIELDS = (
     "tokens", "model", "_provider", "cost", "mcp_tools", "has_plan", "plans",
     "text", "tokens_by_day", "tool_counts", "_skill_counts",
-    "parent_session_id", "subagent_info",
+    "parent_session_id", "subagent_info", "_raw_cwd",
 )
 
 
@@ -3108,6 +3108,7 @@ def _scan_sessions_sync():
             cached = scan_cache.read_cache("codex", sid, source_mtime) if source_mtime is not None else None
             if cached is not None:
                 _apply_codex_cache_hit(sess, cached)
+                sess["project"] = apply_alias(sess.get("_raw_cwd", "unknown"))
                 sess["stub"] = False
                 continue
 
@@ -3120,7 +3121,8 @@ def _scan_sessions_sync():
                                 data = json.loads(line)
                             except Exception: continue
                             if data.get("type") == "session_meta":
-                                sess["project"] = apply_alias(data["payload"].get("cwd", "unknown"))
+                                sess["_raw_cwd"] = data["payload"].get("cwd", "unknown")
+                                sess["project"] = apply_alias(sess["_raw_cwd"])
                                 if not sess.get("model") and data["payload"].get("model"):
                                     sess["model"] = data["payload"].get("model")
                                 if not sess.get("_provider"):
@@ -3236,6 +3238,7 @@ def _scan_sessions_sync():
             if not s.get("model") and s.get("_provider"):
                 s["model"] = s["_provider"]
             s.pop("_provider", None)
+            s.pop("_raw_cwd", None)
             mcp = _mcp_usage_from_counts(s.get("tool_counts") or {})
             if mcp:
                 s["mcp_usage"] = mcp

--- a/backend/main.py
+++ b/backend/main.py
@@ -2881,12 +2881,20 @@ def _scan_sessions_sync():
                 # prior_edit_failed = False
                 tool_counts: Dict[str, int] = {}
                 skill_counts: Dict[str, int] = {}
+                last_real_ts = None
                 try:
                     with open(session_file, "r", encoding="utf-8", errors="replace") as f:
                         for line in f:
                             try:
                                 data = json.loads(line)
                             except Exception: continue
+                            # Only user/assistant turns carry their own "timestamp".
+                            # Housekeeping entries appended on reopen (ai-title, mode,
+                            # last-prompt, file-history-snapshot) have none but still
+                            # bump the file's mtime -- falling back to that alone
+                            # would report the session as happening on reopen day.
+                            if data.get("type") in ("user", "assistant") and data.get("timestamp"):
+                                last_real_ts = data["timestamp"]
                             if data.get("type") == "assistant":
                                 msg = data.get("message", {})
                                 m = msg.get("model")
@@ -2953,6 +2961,11 @@ def _scan_sessions_sync():
                                 #     prior_edit_failed = False
                                 #     pending_edit_tool_ids = set()
                 except Exception: continue
+                if last_real_ts:
+                    try:
+                        sess["timestamp"] = datetime.fromisoformat(last_real_ts.replace("Z", "+00:00"))
+                    except ValueError:
+                        pass
                 _attach_tool_usage(sess, tool_counts, skill_counts)
                 # Subagent (Task/Agent) rollup — separate "delegated" bucket so the
                 # parent's own token fields stay exactly as before. Full per-subagent

--- a/backend/main.py
+++ b/backend/main.py
@@ -3233,7 +3233,7 @@ def _scan_sessions_sync():
 
             if source_mtime is not None:
                 scan_cache.write_cache("codex", sid, source_mtime, _codex_cache_payload(sess))
-            sess["stub"] = False
+                sess["stub"] = False
         for s in codex_sessions.values():
             if not s.get("model") and s.get("_provider"):
                 s["model"] = s["_provider"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -2769,16 +2769,20 @@ def _claude_subagent_usage(session_file: Path, sid: str) -> Optional[Dict[str, A
 
 _CLAUDE_CACHE_FIELDS = (
     "tokens", "model", "cost", "mcp_tools", "has_plan", "plans",
-    "artifacts", "delegation", "delegated_cost",
+    "delegation", "delegated_cost",
 )
 
 
 def _claude_cache_payload(sess: Dict[str, Any]) -> Dict[str, Any]:
     """Snapshot the expensive-to-reparse fields of a fully-parsed Claude
-    session for the sidecar cache. Deliberately excludes `project` (always
-    recomputed fresh so project-alias edits apply retroactively) and `id`/
-    `agent` (known from the cache key already)."""
+    session for the sidecar cache. Deliberately excludes `project` and
+    `artifacts` (always recomputed fresh — `project` so project-alias edits
+    apply retroactively, `artifacts` so Claude Project Memory files added or
+    removed after the last full parse are still reflected) and `id`/`agent`
+    (known from the cache key already)."""
     payload = {k: sess.get(k) for k in _CLAUDE_CACHE_FIELDS}
+    if "delegated_cost" not in sess:
+        payload.pop("delegated_cost", None)
     ts = sess.get("timestamp")
     payload["timestamp"] = ts.isoformat() if isinstance(ts, datetime) else ts
     payload["plans"] = [
@@ -2901,9 +2905,9 @@ def _scan_sessions_sync():
                         break
         except Exception: pass
 
-    # Sort by recency (newest first) BEFORE truncating — insertion-order
-    # slicing previously dropped genuinely recent sessions when totals
-    # exceeded 100.
+    # Sort by recency (newest first) — every discovered session is parsed
+    # (or cache-hit) below, no truncation. Sorting here only affects the
+    # order sessions are processed in, not which ones are included.
     if claude_sessions:
         for sid, sess in sorted(claude_sessions.items(), key=lambda kv: kv[1]["timestamp"], reverse=True):
             session_file = claude_file_map.get(sid)

--- a/backend/main.py
+++ b/backend/main.py
@@ -3016,6 +3016,18 @@ def _scan_sessions_sync():
                 source_mtime = None
                 try:
                     source_mtime = session_file.stat().st_mtime
+                    # Delegation usage comes from separate subagent transcript
+                    # files (see _claude_subagent_usage), so freshness must key
+                    # on them too: a background subagent can finish AFTER the
+                    # parent's last write, and keying on the parent alone would
+                    # serve its stale (undercounted) delegation totals forever.
+                    sub_dir = session_file.parent / sid / "subagents"
+                    if sub_dir.is_dir():
+                        for sub_f in sub_dir.glob("agent-*.jsonl"):
+                            try:
+                                source_mtime = max(source_mtime, sub_f.stat().st_mtime)
+                            except OSError:
+                                continue
                     cached = scan_cache.read_cache("claude", sid, source_mtime)
                 except OSError:
                     cached = None
@@ -4335,7 +4347,12 @@ async def get_sessions_cached(fresh: bool = False) -> List[Dict[str, Any]]:
 @app.get("/sessions")
 async def get_sessions(fresh: bool = False):
     """Return the session list. Pass ?fresh=1 to force a re-scan."""
-    return await get_sessions_cached(fresh=fresh)
+    data = await get_sessions_cached(fresh=fresh)
+    # `stub` is scan→persist plumbing (history_store.upsert_sessions keys its
+    # conflict clause on it), not API surface. Strip it on shallow copies —
+    # never mutate the cached dicts, which the async history persist may
+    # still be reading.
+    return [{k: v for k, v in s.items() if k != "stub"} for s in data]
 
 
 @app.get("/pricing")

--- a/backend/main.py
+++ b/backend/main.py
@@ -2809,6 +2809,47 @@ def _apply_claude_cache_hit(sess: Dict[str, Any], cached: Dict[str, Any]) -> Non
     ]
 
 
+_CODEX_CACHE_FIELDS = (
+    "tokens", "model", "_provider", "cost", "mcp_tools", "has_plan", "plans",
+    "text", "tokens_by_day", "tool_counts", "_skill_counts",
+    "parent_session_id", "subagent_info",
+)
+
+
+def _codex_cache_payload(sess: Dict[str, Any]) -> Dict[str, Any]:
+    """Snapshot the expensive-to-reparse fields of a fully-parsed Codex
+    session for the sidecar cache. Excludes `project` (always recomputed
+    fresh) and `id`/`agent` (known from the cache key already). Includes
+    the RAW `tool_counts`/`_skill_counts` dicts (not the derived
+    `mcp_usage`/`skills_used`) because the unconditional post-processing
+    loop in `_scan_sessions_sync` derives those from the raw counts for
+    every session regardless of cache hit/miss."""
+    payload = {k: sess[k] for k in _CODEX_CACHE_FIELDS if k in sess}
+    payload["timestamp"] = sess["timestamp"].isoformat() if isinstance(sess.get("timestamp"), datetime) else sess.get("timestamp")
+    payload["plans"] = [
+        {**p, "timestamp": p["timestamp"].isoformat() if isinstance(p.get("timestamp"), datetime) else p.get("timestamp")}
+        for p in (payload.get("plans") or [])
+    ]
+    return payload
+
+
+def _apply_codex_cache_hit(sess: Dict[str, Any], cached: Dict[str, Any]) -> None:
+    """Inverse of `_codex_cache_payload`: merge a cache hit back into `sess`."""
+    for k in _CODEX_CACHE_FIELDS:
+        if k in cached:
+            sess[k] = cached[k]
+    ts = cached.get("timestamp")
+    if isinstance(ts, str):
+        try:
+            sess["timestamp"] = datetime.fromisoformat(ts)
+        except ValueError:
+            pass
+    sess["plans"] = [
+        {**p, "timestamp": datetime.fromisoformat(p["timestamp"]) if isinstance(p.get("timestamp"), str) else p.get("timestamp")}
+        for p in (sess.get("plans") or [])
+    ]
+
+
 def _scan_sessions_sync():
     sessions = []
     aliases = _load_project_aliases()
@@ -3056,10 +3097,20 @@ def _scan_sessions_sync():
                 ts = _now()
             codex_sessions[sid] = {"id": sid, "agent": "codex", "project": "unknown", "timestamp": ts, "text": None, "tokens": {"input": 0, "output": 0, "cached": 0, "total": 0}, "mcp_tools": [], "has_plan": False, "plans": [], "model": None, "artifacts": [], "stub": True}
         
-        # Process the 100 most recent sessions
-        for sid, sess in sorted(codex_sessions.items(), key=lambda kv: kv[1]["timestamp"], reverse=True)[:100]:
+        for sid, sess in sorted(codex_sessions.items(), key=lambda kv: kv[1]["timestamp"], reverse=True):
             rollout_files = codex_file_map.get(sid, [])
             rollout_files.sort(key=lambda f: f.name)
+            try:
+                source_mtime = max(f.stat().st_mtime for f in rollout_files) if rollout_files else None
+            except OSError:
+                source_mtime = None
+
+            cached = scan_cache.read_cache("codex", sid, source_mtime) if source_mtime is not None else None
+            if cached is not None:
+                _apply_codex_cache_hit(sess, cached)
+                sess["stub"] = False
+                continue
+
             day_snap = {}
             for rollout_file in rollout_files:
                 try:
@@ -3119,20 +3170,20 @@ def _scan_sessions_sync():
                                     #   Chat-Completions-style APIs; we add reasoning explicitly only if the record's
                                     #   total_tokens doesn't already account for it.
                                     gross_input = usage.get("input_tokens", 0) or 0
-                                    cached      = usage.get("cached_input_tokens", 0) or 0
+                                    cached_tok  = usage.get("cached_input_tokens", 0) or 0
                                     output      = usage.get("output_tokens", 0) or 0
                                     reasoning   = usage.get("reasoning_output_tokens", 0) or 0
                                     total_record = usage.get("total_tokens", 0) or 0
-                                    net_input   = max(0, gross_input - cached)
+                                    net_input   = max(0, gross_input - cached_tok)
                                     # If total_tokens > gross_input + output, the API is reporting reasoning as
                                     # extra (not folded into output_tokens). Otherwise reasoning is implicit.
                                     output_billable = output + (reasoning if total_record > gross_input + output else 0)
 
                                     if event_day:
-                                        day_snap[event_day] = (gross_input, cached, output_billable)
+                                        day_snap[event_day] = (gross_input, cached_tok, output_billable)
 
                                     sess["tokens"]["input"]  = max(sess["tokens"]["input"],  net_input)
-                                    sess["tokens"]["cached"] = max(sess["tokens"]["cached"], cached)
+                                    sess["tokens"]["cached"] = max(sess["tokens"]["cached"], cached_tok)
                                     sess["tokens"]["output"] = max(sess["tokens"]["output"], output_billable)
                                     sess["tokens"]["total"]  = sess["tokens"]["input"] + sess["tokens"]["cached"] + sess["tokens"]["output"]
                                     # Codex/OpenAI usage has no cache-write field (only cached read); nothing to pass.
@@ -3177,6 +3228,9 @@ def _scan_sessions_sync():
                         "cost": calculate_cost(model_for_cost, net_in, do, dc)
                     }
                 sess["tokens_by_day"] = tbd
+
+            if source_mtime is not None:
+                scan_cache.write_cache("codex", sid, source_mtime, _codex_cache_payload(sess))
             sess["stub"] = False
         for s in codex_sessions.values():
             if not s.get("model") and s.get("_provider"):

--- a/backend/main.py
+++ b/backend/main.py
@@ -22,6 +22,7 @@ from harness_config import (
 )
 import notifications as notif
 from tt_paths import data_dir
+import scan_cache
 
 def _aware(dt):
     """Ensure datetime is timezone-aware UTC. Naive inputs are assumed to be UTC."""
@@ -2766,6 +2767,44 @@ def _claude_subagent_usage(session_file: Path, sid: str) -> Optional[Dict[str, A
     }
 
 
+_CLAUDE_CACHE_FIELDS = (
+    "tokens", "model", "cost", "mcp_tools", "has_plan", "plans",
+    "artifacts", "delegation", "delegated_cost",
+)
+
+
+def _claude_cache_payload(sess: Dict[str, Any]) -> Dict[str, Any]:
+    """Snapshot the expensive-to-reparse fields of a fully-parsed Claude
+    session for the sidecar cache. Deliberately excludes `project` (always
+    recomputed fresh so project-alias edits apply retroactively) and `id`/
+    `agent` (known from the cache key already)."""
+    payload = {k: sess.get(k) for k in _CLAUDE_CACHE_FIELDS}
+    ts = sess.get("timestamp")
+    payload["timestamp"] = ts.isoformat() if isinstance(ts, datetime) else ts
+    payload["plans"] = [
+        {**p, "timestamp": p["timestamp"].isoformat() if isinstance(p.get("timestamp"), datetime) else p.get("timestamp")}
+        for p in (payload.get("plans") or [])
+    ]
+    return payload
+
+
+def _apply_claude_cache_hit(sess: Dict[str, Any], cached: Dict[str, Any]) -> None:
+    """Inverse of `_claude_cache_payload`: merge a cache hit back into `sess`."""
+    for k in _CLAUDE_CACHE_FIELDS:
+        if k in cached:
+            sess[k] = cached[k]
+    ts = cached.get("timestamp")
+    if isinstance(ts, str):
+        try:
+            sess["timestamp"] = datetime.fromisoformat(ts)
+        except ValueError:
+            pass
+    sess["plans"] = [
+        {**p, "timestamp": datetime.fromisoformat(p["timestamp"]) if isinstance(p.get("timestamp"), str) else p.get("timestamp")}
+        for p in (sess.get("plans") or [])
+    ]
+
+
 def _scan_sessions_sync():
     sessions = []
     aliases = _load_project_aliases()
@@ -2866,7 +2905,7 @@ def _scan_sessions_sync():
     # slicing previously dropped genuinely recent sessions when totals
     # exceeded 100.
     if claude_sessions:
-        for sid, sess in sorted(claude_sessions.items(), key=lambda kv: kv[1]["timestamp"], reverse=True)[:100]:
+        for sid, sess in sorted(claude_sessions.items(), key=lambda kv: kv[1]["timestamp"], reverse=True):
             session_file = claude_file_map.get(sid)
             if session_file:
                 # Discover Claude Project Memory artifacts
@@ -2877,115 +2916,99 @@ def _scan_sessions_sync():
                             sess["artifacts"].append({"name": mf.name, "path": str(mf), "type": "document"})
                 except Exception: pass
 
-                # pending_edit_tool_ids: Set[str] = set()  # quality signals (commented out)
-                # prior_edit_failed = False
-                tool_counts: Dict[str, int] = {}
-                skill_counts: Dict[str, int] = {}
-                last_real_ts = None
+                cached = None
+                source_mtime = None
                 try:
-                    with open(session_file, "r", encoding="utf-8", errors="replace") as f:
-                        for line in f:
-                            try:
-                                data = json.loads(line)
-                            except Exception: continue
-                            # Only user/assistant turns carry their own "timestamp".
-                            # Housekeeping entries appended on reopen (ai-title, mode,
-                            # last-prompt, file-history-snapshot) have none but still
-                            # bump the file's mtime -- falling back to that alone
-                            # would report the session as happening on reopen day.
-                            if data.get("type") in ("user", "assistant") and data.get("timestamp"):
-                                last_real_ts = data["timestamp"]
-                            if data.get("type") == "assistant":
-                                msg = data.get("message", {})
-                                m = msg.get("model")
-                                if m and m != "<synthetic>" and not sess.get("model"):
-                                    sess["model"] = m
-                                usage = msg.get("usage", {})
-                                if usage:
-                                    cr = usage.get("cache_read_input_tokens", 0) or 0
-                                    cc = usage.get("cache_creation_input_tokens", 0) or 0
-                                    cc_1h = (usage.get("cache_creation", {}) or {}).get("ephemeral_1h_input_tokens", 0) or 0
-                                    sess["tokens"]["input"]  += usage.get("input_tokens", 0) or 0
-                                    sess["tokens"]["output"] += usage.get("output_tokens", 0) or 0
-                                    # cached = unique cached-prefix size (high-water-mark), NOT per-turn sum
-                                    sess["tokens"]["cached"] = max(sess["tokens"]["cached"], cr)
-                                    sess["tokens"]["_cached_sum"] = sess["tokens"].get("_cached_sum", 0) + cr
-                                    # cache_creation (write) IS billed per event → cumulative, like input.
-                                    sess["tokens"]["cache_creation"] = sess["tokens"].get("cache_creation", 0) + cc
-                                    sess["tokens"]["cache_creation_1h"] = sess["tokens"].get("cache_creation_1h", 0) + cc_1h
-                                sess["tokens"]["total"] = sess["tokens"]["input"] + sess["tokens"]["output"] + sess["tokens"]["cached"]
-                                sess["cost"] = calculate_cost(sess.get("model"), sess["tokens"]["input"], sess["tokens"]["output"], sess["tokens"]["cached"], cache_creation_tokens=sess["tokens"].get("cache_creation", 0), cache_creation_1h_tokens=sess["tokens"].get("cache_creation_1h", 0))
-                                for item in msg.get("content", []):
-                                    if item.get("type") == "tool_use":
-                                        tool = item.get("name")
-                                        if tool not in sess["mcp_tools"]: sess["mcp_tools"].append(tool)
-                                        _count_tool(tool_counts, tool)
-                                        if tool == "Skill":
-                                            skill = (item.get("input") or {}).get("skill")
-                                            if skill:
-                                                skill_counts[skill] = skill_counts.get(skill, 0) + 1
-                                        if tool == "ExitPlanMode":
-                                            plan_text = (item.get("input") or {}).get("plan") or ""
-                                            if plan_text:
-                                                sess["has_plan"] = True
-                                                sess["plans"].append({"session_id": sid, "agent": "claude", "timestamp": sess["timestamp"], "content": plan_text})
-                                    if item.get("type") == "thinking":
-                                        t_text = item.get("thinking", "")
-                                        if "plan" in t_text.lower() and len(t_text) > 100:
-                                            sess["has_plan"] = True
-                                            sess["plans"].append({"session_id": sid, "agent": "claude", "timestamp": sess["timestamp"], "content": t_text})
-                                # Quality signals (edit/retry tracking) commented out:
-                                # if this_turn_edit_ids:
-                                #     sess["quality"]["edit_turns"] += 1
-                                #     if prior_edit_failed:
-                                #         sess["quality"]["retry_turns"] += 1
-                                #     pending_edit_tool_ids = this_turn_edit_ids
-                                #     prior_edit_failed = False
-                            if data.get("type") == "user":
-                                u_msg = data.get("message", {})
-                                u_content = u_msg.get("content", "")
-                                if "/plan" in str(u_content):
-                                    sess["has_plan"] = True
-                                # Slash-command echoes: count skill invocations,
-                                # skip built-in CLI commands (/model, /usage, ...).
-                                for cmd in _COMMAND_NAME_RE.findall(str(u_content)):
-                                    if cmd not in _BUILTIN_CLI_COMMANDS:
-                                        skill_counts[cmd] = skill_counts.get(cmd, 0) + 1
-                                # Quality signals (retry chain tracking) commented out:
-                                # if isinstance(u_content, list):
-                                #     for it in u_content:
-                                #         if isinstance(it, dict) and it.get("type") == "tool_result":
-                                #             if it.get("tool_use_id") in pending_edit_tool_ids and it.get("is_error"):
-                                #                 prior_edit_failed = True
-                                # else:
-                                #     prior_edit_failed = False
-                                #     pending_edit_tool_ids = set()
-                except Exception: continue
-                if last_real_ts:
+                    source_mtime = session_file.stat().st_mtime
+                    cached = scan_cache.read_cache("claude", sid, source_mtime)
+                except OSError:
+                    cached = None
+
+                if cached is not None:
+                    _apply_claude_cache_hit(sess, cached)
+                    sess["stub"] = False
+                else:
+                    tool_counts: Dict[str, int] = {}
+                    skill_counts: Dict[str, int] = {}
+                    last_real_ts = None
                     try:
-                        sess["timestamp"] = datetime.fromisoformat(last_real_ts.replace("Z", "+00:00"))
-                    except ValueError:
-                        pass
-                _attach_tool_usage(sess, tool_counts, skill_counts)
-                # Subagent (Task/Agent) rollup — separate "delegated" bucket so the
-                # parent's own token fields stay exactly as before. Full per-subagent
-                # breakdown is served by /sessions/{id}/delegation, the list carries
-                # only the summary.
-                deleg = _claude_subagent_usage(session_file, sid)
-                sess["delegation"] = {
-                    "supported": True,
-                    "tokens_recorded": True,
-                    "spawn_count": deleg["spawn_count"] if deleg else 0,
-                    "delegated_total": deleg["totals"]["total"] if deleg else 0,
-                }
-                if deleg:
-                    sess["delegation"]["by_type"] = deleg["by_type"]
-                    sess["tokens"]["delegated_input"] = deleg["totals"]["input"]
-                    sess["tokens"]["delegated_output"] = deleg["totals"]["output"]
-                    sess["tokens"]["delegated_cached"] = deleg["totals"]["cached"]
-                    sess["tokens"]["delegated_cache_creation"] = deleg["totals"]["cache_creation"]
-                    sess["delegated_cost"] = deleg["cost"]
-                sess["stub"] = False
+                        with open(session_file, "r", encoding="utf-8", errors="replace") as f:
+                            for line in f:
+                                try:
+                                    data = json.loads(line)
+                                except Exception: continue
+                                if data.get("type") in ("user", "assistant") and data.get("timestamp"):
+                                    last_real_ts = data["timestamp"]
+                                if data.get("type") == "assistant":
+                                    msg = data.get("message", {})
+                                    m = msg.get("model")
+                                    if m and m != "<synthetic>" and not sess.get("model"):
+                                        sess["model"] = m
+                                    usage = msg.get("usage", {})
+                                    if usage:
+                                        cr = usage.get("cache_read_input_tokens", 0) or 0
+                                        cc = usage.get("cache_creation_input_tokens", 0) or 0
+                                        cc_1h = (usage.get("cache_creation", {}) or {}).get("ephemeral_1h_input_tokens", 0) or 0
+                                        sess["tokens"]["input"]  += usage.get("input_tokens", 0) or 0
+                                        sess["tokens"]["output"] += usage.get("output_tokens", 0) or 0
+                                        sess["tokens"]["cached"] = max(sess["tokens"]["cached"], cr)
+                                        sess["tokens"]["_cached_sum"] = sess["tokens"].get("_cached_sum", 0) + cr
+                                        sess["tokens"]["cache_creation"] = sess["tokens"].get("cache_creation", 0) + cc
+                                        sess["tokens"]["cache_creation_1h"] = sess["tokens"].get("cache_creation_1h", 0) + cc_1h
+                                    sess["tokens"]["total"] = sess["tokens"]["input"] + sess["tokens"]["output"] + sess["tokens"]["cached"]
+                                    sess["cost"] = calculate_cost(sess.get("model"), sess["tokens"]["input"], sess["tokens"]["output"], sess["tokens"]["cached"], cache_creation_tokens=sess["tokens"].get("cache_creation", 0), cache_creation_1h_tokens=sess["tokens"].get("cache_creation_1h", 0))
+                                    for item in msg.get("content", []):
+                                        if item.get("type") == "tool_use":
+                                            tool = item.get("name")
+                                            if tool not in sess["mcp_tools"]: sess["mcp_tools"].append(tool)
+                                            _count_tool(tool_counts, tool)
+                                            if tool == "Skill":
+                                                skill = (item.get("input") or {}).get("skill")
+                                                if skill:
+                                                    skill_counts[skill] = skill_counts.get(skill, 0) + 1
+                                            if tool == "ExitPlanMode":
+                                                plan_text = (item.get("input") or {}).get("plan") or ""
+                                                if plan_text:
+                                                    sess["has_plan"] = True
+                                                    sess["plans"].append({"session_id": sid, "agent": "claude", "timestamp": sess["timestamp"], "content": plan_text})
+                                        if item.get("type") == "thinking":
+                                            t_text = item.get("thinking", "")
+                                            if "plan" in t_text.lower() and len(t_text) > 100:
+                                                sess["has_plan"] = True
+                                                sess["plans"].append({"session_id": sid, "agent": "claude", "timestamp": sess["timestamp"], "content": t_text})
+                                if data.get("type") == "user":
+                                    u_msg = data.get("message", {})
+                                    u_content = u_msg.get("content", "")
+                                    if "/plan" in str(u_content):
+                                        sess["has_plan"] = True
+                                    for cmd in _COMMAND_NAME_RE.findall(str(u_content)):
+                                        if cmd not in _BUILTIN_CLI_COMMANDS:
+                                            skill_counts[cmd] = skill_counts.get(cmd, 0) + 1
+                    except Exception: continue
+                    if last_real_ts:
+                        try:
+                            sess["timestamp"] = datetime.fromisoformat(last_real_ts.replace("Z", "+00:00"))
+                        except ValueError:
+                            pass
+                    _attach_tool_usage(sess, tool_counts, skill_counts)
+                    deleg = _claude_subagent_usage(session_file, sid)
+                    sess["delegation"] = {
+                        "supported": True,
+                        "tokens_recorded": True,
+                        "spawn_count": deleg["spawn_count"] if deleg else 0,
+                        "delegated_total": deleg["totals"]["total"] if deleg else 0,
+                    }
+                    if deleg:
+                        sess["delegation"]["by_type"] = deleg["by_type"]
+                        sess["tokens"]["delegated_input"] = deleg["totals"]["input"]
+                        sess["tokens"]["delegated_output"] = deleg["totals"]["output"]
+                        sess["tokens"]["delegated_cached"] = deleg["totals"]["cached"]
+                        sess["tokens"]["delegated_cache_creation"] = deleg["totals"]["cache_creation"]
+                        sess["delegated_cost"] = deleg["cost"]
+
+                    if source_mtime is not None:
+                        scan_cache.write_cache("claude", sid, source_mtime, _claude_cache_payload(sess))
+                    sess["stub"] = False
         sessions.extend(claude_sessions.values())
     # 2. Codex
     codex_index = CODEX_DIR / "session_index.jsonl"

--- a/backend/main.py
+++ b/backend/main.py
@@ -2801,7 +2801,7 @@ def _scan_sessions_sync():
             "timestamp": ts, "display": None,
             "tokens": {"input": 0, "output": 0, "cached": 0, "total": 0},
             "mcp_tools": [], "has_plan": False, "plans": [],
-            "model": None, "artifacts": [],
+            "model": None, "artifacts": [], "stub": True,
         }
 
     # Optional enrichment: overlay project/display from legacy history.jsonl.
@@ -2822,7 +2822,7 @@ def _scan_sessions_sync():
                                 "timestamp": ts, "display": data.get("display"),
                                 "tokens": {"input": 0, "output": 0, "cached": 0, "total": 0},
                                 "mcp_tools": [], "has_plan": False, "plans": [],
-                                "model": None, "artifacts": [],
+                                "model": None, "artifacts": [], "stub": True,
                             }
                         else:
                             # Overlay metadata only; keep file-derived timestamp if newer
@@ -2985,6 +2985,7 @@ def _scan_sessions_sync():
                     sess["tokens"]["delegated_cached"] = deleg["totals"]["cached"]
                     sess["tokens"]["delegated_cache_creation"] = deleg["totals"]["cache_creation"]
                     sess["delegated_cost"] = deleg["cost"]
+                sess["stub"] = False
         sessions.extend(claude_sessions.values())
     # 2. Codex
     codex_index = CODEX_DIR / "session_index.jsonl"
@@ -3010,7 +3011,7 @@ def _scan_sessions_sync():
                         if not sid: continue
                         ts = _aware(datetime.fromisoformat(data.get("updated_at").replace('Z', '+00:00'))) if data.get("updated_at") else _file_mtime_utc(codex_index)
                         if sid not in codex_sessions or ts > codex_sessions[sid]["timestamp"]:
-                            codex_sessions[sid] = {"id": sid, "agent": "codex", "project": "unknown", "timestamp": ts, "text": data.get("thread_name"), "tokens": {"input": 0, "output": 0, "cached": 0, "total": 0}, "mcp_tools": [], "has_plan": False, "plans": [], "model": None, "artifacts": []}
+                            codex_sessions[sid] = {"id": sid, "agent": "codex", "project": "unknown", "timestamp": ts, "text": data.get("thread_name"), "tokens": {"input": 0, "output": 0, "cached": 0, "total": 0}, "mcp_tools": [], "has_plan": False, "plans": [], "model": None, "artifacts": [], "stub": True}
                     except Exception: continue
         except Exception: pass
 
@@ -3026,7 +3027,7 @@ def _scan_sessions_sync():
                 ts = max(_file_mtime_utc(f) for f in files)
             except Exception:
                 ts = _now()
-            codex_sessions[sid] = {"id": sid, "agent": "codex", "project": "unknown", "timestamp": ts, "text": None, "tokens": {"input": 0, "output": 0, "cached": 0, "total": 0}, "mcp_tools": [], "has_plan": False, "plans": [], "model": None, "artifacts": []}
+            codex_sessions[sid] = {"id": sid, "agent": "codex", "project": "unknown", "timestamp": ts, "text": None, "tokens": {"input": 0, "output": 0, "cached": 0, "total": 0}, "mcp_tools": [], "has_plan": False, "plans": [], "model": None, "artifacts": [], "stub": True}
         
         # Process the 100 most recent sessions
         for sid, sess in sorted(codex_sessions.items(), key=lambda kv: kv[1]["timestamp"], reverse=True)[:100]:
@@ -3149,6 +3150,7 @@ def _scan_sessions_sync():
                         "cost": calculate_cost(model_for_cost, net_in, do, dc)
                     }
                 sess["tokens_by_day"] = tbd
+            sess["stub"] = False
         for s in codex_sessions.values():
             if not s.get("model") and s.get("_provider"):
                 s["model"] = s["_provider"]

--- a/backend/scan_cache.py
+++ b/backend/scan_cache.py
@@ -28,26 +28,48 @@ from tt_paths import data_dir
 logger = logging.getLogger("tokentelemetry.scan_cache")
 
 
+def _require_safe_component(candidate: str) -> str:
+    """Reject anything that isn't a bare, filename-safe path component.
+
+    Both `agent` and `session_id` end up as path segments under the cache
+    dir. `session_id` in particular can originate from on-disk data we don't
+    control (e.g. Codex's session_index.jsonl), so a crafted id like
+    "../../../foo" must never be allowed to escape data_dir()/cache/.
+    """
+    if not candidate or "/" in candidate or "\\" in candidate or Path(candidate).name != candidate:
+        raise ValueError(f"unsafe path component: {candidate!r}")
+    return candidate
+
+
 def cache_path(agent: str, session_id: str) -> Path:
-    """Path to the sidecar cache file for one session. Does not create it."""
+    """Path to the sidecar cache file for one session. Does not create it.
+
+    Raises ValueError if `agent` or `session_id` isn't a safe, bare filename
+    component (see `_require_safe_component`). Callers (`read_cache`/
+    `write_cache`) catch this and treat it as a miss/no-op — cache code must
+    never raise into the scan.
+    """
+    agent = _require_safe_component(agent)
+    session_id = _require_safe_component(session_id)
     return data_dir() / "cache" / agent / f"{session_id}.json"
 
 
 def read_cache(agent: str, session_id: str, source_mtime: float) -> Optional[Dict[str, Any]]:
     """Return the cached payload if fresh (stored _mtime >= source_mtime), else None.
 
-    Never raises — any OSError/JSONDecodeError/missing-key is treated as a
-    cache miss.
+    Never raises — any OSError/JSONDecodeError/missing-key/unsafe-id is
+    treated as a cache miss.
     """
-    path = cache_path(agent, session_id)
+    path = None
     try:
+        path = cache_path(agent, session_id)
         with path.open("r", encoding="utf-8") as f:
             data = json.load(f)
         cached_mtime = data["_mtime"]
         if cached_mtime >= source_mtime:
             return data
         return None
-    except (OSError, json.JSONDecodeError, KeyError, TypeError) as exc:
+    except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
         logger.debug(
             "scan_cache miss for agent=%s session_id=%s path=%s: %s",
             agent,
@@ -61,16 +83,17 @@ def read_cache(agent: str, session_id: str, source_mtime: float) -> Optional[Dic
 def write_cache(agent: str, session_id: str, source_mtime: float, payload: Dict[str, Any]) -> None:
     """Persist payload with source_mtime folded in as payload["_mtime"].
 
-    Creates parent dirs as needed. Never raises — any OSError, or a
-    non-JSON-serializable payload (TypeError/ValueError from json.dump), is
-    swallowed and logged at debug level. Callers should still serialize their
-    own datetime fields for correctness — this is a safety net, not a
-    substitute for doing that.
+    Creates parent dirs as needed. Never raises — any OSError, unsafe
+    agent/session_id (ValueError from cache_path), or a non-JSON-serializable
+    payload (TypeError/ValueError from json.dump), is swallowed and logged at
+    debug level. Callers should still serialize their own datetime fields for
+    correctness — this is a safety net, not a substitute for doing that.
     """
-    path = cache_path(agent, session_id)
     to_write = dict(payload)
     to_write["_mtime"] = source_mtime
+    path = None
     try:
+        path = cache_path(agent, session_id)
         path.parent.mkdir(parents=True, exist_ok=True)
         with path.open("w", encoding="utf-8") as f:
             json.dump(to_write, f)

--- a/backend/scan_cache.py
+++ b/backend/scan_cache.py
@@ -20,12 +20,21 @@ raised.
 
 import json
 import logging
+import os
+import tempfile
 from pathlib import Path
 from typing import Any, Dict, Optional
 
 from tt_paths import data_dir
 
 logger = logging.getLogger("tokentelemetry.scan_cache")
+
+# Bump whenever the shape or meaning of cached payloads changes: new/renamed
+# payload fields, a parsing fix that alters computed values, or a pricing
+# update that affects cached costs. `_mtime` only detects source-transcript
+# changes; this detects code changes. A mismatch is a miss, so stale entries
+# are transparently reparsed and rewritten — never migrated in place.
+CACHE_VERSION = 1
 
 
 def _require_safe_component(candidate: str) -> str:
@@ -55,7 +64,8 @@ def cache_path(agent: str, session_id: str) -> Path:
 
 
 def read_cache(agent: str, session_id: str, source_mtime: float) -> Optional[Dict[str, Any]]:
-    """Return the cached payload if fresh (stored _mtime >= source_mtime), else None.
+    """Return the cached payload if fresh (stored _mtime >= source_mtime AND
+    written by this CACHE_VERSION), else None.
 
     Never raises — any OSError/JSONDecodeError/missing-key/unsafe-id is
     treated as a cache miss.
@@ -65,6 +75,8 @@ def read_cache(agent: str, session_id: str, source_mtime: float) -> Optional[Dic
         path = cache_path(agent, session_id)
         with path.open("r", encoding="utf-8") as f:
             data = json.load(f)
+        if data.get("_version") != CACHE_VERSION:
+            return None
         cached_mtime = data["_mtime"]
         if cached_mtime >= source_mtime:
             return data
@@ -91,12 +103,21 @@ def write_cache(agent: str, session_id: str, source_mtime: float, payload: Dict[
     """
     to_write = dict(payload)
     to_write["_mtime"] = source_mtime
+    to_write["_version"] = CACHE_VERSION
     path = None
+    tmp_name = None
     try:
         path = cache_path(agent, session_id)
         path.parent.mkdir(parents=True, exist_ok=True)
-        with path.open("w", encoding="utf-8") as f:
+        # Write-to-temp + atomic rename so a crash or concurrent scan can
+        # never leave a torn file at the final path (a torn file is only a
+        # miss, but a whole-file swap means readers see old-or-new, never
+        # garbage).
+        fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.", suffix=".tmp")
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(to_write, f)
+        os.replace(tmp_name, path)
+        tmp_name = None
     except (OSError, TypeError, ValueError) as exc:
         logger.debug(
             "scan_cache write failed for agent=%s session_id=%s path=%s: %s",
@@ -105,3 +126,8 @@ def write_cache(agent: str, session_id: str, source_mtime: float, payload: Dict[
             path,
             exc,
         )
+        if tmp_name is not None:
+            try:
+                os.unlink(tmp_name)
+            except OSError:
+                pass

--- a/backend/scan_cache.py
+++ b/backend/scan_cache.py
@@ -1,0 +1,84 @@
+"""Sidecar, mtime-keyed parse cache for expensive-to-reparse agent session data.
+
+Mirrors the pattern used by `_estimate_antigravity_tokens` in `main.py` (a
+`tokens_cache.json` sidecar next to the transcript, keyed by comparing mtimes),
+but instead of writing into the agent's own data directory — which Claude/Codex
+don't expose a natural scratch subdir for — sidecars live under
+TokenTelemetry's own `data_dir()` (see `tt_paths.py`), namespaced by agent and
+session id.
+
+Freshness is tracked via an explicit `_mtime` float stored INSIDE the JSON
+payload rather than the sidecar file's own on-disk mtime. This is deterministic
+under coarse filesystem mtime resolution and trivially testable with plain
+float comparisons.
+
+Both `read_cache` and `write_cache` are best-effort: a missing, corrupt, or
+unwritable cache — or a non-JSON-serializable payload — must never break a
+scan, so all failure modes are swallowed and logged at debug level rather than
+raised.
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from tt_paths import data_dir
+
+logger = logging.getLogger("tokentelemetry.scan_cache")
+
+
+def cache_path(agent: str, session_id: str) -> Path:
+    """Path to the sidecar cache file for one session. Does not create it."""
+    return data_dir() / "cache" / agent / f"{session_id}.json"
+
+
+def read_cache(agent: str, session_id: str, source_mtime: float) -> Optional[Dict[str, Any]]:
+    """Return the cached payload if fresh (stored _mtime >= source_mtime), else None.
+
+    Never raises — any OSError/JSONDecodeError/missing-key is treated as a
+    cache miss.
+    """
+    path = cache_path(agent, session_id)
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+        cached_mtime = data["_mtime"]
+        if cached_mtime >= source_mtime:
+            return data
+        return None
+    except (OSError, json.JSONDecodeError, KeyError, TypeError) as exc:
+        logger.debug(
+            "scan_cache miss for agent=%s session_id=%s path=%s: %s",
+            agent,
+            session_id,
+            path,
+            exc,
+        )
+        return None
+
+
+def write_cache(agent: str, session_id: str, source_mtime: float, payload: Dict[str, Any]) -> None:
+    """Persist payload with source_mtime folded in as payload["_mtime"].
+
+    Creates parent dirs as needed. Never raises — any OSError, or a
+    non-JSON-serializable payload (TypeError/ValueError from json.dump), is
+    swallowed and logged at debug level. Callers should still serialize their
+    own datetime fields for correctness — this is a safety net, not a
+    substitute for doing that.
+    """
+    path = cache_path(agent, session_id)
+    to_write = dict(payload)
+    to_write["_mtime"] = source_mtime
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf-8") as f:
+            json.dump(to_write, f)
+    except (OSError, TypeError, ValueError) as exc:
+        logger.debug(
+            "scan_cache write failed for agent=%s session_id=%s path=%s: %s",
+            agent,
+            session_id,
+            path,
+            exc,
+        )

--- a/backend/test_delegation.py
+++ b/backend/test_delegation.py
@@ -673,5 +673,75 @@ def test_codex_parsed_session_is_not_stub(scan_env, monkeypatch):
             assert s["stub"] is False
 
 
+def _hist_env(tmp_path, monkeypatch):
+    """Isolate history_store at tmp_path and return a fresh module handle."""
+    monkeypatch.setenv("TOKENTELEMETRY_DATA_DIR", str(tmp_path / "tt_data"))
+    import importlib
+    import history_store
+    importlib.reload(history_store)
+    return history_store
+
+
+def test_upsert_stub_does_not_crush_real_row(tmp_path, monkeypatch):
+    hs = _hist_env(tmp_path, monkeypatch)
+    real = {"agent": "claude", "id": "s1", "project": "/p", "model": "claude-opus-4-8",
+            "timestamp": "2026-06-01T00:00:00+00:00", "cost": 4.2,
+            "tokens": {"input": 100, "output": 50, "cached": 1000, "total": 1150,
+                       "_cached_sum": 3000}}
+    assert hs.upsert_sessions([real]) == 1
+    stub = {"agent": "claude", "id": "s1", "project": "unknown", "model": None,
+            "timestamp": "2026-06-02T00:00:00+00:00", "cost": 0.0,
+            "tokens": {"input": 0, "output": 0, "cached": 0, "total": 0}, "stub": True}
+    assert hs.upsert_sessions([stub]) == 1
+    con = hs._connect()
+    try:
+        row = con.execute("SELECT model, input, output, cached, cache_reads, total, "
+                          "cost, project, last_seen_at, source_present "
+                          "FROM sessions WHERE agent=? AND id=?", ("claude", "s1")).fetchone()
+    finally:
+        con.close()
+    assert row["model"] == "claude-opus-4-8"
+    assert row["input"] == 100 and row["output"] == 50 and row["cached"] == 1000
+    assert row["cache_reads"] == 3000 and row["total"] == 1150
+    assert row["cost"] == 4.2 and row["project"] == "/p"
+    assert row["source_present"] == 1
+    assert row["last_seen_at"] is not None
+
+
+def test_upsert_brand_new_stub_still_inserts(tmp_path, monkeypatch):
+    hs = _hist_env(tmp_path, monkeypatch)
+    stub = {"agent": "codex", "id": "new1", "project": "unknown", "model": None,
+            "timestamp": "2026-06-02T00:00:00+00:00", "cost": 0.0,
+            "tokens": {"input": 0, "output": 0, "cached": 0, "total": 0}, "stub": True}
+    assert hs.upsert_sessions([stub]) == 1
+    con = hs._connect()
+    try:
+        row = con.execute("SELECT input, total, source_present FROM sessions "
+                          "WHERE agent=? AND id=?", ("codex", "new1")).fetchone()
+    finally:
+        con.close()
+    assert row is not None and row["input"] == 0 and row["total"] == 0
+    assert row["source_present"] == 1
+
+
+def test_upsert_nonstub_default_still_overwrites(tmp_path, monkeypatch):
+    hs = _hist_env(tmp_path, monkeypatch)
+    v1 = {"agent": "claude", "id": "s2", "model": "m1",
+          "timestamp": "2026-06-01T00:00:00+00:00", "cost": 1.0,
+          "tokens": {"input": 10, "output": 5, "cached": 0, "total": 15}}
+    v2 = {"agent": "claude", "id": "s2", "model": "m2",
+          "timestamp": "2026-06-02T00:00:00+00:00", "cost": 2.0,
+          "tokens": {"input": 20, "output": 5, "cached": 0, "total": 25}}
+    hs.upsert_sessions([v1]); hs.upsert_sessions([v2])
+    con = hs._connect()
+    try:
+        row = con.execute("SELECT model, input, total, cost FROM sessions "
+                          "WHERE agent=? AND id=?", ("claude", "s2")).fetchone()
+    finally:
+        con.close()
+    assert row["model"] == "m2" and row["input"] == 20 and row["total"] == 25
+    assert row["cost"] == 2.0
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))

--- a/backend/test_delegation.py
+++ b/backend/test_delegation.py
@@ -1094,5 +1094,88 @@ def test_codex_scan_cache_hit_reapplies_alias(scan_env, monkeypatch):
     assert "_raw_cwd" not in sess2
 
 
+def test_scan_cache_version_mismatch_is_miss(tmp_path, monkeypatch):
+    """An entry written by a different CACHE_VERSION must read as a miss even
+    when its _mtime is fresh — parser/pricing changes ship as a version bump,
+    and old entries must be reparsed, not served."""
+    monkeypatch.setenv("TOKENTELEMETRY_DATA_DIR", str(tmp_path / "tt_data"))
+
+    scan_cache.write_cache("claude", "sid1", source_mtime=1000.0, payload={"model": "x"})
+    assert scan_cache.read_cache("claude", "sid1", source_mtime=1000.0) is not None
+
+    path = scan_cache.cache_path("claude", "sid1")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    data["_version"] = scan_cache.CACHE_VERSION - 1
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+    assert scan_cache.read_cache("claude", "sid1", source_mtime=1000.0) is None
+
+
+def test_scan_cache_version_bump_invalidates_old_entries(tmp_path, monkeypatch):
+    """Simulate an app upgrade: entries written before a CACHE_VERSION bump
+    are all misses afterwards, and a rewrite under the new version hits."""
+    monkeypatch.setenv("TOKENTELEMETRY_DATA_DIR", str(tmp_path / "tt_data"))
+
+    scan_cache.write_cache("codex", "sid2", source_mtime=1000.0, payload={"model": "old"})
+    monkeypatch.setattr(scan_cache, "CACHE_VERSION", scan_cache.CACHE_VERSION + 1)
+
+    assert scan_cache.read_cache("codex", "sid2", source_mtime=1000.0) is None
+    scan_cache.write_cache("codex", "sid2", source_mtime=1000.0, payload={"model": "new"})
+    hit = scan_cache.read_cache("codex", "sid2", source_mtime=1000.0)
+    assert hit is not None and hit["model"] == "new"
+
+
+def test_scan_cache_missing_version_field_is_miss(tmp_path, monkeypatch):
+    """Entries written before the version field existed (or hand-mangled)
+    must be misses, not treated as current."""
+    monkeypatch.setenv("TOKENTELEMETRY_DATA_DIR", str(tmp_path / "tt_data"))
+
+    path = scan_cache.cache_path("claude", "sid3")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"model": "x", "_mtime": 1000.0}), encoding="utf-8")
+
+    assert scan_cache.read_cache("claude", "sid3", source_mtime=1000.0) is None
+
+
+def test_claude_cache_refreshes_when_subagent_finishes_late(scan_env, monkeypatch):
+    """Delegation usage lives in separate subagent transcript files, so a
+    subagent that finishes AFTER the parent's last write (background agent)
+    must still invalidate the cache — freshness keys on the max mtime across
+    parent + subagent files, not the parent alone."""
+    monkeypatch.setenv("TOKENTELEMETRY_DATA_DIR", str(scan_env / "tt_data"))
+    session_file = make_claude_tree(scan_env / ".claude")
+
+    first = main._scan_sessions_sync()
+    first_sess = next(s for s in first if s["agent"] == "claude" and s["id"] == SID)
+    first_delegated = first_sess["delegation"]["delegated_total"]
+    assert first_delegated > 0
+
+    parent_mtime = session_file.stat().st_mtime
+    sub_file = session_file.parent / SID / "subagents" / "agent-two.jsonl"
+    with open(sub_file, "a", encoding="utf-8") as f:
+        f.write(_assistant_line(model="claude-sonnet-4-6", inp=500, out=250,
+                                attribution="general-purpose"))
+    # Parent untouched: only the subagent transcript moved forward.
+    os.utime(session_file, (parent_mtime, parent_mtime))
+
+    second = main._scan_sessions_sync()
+    second_sess = next(s for s in second if s["agent"] == "claude" and s["id"] == SID)
+    assert second_sess["delegation"]["delegated_total"] > first_delegated
+
+
+def test_sessions_endpoint_strips_stub_flag(scan_env, monkeypatch):
+    """`stub` is scan→persist plumbing; it must not appear in the /sessions
+    API response."""
+    import asyncio
+    make_claude_tree(scan_env / ".claude")
+    # Keep the fire-and-forget history persist away from the real store.
+    monkeypatch.setattr(main, "_persist_history_async", lambda data: None)
+
+    data = asyncio.run(main.get_sessions(fresh=True))
+
+    assert data, "expected at least one session from the fixture tree"
+    assert all("stub" not in s for s in data)
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))

--- a/backend/test_delegation.py
+++ b/backend/test_delegation.py
@@ -1016,5 +1016,34 @@ def test_codex_scan_cache_miss_after_real_mtime_change(scan_env, monkeypatch):
     assert sess2["tokens"]["total"] == 450
 
 
+def test_codex_scan_cache_hit_reapplies_alias(scan_env, monkeypatch):
+    """project must never freeze at the cached raw cwd — a cache hit should
+    re-derive it via apply_alias() using the CURRENT alias table, so alias
+    edits made between scans apply retroactively (per plan Global
+    Constraints)."""
+    monkeypatch.setattr(main, "CODEX_DIR", scan_env / ".codex")
+    monkeypatch.setenv("TOKENTELEMETRY_DATA_DIR", str(scan_env / "tt_data"))
+    codex_dir = scan_env / ".codex"
+    sid = "019eb056-4eae-7280-8617-000000000003"
+    cwd = "/tmp/proj-cache-alias-test"
+    path = _write_codex_rollout(codex_dir, sid, 0, [
+        _codex_session_meta(cwd=cwd),
+        _codex_token_event("2026-07-01T00:00:00Z", 100, 0, 50),
+    ])
+    mtime = path.stat().st_mtime
+
+    result1 = main._scan_sessions_sync()
+    sess1 = next(s for s in result1 if s["id"] == sid)
+    assert sess1["project"] == cwd
+
+    main.PROJECT_ALIASES_FILE.write_text(json.dumps({cwd: "my-cool-project"}))
+    os.utime(path, (mtime, mtime))  # pin mtime so scan 2 is a cache hit
+
+    result2 = main._scan_sessions_sync()
+    sess2 = next(s for s in result2 if s["id"] == sid)
+    assert sess2["project"] == "my-cool-project"
+    assert "_raw_cwd" not in sess2
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))

--- a/backend/test_delegation.py
+++ b/backend/test_delegation.py
@@ -193,6 +193,7 @@ def scan_env(tmp_path, monkeypatch):
     monkeypatch.setattr(main, "HERMES_DB", tmp_path / "hermes-state.db")
     monkeypatch.setattr(main, "HERMES_PROFILES_DIR", missing / "hermes-profiles")
     monkeypatch.setattr(main, "PROJECT_ALIASES_FILE", tmp_path / "aliases.json")
+    monkeypatch.setenv("TOKENTELEMETRY_DATA_DIR", str(tmp_path / "tt_data"))
     return tmp_path
 
 
@@ -675,6 +676,26 @@ def test_codex_parsed_session_is_not_stub(scan_env, monkeypatch):
             assert s["stub"] is False
 
 
+def test_codex_index_only_entry_without_rollout_stays_stub(scan_env, monkeypatch):
+    """A session_index.jsonl entry with no matching rollout file on disk
+    (Codex pruned/rotated it away while the index entry lingers) must never
+    be marked as parsed — nothing was actually parsed for it. Regression for
+    the bug where `sess["stub"] = False` ran unconditionally, letting an
+    index-only stub overwrite a real persisted row via the unconditional-
+    overwrite upsert path."""
+    codex_dir = scan_env / ".codex"
+    monkeypatch.setattr(main, "CODEX_DIR", codex_dir)
+    (codex_dir / "sessions").mkdir(parents=True)
+    sid = "019eb056-4eae-7280-8617-000000000099"
+    index_line = json.dumps({"id": sid, "updated_at": "2026-06-10T07:01:46Z",
+                              "thread_name": "orphaned index entry"}) + "\n"
+    (codex_dir / "session_index.jsonl").write_text(index_line)
+
+    result = main._scan_sessions_sync()
+    sess = next(s for s in result if s["id"] == sid)
+    assert sess["stub"] is True
+
+
 def _hist_env(tmp_path, monkeypatch):
     """Isolate history_store at tmp_path and return a fresh module handle."""
     monkeypatch.setenv("TOKENTELEMETRY_DATA_DIR", str(tmp_path / "tt_data"))
@@ -799,6 +820,27 @@ def test_scan_cache_write_creates_parent_dirs(tmp_path, monkeypatch):
 
     expected_path = scan_cache.cache_path("claude", "sid1")
     assert expected_path.exists()
+
+
+def test_scan_cache_read_rejects_path_traversal_session_id(tmp_path, monkeypatch):
+    monkeypatch.setenv("TOKENTELEMETRY_DATA_DIR", str(tmp_path / "tt_data"))
+
+    result = scan_cache.read_cache("claude", "../../../etc/passwd", source_mtime=1000.0)
+
+    assert result is None
+
+
+def test_scan_cache_write_rejects_path_traversal_session_id(tmp_path, monkeypatch):
+    data_dir_path = tmp_path / "tt_data"
+    monkeypatch.setenv("TOKENTELEMETRY_DATA_DIR", str(data_dir_path))
+
+    scan_cache.write_cache("claude", "../../../etc/passwd", source_mtime=1000.0, payload={"model": "x"})
+
+    # No-op: nothing written inside the cache dir, and nothing escaped it.
+    assert not (data_dir_path / "cache").exists()
+    assert not (tmp_path / "etc" / "passwd.json").exists()
+    escaped = tmp_path.parent / "etc" / "passwd.json"
+    assert not escaped.exists()
 
 
 def test_claude_scan_has_no_100_cap(scan_env, monkeypatch):

--- a/backend/test_delegation.py
+++ b/backend/test_delegation.py
@@ -856,6 +856,36 @@ def test_claude_scan_cache_hit_serves_stale_content(scan_env, monkeypatch):
     assert second_sess.get("stub") is False
 
 
+def test_claude_scan_cache_hit_still_refreshes_memory_artifacts(scan_env, monkeypatch):
+    """Memory-dir artifacts must be rediscovered fresh on every scan even when
+    the session's own .jsonl is unchanged (a cache hit) — artifacts must not
+    be cached, or newly added memory files silently stop showing up once the
+    session's transcript cache goes warm."""
+    monkeypatch.setenv("TOKENTELEMETRY_DATA_DIR", str(scan_env / "tt_data"))
+    sid = "sid-cache-artifacts"
+    session_file = make_claude_tree(scan_env / ".claude", sid, with_subagents=False)
+    memory_dir = session_file.parent.parent / "memory"
+    memory_dir.mkdir(parents=True, exist_ok=True)
+    (memory_dir / "first.md").write_text("# first\n", encoding="utf-8")
+
+    first = main._scan_sessions_sync()
+    first_sess = next(s for s in first if s["agent"] == "claude" and s["id"] == sid)
+    assert [a["name"] for a in first_sess["artifacts"]] == ["first.md"]
+
+    st = session_file.stat()
+    original_mtime = st.st_mtime
+    (memory_dir / "second.md").write_text("# second\n", encoding="utf-8")
+    # Pin the session file's own mtime back so the cache stays a hit —
+    # only the memory dir gained a new file, not the transcript.
+    os.utime(session_file, (original_mtime, original_mtime))
+
+    second = main._scan_sessions_sync()
+    second_sess = next(s for s in second if s["agent"] == "claude" and s["id"] == sid)
+
+    assert second_sess.get("stub") is False
+    assert sorted(a["name"] for a in second_sess["artifacts"]) == ["first.md", "second.md"]
+
+
 def test_claude_scan_cache_miss_after_real_mtime_change(scan_env, monkeypatch):
     """A genuine content change (which naturally bumps mtime) must be
     reflected on the next scan — the cache must not mask real updates."""

--- a/backend/test_delegation.py
+++ b/backend/test_delegation.py
@@ -876,6 +876,10 @@ def test_claude_scan_cache_hit_serves_stale_content(scan_env, monkeypatch):
     first_sess = next(s for s in first if s["agent"] == "claude" and s["id"] == sid)
     first_tokens = dict(first_sess["tokens"])
     first_model = first_sess.get("model")
+    # make_claude_tree gives this session real MCP-tool and Skill signal;
+    # assert it's non-empty so the equality checks below aren't vacuous.
+    assert first_sess.get("mcp_usage")
+    assert first_sess.get("skills_used")
 
     st = session_file.stat()
     original_mtime = st.st_mtime
@@ -897,6 +901,9 @@ def test_claude_scan_cache_hit_serves_stale_content(scan_env, monkeypatch):
     assert second_sess["tokens"] == first_tokens
     assert second_sess.get("model") == first_model
     assert second_sess.get("stub") is False
+    assert second_sess.get("mcp_usage") == first_sess.get("mcp_usage")
+    assert second_sess.get("skills_used") == first_sess.get("skills_used")
+    assert second_sess.get("tool_counts") == first_sess.get("tool_counts")
 
 
 def test_claude_scan_cache_hit_still_refreshes_memory_artifacts(scan_env, monkeypatch):

--- a/backend/test_delegation.py
+++ b/backend/test_delegation.py
@@ -658,5 +658,20 @@ def test_subagent_trace_endpoint(scan_env):
     assert _run(main.session_subagent_trace(SID, "one", "gemini")) == {"error": "Invalid agent"}
 
 
+def test_claude_parsed_session_is_not_stub(scan_env):
+    make_claude_tree(scan_env / ".claude")
+    s = [s for s in main._scan_sessions_sync() if s["agent"] == "claude"][0]
+    assert s["stub"] is False
+
+
+def test_codex_parsed_session_is_not_stub(scan_env, monkeypatch):
+    codex_dir = scan_env / ".codex"
+    monkeypatch.setattr(main, "CODEX_DIR", codex_dir)
+    _make_codex_tree(codex_dir)
+    for s in main._scan_sessions_sync():
+        if s["agent"] == "codex":
+            assert s["stub"] is False
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))

--- a/backend/test_delegation.py
+++ b/backend/test_delegation.py
@@ -22,6 +22,7 @@ import pytest
 
 sys.path.insert(0, os.path.dirname(__file__))
 import main  # noqa: E402
+import scan_cache  # noqa: E402
 
 SID = "11111111-2222-3333-4444-555555555555"
 PROJ = "-tmp-proj"
@@ -741,6 +742,62 @@ def test_upsert_nonstub_default_still_overwrites(tmp_path, monkeypatch):
         con.close()
     assert row["model"] == "m2" and row["input"] == 20 and row["total"] == 25
     assert row["cost"] == 2.0
+
+
+def test_scan_cache_miss_when_no_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("TOKENTELEMETRY_DATA_DIR", str(tmp_path / "tt_data"))
+
+    result = scan_cache.read_cache("claude", "no-such-session", source_mtime=1000.0)
+
+    assert result is None
+
+
+def test_scan_cache_write_then_read_hit(tmp_path, monkeypatch):
+    monkeypatch.setenv("TOKENTELEMETRY_DATA_DIR", str(tmp_path / "tt_data"))
+
+    payload = {"model": "x", "tokens": {"total": 5}}
+    scan_cache.write_cache("claude", "sid1", source_mtime=1000.0, payload=payload)
+
+    result = scan_cache.read_cache("claude", "sid1", source_mtime=1000.0)
+
+    assert result is not None
+    assert result["model"] == "x"
+    assert result["tokens"] == {"total": 5}
+
+
+def test_scan_cache_miss_when_stale(tmp_path, monkeypatch):
+    monkeypatch.setenv("TOKENTELEMETRY_DATA_DIR", str(tmp_path / "tt_data"))
+
+    scan_cache.write_cache("claude", "sid1", source_mtime=1000.0, payload={"model": "x"})
+
+    result = scan_cache.read_cache("claude", "sid1", source_mtime=2000.0)
+
+    assert result is None
+
+
+def test_scan_cache_miss_on_corrupt_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("TOKENTELEMETRY_DATA_DIR", str(tmp_path / "tt_data"))
+
+    path = scan_cache.cache_path("claude", "sid1")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("not valid json {{{", encoding="utf-8")
+
+    result = scan_cache.read_cache("claude", "sid1", source_mtime=1000.0)
+
+    assert result is None
+
+
+def test_scan_cache_write_creates_parent_dirs(tmp_path, monkeypatch):
+    data_dir_path = tmp_path / "tt_data"
+    monkeypatch.setenv("TOKENTELEMETRY_DATA_DIR", str(data_dir_path))
+
+    assert not (data_dir_path / "cache").exists()
+    assert not (data_dir_path / "cache" / "claude").exists()
+
+    scan_cache.write_cache("claude", "sid1", source_mtime=1000.0, payload={"model": "x"})
+
+    expected_path = scan_cache.cache_path("claude", "sid1")
+    assert expected_path.exists()
 
 
 if __name__ == "__main__":

--- a/backend/test_delegation.py
+++ b/backend/test_delegation.py
@@ -16,6 +16,7 @@ import os
 import sqlite3
 import sys
 import uuid
+from datetime import datetime
 from pathlib import Path
 
 import pytest
@@ -914,6 +915,105 @@ def test_claude_scan_cache_miss_after_real_mtime_change(scan_env, monkeypatch):
 
     assert second_sess["tokens"]["input"] == first_input_tokens + 12345
     assert second_sess.get("stub") is False
+
+
+# --- Codex scan cache / cap removal -----------------------------------------
+
+def _write_codex_rollout(codex_dir, sid: str, seq: int, lines: list[dict]):
+    day = datetime(2026, 7, 1)
+    rollout_dir = codex_dir / "sessions" / f"{day.year:04d}" / f"{day.month:02d}" / f"{day.day:02d}"
+    rollout_dir.mkdir(parents=True, exist_ok=True)
+    path = rollout_dir / f"rollout-2026-07-01T00-00-{seq:02d}-{sid}.jsonl"
+    with open(path, "w", encoding="utf-8") as f:
+        for line in lines:
+            f.write(json.dumps(line) + "\n")
+    return path
+
+
+def _codex_session_meta(cwd="/tmp/proj", model="gpt-5-codex", provider="openai"):
+    return {"type": "session_meta", "payload": {"cwd": cwd, "model": model, "model_provider": provider}}
+
+
+def _codex_token_event(ts, input_tokens, cached, output, reasoning=0, total=None):
+    total = total if total is not None else (input_tokens + output + reasoning)
+    return {
+        "type": "event_msg",
+        "timestamp": ts,
+        "payload": {"type": "token_count", "info": {"total_token_usage": {
+            "input_tokens": input_tokens, "cached_input_tokens": cached,
+            "output_tokens": output, "reasoning_output_tokens": reasoning,
+            "total_tokens": total,
+        }}},
+    }
+
+
+def test_codex_scan_has_no_100_cap(scan_env, monkeypatch):
+    monkeypatch.setattr(main, "CODEX_DIR", scan_env / ".codex")
+    monkeypatch.setenv("TOKENTELEMETRY_DATA_DIR", str(scan_env / "tt_data"))
+    codex_dir = scan_env / ".codex"
+    for i in range(115):
+        sid = f"019eb056-4eae-7280-8617-{i:012d}"
+        _write_codex_rollout(codex_dir, sid, i, [
+            _codex_session_meta(),
+            _codex_token_event("2026-07-01T00:00:00Z", 100, 0, 50),
+        ])
+
+    result = main._scan_sessions_sync()
+    codex_sessions = [s for s in result if s.get("agent") == "codex"]
+    assert len(codex_sessions) >= 115
+    stubs = [s for s in codex_sessions
+             if s.get("model") is None and s["tokens"]["total"] == 0 and s.get("stub") is True]
+    assert not stubs
+
+
+def test_codex_scan_cache_hit_serves_stale_content(scan_env, monkeypatch):
+    monkeypatch.setattr(main, "CODEX_DIR", scan_env / ".codex")
+    monkeypatch.setenv("TOKENTELEMETRY_DATA_DIR", str(scan_env / "tt_data"))
+    codex_dir = scan_env / ".codex"
+    sid = "019eb056-4eae-7280-8617-000000000001"
+    path = _write_codex_rollout(codex_dir, sid, 0, [
+        _codex_session_meta(),
+        _codex_token_event("2026-07-01T00:00:00Z", 100, 10, 50),
+        {"type": "response_item", "payload": {"type": "function_call", "name": "shell", "arguments": ""}},
+    ])
+
+    result1 = main._scan_sessions_sync()
+    sess1 = next(s for s in result1 if s["id"] == sid)
+    mtime = path.stat().st_mtime
+
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(_codex_token_event("2026-07-01T00:05:00Z", 999, 0, 999)) + "\n")
+    os.utime(path, (mtime, mtime))  # pin mtime back after mutating content
+
+    result2 = main._scan_sessions_sync()
+    sess2 = next(s for s in result2 if s["id"] == sid)
+
+    assert sess2["tokens"] == sess1["tokens"]
+    assert sess2["mcp_tools"] == sess1["mcp_tools"]
+    assert sess2.get("mcp_usage") == sess1.get("mcp_usage")
+    assert sess2.get("skills_used") == sess1.get("skills_used")
+
+
+def test_codex_scan_cache_miss_after_real_mtime_change(scan_env, monkeypatch):
+    monkeypatch.setattr(main, "CODEX_DIR", scan_env / ".codex")
+    monkeypatch.setenv("TOKENTELEMETRY_DATA_DIR", str(scan_env / "tt_data"))
+    codex_dir = scan_env / ".codex"
+    sid = "019eb056-4eae-7280-8617-000000000002"
+    path = _write_codex_rollout(codex_dir, sid, 0, [
+        _codex_session_meta(),
+        _codex_token_event("2026-07-01T00:00:00Z", 100, 0, 50),
+    ])
+
+    result1 = main._scan_sessions_sync()
+    sess1 = next(s for s in result1 if s["id"] == sid)
+    assert sess1["tokens"]["total"] == 150
+
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(_codex_token_event("2026-07-01T00:05:00Z", 300, 0, 150)) + "\n")
+
+    result2 = main._scan_sessions_sync()
+    sess2 = next(s for s in result2 if s["id"] == sid)
+    assert sess2["tokens"]["total"] == 450
 
 
 if __name__ == "__main__":

--- a/backend/test_delegation.py
+++ b/backend/test_delegation.py
@@ -800,5 +800,91 @@ def test_scan_cache_write_creates_parent_dirs(tmp_path, monkeypatch):
     assert expected_path.exists()
 
 
+def test_claude_scan_has_no_100_cap(scan_env, monkeypatch):
+    """Every discovered Claude session must be parsed (or cache-hit) — never
+    left as a permanent zero-value stub because of the old [:100] slice."""
+    monkeypatch.setenv("TOKENTELEMETRY_DATA_DIR", str(scan_env / "tt_data"))
+    total = 120
+    for i in range(total):
+        sid = f"sid-{i:04d}"
+        make_claude_tree(scan_env / ".claude", sid, with_subagents=False)
+
+    sessions = main._scan_sessions_sync()
+    claude_sessions = [s for s in sessions if s["agent"] == "claude"]
+
+    assert len(claude_sessions) > 100, f"expected >100 claude sessions, got {len(claude_sessions)}"
+    for s in claude_sessions:
+        assert not (s.get("model") is None and s["tokens"]["total"] == 0), (
+            f"session {s['id']} is a permanent stub: model={s.get('model')!r}, "
+            f"tokens={s['tokens']}"
+        )
+        assert s.get("stub") is False
+
+
+def test_claude_scan_cache_hit_serves_stale_content(scan_env, monkeypatch):
+    """If the underlying .jsonl mutates but mtime is pinned back to the value
+    seen on the first scan, the second scan must serve the cached result
+    rather than re-reading the (now different) file content."""
+    monkeypatch.setenv("TOKENTELEMETRY_DATA_DIR", str(scan_env / "tt_data"))
+    sid = "sid-cache-hit"
+    session_file = make_claude_tree(scan_env / ".claude", sid, with_subagents=False)
+
+    first = main._scan_sessions_sync()
+    first_sess = next(s for s in first if s["agent"] == "claude" and s["id"] == sid)
+    first_tokens = dict(first_sess["tokens"])
+    first_model = first_sess.get("model")
+
+    st = session_file.stat()
+    original_mtime = st.st_mtime
+    with open(session_file, "a", encoding="utf-8") as f:
+        f.write(json.dumps({
+            "type": "assistant",
+            "timestamp": "2099-01-01T00:00:00Z",
+            "message": {
+                "model": "claude-mutated-model",
+                "usage": {"input_tokens": 999999, "output_tokens": 999999},
+                "content": [],
+            },
+        }) + "\n")
+    os.utime(session_file, (original_mtime, original_mtime))
+
+    second = main._scan_sessions_sync()
+    second_sess = next(s for s in second if s["agent"] == "claude" and s["id"] == sid)
+
+    assert second_sess["tokens"] == first_tokens
+    assert second_sess.get("model") == first_model
+    assert second_sess.get("stub") is False
+
+
+def test_claude_scan_cache_miss_after_real_mtime_change(scan_env, monkeypatch):
+    """A genuine content change (which naturally bumps mtime) must be
+    reflected on the next scan — the cache must not mask real updates."""
+    monkeypatch.setenv("TOKENTELEMETRY_DATA_DIR", str(scan_env / "tt_data"))
+    sid = "sid-cache-miss"
+    session_file = make_claude_tree(scan_env / ".claude", sid, with_subagents=False)
+
+    first = main._scan_sessions_sync()
+    first_sess = next(s for s in first if s["agent"] == "claude" and s["id"] == sid)
+    first_input_tokens = first_sess["tokens"]["input"]
+
+    with open(session_file, "a", encoding="utf-8") as f:
+        f.write(json.dumps({
+            "type": "assistant",
+            "timestamp": "2099-01-01T00:00:00Z",
+            "message": {
+                "model": "claude-new-turn",
+                "usage": {"input_tokens": 12345, "output_tokens": 1},
+                "content": [],
+            },
+        }) + "\n")
+    # mtime NOT pinned back — real change, real mtime bump
+
+    second = main._scan_sessions_sync()
+    second_sess = next(s for s in second if s["agent"] == "claude" and s["id"] == sid)
+
+    assert second_sess["tokens"]["input"] == first_input_tokens + 12345
+    assert second_sess.get("stub") is False
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary
Claude and Codex session scans stopped being trustworthy once a machine had more than 100 sessions: everything past the 100 most-recent was permanently stubbed at zero tokens, and reopening an old session could misdate it into "today." This branch removes the cap (backed by a new mtime-keyed sidecar cache so full scans stay fast), fixes timestamp/project/artifact/analytics correctness bugs the cap-removal exposed along the way, and hardens the new cache against a path-traversal input and a stub-vs-real data race.

### Features
- **scan:** add a reusable, mtime-keyed sidecar parse cache (`scan_cache.py`) so Claude/Codex session parsing can skip reparsing unchanged transcripts, with freshness tracked inside the JSON payload rather than relying on filesystem mtimes.

### Fixes
- **claude:** derive a session's reported timestamp from its last real user/assistant turn instead of the file's mtime — reopening an old session (e.g. via VS Code's history sidebar) no longer misdates it as happening today, which previously scattered old work into the wrong `/analytics` day bucket and could trip a false recent-activity flag.
- **claude:** remove the `[:100]` parse cap that silently froze every session past the 100 most recent as a zero-token stub; every discovered session is now parsed (or served from cache).
- **claude:** exclude `artifacts` from the sidecar cache payload so Claude Project Memory files are always rediscovered fresh, and stop `delegated_cost` from appearing as an explicit `null` on cache hits for delegation-less sessions.
- **claude:** keep MCP-tool and Skill usage analytics (`mcp_usage`/`skills_used`/`tool_counts`) intact on a cache hit — they were previously omitted from the cache payload, so the ecosystem-analytics aggregation silently undercounted toward zero as caches warmed up, with no error surfaced anywhere.
- **codex:** remove the equivalent `[:100]` parse cap and wire in the same sidecar cache, keyed on the max mtime across a session's (possibly multi-file, resumed/forked) rollout files.
- **codex:** re-run project aliasing from the cached raw cwd on every cache hit, so a session's reported project no longer freezes at `"unknown"` once its cache goes warm, and alias-table edits keep applying retroactively.
- **codex:** gate the stub→real flip on `source_mtime` (matching Claude) so an index-only session with no rollout file can no longer flip to "real" and zero-crush a previously-persisted row — the core hazard class this branch exists to fix.
- **history:** branch `upsert_sessions`'s `ON CONFLICT` clause on a `stub` flag so a stub row (partially known this scan) only touches liveness columns, never overwriting a previously-persisted real rollup's tokens/cost.
- **scan:** reject path-unsafe session ids in `scan_cache` (mirrors the existing subagent-trace guard).

### Other
- **refactor(scan):** seed a transient `stub` flag on every Claude/Codex session dict at construction, flipped to `False` once a full parse (or cache hit) completes.
- **test:** isolate `scan_cache` writes under `TOKENTELEMETRY_DATA_DIR` in the `scan_env` fixture so no scan test can leak cache files into a real `~/.tokentelemetry`; extensive new coverage for the cache, the stub-vs-real upsert guard, and the removed parse caps.
- **docs:** add an `UPDATE.json` entry (full session-history coverage + accurate session dating) per this repo's pre-push policy for the `feat:` commit above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
