### PR TITLE
feat: anonymous per-agent model-family telemetry

### DIFF
--- a/UPDATE.json
+++ b/UPDATE.json
@@ -2,6 +2,17 @@
   "releases": [
     {
       "tag": "2026-07-12",
+      "title": "Anonymous model-family stats",
+      "highlights": [
+        {
+          "title": "Telemetry now counts model families per agent",
+          "description": "The anonymous usage stats now include which model family (e.g. \"claude-opus\", \"gpt\", \"gemini\") each detected agent is used with — never the exact model name, so custom or local model names stay on your machine. This helps us build smarter token-efficiency suggestions per agent. As always, you can inspect the exact payload or turn telemetry off in Settings.",
+          "href": "/settings"
+        }
+      ]
+    },
+    {
+      "tag": "2026-07-12",
       "title": "Pi Coding Agent support",
       "highlights": [
         {

--- a/backend/main.py
+++ b/backend/main.py
@@ -4434,6 +4434,7 @@ SESSIONS_TTL_SEC = 30.0
 
 _sessions_cache: Dict[str, Any] = {"data": None, "at": 0.0, "building": False}
 _sessions_lock: Optional[_asyncio.Lock] = None  # lazy-init inside event loop
+_model_usage_sent = False   # once-per-process guard for agent.model_used
 
 
 def _get_sessions_lock() -> _asyncio.Lock:
@@ -4503,6 +4504,55 @@ def _persist_history_async(data: List[Dict[str, Any]]) -> None:
         _work()
 
 
+def _emit_model_usage(data: List[Dict[str, Any]]) -> None:
+    """Once per process: emit one agent.model_used per distinct (agent, family)
+    pair seen in sessions from the last 30 days. Model ids are collapsed to a
+    hardcoded family enum by telemetry.normalize_model_family — the raw id
+    never leaves the machine. Best-effort; never raises."""
+    global _model_usage_sent
+    if _model_usage_sent or not _telemetry.enabled():
+        return
+    try:
+        cutoff = datetime.now(timezone.utc) - timedelta(days=30)
+        pairs = set()
+        for s in data:
+            agent = s.get("agent")
+            if not agent:
+                continue
+            ts = s.get("timestamp")
+            if isinstance(ts, str):
+                # Cache paths may carry ISO strings; parse best-effort and
+                # skip the window filter (not the session) on failure.
+                try:
+                    ts = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+                except ValueError:
+                    ts = None
+            if isinstance(ts, datetime):
+                t = ts if ts.tzinfo else ts.replace(tzinfo=timezone.utc)
+                if t < cutoff:
+                    continue
+            models = list(s.get("models_used") or [])
+            if s.get("model"):
+                models.append(s["model"])
+            for m in models:
+                # Placeholder ids ("", "unknown", "<synthetic>", …) carry no
+                # signal — skip entirely rather than emit family "other".
+                if not m or (isinstance(m, str)
+                             and m.strip().lower() in _telemetry._SKIP_MODELS):
+                    continue
+                fam = _telemetry.normalize_model_family(m)
+                pairs.add((agent, fam))
+                if len(pairs) >= 30:
+                    break
+            if len(pairs) >= 30:
+                break
+        for agent, fam in pairs:
+            _telemetry.emit("agent.model_used", {"agent": agent, "family": fam})
+        _model_usage_sent = True
+    except Exception:
+        pass
+
+
 async def get_sessions_cached(fresh: bool = False) -> List[Dict[str, Any]]:
     """Cached, non-blocking access to the session list.
 
@@ -4538,6 +4588,7 @@ async def get_sessions_cached(fresh: bool = False) -> List[Dict[str, Any]]:
             # worker thread — a store failure must never break a request, and the
             # write must not add latency to this scan.
             _persist_history_async(data)
+            _emit_model_usage(data)
         except Exception as e:
             _log.exception("sessions scan failed: %s", e)
             # If we have a previous value, keep serving it rather than 500-ing.

--- a/backend/telemetry.py
+++ b/backend/telemetry.py
@@ -123,6 +123,7 @@ _EVENT_PROPS: Dict[str, set] = {
     "analytics.filtered": {"dimension"},
     "feature.used":       {"name"},
     "retention.opted_in": {"tier"},
+    "agent.model_used":   {"agent", "family"},
 }
 
 # Enum-controlled values. A value outside its set becomes "other" — never the
@@ -147,7 +148,26 @@ _ENUMS: Dict[str, set] = {
         "other",
     },
     "tier": {"full", "rollup", "other"},
+    # Detected-agent names for agent.model_used — the full set
+    # _list_available_agents() in main.py can return, plus "other". Any name
+    # outside this set (a fork, a custom harness) collapses to "other".
+    "agent": {
+        "claude", "codex", "gemini", "antigravity", "qwen", "vibe", "cursor",
+        "copilot", "opencode", "hermes", "grok", "pi", "cline", "smallcode",
+        "other",
+    },
+    # Model FAMILIES only — the family token is hardcoded by
+    # normalize_model_family(), so a custom/identifying model id can never
+    # ride through; anything unrecognised is "other".
+    "model_family": {
+        "claude-opus", "claude-sonnet", "claude-haiku", "claude-fable", "claude",
+        "gpt", "o-series", "gemini", "gemma", "qwen", "deepseek", "llama",
+        "mistral", "grok", "glm", "kimi", "minimax", "command", "other",
+    },
 }
+# _sanitize_props keys enums by PROP name; the agent.model_used prop is
+# "family", so alias it to the canonical model_family set (same object).
+_ENUMS["family"] = _ENUMS["model_family"]
 
 # Detected-agent names we recognise — must match _list_available_agents() in
 # main.py. Anything else is bucketed as "other-agent" so a custom/identifying
@@ -156,6 +176,66 @@ _KNOWN_AGENTS = {
     "claude", "codex", "gemini", "antigravity", "qwen", "vibe",
     "cursor", "copilot", "opencode", "hermes", "grok",
 }
+
+# Model ids that carry no signal at all — placeholders the scanners emit when a
+# session has no real model. Callers should skip these BEFORE normalizing so a
+# placeholder-only session emits nothing (vs a real-but-unknown model, which
+# still counts as family "other").
+_SKIP_MODELS = {"", "unknown", "<synthetic>", "_default", "none", "default"}
+
+
+def normalize_model_family(raw: Any) -> str:
+    """Map a raw model id to a controlled family literal, else 'other'.
+
+    Never returns the raw string — the family token is hardcoded, so an
+    identifying/custom model name can never ride through.
+    """
+    if not isinstance(raw, str):
+        return "other"
+    s = raw.strip().lower()
+    if not s or s in _SKIP_MODELS:
+        return "other"
+    s = s.rsplit("/", 1)[-1]          # drop provider prefix: alibaba/, @cf/meta/, accounts/fireworks/models/
+    s = s.split(":", 1)[0]            # drop ollama ":latest"/":q4" tags
+    # order matters — specific before generic (first match wins)
+    if "claude" in s or "anthropic" in s:
+        if "opus" in s:
+            return "claude-opus"
+        if "sonnet" in s:
+            return "claude-sonnet"
+        if "haiku" in s:
+            return "claude-haiku"
+        if "fable" in s:
+            return "claude-fable"
+        return "claude"
+    if "gpt" in s or "chatgpt" in s or "codex" in s:
+        return "gpt"
+    if s.startswith(("o1", "o3", "o4")):
+        return "o-series"
+    if "gemini" in s:
+        return "gemini"
+    if "gemma" in s:
+        return "gemma"
+    if "qwen" in s or "qwq" in s or "tongyi" in s:
+        return "qwen"
+    if "deepseek" in s:
+        return "deepseek"
+    if "llama" in s:
+        return "llama"
+    if ("mistral" in s or "mixtral" in s or "codestral" in s
+            or "ministral" in s or "magistral" in s):
+        return "mistral"
+    if "grok" in s:
+        return "grok"
+    if "glm" in s:
+        return "glm"
+    if "kimi" in s:
+        return "kimi"
+    if "minimax" in s:
+        return "minimax"
+    if "command" in s or "cohere" in s:
+        return "command"
+    return "other"
 
 
 def _safe_scalar(v: Any) -> Optional[Any]:
@@ -351,6 +431,7 @@ def sample_payloads() -> List[Dict[str, Any]]:
         "analytics.filtered": {"dimension": "local-only"},
         "feature.used": {"name": "plan-library"},
         "retention.opted_in": {"tier": "full"},
+        "agent.model_used": {"agent": "claude", "family": "claude-opus"},
     }
     return [build_event(ev, p) for ev, p in samples.items()]
 

--- a/backend/test_telemetry_redaction.py
+++ b/backend/test_telemetry_redaction.py
@@ -134,6 +134,61 @@ def test_emit_is_noop_when_disabled(monkeypatch):
     assert len(telemetry._SENT) == before  # nothing recorded, nothing sent
 
 
+def test_model_family_normalizes_known_ids():
+    cases = {
+        "claude-opus-4-8": "claude-opus",
+        "claude-3-5-sonnet": "claude-sonnet",
+        "gpt-5.4-codex": "gpt",
+        "gpt-oss-120b": "gpt",
+        "o3-mini": "o-series",
+        "gemini-2.5-pro": "gemini",
+        "alibaba/qwen3-coder": "qwen",
+        "@cf/meta/llama-3.3-70b-instruct": "llama",
+        "accounts/fireworks/models/kimi-k2p6": "kimi",
+        "deepseek-v4-pro": "deepseek",
+        "us.anthropic.claude-opus-4-8-v1": "claude-opus",
+        "copilot/gpt-5-mini": "gpt",
+        "grok-build": "grok",
+        "nemotron-3-nano:4b": "other",
+    }
+    for raw, want in cases.items():
+        assert telemetry.normalize_model_family(raw) == want, raw
+
+
+def test_model_family_custom_names_never_leak():
+    # Whatever comes in, only a hardcoded enum literal comes out.
+    for raw in ["acme-internal-secret-llama-ft:latest", "/Users/me/models/private",
+                "my-company-tuned-thing", "unknown", "<synthetic>"]:
+        fam = telemetry.normalize_model_family(raw)
+        assert fam in telemetry._ENUMS["model_family"], raw
+        assert fam != raw, raw
+    # A recognisable substring maps to its family token — never the raw id.
+    assert telemetry.normalize_model_family("acme-internal-secret-llama-ft") == "llama"
+    assert telemetry.normalize_model_family("totally-custom-thing") == "other"
+
+
+def test_agent_model_used_enum_guardrail():
+    out = telemetry._sanitize_props("agent.model_used",
+                                    {"agent": "claude", "family": "claude-opus"})
+    assert out == {"agent": "claude", "family": "claude-opus"}
+    out = telemetry._sanitize_props("agent.model_used",
+                                    {"agent": "my-secret-agent", "family": "sk-leak"})
+    assert out == {"agent": "other", "family": "other"}
+
+
+def test_agent_model_used_payload_is_content_free():
+    payload = telemetry.build_event("agent.model_used", {
+        "agent": "claude",
+        "family": "/Users/me/models/private",   # path-shaped → enum → "other"
+        "raw": "acme-internal-secret-llama-ft", # not allowlisted → dropped
+    })
+    assert payload["props"]["family"] == "other"
+    assert "raw" not in payload["props"]
+    blob = _blob(payload)
+    assert "/users/me/models/private" not in blob
+    assert "acme-internal-secret-llama-ft" not in blob
+
+
 def test_sample_payloads_cover_every_event():
     samples = telemetry.sample_payloads()
     names = {s["eventName"] for s in samples}

--- a/docs/design/product-telemetry.md
+++ b/docs/design/product-telemetry.md
@@ -108,6 +108,7 @@ sent at most once per meaningful action.
 | `analytics.filtered` | a filter is applied on Analytics | `dimension` (agent/model/local-only/day), no values | **Is local-model filtering used?** (your explicit question) |
 | `feature.used` | generic, for discrete features | `name` (plan-library, project-insights, delegation-view, power-cost, billing-mode, search…) | Long-tail feature adoption |
 | `retention.opted_in` | user enables durable history | `tier` | Which power features convert |
+| `agent.model_used` | once per launch, after the first full sessions scan | `agent` (enum: claude, codex, …), `family` (enum: claude-opus, gpt, gemini, …) | **Which model families each agent runs** (last 30 days) → seeds per-agent token-efficiency suggestions. Family is a hardcoded enum via `normalize_model_family()` — custom model ids collapse to `other`, never sent raw |
 
 **Duration/outcome buckets, never raw values.** e.g. summary latency as
 `fast/medium/slow`, not milliseconds tied to a specific trace.

--- a/frontend/src/components/settings/UsagePrivacySettings.tsx
+++ b/frontend/src/components/settings/UsagePrivacySettings.tsx
@@ -140,6 +140,7 @@ export default function UsagePrivacySettings() {
                     <li className="list-disc">Your OS, CPU type, and app version</li>
                     <li className="list-disc">Your country (from the network edge — never your IP)</li>
                     <li className="list-disc">Which AI agents are detected (Claude, Codex, …)</li>
+                    <li className="list-disc">Which model families each agent uses (e.g. claude-opus, gpt) — never the exact model id or a custom model name</li>
                     <li className="list-disc">A random per-launch session id (reset each launch, not linked to you)</li>
                   </ul>
                 </div>

--- a/proxy/cloudflare-worker.js
+++ b/proxy/cloudflare-worker.js
@@ -39,6 +39,8 @@
  *   blob14  = summarizer_backend     (context)
  *   blob15  = country                (CF edge 2-letter, no IP stored)
  *   blob16  = sdkVersion
+ *   blob17  = agent                 (agent.model_used)
+ *   blob18  = model family          (agent.model_used "family")
  *   double1 = agent_count
  *   double2 = isDebug                (0/1)
  */
@@ -53,6 +55,7 @@ const MAX_BODY = 8 * 1024; // events are tiny; reject anything bigger as abuse.
 const ALLOWED_EVENTS = new Set([
   "app.launched", "page.viewed", "trace.summarized",
   "analytics.filtered", "feature.used", "retention.opted_in",
+  "agent.model_used",
 ]);
 
 // Cheap, stateless validation. This is NOT anti-spoof (an open-source client
@@ -129,6 +132,8 @@ export default {
           blob(p.summarizer_backend), // blob14
           blob(country, 8),           // blob15
           blob(s.sdkVersion),         // blob16
+          blob(p.agent),              // blob17
+          blob(p.family),             // blob18
         ],
         doubles: [
           num(p.agent_count),         // double1

--- a/proxy/cloudflare/src/index.js
+++ b/proxy/cloudflare/src/index.js
@@ -39,6 +39,8 @@
  *   blob14  = summarizer_backend     (context)
  *   blob15  = country                (CF edge 2-letter, no IP stored)
  *   blob16  = sdkVersion
+ *   blob17  = agent                 (agent.model_used)
+ *   blob18  = model family          (agent.model_used "family")
  *   double1 = agent_count
  *   double2 = isDebug                (0/1)
  */
@@ -53,6 +55,7 @@ const MAX_BODY = 8 * 1024; // events are tiny; reject anything bigger as abuse.
 const ALLOWED_EVENTS = new Set([
   "app.launched", "page.viewed", "trace.summarized",
   "analytics.filtered", "feature.used", "retention.opted_in",
+  "agent.model_used",
 ]);
 
 // Cheap, stateless validation. This is NOT anti-spoof (an open-source client
@@ -129,6 +132,8 @@ export default {
           blob(p.summarizer_backend), // blob14
           blob(country, 8),           // blob15
           blob(s.sdkVersion),         // blob16
+          blob(p.agent),              // blob17
+          blob(p.family),             // blob18
         ],
         doubles: [
           num(p.agent_count),         // double1

--- a/website/src/app/privacy/page.tsx
+++ b/website/src/app/privacy/page.tsx
@@ -52,6 +52,10 @@ export default function PrivacyPage() {
           </li>
           <li>Which AI agents are detected on your machine (e.g. Claude, Codex), as a generic list</li>
           <li>
+            Which model families each agent uses (e.g. claude-opus, gpt) — a fixed set of family
+            names only, never the exact model id or a custom model name
+          </li>
+          <li>
             A random session id that is regenerated every launch and is never linked to you across
             sessions
           </li>


### PR DESCRIPTION
## What

New `agent.model_used` product-telemetry event: which model **family** each detected coding agent is used with (e.g. claude ↔ claude-opus, codex ↔ gpt). Purpose: understand model popularity per agent so we can build per-agent token-efficiency suggestions later.

## How it stays privacy-safe

- `normalize_model_family()` in `backend/telemetry.py` maps raw model ids to a **hardcoded** family enum (claude-opus, claude-sonnet, gpt, o-series, gemini, qwen, deepseek, llama, mistral, grok, glm, kimi, minimax, command, gemma, ...) and returns `"other"` for anything unrecognized. It never returns the raw string, so a custom fine-tune or local model name cannot be transmitted.
- Guarded twice more by the existing pipeline: per-event prop allowlist, enum collapse to `"other"`, and the safe-scalar charset filter.
- Placeholder ids (`""`, `unknown`, `<synthetic>`, ...) emit nothing at all.
- Backend-origin only: the event is NOT in `_TELEMETRY_CLIENT_EVENTS`, so the frontend bridge can't forge it.
- Disclosed in the Settings transparency panel (sample payload auto-included via `sample_payloads()`), website privacy page, design doc §3.2, and UPDATE.json.

## Emission

Once per process, in `get_sessions_cached()` right after the first successful full scan: one event per distinct (agent, family) pair from sessions in the last 30 days (current usage, not all history), capped at 30 pairs. Fire-and-forget, adds no request latency. ~7.5k events/30d at current launch volume (0.25% of the AE daily budget).

## Worker

`proxy/cloudflare-worker.js` + `proxy/cloudflare/src/index.js`: `agent.model_used` added to `ALLOWED_EVENTS`, blob17 = agent, blob18 = family (appended; no existing columns move). Per-agent model popularity becomes:

```sql
SELECT blob17 AS agent, blob18 AS family, SUM(_sample_interval) AS launches
FROM tt_telemetry
WHERE blob1 = 'agent.model_used' AND timestamp > now() - INTERVAL '30' DAY
GROUP BY agent, family ORDER BY agent, launches DESC;
```

**Deploy note:** the Worker must be redeployed (`cd proxy/cloudflare && npx wrangler deploy`) after merge, or the new event is dropped at the sink (harmless, fire-and-forget).

## Verification

- `pytest test_telemetry_redaction.py`: 16 passed (4 new tests: known-id normalization, custom-names-never-leak, enum guardrail, content-free payload).
- Normalizer recomputed independently over all 2341 model ids in `pricing_data.json`: 75% map to a named family, every output is in the enum, bucket counts matched a standalone reimplementation exactly (588 other / 336 qwen / 231 gpt / 111 claude-opus / ...). Bedrock `us.anthropic.*`, `provider/model` slugs, and ollama `:tag` forms all normalize correctly.
- Session `agent` labels grepped from `main.py` (13 literals + gemini via `agent_type`) all appear in the new `agent` enum, matching `_list_available_agents()`.
- `wrangler deploy --dry-run` OK; `tsc --noEmit` clean; `py_compile` clean.

Note for review: `_ENUMS["family"]` is aliased to `_ENUMS["model_family"]` because `_sanitize_props` keys enums by prop name — without the alias a slug-shaped raw value would pass un-bucketed (caught by the new guardrail test). Follow-up candidate (pre-existing, untouched): `_KNOWN_AGENTS` omits pi/cline/smallcode despite its "must match" comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGye4QMHGCpuL3n4i7ux3a