### PR TITLE
fix(copilot): stop double-counting cache tokens from CLI shutdown metrics

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -76,10 +76,18 @@ def _copilot_cli_tokens_from_metrics(metrics) -> Optional[dict]:
     `session.shutdown.modelMetrics`. The exact shape varies by Copilot
     version, so we defensively sum any recognizable input/output/cache token
     counts found anywhere in the structure. Returns None when nothing usable
-    is present (caller then falls back to the per-message estimate)."""
+    is present (caller then falls back to the per-message estimate).
+
+    Copilot's `usage.inputTokens` is GROSS: it already includes
+    cacheReadTokens + cacheWriteTokens (verified against tokenDetails, whose
+    net input.tokenCount + cache_read + cache_write sums exactly to
+    inputTokens). So after collection, cache traffic is subtracted back out
+    of input — otherwise it's billed twice across the input and cached
+    buckets. The subtraction is guarded (only when input covers it) so an
+    unknown future shape that reports net input can't go negative."""
     if not isinstance(metrics, (dict, list)):
         return None
-    tot = {"input": 0, "output": 0, "cached": 0}
+    tot = {"input": 0, "output": 0, "cached": 0, "cache_creation": 0}
     found = False
 
     def grab(obj):
@@ -88,8 +96,15 @@ def _copilot_cli_tokens_from_metrics(metrics) -> Optional[dict]:
             for k, v in obj.items():
                 kl = str(k).lower()
                 if isinstance(v, (int, float)) and not isinstance(v, bool) and "token" in kl:
+                    if "reasoning" in kl:
+                        # Folded into outputTokens already; counting it (the
+                        # old "in" match caught reasonINg) double-bills it.
+                        continue
                     if "cache" in kl:
-                        tot["cached"] += int(v); found = True
+                        if "write" in kl or "creation" in kl:
+                            tot["cache_creation"] += int(v); found = True
+                        else:
+                            tot["cached"] += int(v); found = True
                     elif "out" in kl or "completion" in kl or "output" in kl:
                         tot["output"] += int(v); found = True
                     elif "in" in kl or "prompt" in kl:
@@ -101,7 +116,12 @@ def _copilot_cli_tokens_from_metrics(metrics) -> Optional[dict]:
                 grab(x)
 
     grab(metrics)
