### PR TITLE
docs: credit external contributors in UPDATE.json release notes

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -66,6 +66,10 @@ easy to forget the file, and a stale banner is worse than no banner
 - Go to the **top** of `releases[]` (newest first — drawer renders top-down)
 - Have a description that helps a non-technical user understand *why* this matters, not just *what* changed
 - Use an `href` when a single page is the natural landing spot for the change (e.g. a new feature page, a redesigned section)
+- Credit external contributors for major community-raised bugs/fixes: end the
+  relevant highlight's description with "Thanks to <github-username> for
+  reporting and fixing this (PR #N)." Reserve credit for significant external
+  contributions so it stays meaningful; maintainer changes carry no credit line.
 
 ## When the hook gets in your way
 


### PR DESCRIPTION
Codifies the convention started in PR #131: major community-raised bugs/fixes get a closing thanks line (GitHub username + PR number) in the relevant UPDATE.json highlight description. Reserved for significant external contributions so credit stays meaningful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)