### PR TITLE
feat: add Pi Coding Agent session support (#135)

### DIFF
--- a/UPDATE.json
+++ b/UPDATE.json
@@ -1,6 +1,22 @@
 {
   "releases": [
     {
+      "tag": "2026-07-12",
+      "title": "Pi Coding Agent support",
+      "highlights": [
+        {
+          "title": "Pi sessions now show up automatically",
+          "description": "If you use the Pi Coding Agent, its sessions are now detected and tracked alongside Claude Code, Codex, Cursor and the rest — grouped by project, with the full prompt/response trace, tools used, and model. Nothing to configure; TokenTelemetry reads Pi's local session history. Thanks to Tharun-tharun for requesting this (issue #135).",
+          "href": "/sessions"
+        },
+        {
+          "title": "Accurate per-turn cost, including local models",
+          "description": "Pi records real token usage on every turn, so cost is computed per message using that turn's own model — mixed-model sessions add up correctly. When Pi runs against Ollama or another local endpoint, those turns are priced by electricity instead of API rates.",
+          "href": "/analytics"
+        }
+      ]
+    },
+    {
       "tag": "2026-07-09",
       "title": "Every session tracked, correctly dated",
       "highlights": [

--- a/backend/main.py
+++ b/backend/main.py
@@ -278,6 +278,13 @@ QWEN_DIR = HOME / ".qwen"
 VIBE_DIR = HOME / ".vibe"
 CURSOR_DIR = HOME / ".cursor"
 OLLAMA_DIR = HOME / ".ollama"
+# Pi Coding Agent (earendil-works) — stores one JSONL per session under
+# ~/.pi/agent/sessions/<encoded-cwd>/<timestamp>_<uuid>.jsonl. Each file opens
+# with a {"type":"session", cwd, timestamp} header, then message events whose
+# assistant turns carry per-request usage + cost + provider/model. See
+# _scan_pi_sessions.
+PI_DIR = HOME / ".pi" / "agent"
+PI_SESSIONS_DIR = PI_DIR / "sessions"
 HF_DIR = HOME / ".cache/huggingface"
 OPENCODE_DB = HOME / ".local/share/opencode/opencode.db"
 # Hermes installs to ~/.hermes by default, but the agent honors HERMES_HOME for
@@ -1788,6 +1795,7 @@ def _list_available_agents() -> list:
     if OPENCODE_DB.exists(): agents.append("opencode")
     if _hermes_dbs(): agents.append("hermes")
     if GROK_SESSIONS_DIR.exists(): agents.append("grok")
+    if PI_SESSIONS_DIR.exists(): agents.append("pi")
     if (CLINE_DIR / "data" / "db" / "sessions.db").exists() or (CLINE_VSCODE_DIR / "state" / "taskHistory.json").exists():
         agents.append("cline")
     # SmallCode traces are project-local; cheaply check only the explicitly
@@ -2392,6 +2400,180 @@ def _scan_cline_sessions() -> List[Dict[str, Any]]:
                     },
                 })
                 seen_ids.add(sid)
+
+    return out
+
+
+def _scan_pi_sessions() -> List[Dict[str, Any]]:
+    """Scan Pi Coding Agent sessions under ~/.pi/agent/sessions/.
+
+    Layout: one JSONL per session, bucketed by encoded cwd:
+        ~/.pi/agent/sessions/<encoded-cwd>/<ts>_<uuid>.jsonl
+
+    Each file begins with a {"type":"session", id, cwd, timestamp} header, then a
+    stream of events. The ones we read:
+      - {"type":"model_change", provider, modelId}   -> current model/provider
+      - {"type":"message", message:{...}}            -> a turn. For assistant turns
+        `message` carries `provider`, `model` and a per-request `usage`:
+          {input, output, cacheRead, cacheWrite, reasoning, totalTokens,
+           cost:{...}}  (reasoning is a subset of output; totalTokens =
+           input + output + cacheRead, so we never double-count it.)
+
+    Cost is recomputed with TokenTelemetry's own pricing PER MESSAGE using that
+    message's model+provider, so mixed-model sessions bill correctly and Pi→Ollama
+    sessions fall through to the local-electricity branch in calculate_cost.
+    """
+    if not PI_SESSIONS_DIR.exists():
+        return []
+
+    aliases = _load_project_aliases()
+    def _apply_alias(p: str) -> str:
+        return aliases.get(p, p)
+
+    out: List[Dict[str, Any]] = []
+
+    for bucket in PI_SESSIONS_DIR.iterdir():
+        if not bucket.is_dir():
+            continue
+        for sess_file in bucket.glob("*.jsonl"):
+            try:
+                sid = None
+                project = None
+                header_ts = None
+                last_ts = None
+                cur_model = None
+                cur_provider = None
+                sess_model = None
+                sess_provider = None
+                display = None
+                msg_count = 0
+                tokens = {"input": 0, "output": 0, "cached": 0,
+                          "cache_creation": 0, "reasoning": 0, "total": 0}
+                cost = 0.0
+                tool_counts: Dict[str, int] = {}
+                models_used: List[str] = []
+
+                with open(sess_file, "r", encoding="utf-8", errors="replace") as f:
+                    for line in f:
+                        line = line.strip()
+                        if not line:
+                            continue
+                        try:
+                            evt = json.loads(line)
+                        except Exception:
+                            continue
+                        etype = evt.get("type")
+
+                        if etype == "session":
+                            sid = evt.get("id") or sid
+                            cwd = evt.get("cwd")
+                            if cwd:
+                                project = _apply_alias(cwd)
+                            ts_raw = evt.get("timestamp")
+                            if ts_raw:
+                                try:
+                                    header_ts = _aware(datetime.fromisoformat(
+                                        str(ts_raw).replace("Z", "+00:00")))
+                                except Exception:
+                                    header_ts = None
+                            continue
+
+                        if etype == "model_change":
+                            cur_provider = evt.get("provider") or cur_provider
+                            cur_model = evt.get("modelId") or cur_model
+                            continue
+
+                        if etype != "message":
+                            continue
+
+                        m = evt.get("message") or {}
+                        role = m.get("role")
+
+                        ts_raw = evt.get("timestamp")
+                        if ts_raw:
+                            try:
+                                _ts = _aware(datetime.fromisoformat(
+                                    str(ts_raw).replace("Z", "+00:00")))
+                                if last_ts is None or _ts > last_ts:
+                                    last_ts = _ts
+                            except Exception:
+                                pass
+
+                        if role == "user" and display is None:
+                            for c in (m.get("content") or []):
+                                if isinstance(c, dict) and c.get("type") == "text":
+                                    t = (c.get("text") or "").strip()
+                                    preview = _strip_context_tags(t).strip()
+                                    if preview:
+                                        display = preview[:120]
+                                        break
+
+                        if role == "assistant":
+                            msg_model = m.get("model") or cur_model
+                            msg_provider = m.get("provider") or cur_provider
+                            if msg_model:
+                                sess_model = msg_model
+                                sess_provider = msg_provider
+                                if msg_model not in models_used:
+                                    models_used.append(msg_model)
+                            for c in (m.get("content") or []):
+                                if isinstance(c, dict) and c.get("type") == "toolCall":
+                                    _count_tool(tool_counts, c.get("name"))
+                            u = m.get("usage")
+                            if isinstance(u, dict):
+                                in_t = u.get("input", 0) or 0
+                                out_t = u.get("output", 0) or 0
+                                cr = u.get("cacheRead", 0) or 0
+                                cw = u.get("cacheWrite", 0) or 0
+                                reas = u.get("reasoning", 0) or 0
+                                tokens["input"] += in_t
+                                tokens["output"] += out_t
+                                tokens["cached"] += cr
+                                tokens["cache_creation"] += cw
+                                tokens["reasoning"] += reas
+                                # Recompute per message with that turn's own model
+                                # so mixed-model / local sessions price correctly.
+                                cost += calculate_cost(
+                                    msg_model, in_t, out_t, cr,
+                                    cache_creation_tokens=cw,
+                                    provider=msg_provider,
+                                )
+                            msg_count += 1
+                        elif role in ("user", "toolResult"):
+                            msg_count += 1
+            except Exception:
+                continue
+
+            if sid is None:
+                continue
+
+            ts = last_ts or header_ts or _file_mtime_utc(sess_file)
+            tokens["total"] = tokens["input"] + tokens["output"] + tokens["cached"]
+            tokens["cost"] = cost
+
+            sess = {
+                "id": sid,
+                "agent": "pi",
+                "project": project or "unknown",
+                "timestamp": ts,
+                "display": display or f"Pi session {sid[:8]}",
+                "text": display,
+                "tokens": tokens,
+                "mcp_tools": [t for t in tool_counts if isinstance(t, str) and t.startswith("mcp")],
+                "has_plan": False,
+                "plans": [],
+                "model": sess_model or cur_model,
+                "artifacts": [{"name": sess_file.name, "path": str(sess_file), "type": "document"}],
+                "cost": cost,
+                "pi": {
+                    "provider": sess_provider or cur_provider,
+                    "models_used": models_used,
+                    "num_messages": msg_count,
+                    "reasoning_tokens": tokens["reasoning"],
+                },
+            }
+            _attach_tool_usage(sess, tool_counts)
+            out.append(sess)
 
     return out
 
@@ -4086,6 +4268,9 @@ def _scan_sessions_sync():
     # 8b. Cline — CLI SQLite store + VS Code extension JSON store
     sessions.extend(_scan_cline_sessions())
 
+    # 8b2. Pi Coding Agent — one JSONL per session under ~/.pi/agent/sessions/
+    sessions.extend(_scan_pi_sessions())
+
     # 8c. SmallCode — traces are PROJECT-LOCAL (<project>/.smallcode/traces/),
     # so discover roots from projects already seen from other agents (they ran
     # somewhere real) unioned with any user-configured extra roots, then scan.
@@ -4597,6 +4782,97 @@ async def get_session_detail(session_id: str, agent: str):
                 pass
 
         # Already in file order (monotonic via seq).
+        return events
+
+    elif agent == "pi":
+        # Pi Coding Agent JSONL. Normalize each message into Claude-shaped events
+        # (role user/assistant, content blocks type text/thinking/tool_use/
+        # tool_result) so the existing EventCard renderer handles it unchanged.
+        # Pi carries real per-message timestamps, so no synthetic timeline needed.
+        sess_file = None
+        if PI_SESSIONS_DIR.exists():
+            for bucket in PI_SESSIONS_DIR.iterdir():
+                if not bucket.is_dir():
+                    continue
+                match = list(bucket.glob(f"*{session_id}*.jsonl"))
+                if match:
+                    sess_file = match[0]
+                    break
+        if not sess_file:
+            return {"error": "Not found"}
+
+        events: List[Dict[str, Any]] = []
+        with open(sess_file, "r", encoding="utf-8", errors="replace") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    evt = json.loads(line)
+                except Exception:
+                    continue
+                if evt.get("type") != "message":
+                    continue
+                m = evt.get("message") or {}
+                role = m.get("role")
+                norm = None
+
+                if role == "user":
+                    text = "".join(
+                        c.get("text", "") for c in (m.get("content") or [])
+                        if isinstance(c, dict) and c.get("type") == "text"
+                    )
+                    norm = {"type": "user", "message": {"role": "user",
+                            "content": [{"type": "text", "text": text}]}}
+
+                elif role == "assistant":
+                    blocks: List[Dict[str, Any]] = []
+                    for c in (m.get("content") or []):
+                        if not isinstance(c, dict):
+                            continue
+                        ctype = c.get("type")
+                        if ctype == "thinking":
+                            think = c.get("thinking") or ""
+                            if think.strip():
+                                blocks.append({"type": "thinking", "thinking": think})
+                        elif ctype == "text":
+                            txt = c.get("text") or ""
+                            if txt.strip():
+                                blocks.append({"type": "text", "text": txt})
+                        elif ctype == "toolCall":
+                            blocks.append({
+                                "type": "tool_use",
+                                "id": c.get("id"),
+                                "name": c.get("name"),
+                                "input": c.get("arguments") or {},
+                            })
+                    if blocks:
+                        norm = {"type": "assistant", "message":
+                                {"role": "assistant", "content": blocks}}
+
+                elif role == "toolResult":
+                    content = m.get("content")
+                    if isinstance(content, list):
+                        content = "".join(
+                            c.get("text", "") for c in content
+                            if isinstance(c, dict) and c.get("type") == "text"
+                        )
+                    norm = {"type": "user", "message": {"role": "user", "content": [{
+                        "type": "tool_result",
+                        "tool_use_id": m.get("toolCallId"),
+                        "content": content or "",
+                    }]}}
+
+                if norm is None:
+                    continue
+                ts_raw = evt.get("timestamp")
+                if ts_raw:
+                    try:
+                        _ts = _aware(datetime.fromisoformat(str(ts_raw).replace("Z", "+00:00")))
+                        norm["normalized_timestamp"] = _ts.timestamp() * 1000
+                    except Exception:
+                        pass
+                events.append(norm)
         return events
 
     elif agent in ["gemini", "antigravity"]:

--- a/backend/test_pi_scan.py
+++ b/backend/test_pi_scan.py
@@ -1,0 +1,235 @@
+"""Tests for native session scanning of the Pi Coding Agent (issue #135).
+
+Pi stores one JSONL per session, bucketed by encoded cwd:
+    ~/.pi/agent/sessions/<encoded-cwd>/<ts>_<uuid>.jsonl
+
+Each file opens with a {"type":"session", id, cwd, timestamp} header, then a
+stream of message events. Assistant turns carry `message.provider`,
+`message.model` and a per-request `message.usage` block with input/output/
+cacheRead/cacheWrite/reasoning and a nested cost — verified against a real Pi
+0.80.3 session on disk. The scanner recomputes cost with TokenTelemetry's own
+pricing (per message, so mixed-model sessions bill correctly).
+
+Run: pytest backend/test_pi_scan.py -q
+"""
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+import main  # noqa: E402
+from pricing import calculate_cost  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixture builder — mirrors the real Pi JSONL event shape.
+# ---------------------------------------------------------------------------
+
+def _assistant(model, provider, *, input, output, cacheRead=0, cacheWrite=0,
+               reasoning=0, ts, content):
+    return {
+        "type": "message",
+        "id": "a" + str(ts),
+        "timestamp": ts,
+        "message": {
+            "role": "assistant",
+            "content": content,
+            "api": "openai-completions",
+            "provider": provider,
+            "model": model,
+            "usage": {
+                "input": input, "output": output,
+                "cacheRead": cacheRead, "cacheWrite": cacheWrite,
+                "reasoning": reasoning,
+                "totalTokens": input + output + cacheRead,
+                "cost": {"total": 0.0},  # ignored; TT recomputes
+            },
+            "stopReason": "toolUse" if any(c.get("type") == "toolCall" for c in content) else "endTurn",
+        },
+    }
+
+
+def _write_pi_session(root: Path, *, cwd, sid, provider="cerebras",
+                      model="zai-glm-4.7", second_model=None):
+    """Write one Pi session JSONL and return its path. The session:
+      user -> assistant(thinking+toolCall) -> toolResult -> assistant(text).
+    When second_model is set, the final assistant turn uses a different model
+    to exercise per-message pricing on mixed-model sessions.
+    """
+    bucket = root / cwd.replace("/", "-")
+    bucket.mkdir(parents=True, exist_ok=True)
+    m2 = second_model or model
+    events = [
+        {"type": "session", "version": 3, "id": sid,
+         "timestamp": "2026-07-05T07:40:17.539Z", "cwd": cwd},
+        {"type": "model_change", "id": "mc1", "provider": provider, "modelId": model},
+        {"type": "thinking_level_change", "id": "tl1", "thinkingLevel": "medium"},
+        {"type": "message", "id": "u1", "timestamp": "2026-07-05T07:40:59.792Z",
+         "message": {"role": "user",
+                     "content": [{"type": "text", "text": "add pi support to the scanner"}]}},
+        _assistant(model, provider, input=2965, output=185, cacheRead=100,
+                   cacheWrite=50, reasoning=100, ts="2026-07-05T07:41:00.789Z",
+                   content=[
+                       {"type": "thinking", "thinking": "Let me read the docs."},
+                       {"type": "text", "text": "Reading the provider docs."},
+                       {"type": "toolCall", "id": "tc1", "name": "read",
+                        "arguments": {"path": "/docs/models.md"}},
+                   ]),
+        {"type": "message", "id": "tr1", "timestamp": "2026-07-05T07:41:01.000Z",
+         "message": {"role": "toolResult", "toolCallId": "tc1", "toolName": "read",
+                     "content": [{"type": "text", "text": "# Custom Models ..."}]}},
+        _assistant(m2, provider, input=500, output=42, cacheRead=200, cacheWrite=0,
+                   reasoning=0, ts="2026-07-05T07:41:05.000Z",
+                   content=[{"type": "text", "text": "Done."}]),
+    ]
+    f = bucket / f"2026-07-05T07-40-17-539Z_{sid}.jsonl"
+    f.write_text("\n".join(json.dumps(e) for e in events) + "\n", encoding="utf-8")
+    return f
+
+
+# ---------------------------------------------------------------------------
+# Scan
+# ---------------------------------------------------------------------------
+
+def test_scan_pi_maps_tokens_cost_and_project(tmp_path, monkeypatch):
+    root = tmp_path / "sessions"
+    cwd = "/Users/dev/proj-alpha"
+    sid = "019f3138-8d03-76e7-9793-2510fffacaef"
+    _write_pi_session(root, cwd=cwd, sid=sid)
+    monkeypatch.setattr(main, "PI_SESSIONS_DIR", root)
+    monkeypatch.setattr(main, "_load_project_aliases", lambda: {})
+
+    out = main._scan_pi_sessions()
+    assert len(out) == 1
+    s = out[0]
+    assert s["agent"] == "pi"
+    assert s["id"] == sid
+    assert s["project"] == cwd
+    assert s["model"] == "zai-glm-4.7"
+
+    # Tokens summed across the two assistant turns.
+    tk = s["tokens"]
+    assert tk["input"] == 2965 + 500
+    assert tk["output"] == 185 + 42
+    assert tk["cached"] == 100 + 200
+    assert tk["cache_creation"] == 50
+    assert tk["reasoning"] == 100
+    assert tk["total"] == tk["input"] + tk["output"] + tk["cached"]
+
+    # Cost recomputed per message with TT pricing — must match the sum of the
+    # two independent per-turn calculate_cost calls exactly.
+    expected = (
+        calculate_cost("zai-glm-4.7", 2965, 185, 100, cache_creation_tokens=50, provider="cerebras")
+        + calculate_cost("zai-glm-4.7", 500, 42, 200, cache_creation_tokens=0, provider="cerebras")
+    )
+    assert s["cost"] == pytest.approx(expected)
+    assert s["tokens"]["cost"] == pytest.approx(expected)
+
+    # Tool call captured; display taken from the first user prompt.
+    assert s["tool_counts"] == {"read": 1}
+    assert s["display"] == "add pi support to the scanner"
+    assert s["pi"]["provider"] == "cerebras"
+
+
+def test_scan_pi_mixed_model_prices_each_turn(tmp_path, monkeypatch):
+    """A session that switches model mid-way must price each turn with its own
+    model, not one session-level model applied to all tokens."""
+    root = tmp_path / "sessions"
+    _write_pi_session(root, cwd="/Users/dev/proj-beta",
+                      sid="019f3139-aaaa-bbbb-cccc-000000000001",
+                      provider="cerebras", model="zai-glm-4.7",
+                      second_model="qwen-3-235b-a22b-instruct-2507")
+    monkeypatch.setattr(main, "PI_SESSIONS_DIR", root)
+    monkeypatch.setattr(main, "_load_project_aliases", lambda: {})
+
+    s = main._scan_pi_sessions()[0]
+    expected = (
+        calculate_cost("zai-glm-4.7", 2965, 185, 100, cache_creation_tokens=50, provider="cerebras")
+        + calculate_cost("qwen-3-235b-a22b-instruct-2507", 500, 42, 200, cache_creation_tokens=0, provider="cerebras")
+    )
+    assert s["cost"] == pytest.approx(expected)
+    # Last-seen model wins as the session's headline model.
+    assert s["model"] == "qwen-3-235b-a22b-instruct-2507"
+    assert set(s["pi"]["models_used"]) == {"zai-glm-4.7", "qwen-3-235b-a22b-instruct-2507"}
+
+
+def test_scan_pi_applies_project_alias(tmp_path, monkeypatch):
+    root = tmp_path / "sessions"
+    _write_pi_session(root, cwd="/old/path", sid="019f3140-dead-beef-cafe-000000000002")
+    monkeypatch.setattr(main, "PI_SESSIONS_DIR", root)
+    monkeypatch.setattr(main, "_load_project_aliases", lambda: {"/old/path": "/new/path"})
+    s = main._scan_pi_sessions()[0]
+    assert s["project"] == "/new/path"
+
+
+def test_scan_pi_missing_dir_returns_empty(tmp_path, monkeypatch):
+    monkeypatch.setattr(main, "PI_SESSIONS_DIR", tmp_path / "nope")
+    assert main._scan_pi_sessions() == []
+
+
+def test_scan_pi_skips_corrupt_lines(tmp_path, monkeypatch):
+    root = tmp_path / "sessions"
+    f = _write_pi_session(root, cwd="/Users/dev/proj", sid="019f3141-0000-0000-0000-000000000003")
+    # Corrupt the file with a garbage line in the middle; scan must still work.
+    good = f.read_text().splitlines()
+    good.insert(4, "{not json at all")
+    f.write_text("\n".join(good) + "\n", encoding="utf-8")
+    monkeypatch.setattr(main, "PI_SESSIONS_DIR", root)
+    monkeypatch.setattr(main, "_load_project_aliases", lambda: {})
+    out = main._scan_pi_sessions()
+    assert len(out) == 1
+    assert out[0]["tokens"]["input"] > 0
+
+
+# ---------------------------------------------------------------------------
+# Detection
+# ---------------------------------------------------------------------------
+
+def test_pi_detected_when_sessions_dir_exists(tmp_path, monkeypatch):
+    root = tmp_path / "sessions"
+    _write_pi_session(root, cwd="/Users/dev/proj", sid="019f3142-0000-0000-0000-000000000004")
+    monkeypatch.setattr(main, "PI_SESSIONS_DIR", root)
+    assert "pi" in main._list_available_agents()
+
+    monkeypatch.setattr(main, "PI_SESSIONS_DIR", tmp_path / "gone")
+    assert "pi" not in main._list_available_agents()
+
+
+# ---------------------------------------------------------------------------
+# Session detail trace
+# ---------------------------------------------------------------------------
+
+def test_session_detail_pi_normalizes_to_claude_shape(tmp_path, monkeypatch):
+    root = tmp_path / "sessions"
+    sid = "019f3143-0000-0000-0000-000000000005"
+    _write_pi_session(root, cwd="/Users/dev/proj", sid=sid)
+    monkeypatch.setattr(main, "PI_SESSIONS_DIR", root)
+
+    events = asyncio.get_event_loop().run_until_complete(
+        main.get_session_detail(sid, "pi"))
+    assert isinstance(events, list) and events
+
+    # Every event is Claude-shaped and carries a normalized timestamp.
+    assert all("normalized_timestamp" in e for e in events)
+    roles = [e["message"]["role"] for e in events]
+    assert roles[0] == "user"
+
+    # tool_use blocks must pair 1:1 with tool_result blocks by id.
+    tu = {b["id"] for e in events for b in e["message"]["content"] if b["type"] == "tool_use"}
+    tr = {b["tool_use_id"] for e in events for b in e["message"]["content"] if b.get("type") == "tool_result"}
+    assert tu and tu == tr
+
+    # Thinking + text blocks survive on the assistant turn.
+    kinds = {b["type"] for e in events for b in e["message"]["content"]}
+    assert {"thinking", "text", "tool_use", "tool_result"} <= kinds
+
+
+def test_session_detail_pi_not_found(tmp_path, monkeypatch):
+    monkeypatch.setattr(main, "PI_SESSIONS_DIR", tmp_path / "sessions")
+    res = asyncio.get_event_loop().run_until_complete(
+        main.get_session_detail("nonexistent-id", "pi"))
+    assert res == {"error": "Not found"}

--- a/frontend/src/components/icons/PiIcon.tsx
+++ b/frontend/src/components/icons/PiIcon.tsx
@@ -1,0 +1,29 @@
+import { forwardRef } from "react";
+import type { LucideIcon, LucideProps } from "lucide-react";
+
+// Pi Coding Agent brand mark — the blocky geometric "pi" glyph from
+// pi.dev/favicon.svg (viewBox 0 0 800 800). Rendered as a FILLED glyph
+// (fill="currentColor") so it inherits the agent's accent color and stays solid
+// on the dark theme, matching GrokIcon. The brand's rounded #09090b container
+// square is intentionally dropped so it reads as an icon like the others.
+const PiIcon = forwardRef<SVGSVGElement, LucideProps>(({ size, strokeWidth, ...props }, ref) => (
+  <svg
+    ref={ref}
+    xmlns="http://www.w3.org/2000/svg"
+    width={size ?? 24}
+    height={size ?? 24}
+    viewBox="0 0 800 800"
+    fill="currentColor"
+    stroke="none"
+    {...props}
+  >
+    <path
+      fillRule="evenodd"
+      d="M165.29 165.29H517.36V400H400V517.36H282.65V634.72H165.29ZM282.65 282.65V400H400V282.65Z"
+    />
+    <path d="M517.36 400H634.72V634.72H517.36Z" />
+  </svg>
+));
+PiIcon.displayName = "PiIcon";
+
+export default PiIcon as LucideIcon;

--- a/frontend/src/lib/agents.ts
+++ b/frontend/src/lib/agents.ts
@@ -1,6 +1,6 @@
 import {
   Terminal, Database, Sparkles, Orbit, Cpu, Zap, MousePointer2,
-  GitBranch, Code2, Server, Bot, Boxes, type LucideIcon,
+  GitBranch, Code2, Server, Bot, Boxes, Pi, type LucideIcon,
 } from "lucide-react";
 import HermesIcon from "@/components/icons/HermesIcon";
 import GrokIcon from "@/components/icons/GrokIcon";
@@ -8,7 +8,7 @@ import GrokIcon from "@/components/icons/GrokIcon";
 export type AgentKey =
   | "claude" | "codex" | "gemini" | "antigravity"
   | "qwen" | "vibe" | "cursor" | "copilot" | "opencode" | "hermes" | "grok"
-  | "openai_compat" | "cline" | "smallcode";
+  | "openai_compat" | "cline" | "smallcode" | "pi";
 
 export interface AgentMeta {
   key: AgentKey;
@@ -33,6 +33,7 @@ export const AGENTS: Record<AgentKey, AgentMeta> = {
   openai_compat: { key: "openai_compat", label: "OpenAI-compatible server", hex: "#14b8a6", icon: Server },
   cline:       { key: "cline",       label: "Cline",       hex: "#7c3aed", icon: Bot },
   smallcode:   { key: "smallcode",   label: "SmallCode",   hex: "#0d9488", icon: Boxes },
+  pi:          { key: "pi",          label: "Pi",          hex: "#e11d48", icon: Pi },
 };
 
 const FALLBACK: AgentMeta = {

--- a/frontend/src/lib/agents.ts
+++ b/frontend/src/lib/agents.ts
@@ -33,7 +33,7 @@ export const AGENTS: Record<AgentKey, AgentMeta> = {
   openai_compat: { key: "openai_compat", label: "OpenAI-compatible server", hex: "#14b8a6", icon: Server },
   cline:       { key: "cline",       label: "Cline",       hex: "#7c3aed", icon: Bot },
   smallcode:   { key: "smallcode",   label: "SmallCode",   hex: "#0d9488", icon: Boxes },
-  pi:          { key: "pi",          label: "Pi",          hex: "#e11d48", icon: Pi },
+  pi:          { key: "pi",          label: "Pi",          hex: "#d946ef", icon: Pi },
 };
 
 const FALLBACK: AgentMeta = {

--- a/frontend/src/lib/agents.ts
+++ b/frontend/src/lib/agents.ts
@@ -1,9 +1,10 @@
 import {
   Terminal, Database, Sparkles, Orbit, Cpu, Zap, MousePointer2,
-  GitBranch, Code2, Server, Bot, Boxes, Pi, type LucideIcon,
+  GitBranch, Code2, Server, Bot, Boxes, type LucideIcon,
 } from "lucide-react";
 import HermesIcon from "@/components/icons/HermesIcon";
 import GrokIcon from "@/components/icons/GrokIcon";
+import PiIcon from "@/components/icons/PiIcon";
 
 export type AgentKey =
   | "claude" | "codex" | "gemini" | "antigravity"
@@ -33,7 +34,7 @@ export const AGENTS: Record<AgentKey, AgentMeta> = {
   openai_compat: { key: "openai_compat", label: "OpenAI-compatible server", hex: "#14b8a6", icon: Server },
   cline:       { key: "cline",       label: "Cline",       hex: "#7c3aed", icon: Bot },
   smallcode:   { key: "smallcode",   label: "SmallCode",   hex: "#0d9488", icon: Boxes },
-  pi:          { key: "pi",          label: "Pi",          hex: "#d946ef", icon: Pi },
+  pi:          { key: "pi",          label: "Pi",          hex: "#fafafa", icon: PiIcon },
 };
 
 const FALLBACK: AgentMeta = {


### PR DESCRIPTION
Closes #135.

Adds detection and tracking for the [Pi Coding Agent](https://github.com/earendil-works) alongside Claude Code, Codex, Cursor, etc.

## What Pi stores
One JSONL per session under `~/.pi/agent/sessions/<encoded-cwd>/<ts>_<uuid>.jsonl`. Each file opens with a `{"type":"session", id, cwd, timestamp}` header, then message events. Assistant turns carry `message.provider`, `message.model`, and a per-request `message.usage` (`input`/`output`/`cacheRead`/`cacheWrite`/`reasoning` + a nested cost). Verified against real Pi 0.80.3 sessions on disk.

## Changes
- **`backend/main.py`**
  - `PI_DIR` / `PI_SESSIONS_DIR` constants; `"pi"` added to `_list_available_agents`.
  - `_scan_pi_sessions()` — one session per JSONL. Project comes from the header `cwd` (alias-applied). Tokens are summed across assistant turns; **cost is recomputed with TokenTelemetry pricing per message** using that turn's own model+provider, so mixed-model sessions bill correctly and Pi→Ollama turns fall through to the local-electricity branch in `calculate_cost`. Tool calls feed `tool_counts` / `mcp_usage`.
  - `get_session_detail` `"pi"` branch normalizes each message into Claude-shaped events (`text`/`thinking`/`tool_use`/`tool_result`) with real per-message timestamps, so the existing trace renderer handles Pi unchanged. `tool_use` pairs 1:1 with `tool_result` by id.
- **`frontend/src/lib/agents.ts`** — register the `pi` agent (label "Pi", colour, lucide `Pi` icon).
- **`backend/test_pi_scan.py`** — new tests: token/cost mapping, per-turn pricing on mixed-model sessions, alias application, corrupt-line tolerance, detection, detail-trace normalization.

## Verification
- 8/8 new tests pass; full existing suite green except one **pre-existing** unrelated failure (`test_analytics_ecosystem_aggregates`, reproduces on `main` with this change stashed).
- End-to-end against real on-disk Pi sessions: scanner tokens **and** cost match an independent raw-file recompute **exactly** across all 8 local sessions (mixed models: grok-4.3 via xai-auth, zai-glm-4.7 / qwen via cerebras).
- `frontend` `tsc --noEmit` passes.

Maps to every capability in the issue: automatic detection, project grouping, session timeline, prompt/response traces, token usage, model info, cost estimation for API-backed models, and local-model (Ollama) stats via the electricity-costing branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)