-    return tot if found else None
+    if not found:
+        return None
+    cache_total = tot["cached"] + tot["cache_creation"]
+    if cache_total and tot["input"] >= cache_total:
+        tot["input"] -= cache_total
+    return tot
 
 def _antigravity_surface_map() -> Dict[str, str]:
     """Map Antigravity session id → surface (cli / ide / app) from the brain dirs,
@@ -3784,8 +3804,8 @@ def _scan_sessions_sync():
                     tokens["input"] = in_estimate
                     tokens["output"] = out_tokens
                 tokens["total"] = tokens["input"] + tokens["output"] + tokens["cached"]
-                # Copilot CLI modelMetrics has no distinct cache-write field; nothing to pass.
-                tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"])
+                tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"],
+                                                cache_creation_tokens=tokens.get("cache_creation", 0))
                 if model and model not in models_used: models_used.insert(0, model)
                 ts = last_ts or start_ts or _file_mtime_utc(ev_file)
                 sessions.append({

--- a/backend/test_copilot_cli_metrics.py
+++ b/backend/test_copilot_cli_metrics.py
@@ -1,0 +1,86 @@
+"""Tests for _copilot_cli_tokens_from_metrics (Copilot CLI shutdown rollup).
+
+Copilot's session.shutdown.modelMetrics reports usage.inputTokens as GROSS
+(net input + cacheReadTokens + cacheWriteTokens — verifiable against the
+sibling tokenDetails breakdown). The old heuristic summed inputTokens AND
+both cache counters, double-billing all cache traffic, and its "in" substring
+match also swept reasoningTokens (reasonINg) into input.
+
+Run: pytest backend/test_copilot_cli_metrics.py
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+import main  # noqa: E402
+
+
+# Real shape captured from ~/.copilot/session-state (claude-haiku-4.5):
+# tokenDetails proves inputTokens is gross: 27 + 34516 + 28676 = 63219.
+REAL_METRICS = {
+    "claude-haiku-4.5": {
+        "requests": {"count": 3, "cost": 0.33},
+        "usage": {
+            "inputTokens": 63219,
+            "outputTokens": 1365,
+            "cacheReadTokens": 34516,
+            "cacheWriteTokens": 28676,
+            "reasoningTokens": 355,
+        },
+        "totalNanoAiu": 4614860000,
+        "tokenDetails": {
+            "input": {"tokenCount": 27},
+            "cache_read": {"tokenCount": 34516},
+            "cache_write": {"tokenCount": 28676},
+            "output": {"tokenCount": 1365},
+        },
+    }
+}
+
+
+def test_gross_input_nets_out_cache_traffic():
+    tot = main._copilot_cli_tokens_from_metrics(REAL_METRICS)
+    assert tot == {
+        "input": 27,           # 63219 - 34516 - 28676, matches tokenDetails
+        "output": 1365,
+        "cached": 34516,       # reads only
+        "cache_creation": 28676,  # writes split out, billed at write rate
+    }
+
+
+def test_reasoning_tokens_not_counted_as_input():
+    tot = main._copilot_cli_tokens_from_metrics(
+        {"usage": {"inputTokens": 100, "outputTokens": 50, "reasoningTokens": 999}})
+    assert tot["input"] == 100
+    assert tot["output"] == 50
+
+
+def test_net_input_shape_not_driven_negative():
+    # A hypothetical future shape reporting NET input alongside cache
+    # counters: input (10) < cache traffic (300), so the gross-input
+    # subtraction must not fire.
+    tot = main._copilot_cli_tokens_from_metrics(
+        {"usage": {"inputTokens": 10, "outputTokens": 5,
+                   "cacheReadTokens": 200, "cacheWriteTokens": 100}})
+    assert tot["input"] == 10
+    assert tot["cached"] == 200
+    assert tot["cache_creation"] == 100
+
+
+def test_simple_prompt_completion_shape_unchanged():
+    tot = main._copilot_cli_tokens_from_metrics(
+        {"gpt-x": {"promptTokens": 120, "completionTokens": 30}})
+    assert tot["input"] == 120
+    assert tot["output"] == 30
+    assert tot["cached"] == 0 and tot["cache_creation"] == 0
+
+
+def test_unusable_metrics_return_none():
+    assert main._copilot_cli_tokens_from_metrics(None) is None
+    assert main._copilot_cli_tokens_from_metrics({"requests": {"count": 3}}) is None
+    assert main._copilot_cli_tokens_from_metrics("nope") is None
+
+
+if __name__ == "__main__":
+    import pytest
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary
Found while auditing compaction handling across agent scanners: Copilot CLI session totals were inflated because `usage.inputTokens` in `session.shutdown.modelMetrics` is **gross** (it already includes `cacheReadTokens` + `cacheWriteTokens`), and the rollup heuristic summed the gross figure *and* both cache counters. In the one real Copilot CLI session on this machine, 62.9k of 63.2k input tokens are cache traffic counted twice (true net input: 27 tokens, per Copilot's own `tokenDetails` breakdown).

Two more inaccuracies in the same helper:
- `reasoningTokens` matched the `"in"` substring check (reason**in**g) and landed in input, though Copilot folds reasoning into `outputTokens`.
- `cacheWriteTokens` was lumped into `cached` and priced at the cache-read rate; it's now a separate `cache_creation` bucket passed to `calculate_cost`.

The gross→net subtraction is guarded (only fires when input covers the cache total) so a future Copilot shape reporting net input can't go negative.

## Tests
`backend/test_copilot_cli_metrics.py`: real captured metrics shape (asserts net 27/34516/28676/1365 split), reasoning exclusion, net-input guard, legacy prompt/completion shape, unusable-input None. All pass; no regressions in the scan suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)