### PR TITLE
feat(hermes): profiles — attribution, scope UI, burn budgets, kanban costs

### DIFF
--- a/UPDATE.json
+++ b/UPDATE.json
@@ -2,6 +2,21 @@
   "releases": [
     {
       "tag": "2026-07-12",
+      "title": "Hermes profiles: per-profile usage",
+      "highlights": [
+        {
+          "title": "See which Hermes profile spent what",
+          "description": "If you run multiple Hermes profiles (work, personal, per-client), Hermes itself has no combined view of their usage. The Profiles page now shows every profile with its sessions, tokens, cost, last activity, gateway status, skills and cron jobs — and each session is tagged with the profile that ran it.",
+          "href": "/hermes/profiles"
+        },
+        {
+          "title": "Profile sessions get their full trace details",
+          "description": "Session timings, per-call latency and working-directory info for sessions run under a named profile were silently missing (only the default home's logs were read). Profile logs are now picked up, so those sessions show the same detail as everything else."
+        }
+      ]
+    },
+    {
+      "tag": "2026-07-12",
       "title": "Pi Coding Agent support",
       "highlights": [
         {

--- a/UPDATE.json
+++ b/UPDATE.json
@@ -1,6 +1,27 @@
 {
   "releases": [
     {
+      "tag": "2026-07-13",
+      "title": "Hermes profiles: burn, budgets & swarm costs",
+      "highlights": [
+        {
+          "title": "Filter the Hermes dashboard by profile",
+          "description": "A profile switcher scopes every stat, model and session list to one profile (or all, grouped with each profile's color — the same color Hermes desktop gives it). Spot at a glance which persona a session belongs to.",
+          "href": "/hermes"
+        },
+        {
+          "title": "Know which profile is burning budget",
+          "description": "Each profile card now shows a 14-day cost sparkline, 7-day burn with trend, and how much of it was spent unattended (cron, subagents, kanban workers). Set an alerts-only monthly budget per profile right on the card — the overnight-swarm surprise bill gets caught early.",
+          "href": "/hermes/profiles"
+        },
+        {
+          "title": "Kanban swarm board with per-task cost",
+          "description": "Hermes tracks swarm tasks but never prices them. The new Kanban page shows every board's tasks by status with the cost of each task's linked session, per-worker cost lanes, and failure/retry burn.",
+          "href": "/hermes/kanban"
+        }
+      ]
+    },
+    {
       "tag": "2026-07-12",
       "title": "Hermes profiles: per-profile usage",
       "highlights": [

--- a/backend/harness_config.py
+++ b/backend/harness_config.py
@@ -198,7 +198,7 @@ def save_aliases(aliases: Dict[str, str]) -> None:
 
 BUDGET_PERIODS = ("monthly", "weekly", "rolling_30d")
 BUDGET_LIMIT_TYPES = ("usd", "tokens")
-BUDGET_FILTER_KEYS = ("project", "agent", "model")
+BUDGET_FILTER_KEYS = ("project", "agent", "model", "hermes_profile")
 _DEFAULT_THRESHOLDS = [0.8, 1.0]
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1057,8 +1057,17 @@ async def hermes_profiles():
 
     def _empty_usage() -> Dict[str, Any]:
         return {"sessions": 0, "input_tokens": 0, "output_tokens": 0,
-                "total_tokens": 0, "cost": 0.0, "last_activity": None}
+                "total_tokens": 0, "cost": 0.0, "last_activity": None,
+                "cost_7d": 0.0, "cost_prev_7d": 0.0, "unattended_cost_7d": 0.0,
+                "daily": []}
 
+    # Sessions nobody was watching when they spent — the runaway-swarm /
+    # overnight-cron burn users get surprised by. Matches Hermes's own
+    # autonomous source values.
+    _UNATTENDED_SOURCES = {"cron", "subagent", "kanban", "tool"}
+
+    now_local = datetime.now().astimezone()
+    day_cost: Dict[str, Dict[str, float]] = {}
     usage: Dict[str, Dict[str, Any]] = {}
     try:
         for s in await get_sessions_cached():
@@ -1071,19 +1080,47 @@ async def hermes_profiles():
             u["input_tokens"] += tk.get("input", 0) or 0
             u["output_tokens"] += tk.get("output", 0) or 0
             u["total_tokens"] += tk.get("total", 0) or 0
-            u["cost"] += float(s.get("cost") or 0)
+            cost = float(s.get("cost") or 0)
+            u["cost"] += cost
             ts = s.get("timestamp")
             iso = ts.isoformat() if isinstance(ts, datetime) else ts
             if iso and (u["last_activity"] is None or iso > u["last_activity"]):
                 u["last_activity"] = iso
+            if isinstance(ts, datetime):
+                ts_local = ts.astimezone()
+                age_days = (now_local - ts_local).total_seconds() / 86400
+                if age_days <= 7:
+                    u["cost_7d"] += cost
+                    if (s.get("source_subtype") or "") in _UNATTENDED_SOURCES:
+                        u["unattended_cost_7d"] += cost
+                elif age_days <= 14:
+                    u["cost_prev_7d"] += cost
+                # Day buckets are LOCAL days — build keys from local Y/M/D,
+                # never toISOString/utc (see project rule on day bucketing).
+                dkey = f"{ts_local.year:04d}-{ts_local.month:02d}-{ts_local.day:02d}"
+                day_cost.setdefault(key, {})
+                day_cost[key][dkey] = day_cost[key].get(dkey, 0.0) + cost
     except Exception:
         pass
+
+    # Last 14 local days, oldest first, zero-filled so sparklines align.
+    day_keys: List[str] = []
+    for i in range(13, -1, -1):
+        d = now_local - timedelta(days=i)
+        day_keys.append(f"{d.year:04d}-{d.month:02d}-{d.day:02d}")
+
+    def _usage_for(key: str) -> Dict[str, Any]:
+        u = usage.get(key) or _empty_usage()
+        per = day_cost.get(key, {})
+        u["daily"] = [{"date": dk, "cost": round(per.get(dk, 0.0), 6)}
+                      for dk in day_keys]
+        return u
 
     profiles: List[Dict[str, Any]] = [{
         "name": "default",
         "is_default": True,
         "active": active is None,
-        "usage": usage.get("default") or _empty_usage(),
+        "usage": _usage_for("default"),
         **_hermes_profile_meta(HERMES_DIR),
     }]
     if HERMES_PROFILES_DIR.is_dir():
@@ -1094,10 +1131,153 @@ async def hermes_profiles():
                 "name": p.name,
                 "is_default": False,
                 "active": active == p.name,
-                "usage": usage.get(p.name) or _empty_usage(),
+                "usage": _usage_for(p.name),
                 **_hermes_profile_meta(p),
             })
     return {"profiles": profiles, "active_profile": active}
+
+
+def _hermes_kanban_dbs() -> List[Tuple[Path, Optional[str], str]]:
+    """(db_path, profile, board) for every Hermes kanban DB.
+
+    Layout per home: the default board is <home>/kanban.db (back-compat with
+    pre-boards installs); named boards live at <home>/kanban/boards/<slug>/kanban.db.
+    """
+    out: List[Tuple[Path, Optional[str], str]] = []
+    homes: List[Tuple[Path, Optional[str]]] = [(HERMES_DIR, None)]
+    if HERMES_PROFILES_DIR.is_dir():
+        homes.extend((p, p.name) for p in sorted(HERMES_PROFILES_DIR.iterdir())
+                     if p.is_dir())
+    for home, profile in homes:
+        default_db = home / "kanban.db"
+        if default_db.exists():
+            out.append((default_db, profile, "default"))
+        boards_dir = home / "kanban" / "boards"
+        if boards_dir.is_dir():
+            for db in sorted(boards_dir.glob("*/kanban.db")):
+                out.append((db, profile, db.parent.name))
+    return out
+
+
+def _connect_kanban_ro(db_path: Path) -> sqlite3.Connection:
+    """mode=ro, falling back to immutable=1 — a kanban DB in WAL mode inside a
+    0700 home can refuse a plain read-only open (no -shm access)."""
+    uri = _sqlite_ro_uri(db_path)
+    try:
+        conn = sqlite3.connect(uri, uri=True, timeout=1.0)
+        conn.execute("SELECT 1 FROM sqlite_master LIMIT 1")
+        return conn
+    except sqlite3.OperationalError:
+        return sqlite3.connect(uri + "&immutable=1", uri=True, timeout=1.0)
+
+
+@app.get("/hermes/kanban")
+async def hermes_kanban():
+    """Kanban boards with per-task cost attribution.
+
+    Hermes's swarm/board tracks tasks and runs but never costs them
+    (per-goal cost attribution is a standing user ask). Newer Hermes links
+    tasks to state.db sessions via tasks.session_id — where present we join
+    the session's cost/tokens from the shared scan; task_runs.profile tells
+    us which profile-worker did the work.
+    """
+    dbs = _hermes_kanban_dbs()
+    if not dbs:
+        return {"installed": False, "boards": []}
+
+    # session id -> (cost, tokens) from the shared scan, so task costs match
+    # every other number on the dashboard.
+    sess_cost: Dict[str, Tuple[float, int]] = {}
+    try:
+        for s in await get_sessions_cached():
+            if s.get("agent") == "hermes":
+                sess_cost[s["id"]] = (float(s.get("cost") or 0),
+                                      int((s.get("tokens") or {}).get("total", 0) or 0))
+    except Exception:
+        pass
+
+    def _iso(unix) -> Optional[str]:
+        try:
+            if not unix:
+                return None
+            return datetime.fromtimestamp(float(unix), tz=timezone.utc).isoformat()
+        except Exception:
+            return None
+
+    boards: List[Dict[str, Any]] = []
+    for db_path, profile, board in dbs:
+        try:
+            conn = _connect_kanban_ro(db_path)
+            conn.row_factory = sqlite3.Row
+            try:
+                cols = {r[1] for r in conn.execute("PRAGMA table_info(tasks)").fetchall()}
+                if "id" not in cols:
+                    continue
+                # session_id arrived via migration — older boards lack it.
+                sid_col = "session_id" if "session_id" in cols else "NULL AS session_id"
+                rows = conn.execute(
+                    "SELECT id, title, status, assignee, priority, created_at, "
+                    "started_at, completed_at, consecutive_failures, "
+                    f"last_failure_error, {sid_col} FROM tasks"
+                ).fetchall()
+                runs_by_task: Dict[str, Dict[str, Any]] = {}
+                try:
+                    for r in conn.execute(
+                        "SELECT task_id, profile, status, outcome FROM task_runs"
+                    ):
+                        agg = runs_by_task.setdefault(r["task_id"], {
+                            "count": 0, "failed": 0, "profiles": []})
+                        agg["count"] += 1
+                        if (r["outcome"] or "") not in ("", "completed"):
+                            agg["failed"] += 1
+                        if r["profile"] and r["profile"] not in agg["profiles"]:
+                            agg["profiles"].append(r["profile"])
+                except Exception:
+                    pass
+
+                tasks: List[Dict[str, Any]] = []
+                totals_cost = 0.0
+                by_status: Dict[str, int] = {}
+                by_assignee: Dict[str, Dict[str, Any]] = {}
+                for row in rows:
+                    sid = row["session_id"]
+                    cost, toks = sess_cost.get(sid, (0.0, 0)) if sid else (0.0, 0)
+                    status = row["status"] or "unknown"
+                    assignee = row["assignee"] or "(unassigned)"
+                    totals_cost += cost
+                    by_status[status] = by_status.get(status, 0) + 1
+                    a = by_assignee.setdefault(assignee, {"assignee": assignee,
+                                                          "tasks": 0, "cost": 0.0})
+                    a["tasks"] += 1
+                    a["cost"] += cost
+                    tasks.append({
+                        "id": row["id"], "title": row["title"],
+                        "status": status, "assignee": row["assignee"],
+                        "priority": row["priority"] or 0,
+                        "created_at": _iso(row["created_at"]),
+                        "started_at": _iso(row["started_at"]),
+                        "completed_at": _iso(row["completed_at"]),
+                        "consecutive_failures": row["consecutive_failures"] or 0,
+                        "last_failure_error": row["last_failure_error"],
+                        "session_id": sid,
+                        "cost": cost, "tokens": toks,
+                        "runs": runs_by_task.get(row["id"]),
+                    })
+            finally:
+                conn.close()
+        except Exception:
+            continue
+        boards.append({
+            "profile": profile, "board": board,
+            "tasks": tasks,
+            "totals": {
+                "tasks": len(tasks), "cost": round(totals_cost, 6),
+                "by_status": by_status,
+                "by_assignee": sorted(by_assignee.values(),
+                                      key=lambda x: -x["cost"]),
+            },
+        })
+    return {"installed": True, "boards": boards}
 
 
 @app.get("/hermes/tools")
@@ -6409,6 +6589,11 @@ def _session_matches_filters(s: Dict[str, Any], filters: Dict[str, str]) -> bool
     if "agent" in filters and s.get("agent") != filters["agent"]:
         return False
     if "model" in filters and (s.get("model") or "") != filters["model"]:
+        return False
+    # Hermes profile scope. Sessions from the default home carry no
+    # hermes_profile key, so "default" matches them explicitly.
+    if "hermes_profile" in filters and \
+            (s.get("hermes_profile") or "default") != filters["hermes_profile"]:
         return False
     return True
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -8,7 +8,7 @@ import json
 import yaml
 import sqlite3
 from pathlib import Path
-from typing import List, Optional, Dict, Any, Set, Iterable
+from typing import List, Optional, Dict, Any, Set, Iterable, Tuple
 from pydantic import BaseModel
 from datetime import datetime, timezone, timedelta, time as _dtime
 from urllib.parse import unquote, quote
@@ -740,15 +740,31 @@ class Session(BaseModel):
 
 # EDIT_TOOLS: Set[str] = {"Edit", "MultiEdit", "Write", "NotebookEdit"}
 
-def _hermes_dbs() -> List[Path]:
-    dbs: List[Path] = []
+def _hermes_dbs_with_profiles() -> List[Tuple[Path, Optional[str]]]:
+    """Every Hermes state.db paired with its owning profile (None = default).
+
+    A Hermes profile (~/.hermes/profiles/<name>/) is a full parallel agent
+    home — own config, SOUL.md, sessions, state.db, skills, cron, gateway.
+    Hermes itself has no cross-profile usage view, so the profile tag is
+    what lets TT attribute sessions to the profile that produced them.
+    """
+    dbs: List[Tuple[Path, Optional[str]]] = []
     if HERMES_DB.exists():
-        dbs.append(HERMES_DB)
+        dbs.append((HERMES_DB, None))
     if HERMES_PROFILES_DIR.is_dir():
-        for p in HERMES_PROFILES_DIR.glob("*/state.db"):
+        for p in sorted(HERMES_PROFILES_DIR.glob("*/state.db")):
             if p.exists():
-                dbs.append(p)
+                dbs.append((p, p.parent.name))
     return dbs
+
+
+def _hermes_dbs() -> List[Path]:
+    return [p for p, _ in _hermes_dbs_with_profiles()]
+
+
+def _hermes_home(profile: Optional[str]) -> Path:
+    """Root dir whose logs/gateway/cron belong to the given profile."""
+    return (HERMES_PROFILES_DIR / profile) if profile else HERMES_DIR
 
 
 _HERMES_CWD_RE = re.compile(r"\[(\d{8}_\d{6}_[a-f0-9]+)\][^\n]*cwd=([^\s,)]+)")
@@ -778,8 +794,12 @@ def _parse_hermes_log_ts(s: str) -> Optional[datetime]:
         return None
 
 
-def _hermes_log_summary(session_id: str) -> Dict[str, Any]:
-    """Parse ~/.hermes/logs/agent.log for one session.
+def _hermes_log_summary(session_id: str, profile: Optional[str] = None) -> Dict[str, Any]:
+    """Parse the owning home's logs/agent.log for one session.
+
+    Each profile writes its own agent.log, so sessions recorded in a
+    profile's state.db never appear in the root log — pass the profile
+    or the overlay comes back empty.
 
     Returns:
       api_calls: list of {ts, n, model, provider, in, out, total, latency_s, cache_hit_pct?, cache_read?}
@@ -787,7 +807,7 @@ def _hermes_log_summary(session_id: str) -> Dict[str, Any]:
       model_journey: distinct models in temporal order
       summary: {api_call_count, total_latency_s, avg_latency_s, cache_hit_pct, models_used}
     """
-    log_path = HERMES_DIR / "logs" / "agent.log"
+    log_path = _hermes_home(profile) / "logs" / "agent.log"
     if not log_path.exists():
         return {"api_calls": [], "tool_calls": [], "model_journey": [], "summary": None}
     api_calls: List[Dict[str, Any]] = []
@@ -985,16 +1005,99 @@ async def hermes_soul():
     return {"content": content, "exists": True}
 
 
+def _hermes_profile_meta(home: Path) -> Dict[str, Any]:
+    """Cheap local reads only — never .env, auth.json, or full config.yaml."""
+    description = None
+    try:
+        py = home / "profile.yaml"
+        if py.exists():
+            m = re.search(r"^description\s*:\s*(.+)$",
+                          py.read_text(encoding="utf-8", errors="ignore"), re.M)
+            if m:
+                description = m.group(1).strip().strip("'\"") or None
+    except Exception:
+        pass
+    skills_count = 0
+    try:
+        skills_dir = home / "skills"
+        if skills_dir.is_dir():
+            skills_count = sum(1 for d in skills_dir.iterdir()
+                               if d.is_dir() and not d.name.startswith("."))
+    except Exception:
+        pass
+    return {
+        "description": description,
+        "soul_exists": (home / "SOUL.md").exists(),
+        "skills_count": skills_count,
+        "cron_jobs": len(_hermes_cron_jobs(home)),
+        "gateway": _hermes_gateway_state(home),
+    }
+
+
 @app.get("/hermes/profiles")
 async def hermes_profiles():
-    """List available profiles."""
-    if not HERMES_PROFILES_DIR.exists():
-        return {"profiles": []}
-    profiles = []
-    for p in HERMES_PROFILES_DIR.iterdir():
-        if p.is_dir():
-            profiles.append({"name": p.name})
-    return {"profiles": profiles}
+    """Profiles with metadata and a per-profile usage rollup.
+
+    A profile is a full parallel Hermes home; Hermes itself offers no
+    combined usage/cost view across profiles, so TT aggregates one here.
+    Usage comes from the shared session scan (grouped by the scan's
+    hermes_profile tag) so the numbers match the rest of the dashboard.
+    """
+    if not HERMES_DIR.is_dir():
+        return {"profiles": [], "active_profile": None}
+
+    # `hermes profile use <name>` writes the sticky marker; absent = default.
+    active = None
+    try:
+        marker = HERMES_DIR / "active_profile"
+        if marker.exists():
+            active = marker.read_text(encoding="utf-8").strip() or None
+    except Exception:
+        pass
+
+    def _empty_usage() -> Dict[str, Any]:
+        return {"sessions": 0, "input_tokens": 0, "output_tokens": 0,
+                "total_tokens": 0, "cost": 0.0, "last_activity": None}
+
+    usage: Dict[str, Dict[str, Any]] = {}
+    try:
+        for s in await get_sessions_cached():
+            if s.get("agent") != "hermes":
+                continue
+            key = s.get("hermes_profile") or "default"
+            u = usage.setdefault(key, _empty_usage())
+            u["sessions"] += 1
+            tk = s.get("tokens") or {}
+            u["input_tokens"] += tk.get("input", 0) or 0
+            u["output_tokens"] += tk.get("output", 0) or 0
+            u["total_tokens"] += tk.get("total", 0) or 0
+            u["cost"] += float(s.get("cost") or 0)
+            ts = s.get("timestamp")
+            iso = ts.isoformat() if isinstance(ts, datetime) else ts
+            if iso and (u["last_activity"] is None or iso > u["last_activity"]):
+                u["last_activity"] = iso
+    except Exception:
+        pass
+
+    profiles: List[Dict[str, Any]] = [{
+        "name": "default",
+        "is_default": True,
+        "active": active is None,
+        "usage": usage.get("default") or _empty_usage(),
+        **_hermes_profile_meta(HERMES_DIR),
+    }]
+    if HERMES_PROFILES_DIR.is_dir():
+        for p in sorted(HERMES_PROFILES_DIR.iterdir()):
+            if not p.is_dir():
+                continue
+            profiles.append({
+                "name": p.name,
+                "is_default": False,
+                "active": active == p.name,
+                "usage": usage.get(p.name) or _empty_usage(),
+                **_hermes_profile_meta(p),
+            })
+    return {"profiles": profiles, "active_profile": active}
 
 
 @app.get("/hermes/tools")
@@ -1139,13 +1242,33 @@ async def grok_session_forensics(session_id: str):
     }
 
 
+def _hermes_session_profile(session_id: str) -> Optional[str]:
+    """Which profile's state.db holds this session (None = default root)."""
+    for db_path, profile in _hermes_dbs_with_profiles():
+        try:
+            conn = sqlite3.connect(_sqlite_ro_uri(db_path), uri=True, timeout=1.0)
+            try:
+                row = conn.execute(
+                    "SELECT 1 FROM sessions WHERE id=? LIMIT 1", (session_id,)
+                ).fetchone()
+            finally:
+                conn.close()
+            if row:
+                return profile
+        except Exception:
+            continue
+    return None
+
+
 @app.get("/sessions/{session_id}/hermes-overlay")
 async def hermes_session_overlay(session_id: str):
     """Per-session overlay derived from agent.log + memory tool calls."""
-    log = _hermes_log_summary(session_id)
+    profile = _hermes_session_profile(session_id)
+    log = _hermes_log_summary(session_id, profile)
     mem = _hermes_memory_io(session_id)
     return {
         "session_id": session_id,
+        "profile": profile,
         "performance": log["summary"],
         "api_calls": log["api_calls"],
         "tool_calls": log["tool_calls"],
@@ -1155,7 +1278,7 @@ async def hermes_session_overlay(session_id: str):
 
 
 def _hermes_cwd_by_session() -> Dict[str, str]:
-    """Recover per-session cwd from ~/.hermes/logs/agent.log.
+    """Recover per-session cwd from agent.log (root home + every profile).
 
     Hermes doesn't persist cwd in its schema (it's a portable agent — no project
     concept). The cwd surfaces only as a side effect when the `terminal` tool
@@ -1163,33 +1286,40 @@ def _hermes_cwd_by_session() -> Dict[str, str]:
     seen per session id. Sessions that never invoked the terminal stay 'unknown'.
     Fidelity: inferred.
     """
-    log_path = HERMES_DIR / "logs" / "agent.log"
-    if not log_path.exists():
-        return {}
+    log_paths = [HERMES_DIR / "logs" / "agent.log"]
+    if HERMES_PROFILES_DIR.is_dir():
+        log_paths.extend(sorted(HERMES_PROFILES_DIR.glob("*/logs/agent.log")))
     out: Dict[str, str] = {}
-    try:
-        with open(log_path, "r", encoding="utf-8", errors="ignore") as f:
-            for line in f:
-                m = _HERMES_CWD_RE.search(line)
-                if not m:
-                    continue
-                sid, cwd = m.group(1), m.group(2)
-                if sid not in out:  # first wins
-                    out[sid] = cwd
-    except Exception:
-        return out
+    for log_path in log_paths:
+        if not log_path.exists():
+            continue
+        try:
+            with open(log_path, "r", encoding="utf-8", errors="ignore") as f:
+                for line in f:
+                    m = _HERMES_CWD_RE.search(line)
+                    if not m:
+                        continue
+                    sid, cwd = m.group(1), m.group(2)
+                    if sid not in out:  # first wins
+                        out[sid] = cwd
+        except Exception:
+            continue
     return out
 
 
-def _hermes_gateway_state() -> Dict[str, Any]:
-    """Read ~/.hermes/gateway_state.json + gateway.pid. Both are optional.
+def _hermes_gateway_state(home: Optional[Path] = None) -> Dict[str, Any]:
+    """Read gateway_state.json + gateway.pid from a Hermes home (default root).
+
+    Each profile runs its own gateway with its own pid/state files, so pass
+    the profile's home to get that gateway's health.
 
     Returns dict with keys: state (str), pid (int|None), pid_alive (bool),
     active_agents (int), platforms (list[{name, state, error_code}]),
     updated_at (iso str|None). All-NULL if no gateway file present.
     """
-    state_path = HERMES_DIR / "gateway_state.json"
-    pid_path = HERMES_DIR / "gateway.pid"
+    base = home or HERMES_DIR
+    state_path = base / "gateway_state.json"
+    pid_path = base / "gateway.pid"
     out: Dict[str, Any] = {
         "state": None, "pid": None, "pid_alive": False,
         "active_agents": 0, "platforms": [], "updated_at": None,
@@ -1229,14 +1359,15 @@ def _hermes_gateway_state() -> Dict[str, Any]:
     return out
 
 
-def _hermes_cron_jobs() -> List[Dict[str, Any]]:
-    """Read ~/.hermes/cron/jobs.json — Hermes's scheduled-job registry.
+def _hermes_cron_jobs(home: Optional[Path] = None) -> List[Dict[str, Any]]:
+    """Read cron/jobs.json from a Hermes home (default root) — the
+    scheduled-job registry.
 
     Annotates each job with `at_risk` when next_run_at is past now (grace window
     applied per Hermes's own rule: daily=2h, hourly=30m, 10min=5m). Hermes itself
     fast-forwards past these but doesn't expose them — so we flag them.
     """
-    jobs_path = HERMES_DIR / "cron" / "jobs.json"
+    jobs_path = (home or HERMES_DIR) / "cron" / "jobs.json"
     if not jobs_path.exists():
         return []
     try:
@@ -4283,9 +4414,10 @@ def _scan_sessions_sync():
     sessions.extend(_scan_smallcode_sessions(smallcode_roots))
 
     # 9. Hermes Agent (SQLite: sessions / messages, pre-aggregated tokens)
-    hermes_cwd_map = _hermes_cwd_by_session() if _hermes_dbs() else {}
+    hermes_dbs = _hermes_dbs_with_profiles()
+    hermes_cwd_map = _hermes_cwd_by_session() if hermes_dbs else {}
     hermes_by_id: Dict[str, Dict[str, Any]] = {}
-    for db_path in _hermes_dbs():
+    for db_path, h_profile in hermes_dbs:
         try:
             uri = _sqlite_ro_uri(db_path)
             conn = sqlite3.connect(uri, uri=True, timeout=1.0)
@@ -4338,7 +4470,7 @@ def _scan_sessions_sync():
                         try:
                             from power_config import is_local_session
                             if is_local_session(model, srow["billing_base_url"], srow["billing_provider"]):
-                                _summ = _hermes_log_summary(sid).get("summary")
+                                _summ = _hermes_log_summary(sid, h_profile).get("summary")
                                 if _summ and _summ.get("total_latency_s", 0) > 0 and out_t > 0:
                                     _measured_tps = out_t / _summ["total_latency_s"]
                         except Exception:
@@ -4383,6 +4515,8 @@ def _scan_sessions_sync():
                         "endpoint": srow["billing_base_url"],
                         "tok_per_sec": _measured_tps,
                     }
+                    if h_profile:
+                        hermes_by_id[sid]["hermes_profile"] = h_profile
                     _attach_tool_usage(hermes_by_id[sid], h_tool_counts)
                     sessions.append(hermes_by_id[sid])
             finally:

--- a/backend/test_cline_smallcode.py
+++ b/backend/test_cline_smallcode.py
@@ -90,7 +90,7 @@ def scan_env(tmp_path, monkeypatch):
     for attr in ("CODEX_DIR", "GEMINI_DIR", "QWEN_DIR", "VIBE_DIR", "OLLAMA_DIR",
                  "GROK_SESSIONS_DIR", "VSCODE_STORAGE", "CURSOR_STORAGE",
                  "COPILOT_CLI_DIR", "ANTIGRAVITY_BRAIN_DIR", "ANTIGRAVITY_CLI_DIR",
-                 "HERMES_DIR"):
+                 "HERMES_DIR", "PI_SESSIONS_DIR"):
         monkeypatch.setattr(main, attr, missing / attr.lower())
     monkeypatch.setattr(main, "ANTIGRAVITY_BRAIN_SOURCES", [])
     monkeypatch.setattr(main, "ANTIGRAVITY_BRAIN_DIRS", [])

--- a/backend/test_copilot_vscode_scan.py
+++ b/backend/test_copilot_vscode_scan.py
@@ -26,7 +26,7 @@ def scan_env(tmp_path, monkeypatch):
     for attr in ("CODEX_DIR", "GEMINI_DIR", "QWEN_DIR", "VIBE_DIR", "OLLAMA_DIR",
                  "GROK_SESSIONS_DIR", "VSCODE_STORAGE", "CURSOR_STORAGE",
                  "COPILOT_CLI_DIR", "ANTIGRAVITY_BRAIN_DIR", "ANTIGRAVITY_CLI_DIR",
-                 "HERMES_DIR"):
+                 "HERMES_DIR", "PI_SESSIONS_DIR"):
         monkeypatch.setattr(main, attr, missing / attr.lower())
     monkeypatch.setattr(main, "ANTIGRAVITY_BRAIN_SOURCES", [])
     monkeypatch.setattr(main, "ANTIGRAVITY_BRAIN_DIRS", [])

--- a/backend/test_delegation.py
+++ b/backend/test_delegation.py
@@ -182,7 +182,7 @@ def scan_env(tmp_path, monkeypatch):
     for attr in ("CODEX_DIR", "GEMINI_DIR", "QWEN_DIR", "VIBE_DIR", "OLLAMA_DIR",
                  "GROK_SESSIONS_DIR", "VSCODE_STORAGE", "CURSOR_STORAGE",
                  "COPILOT_CLI_DIR", "ANTIGRAVITY_BRAIN_DIR", "ANTIGRAVITY_CLI_DIR",
-                 "HERMES_DIR"):
+                 "HERMES_DIR", "PI_SESSIONS_DIR"):
         monkeypatch.setattr(main, attr, missing / attr.lower())
     monkeypatch.setattr(main, "ANTIGRAVITY_BRAIN_SOURCES", [])
     monkeypatch.setattr(main, "ANTIGRAVITY_BRAIN_DIRS", [])

--- a/backend/test_hermes_profiles.py
+++ b/backend/test_hermes_profiles.py
@@ -1,0 +1,183 @@
+"""Tests for Hermes profile attribution and the /hermes/profiles endpoint.
+
+A Hermes profile (~/.hermes/profiles/<name>/) is a full parallel agent home
+with its own state.db, logs, cron, and gateway. Covers:
+  - _hermes_dbs_with_profiles(): root tagged None, profile DBs tagged by name.
+  - _scan_sessions_sync(): sessions from a profile DB carry hermes_profile.
+  - _hermes_session_profile(): resolves which home owns a session id.
+  - _hermes_log_summary(profile=...): reads the profile's agent.log.
+  - _hermes_cwd_by_session(): merges root + profile logs.
+  - /hermes/profiles: metadata + per-profile usage rollup, active marker.
+
+Run: pytest backend/test_hermes_profiles.py
+"""
+import asyncio
+import json
+import os
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+import main  # noqa: E402
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _make_hermes_db(path: Path, sid: str, tokens=(100, 40)):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    con = sqlite3.connect(path)
+    con.execute("CREATE TABLE sessions (id TEXT, source TEXT, model TEXT, "
+                "parent_session_id TEXT, started_at INT, ended_at INT, "
+                "input_tokens INT, output_tokens INT, cache_read_tokens INT, "
+                "cache_write_tokens INT, reasoning_tokens INT, "
+                "estimated_cost_usd REAL, actual_cost_usd REAL, title TEXT, "
+                "billing_provider TEXT, billing_base_url TEXT, end_reason TEXT)")
+    con.execute("CREATE TABLE messages (session_id TEXT, role TEXT, content TEXT, "
+                "timestamp INT, tool_name TEXT)")
+    con.execute("INSERT INTO sessions VALUES (?, 'cli', 'claude-sonnet-4-6', NULL, "
+                "1750000000, 1750000100, ?, ?, 0, 0, 0, 0.01, 0.01, 'sess', "
+                "'anthropic', NULL, 'done')", (sid, tokens[0], tokens[1]))
+    con.commit()
+    con.close()
+
+
+@pytest.fixture
+def hermes_env(tmp_path, monkeypatch):
+    """Hermetic Hermes home: root state.db plus one 'coder' profile."""
+    missing = tmp_path / "missing"
+    for attr in ("CODEX_DIR", "GEMINI_DIR", "QWEN_DIR", "VIBE_DIR", "OLLAMA_DIR",
+                 "GROK_SESSIONS_DIR", "VSCODE_STORAGE", "CURSOR_STORAGE",
+                 "COPILOT_CLI_DIR", "ANTIGRAVITY_BRAIN_DIR", "ANTIGRAVITY_CLI_DIR"):
+        monkeypatch.setattr(main, attr, missing / attr.lower())
+    monkeypatch.setattr(main, "ANTIGRAVITY_BRAIN_SOURCES", [])
+    monkeypatch.setattr(main, "ANTIGRAVITY_BRAIN_DIRS", [])
+    monkeypatch.setattr(main, "_antigravity_cli_meta", lambda *a, **k: {})
+    monkeypatch.setattr(main, "CLAUDE_DIR", tmp_path / ".claude")
+    monkeypatch.setattr(main, "CURSOR_DIR", tmp_path / ".cursor")
+    monkeypatch.setattr(main, "OPENCODE_DB", tmp_path / "opencode.db")
+    monkeypatch.setattr(main, "PROJECT_ALIASES_FILE", tmp_path / "aliases.json")
+    monkeypatch.setenv("TOKENTELEMETRY_DATA_DIR", str(tmp_path / "tt_data"))
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(main, "HERMES_DIR", home)
+    monkeypatch.setattr(main, "HERMES_DB", home / "state.db")
+    monkeypatch.setattr(main, "HERMES_PROFILES_DIR", home / "profiles")
+    _make_hermes_db(home / "state.db", "20260101_000000_aaaa1111")
+    _make_hermes_db(home / "profiles" / "coder" / "state.db",
+                    "20260102_000000_bbbb2222", tokens=(50, 20))
+    return home
+
+
+def test_dbs_with_profiles(hermes_env):
+    got = main._hermes_dbs_with_profiles()
+    assert [(p.parent.name if prof else "root", prof) for p, prof in got] == \
+        [("root", None), ("coder", "coder")]
+    assert main._hermes_dbs() == [p for p, _ in got]
+
+
+def test_scan_tags_profile(hermes_env):
+    by_id = {s["id"]: s for s in main._scan_sessions_sync()
+             if s["agent"] == "hermes"}
+    assert len(by_id) == 2
+    assert "hermes_profile" not in by_id["20260101_000000_aaaa1111"]
+    assert by_id["20260102_000000_bbbb2222"]["hermes_profile"] == "coder"
+
+
+def test_session_profile_resolver(hermes_env):
+    assert main._hermes_session_profile("20260101_000000_aaaa1111") is None
+    assert main._hermes_session_profile("20260102_000000_bbbb2222") == "coder"
+    assert main._hermes_session_profile("20260103_000000_cccc3333") is None
+
+
+def test_log_summary_reads_profile_log(hermes_env):
+    sid = "20260102_000000_bbbb2222"
+    line = (f"2026-01-02 00:00:05,123 INFO [{sid}] API call #1: "
+            "model=claude-sonnet-4-6 provider=anthropic in=50 out=20 total=70 "
+            "latency=1.5s\n")
+    logs = hermes_env / "profiles" / "coder" / "logs"
+    logs.mkdir(parents=True)
+    (logs / "agent.log").write_text(line, encoding="utf-8")
+    # Root log has no trace of the session → empty without the profile arg.
+    assert main._hermes_log_summary(sid)["summary"] is None
+    summ = main._hermes_log_summary(sid, "coder")["summary"]
+    assert summ["api_call_count"] == 1
+    assert summ["total_latency_s"] == 1.5
+
+
+def test_cwd_map_merges_profile_logs(hermes_env):
+    root_logs = hermes_env / "logs"
+    root_logs.mkdir()
+    (root_logs / "agent.log").write_text(
+        "2026-01-01 00:00:01,000 INFO [20260101_000000_aaaa1111] terminal "
+        "sandbox init cwd=/tmp/rootproj\n", encoding="utf-8")
+    prof_logs = hermes_env / "profiles" / "coder" / "logs"
+    prof_logs.mkdir(parents=True)
+    (prof_logs / "agent.log").write_text(
+        "2026-01-02 00:00:01,000 INFO [20260102_000000_bbbb2222] terminal "
+        "sandbox init cwd=/tmp/coderproj\n", encoding="utf-8")
+    cwds = main._hermes_cwd_by_session()
+    assert cwds["20260101_000000_aaaa1111"] == "/tmp/rootproj"
+    assert cwds["20260102_000000_bbbb2222"] == "/tmp/coderproj"
+
+
+def test_profiles_endpoint(hermes_env, monkeypatch):
+    (hermes_env / "SOUL.md").write_text("root soul", encoding="utf-8")
+    coder = hermes_env / "profiles" / "coder"
+    (coder / "profile.yaml").write_text(
+        "name: coder\ndescription: 'Coding assistant persona'\n",
+        encoding="utf-8")
+    (coder / "SOUL.md").write_text("coder soul", encoding="utf-8")
+    for skill in ("devops", "research"):
+        (coder / "skills" / skill).mkdir(parents=True)
+    (coder / "skills" / ".curator_state").mkdir()  # hidden → not counted
+    (coder / "cron").mkdir()
+    (coder / "cron" / "jobs.json").write_text(json.dumps({"jobs": [
+        {"id": "j1", "name": "daily", "schedule": {"kind": "daily"}},
+    ]}), encoding="utf-8")
+    (hermes_env / "active_profile").write_text("coder\n", encoding="utf-8")
+
+    async def fake_sessions(fresh=False):
+        ts = datetime(2026, 1, 2, tzinfo=timezone.utc)
+        return [
+            {"agent": "hermes", "cost": 0.01, "timestamp": ts,
+             "tokens": {"input": 100, "output": 40, "total": 140}},
+            {"agent": "hermes", "hermes_profile": "coder", "cost": 0.005,
+             "timestamp": ts, "tokens": {"input": 50, "output": 20, "total": 70}},
+            {"agent": "claude", "cost": 9.99, "timestamp": ts,
+             "tokens": {"input": 1, "output": 1, "total": 2}},
+        ]
+    monkeypatch.setattr(main, "get_sessions_cached", fake_sessions)
+
+    res = _run(main.hermes_profiles())
+    assert res["active_profile"] == "coder"
+    by_name = {p["name"]: p for p in res["profiles"]}
+    assert set(by_name) == {"default", "coder"}
+
+    d = by_name["default"]
+    assert d["is_default"] is True and d["active"] is False
+    assert d["soul_exists"] is True
+    assert d["usage"]["sessions"] == 1
+    assert d["usage"]["total_tokens"] == 140
+
+    c = by_name["coder"]
+    assert c["active"] is True
+    assert c["description"] == "Coding assistant persona"
+    assert c["skills_count"] == 2
+    assert c["cron_jobs"] == 1
+    assert c["usage"] == {"sessions": 1, "input_tokens": 50, "output_tokens": 20,
+                          "total_tokens": 70, "cost": 0.005,
+                          "last_activity": "2026-01-02T00:00:00+00:00"}
+
+
+def test_profiles_endpoint_no_hermes(tmp_path, monkeypatch):
+    monkeypatch.setattr(main, "HERMES_DIR", tmp_path / "nope")
+    monkeypatch.setattr(main, "HERMES_PROFILES_DIR", tmp_path / "nope" / "profiles")
+    res = _run(main.hermes_profiles())
+    assert res == {"profiles": [], "active_profile": None}

--- a/backend/test_hermes_profiles.py
+++ b/backend/test_hermes_profiles.py
@@ -53,7 +53,8 @@ def hermes_env(tmp_path, monkeypatch):
     missing = tmp_path / "missing"
     for attr in ("CODEX_DIR", "GEMINI_DIR", "QWEN_DIR", "VIBE_DIR", "OLLAMA_DIR",
                  "GROK_SESSIONS_DIR", "VSCODE_STORAGE", "CURSOR_STORAGE",
-                 "COPILOT_CLI_DIR", "ANTIGRAVITY_BRAIN_DIR", "ANTIGRAVITY_CLI_DIR"):
+                 "COPILOT_CLI_DIR", "ANTIGRAVITY_BRAIN_DIR", "ANTIGRAVITY_CLI_DIR",
+                 "PI_SESSIONS_DIR"):
         monkeypatch.setattr(main, attr, missing / attr.lower())
     monkeypatch.setattr(main, "ANTIGRAVITY_BRAIN_SOURCES", [])
     monkeypatch.setattr(main, "ANTIGRAVITY_BRAIN_DIRS", [])
@@ -171,9 +172,18 @@ def test_profiles_endpoint(hermes_env, monkeypatch):
     assert c["description"] == "Coding assistant persona"
     assert c["skills_count"] == 2
     assert c["cron_jobs"] == 1
-    assert c["usage"] == {"sessions": 1, "input_tokens": 50, "output_tokens": 20,
-                          "total_tokens": 70, "cost": 0.005,
-                          "last_activity": "2026-01-02T00:00:00+00:00"}
+    cu = c["usage"]
+    assert cu["sessions"] == 1
+    assert cu["input_tokens"] == 50 and cu["output_tokens"] == 20
+    assert cu["total_tokens"] == 70
+    assert cu["cost"] == 0.005
+    assert cu["last_activity"] == "2026-01-02T00:00:00+00:00"
+    # The canned session is older than 14 days → burn windows and the 14-day
+    # sparkline are all zero, but the shape is always present.
+    assert cu["cost_7d"] == 0.0 and cu["cost_prev_7d"] == 0.0
+    assert cu["unattended_cost_7d"] == 0.0
+    assert len(cu["daily"]) == 14
+    assert all(d["cost"] == 0.0 for d in cu["daily"])
 
 
 def test_profiles_endpoint_no_hermes(tmp_path, monkeypatch):
@@ -181,3 +191,126 @@ def test_profiles_endpoint_no_hermes(tmp_path, monkeypatch):
     monkeypatch.setattr(main, "HERMES_PROFILES_DIR", tmp_path / "nope" / "profiles")
     res = _run(main.hermes_profiles())
     assert res == {"profiles": [], "active_profile": None}
+
+
+def test_profiles_burn_windows(hermes_env, monkeypatch):
+    from datetime import timedelta
+    now = datetime.now(timezone.utc)
+
+    async def fake_sessions(fresh=False):
+        return [
+            # yesterday, unattended (cron) → cost_7d + unattended_cost_7d
+            {"agent": "hermes", "cost": 1.0, "timestamp": now - timedelta(days=1),
+             "source_subtype": "cron", "tokens": {"total": 10}},
+            # yesterday, interactive → cost_7d only
+            {"agent": "hermes", "cost": 0.5, "timestamp": now - timedelta(days=1),
+             "source_subtype": "cli", "tokens": {"total": 10}},
+            # 10 days ago → prev window
+            {"agent": "hermes", "cost": 2.0, "timestamp": now - timedelta(days=10),
+             "source_subtype": "cli", "tokens": {"total": 10}},
+        ]
+    monkeypatch.setattr(main, "get_sessions_cached", fake_sessions)
+
+    u = _run(main.hermes_profiles())
+    d = {p["name"]: p for p in u["profiles"]}["default"]["usage"]
+    assert d["cost_7d"] == pytest.approx(1.5)
+    assert d["unattended_cost_7d"] == pytest.approx(1.0)
+    assert d["cost_prev_7d"] == pytest.approx(2.0)
+    # The 14-day sparkline spans BOTH windows, so all three sessions land in it.
+    assert sum(x["cost"] for x in d["daily"]) == pytest.approx(3.5)
+    # A profile with zero sessions still gets a zero-filled 14-day series so
+    # frontend sparklines align.
+    c = {p["name"]: p for p in u["profiles"]}["coder"]["usage"]
+    assert len(c["daily"]) == 14 and all(x["cost"] == 0.0 for x in c["daily"])
+
+
+def test_budget_filter_hermes_profile():
+    coder = {"agent": "hermes", "hermes_profile": "coder"}
+    root = {"agent": "hermes"}
+    assert main._session_matches_filters(coder, {"hermes_profile": "coder"})
+    assert not main._session_matches_filters(root, {"hermes_profile": "coder"})
+    assert main._session_matches_filters(root, {"hermes_profile": "default"})
+    assert not main._session_matches_filters(coder, {"hermes_profile": "default"})
+
+
+# --- kanban cost board --------------------------------------------------------
+
+def _make_kanban_db(path: Path, with_session_col: bool = True):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    con = sqlite3.connect(path)
+    sid_col = ", session_id TEXT" if with_session_col else ""
+    con.execute("CREATE TABLE tasks (id TEXT PRIMARY KEY, title TEXT, body TEXT, "
+                "assignee TEXT, status TEXT, priority INTEGER DEFAULT 0, "
+                "created_at INTEGER, started_at INTEGER, completed_at INTEGER, "
+                "consecutive_failures INTEGER DEFAULT 0, last_failure_error TEXT"
+                f"{sid_col})")
+    con.execute("CREATE TABLE task_runs (id INTEGER PRIMARY KEY, task_id TEXT, "
+                "profile TEXT, status TEXT, outcome TEXT, started_at INTEGER)")
+    if with_session_col:
+        con.execute("INSERT INTO tasks (id, title, assignee, status, created_at, "
+                    "completed_at, session_id) VALUES "
+                    "('t1', 'build UI', 'frontend-eng', 'done', 1750000000, "
+                    "1750000500, '20260102_000000_bbbb2222')")
+        con.execute("INSERT INTO tasks (id, title, assignee, status, created_at, "
+                    "consecutive_failures, last_failure_error, session_id) VALUES "
+                    "('t2', 'flaky deploy', 'devops', 'blocked', 1750000000, 2, "
+                    "'spawn timeout', NULL)")
+        con.execute("INSERT INTO task_runs (task_id, profile, status, outcome, "
+                    "started_at) VALUES ('t1', 'coder', 'done', 'completed', 1750000000)")
+        con.execute("INSERT INTO task_runs (task_id, profile, status, outcome, "
+                    "started_at) VALUES ('t2', 'coder', 'crashed', 'timed_out', 1750000000)")
+    else:
+        con.execute("INSERT INTO tasks (id, title, assignee, status, created_at) "
+                    "VALUES ('old1', 'legacy task', 'worker', 'todo', 1750000000)")
+    con.commit()
+    con.close()
+
+
+def test_kanban_endpoint_joins_session_cost(hermes_env, monkeypatch):
+    _make_kanban_db(hermes_env / "kanban.db")
+
+    async def fake_sessions(fresh=False):
+        return [{"id": "20260102_000000_bbbb2222", "agent": "hermes",
+                 "cost": 0.25, "tokens": {"total": 70},
+                 "timestamp": datetime(2026, 1, 2, tzinfo=timezone.utc)}]
+    monkeypatch.setattr(main, "get_sessions_cached", fake_sessions)
+
+    res = _run(main.hermes_kanban())
+    assert res["installed"] is True
+    assert len(res["boards"]) == 1
+    b = res["boards"][0]
+    assert b["profile"] is None and b["board"] == "default"
+    by_id = {t["id"]: t for t in b["tasks"]}
+    assert by_id["t1"]["cost"] == 0.25 and by_id["t1"]["tokens"] == 70
+    assert by_id["t1"]["runs"] == {"count": 1, "failed": 0, "profiles": ["coder"]}
+    assert by_id["t2"]["cost"] == 0.0
+    assert by_id["t2"]["runs"]["failed"] == 1
+    assert by_id["t2"]["last_failure_error"] == "spawn timeout"
+    assert b["totals"]["cost"] == pytest.approx(0.25)
+    assert b["totals"]["by_status"] == {"done": 1, "blocked": 1}
+    assert b["totals"]["by_assignee"][0] == {"assignee": "frontend-eng",
+                                             "tasks": 1, "cost": 0.25}
+
+
+def test_kanban_endpoint_tolerates_old_schema_and_boards(hermes_env, monkeypatch):
+    # Pre-migration DB without session_id, plus a named board in a profile home.
+    _make_kanban_db(hermes_env / "kanban.db", with_session_col=False)
+    _make_kanban_db(hermes_env / "profiles" / "coder" / "kanban" / "boards" /
+                    "swarm" / "kanban.db")
+
+    async def fake_sessions(fresh=False):
+        return []
+    monkeypatch.setattr(main, "get_sessions_cached", fake_sessions)
+
+    res = _run(main.hermes_kanban())
+    keys = [(b["profile"], b["board"]) for b in res["boards"]]
+    assert keys == [(None, "default"), ("coder", "swarm")]
+    legacy = res["boards"][0]["tasks"][0]
+    assert legacy["session_id"] is None and legacy["cost"] == 0.0
+
+
+def test_kanban_endpoint_no_dbs(tmp_path, monkeypatch):
+    monkeypatch.setattr(main, "HERMES_DIR", tmp_path / "nope")
+    monkeypatch.setattr(main, "HERMES_PROFILES_DIR", tmp_path / "nope" / "profiles")
+    res = _run(main.hermes_kanban())
+    assert res == {"installed": False, "boards": []}

--- a/frontend/src/app/hermes/kanban/page.tsx
+++ b/frontend/src/app/hermes/kanban/page.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import Link from "next/link";
+import { useResource } from "@/lib/api";
+import { PageHeader, Card, CardHeader, CardTitle, StatTile, EmptyState, Badge } from "@/components/ui";
+import { formatTokens, formatCost } from "@/lib/format";
+import { timeAgo } from "@/lib/notifications";
+import { profileColor, profileTint } from "@/lib/profileColor";
+import { Kanban, AlertTriangle, Bot } from "lucide-react";
+
+interface TaskRuns {
+  count: number;
+  failed: number;
+  profiles: string[];
+}
+
+interface Task {
+  id: string;
+  title: string;
+  status: string;
+  assignee: string | null;
+  priority: number;
+  created_at: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+  consecutive_failures: number;
+  last_failure_error: string | null;
+  session_id: string | null;
+  cost: number;
+  tokens: number;
+  runs: TaskRuns | null;
+}
+
+interface Board {
+  profile: string | null;
+  board: string;
+  tasks: Task[];
+  totals: {
+    tasks: number;
+    cost: number;
+    by_status: Record<string, number>;
+    by_assignee: { assignee: string; tasks: number; cost: number }[];
+  };
+}
+
+interface KanbanResp {
+  installed: boolean;
+  boards: Board[];
+}
+
+// Hermes's own status vocabulary, in board order. Archived is summarized, not
+// rendered as a column.
+const STATUS_ORDER = ["triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done"];
+const STATUS_VARIANT: Record<string, "neutral" | "info" | "warn" | "success" | "danger"> = {
+  running: "info", blocked: "warn", done: "success", review: "info",
+};
+
+export default function HermesKanbanPage() {
+  const { data, loading } = useResource<KanbanResp>("/hermes/kanban", { pollMs: 30_000 });
+  const boards = data?.boards ?? [];
+  const allTasks = boards.flatMap((b) => b.tasks);
+  const totalCost = boards.reduce((a, b) => a + b.totals.cost, 0);
+  const failing = allTasks.filter((t) => t.consecutive_failures > 0).length;
+  const costed = allTasks.filter((t) => t.cost > 0).length;
+
+  return (
+    <div className="px-8 py-8 max-w-[1600px] mx-auto space-y-6 pb-20">
+      <PageHeader
+        backHref="/hermes"
+        icon={<div className="h-10 w-10 grid place-items-center rounded-[var(--tt-radius)] bg-rose-500/10 border border-rose-500/30"><Kanban className="text-rose-500" size={20} /></div>}
+        eyebrow="Hermes Agent"
+        title="Kanban"
+        description="Swarm task boards with per-task cost — Hermes tracks the tasks, TokenTelemetry prices them via each task's linked session."
+      />
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <StatTile label="Boards" value={loading ? "—" : String(boards.length)} />
+        <StatTile label="Tasks" value={loading ? "—" : String(allTasks.length)} hint={loading || !failing ? undefined : `${failing} failing`} />
+        <StatTile label="Attributed cost" value={loading ? "—" : formatCost(totalCost)} hint={loading || !allTasks.length ? undefined : `${costed}/${allTasks.length} tasks linked to a session`} />
+        <StatTile label="Workers" value={loading ? "—" : String(new Set(allTasks.map((t) => t.assignee).filter(Boolean)).size)} />
+      </div>
+
+      {loading ? (
+        <div className="animate-pulse h-40 bg-[var(--tt-panel)] rounded-xl" />
+      ) : !data?.installed ? (
+        <EmptyState
+          title="No kanban boards"
+          description="No kanban.db found under ~/.hermes (or any profile). Create tasks with `hermes kanban` or launch a swarm and the board shows up here."
+        />
+      ) : allTasks.length === 0 ? (
+        <EmptyState
+          title="Boards are empty"
+          description="Kanban is set up but no tasks have been created yet. Older Hermes versions don't link tasks to sessions (no session_id column) — cost shows as — for those."
+        />
+      ) : (
+        boards.map((b) => <BoardCard key={`${b.profile ?? "default"}/${b.board}`} b={b} />)
+      )}
+    </div>
+  );
+}
+
+function BoardCard({ b }: { b: Board }) {
+  const profileName = b.profile ?? "default";
+  const color = profileColor(profileName);
+  const byStatus = new Map<string, Task[]>();
+  for (const t of b.tasks) {
+    const s = t.status === "archived" ? "archived" : t.status;
+    if (!byStatus.has(s)) byStatus.set(s, []);
+    byStatus.get(s)!.push(t);
+  }
+  const columns = STATUS_ORDER.filter((s) => byStatus.has(s));
+  const other = [...byStatus.keys()].filter((s) => !STATUS_ORDER.includes(s) && s !== "archived");
+  const archived = byStatus.get("archived")?.length ?? 0;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>
+          <span className="flex items-center gap-2 font-mono">
+            {color && <span className="h-2.5 w-2.5 rounded-full" style={{ background: color }} />}
+            {profileName} / {b.board}
+          </span>
+        </CardTitle>
+        <div className="ml-auto text-[11px] tabular text-[var(--tt-fg-muted)]">
+          {b.totals.tasks} task{b.totals.tasks === 1 ? "" : "s"}
+          {b.totals.cost > 0 && ` · ${formatCost(b.totals.cost)}`}
+          {archived > 0 && ` · ${archived} archived`}
+        </div>
+      </CardHeader>
+
+      {/* Per-worker cost lanes — the "which persona is burning budget" view */}
+      {b.totals.by_assignee.length > 0 && (
+        <div className="px-5 pb-3 flex flex-wrap gap-2">
+          {b.totals.by_assignee.map((a) => (
+            <span
+              key={a.assignee}
+              className="inline-flex items-center gap-1.5 font-mono text-[10px] px-2 h-6 rounded-full border border-[var(--tt-border)] text-[var(--tt-fg-muted)]"
+              style={profileColor(a.assignee) ? {
+                color: profileColor(a.assignee)!,
+                borderColor: profileColor(a.assignee)!,
+                background: profileTint(a.assignee)!,
+              } : undefined}
+            >
+              <Bot size={10} /> {a.assignee}
+              <span className="tabular">{a.tasks} · {a.cost > 0 ? formatCost(a.cost) : "—"}</span>
+            </span>
+          ))}
+        </div>
+      )}
+
+      <div className="px-5 pb-5 overflow-x-auto">
+        <div className="flex gap-3 min-w-fit">
+          {[...columns, ...other].map((status) => (
+            <div key={status} className="w-[260px] shrink-0 space-y-2">
+              <div className="flex items-center gap-2">
+                <Badge variant={STATUS_VARIANT[status] ?? "neutral"} size="xs">{status}</Badge>
+                <span className="text-[10px] tabular text-[var(--tt-fg-dim)]">{byStatus.get(status)!.length}</span>
+              </div>
+              {byStatus.get(status)!.map((t) => (
+                <div key={t.id} className="bg-[var(--tt-sunken)] border border-[var(--tt-border)] rounded-[var(--tt-radius)] p-3 space-y-1.5">
+                  <div className="text-[12px] text-[var(--tt-fg)] line-clamp-2" title={t.title}>{t.title}</div>
+                  <div className="flex items-center justify-between gap-2 text-[10px] text-[var(--tt-fg-muted)]">
+                    <span className="font-mono truncate" title={t.assignee ?? undefined}>{t.assignee || "unassigned"}</span>
+                    <span className="tabular shrink-0">
+                      {t.cost > 0 ? (
+                        <span title={`${formatTokens(t.tokens)} tokens`}>{formatCost(t.cost)}</span>
+                      ) : "—"}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between gap-2 text-[9px] text-[var(--tt-fg-dim)]">
+                    <span>{t.completed_at ? `done ${timeAgo(t.completed_at)}` : t.started_at ? `started ${timeAgo(t.started_at)}` : t.created_at ? timeAgo(t.created_at) : ""}</span>
+                    {t.runs && t.runs.count > 0 && (
+                      <span className="tabular" title={t.runs.profiles.length ? `Ran on: ${t.runs.profiles.join(", ")}` : undefined}>
+                        {t.runs.count} run{t.runs.count === 1 ? "" : "s"}{t.runs.failed > 0 && ` · ${t.runs.failed} failed`}
+                      </span>
+                    )}
+                  </div>
+                  {t.consecutive_failures > 0 && (
+                    <div className="flex items-center gap-1 text-[9px] text-[var(--tt-danger-fg)]" title={t.last_failure_error ?? undefined}>
+                      <AlertTriangle size={9} /> {t.consecutive_failures} consecutive failure{t.consecutive_failures === 1 ? "" : "s"}
+                    </div>
+                  )}
+                  {t.session_id && (
+                    <Link
+                      href={`/sessions/${t.session_id}?agent=hermes&from=${encodeURIComponent("/hermes/kanban")}`}
+                      className="block text-[9px] font-mono text-[var(--tt-brand)] hover:underline truncate"
+                    >
+                      {t.session_id}
+                    </Link>
+                  )}
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/app/hermes/page.tsx
+++ b/frontend/src/app/hermes/page.tsx
@@ -3,10 +3,11 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { format, formatDistanceToNow } from "date-fns";
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   Activity, DollarSign, Cpu, Power, AlertTriangle, Clock, CheckCircle2,
-  BookOpen, Brain, ArrowRight, Sparkles, Users, Wrench, Signal, Timer
+  BookOpen, Brain, ArrowRight, Sparkles, Users, Wrench, Signal, Timer,
+  Kanban,
 } from "lucide-react";
 import { useResource } from "@/lib/api";
 import {
@@ -16,6 +17,7 @@ import {
 import SourceBadge from "@/components/SourceBadge";
 import HermesIcon from "@/components/icons/HermesIcon";
 import { formatTokens, formatCost } from "@/lib/format";
+import { profileColor, profileTint } from "@/lib/profileColor";
 import { trackEvent } from "@/lib/telemetry";
 
 interface GatewayState {
@@ -55,6 +57,7 @@ interface Session {
   cost?: number;
   model?: string;
   source_subtype?: string;
+  hermes_profile?: string;
   project_inferred?: boolean;
   cost_anomaly?: boolean;
 }
@@ -74,11 +77,28 @@ export default function HermesPage() {
   const pathname = usePathname();
   const sessionsRes = useResource<Session[]>("/sessions", { pollMs: 15_000, initial: [] });
   const overviewRes = useResource<Overview>("/hermes/overview", { pollMs: 30_000 });
+  const profilesRes = useResource<{ profiles: { name: string }[] }>("/hermes/profiles", { pollMs: 60_000 });
   const gateway = overviewRes.data?.gateway;
   const cronJobs = overviewRes.data?.cron_jobs ?? [];
-  const hermesSessions = useMemo(
+  // "all" | "default" | profile name — scopes every number and list below.
+  const [profileScope, setProfileScope] = useState<string>("all");
+  const allHermesSessions = useMemo(
     () => (sessionsRes.data ?? []).filter((s) => s.agent === "hermes"),
     [sessionsRes.data]
+  );
+  // Pills come from the profiles endpoint (so a zero-session profile still
+  // shows) unioned with whatever the sessions carry.
+  const profileNames = useMemo(() => {
+    const names = new Set<string>((profilesRes.data?.profiles ?? []).map((p) => p.name));
+    for (const s of allHermesSessions) names.add(s.hermes_profile || "default");
+    names.delete("default");
+    return ["default", ...[...names].sort()];
+  }, [profilesRes.data, allHermesSessions]);
+  const hermesSessions = useMemo(
+    () => profileScope === "all"
+      ? allHermesSessions
+      : allHermesSessions.filter((s) => (s.hermes_profile || "default") === profileScope),
+    [allHermesSessions, profileScope]
   );
 
   // Explicit signal that the Hermes dashboard (the differentiator surface) was
@@ -153,6 +173,37 @@ export default function HermesPage() {
         description="Autonomous agent observability — sessions, sources, costs across every platform"
         actions={gateway && <GatewayPill g={gateway} />}
       />
+
+      {/* Profile scope — desktop-style switcher; hidden when only the default home exists */}
+      {profileNames.length > 1 && (
+        <div className="flex items-center gap-1.5 flex-wrap">
+          {["all", ...profileNames].map((name) => {
+            const selected = profileScope === name;
+            const color = profileColor(name);
+            const count = name === "all"
+              ? allHermesSessions.length
+              : allHermesSessions.filter((s) => (s.hermes_profile || "default") === name).length;
+            return (
+              <button
+                key={name}
+                onClick={() => setProfileScope(name)}
+                className={`inline-flex items-center gap-1.5 font-mono text-[11px] px-2.5 h-7 rounded-full border transition-colors ${
+                  selected
+                    ? "border-[var(--tt-border-strong)] bg-[var(--tt-sunken)] text-[var(--tt-fg)]"
+                    : "border-[var(--tt-border)] text-[var(--tt-fg-muted)] hover:text-[var(--tt-fg)]"
+                }`}
+                style={selected && color ? { borderColor: color } : undefined}
+              >
+                {color && (
+                  <span className="h-2 w-2 rounded-full shrink-0" style={{ background: color }} />
+                )}
+                {name === "all" ? "All profiles" : name}
+                <span className="text-[9px] tabular text-[var(--tt-fg-dim)]">{count}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
 
       {/* Summary tiles */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
@@ -255,6 +306,19 @@ export default function HermesPage() {
           <div className="flex-1 min-w-0">
             <div className="text-[13px] font-semibold text-[var(--tt-fg)]">Gateway</div>
             <div className="text-[11px] text-[var(--tt-fg-muted)]">Live platform connections</div>
+          </div>
+          <ArrowRight size={14} className="text-[var(--tt-fg-dim)] group-hover:text-[var(--tt-fg)] transition-colors" />
+        </Link>
+        <Link
+          href="/hermes/kanban"
+          className="group flex items-center gap-3 bg-[var(--tt-panel)] border border-[var(--tt-border)] rounded-[var(--tt-radius-lg)] p-4 hover:border-[var(--tt-border-strong)] hover:bg-[var(--tt-sunken)] transition-colors"
+        >
+          <div className="h-9 w-9 grid place-items-center rounded-md bg-rose-500/10 text-rose-500">
+            <Kanban size={16} />
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="text-[13px] font-semibold text-[var(--tt-fg)]">Kanban</div>
+            <div className="text-[11px] text-[var(--tt-fg-muted)]">Swarm board with per-task cost</div>
           </div>
           <ArrowRight size={14} className="text-[var(--tt-fg-dim)] group-hover:text-[var(--tt-fg)] transition-colors" />
         </Link>
@@ -429,7 +493,22 @@ export default function HermesPage() {
                   <TR key={s.id} interactive>
                     <TD className="pl-5">
                       <Link href={`/sessions/${s.id}?agent=hermes&from=${encodeURIComponent(pathname)}`} className="block">
-                        <SourceBadge source={s.source_subtype} size="xs" />
+                        <span className="inline-flex items-center gap-1.5">
+                          <SourceBadge source={s.source_subtype} size="xs" />
+                          {s.hermes_profile && profileScope === "all" && (
+                            <span
+                              className="inline-flex items-center gap-1 font-mono text-[9px] px-1.5 h-4 rounded-full border"
+                              style={{
+                                color: profileColor(s.hermes_profile) ?? undefined,
+                                borderColor: profileColor(s.hermes_profile) ?? undefined,
+                                background: profileTint(s.hermes_profile) ?? undefined,
+                              }}
+                              title={`Profile: ${s.hermes_profile}`}
+                            >
+                              {s.hermes_profile}
+                            </span>
+                          )}
+                        </span>
                       </Link>
                     </TD>
                     <TD className="font-mono text-[11px] text-[var(--tt-fg-muted)] max-w-[180px] truncate" title={s.model}>

--- a/frontend/src/app/hermes/profiles/page.tsx
+++ b/frontend/src/app/hermes/profiles/page.tsx
@@ -1,10 +1,16 @@
 "use client";
 
+import { useCallback, useEffect, useState } from "react";
 import { useResource } from "@/lib/api";
 import { PageHeader, Card, EmptyState, StatTile, Badge } from "@/components/ui";
 import { formatTokens, formatCost } from "@/lib/format";
 import { timeAgo } from "@/lib/notifications";
-import { Users, Power, BookOpen, Clock, Sparkles } from "lucide-react";
+import { profileColor, profileTint } from "@/lib/profileColor";
+import { Budget, BudgetStatus, getBudgets, putBudgets } from "@/lib/budgets";
+import {
+  Users, Power, BookOpen, Clock, Sparkles, TrendingUp, TrendingDown,
+  Bot, Wallet,
+} from "lucide-react";
 
 interface ProfileGateway {
   state: string | null;
@@ -19,6 +25,10 @@ interface ProfileUsage {
   total_tokens: number;
   cost: number;
   last_activity: string | null;
+  cost_7d: number;
+  cost_prev_7d: number;
+  unattended_cost_7d: number;
+  daily: { date: string; cost: number }[];
 }
 
 interface Profile {
@@ -47,9 +57,49 @@ export default function ProfilesPage() {
       sessions: acc.sessions + p.usage.sessions,
       tokens: acc.tokens + p.usage.total_tokens,
       cost: acc.cost + p.usage.cost,
+      cost7d: acc.cost7d + p.usage.cost_7d,
     }),
-    { sessions: 0, tokens: 0, cost: 0 },
+    { sessions: 0, tokens: 0, cost: 0, cost7d: 0 },
   );
+
+  // Per-profile budgets ride the standard budgets engine via the
+  // hermes_profile filter; this page only manages that one budget shape.
+  const [budgets, setBudgets] = useState<BudgetStatus[] | null>(null);
+  const refreshBudgets = useCallback(() => {
+    getBudgets().then(setBudgets).catch(() => setBudgets([]));
+  }, []);
+  useEffect(refreshBudgets, [refreshBudgets]);
+
+  const budgetFor = (name: string) =>
+    (budgets ?? []).find(
+      (b) => b.filters.agent === "hermes" && b.filters.hermes_profile === name
+        && !b.filters.project && !b.filters.model,
+    );
+
+  const saveBudget = async (name: string, limit: number | null) => {
+    const all: Budget[] = (budgets ?? []).map(
+      ({ id, filters, period, limit_type, limit_value, thresholds, enabled }) =>
+        ({ id, filters, period, limit_type, limit_value, thresholds, enabled }),
+    );
+    const idx = all.findIndex(
+      (b) => b.filters.agent === "hermes" && b.filters.hermes_profile === name
+        && !b.filters.project && !b.filters.model,
+    );
+    if (limit === null || limit <= 0) {
+      if (idx >= 0) all.splice(idx, 1);
+    } else if (idx >= 0) {
+      all[idx] = { ...all[idx], limit_value: limit };
+    } else {
+      all.push({
+        id: `hermes-profile-${name}-${Date.now().toString(36)}`,
+        filters: { agent: "hermes", hermes_profile: name },
+        period: "monthly", limit_type: "usd", limit_value: limit,
+        thresholds: [0.8, 1.0], enabled: true,
+      });
+    }
+    await putBudgets(all);
+    refreshBudgets();
+  };
 
   return (
     <div className="px-8 py-8 max-w-[1200px] mx-auto space-y-6 pb-20">
@@ -65,7 +115,7 @@ export default function ProfilesPage() {
         <StatTile label="Profiles" value={loading ? "—" : String(profiles.length)} hint={named.length ? `${named.length} named + default` : "default only"} />
         <StatTile label="Sessions" value={loading ? "—" : String(totals.sessions)} />
         <StatTile label="Tokens" value={loading ? "—" : formatTokens(totals.tokens)} />
-        <StatTile label="Cost" value={loading ? "—" : formatCost(totals.cost)} />
+        <StatTile label="Cost / 7d" value={loading ? "—" : formatCost(totals.cost7d)} hint={loading ? undefined : `${formatCost(totals.cost)} all-time`} />
       </div>
 
       {loading ? (
@@ -75,53 +125,12 @@ export default function ProfilesPage() {
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           {profiles.map((p) => (
-            <Card key={p.name} className="p-5 space-y-3">
-              <div className="flex items-center gap-3">
-                <div className="h-10 w-10 bg-[var(--tt-border)] text-[var(--tt-fg)] rounded-full flex items-center justify-center font-semibold text-lg uppercase shrink-0">
-                  {p.name.charAt(0)}
-                </div>
-                <div className="min-w-0">
-                  <div className="flex items-center gap-2 flex-wrap">
-                    <span className="font-mono text-sm text-[var(--tt-fg)] truncate">{p.name}</span>
-                    {p.active && <Badge variant="brand" size="xs">active</Badge>}
-                    {p.is_default && <Badge variant="outline" size="xs">default home</Badge>}
-                  </div>
-                  <div className="text-[11px] text-[var(--tt-fg-muted)] truncate" title={p.description || undefined}>
-                    {p.description || (p.is_default ? "~/.hermes" : `~/.hermes/profiles/${p.name}`)}
-                  </div>
-                </div>
-                <div className="ml-auto shrink-0">
-                  <Badge variant={p.gateway.pid_alive ? "success" : "neutral"} size="xs" title={p.gateway.pid ? `PID ${p.gateway.pid}` : "no gateway"}>
-                    <Power size={10} /> {p.gateway.pid_alive ? "gateway up" : "gateway off"}
-                  </Badge>
-                </div>
-              </div>
-
-              <div className="grid grid-cols-4 gap-2 text-center">
-                <div className="bg-[var(--tt-sunken)] border border-[var(--tt-border)] rounded-[var(--tt-radius)] p-2">
-                  <div className="text-[15px] tabular font-semibold text-[var(--tt-fg)]">{p.usage.sessions}</div>
-                  <div className="text-[9px] uppercase tracking-wider text-[var(--tt-fg-dim)]">Sessions</div>
-                </div>
-                <div className="bg-[var(--tt-sunken)] border border-[var(--tt-border)] rounded-[var(--tt-radius)] p-2">
-                  <div className="text-[15px] tabular font-semibold text-[var(--tt-fg)]">{formatTokens(p.usage.total_tokens)}</div>
-                  <div className="text-[9px] uppercase tracking-wider text-[var(--tt-fg-dim)]">Tokens</div>
-                </div>
-                <div className="bg-[var(--tt-sunken)] border border-[var(--tt-border)] rounded-[var(--tt-radius)] p-2">
-                  <div className="text-[15px] tabular font-semibold text-[var(--tt-fg)]">{formatCost(p.usage.cost)}</div>
-                  <div className="text-[9px] uppercase tracking-wider text-[var(--tt-fg-dim)]">Cost</div>
-                </div>
-                <div className="bg-[var(--tt-sunken)] border border-[var(--tt-border)] rounded-[var(--tt-radius)] p-2">
-                  <div className="text-[15px] tabular font-semibold text-[var(--tt-fg)]">{p.usage.last_activity ? timeAgo(p.usage.last_activity) : "—"}</div>
-                  <div className="text-[9px] uppercase tracking-wider text-[var(--tt-fg-dim)]">Last active</div>
-                </div>
-              </div>
-
-              <div className="flex items-center gap-3 text-[11px] text-[var(--tt-fg-muted)]">
-                <span className="inline-flex items-center gap-1"><BookOpen size={11} /> {p.skills_count} skills</span>
-                <span className="inline-flex items-center gap-1"><Clock size={11} /> {p.cron_jobs} cron jobs</span>
-                {p.soul_exists && <span className="inline-flex items-center gap-1"><Sparkles size={11} /> SOUL.md</span>}
-              </div>
-            </Card>
+            <ProfileCard
+              key={p.name}
+              p={p}
+              budget={budgetFor(p.name)}
+              onSaveBudget={(v) => saveBudget(p.name, v)}
+            />
           ))}
         </div>
       )}
@@ -132,5 +141,176 @@ export default function ProfilesPage() {
         </div>
       )}
     </div>
+  );
+}
+
+function ProfileCard({ p, budget, onSaveBudget }: {
+  p: Profile;
+  budget: BudgetStatus | undefined;
+  onSaveBudget: (v: number | null) => Promise<void>;
+}) {
+  const color = profileColor(p.name);
+  const tint = profileTint(p.name);
+  const burnDelta = p.usage.cost_7d - p.usage.cost_prev_7d;
+  const maxDay = Math.max(...p.usage.daily.map((d) => d.cost), 0.000001);
+
+  const [editing, setEditing] = useState(false);
+  const [limitInput, setLimitInput] = useState("");
+  const [saving, setSaving] = useState(false);
+  const submitBudget = async () => {
+    const v = parseFloat(limitInput);
+    setSaving(true);
+    try {
+      await onSaveBudget(Number.isFinite(v) && v > 0 ? v : null);
+      setEditing(false);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Card className="p-5 space-y-3">
+      <div className="flex items-center gap-3">
+        <div
+          className={`h-10 w-10 rounded-full flex items-center justify-center font-semibold text-lg uppercase shrink-0 ${color ? "" : "bg-[var(--tt-border)] text-[var(--tt-fg)]"}`}
+          style={color ? { background: tint ?? undefined, color, border: `1px solid ${color}` } : undefined}
+        >
+          {p.name.charAt(0)}
+        </div>
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="font-mono text-sm text-[var(--tt-fg)] truncate">{p.name}</span>
+            {p.active && <Badge variant="brand" size="xs">active</Badge>}
+            {p.is_default && <Badge variant="outline" size="xs">default home</Badge>}
+          </div>
+          <div className="text-[11px] text-[var(--tt-fg-muted)] truncate" title={p.description || undefined}>
+            {p.description || (p.is_default ? "~/.hermes" : `~/.hermes/profiles/${p.name}`)}
+          </div>
+        </div>
+        <div className="ml-auto shrink-0">
+          <Badge variant={p.gateway.pid_alive ? "success" : "neutral"} size="xs" title={p.gateway.pid ? `PID ${p.gateway.pid}` : "no gateway"}>
+            <Power size={10} /> {p.gateway.pid_alive ? "gateway up" : "gateway off"}
+          </Badge>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-4 gap-2 text-center">
+        <div className="bg-[var(--tt-sunken)] border border-[var(--tt-border)] rounded-[var(--tt-radius)] p-2">
+          <div className="text-[15px] tabular font-semibold text-[var(--tt-fg)]">{p.usage.sessions}</div>
+          <div className="text-[9px] uppercase tracking-wider text-[var(--tt-fg-dim)]">Sessions</div>
+        </div>
+        <div className="bg-[var(--tt-sunken)] border border-[var(--tt-border)] rounded-[var(--tt-radius)] p-2">
+          <div className="text-[15px] tabular font-semibold text-[var(--tt-fg)]">{formatTokens(p.usage.total_tokens)}</div>
+          <div className="text-[9px] uppercase tracking-wider text-[var(--tt-fg-dim)]">Tokens</div>
+        </div>
+        <div className="bg-[var(--tt-sunken)] border border-[var(--tt-border)] rounded-[var(--tt-radius)] p-2">
+          <div className="text-[15px] tabular font-semibold text-[var(--tt-fg)]">{formatCost(p.usage.cost)}</div>
+          <div className="text-[9px] uppercase tracking-wider text-[var(--tt-fg-dim)]">Cost</div>
+        </div>
+        <div className="bg-[var(--tt-sunken)] border border-[var(--tt-border)] rounded-[var(--tt-radius)] p-2">
+          <div className="text-[15px] tabular font-semibold text-[var(--tt-fg)]">{p.usage.last_activity ? timeAgo(p.usage.last_activity) : "—"}</div>
+          <div className="text-[9px] uppercase tracking-wider text-[var(--tt-fg-dim)]">Last active</div>
+        </div>
+      </div>
+
+      {/* Burn strip: 14-day daily-cost sparkline + 7d vs prior-7d trend + unattended share */}
+      <div className="flex items-end gap-3">
+        <div className="flex items-end gap-[2px] h-8 flex-1" title="Daily cost, last 14 days">
+          {p.usage.daily.map((d) => (
+            <div
+              key={d.date}
+              className="flex-1 rounded-sm min-h-[2px]"
+              style={{
+                height: `${Math.max(2, Math.round((d.cost / maxDay) * 100))}%`,
+                background: d.cost > 0 ? (color ?? "var(--tt-brand)") : "var(--tt-border)",
+                opacity: d.cost > 0 ? 0.9 : 0.5,
+              }}
+              title={`${d.date} · ${formatCost(d.cost)}`}
+            />
+          ))}
+        </div>
+        <div className="text-right shrink-0">
+          <div className="flex items-center justify-end gap-1 text-[12px] tabular font-semibold text-[var(--tt-fg)]">
+            {formatCost(p.usage.cost_7d)}
+            {burnDelta > 0.0001 ? (
+              <TrendingUp size={11} className="text-[var(--tt-warn-fg)]" />
+            ) : burnDelta < -0.0001 ? (
+              <TrendingDown size={11} className="text-[var(--tt-success-fg)]" />
+            ) : null}
+          </div>
+          <div className="text-[9px] uppercase tracking-wider text-[var(--tt-fg-dim)]">7-day burn</div>
+          {p.usage.unattended_cost_7d > 0 && (
+            <div className="flex items-center justify-end gap-1 text-[10px] tabular text-[var(--tt-warn-fg)]" title="Spent by cron / subagent / kanban sessions nobody was watching">
+              <Bot size={10} /> {formatCost(p.usage.unattended_cost_7d)} unattended
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Budget: alerts-only, rides the standard budgets engine */}
+      <div className="flex items-center gap-2 min-h-6">
+        <Wallet size={11} className="text-[var(--tt-fg-dim)] shrink-0" />
+        {budget && !editing ? (
+          <>
+            <div className="flex-1 h-1.5 rounded-full bg-[var(--tt-border)] overflow-hidden">
+              <div
+                className="h-full rounded-full"
+                style={{
+                  width: `${Math.min(100, Math.round(budget.fraction * 100))}%`,
+                  background: budget.alert_level ? "var(--tt-danger-fg)" : (color ?? "var(--tt-brand)"),
+                }}
+              />
+            </div>
+            <button
+              onClick={() => { setLimitInput(String(budget.limit_value)); setEditing(true); }}
+              className="text-[10px] tabular text-[var(--tt-fg-muted)] hover:text-[var(--tt-fg)] shrink-0"
+              title="Edit monthly budget"
+            >
+              {formatCost(budget.used)} / {formatCost(budget.limit_value)} mo
+            </button>
+            {budget.alert_level && (
+              <Badge variant="danger" size="xs">{Math.round(budget.fraction * 100)}%</Badge>
+            )}
+          </>
+        ) : editing ? (
+          <div className="flex items-center gap-1.5 flex-1">
+            <input
+              type="number"
+              min="0"
+              step="0.5"
+              value={limitInput}
+              onChange={(e) => setLimitInput(e.target.value)}
+              placeholder="USD / month"
+              className="w-24 px-2 py-1 bg-[var(--tt-sunken)] border border-[var(--tt-border)] rounded text-[11px] text-[var(--tt-fg)] focus:outline-none focus:border-[var(--tt-border-strong)]"
+              autoFocus
+            />
+            <button onClick={submitBudget} disabled={saving} className="text-[10px] text-[var(--tt-brand)] hover:underline disabled:opacity-50">
+              {saving ? "saving…" : "save"}
+            </button>
+            {budget && (
+              <button onClick={() => { setLimitInput(""); submitBudget(); }} disabled={saving} className="text-[10px] text-[var(--tt-danger-fg)] hover:underline disabled:opacity-50">
+                remove
+              </button>
+            )}
+            <button onClick={() => setEditing(false)} disabled={saving} className="text-[10px] text-[var(--tt-fg-dim)] hover:underline">
+              cancel
+            </button>
+          </div>
+        ) : (
+          <button
+            onClick={() => { setLimitInput(""); setEditing(true); }}
+            className="text-[10px] text-[var(--tt-fg-dim)] hover:text-[var(--tt-fg)]"
+          >
+            Set monthly budget (alerts only)
+          </button>
+        )}
+      </div>
+
+      <div className="flex items-center gap-3 text-[11px] text-[var(--tt-fg-muted)]">
+        <span className="inline-flex items-center gap-1"><BookOpen size={11} /> {p.skills_count} skills</span>
+        <span className="inline-flex items-center gap-1"><Clock size={11} /> {p.cron_jobs} cron jobs</span>
+        {p.soul_exists && <span className="inline-flex items-center gap-1"><Sparkles size={11} /> SOUL.md</span>}
+      </div>
+    </Card>
   );
 }

--- a/frontend/src/app/hermes/profiles/page.tsx
+++ b/frontend/src/app/hermes/profiles/page.tsx
@@ -1,13 +1,55 @@
 "use client";
 
 import { useResource } from "@/lib/api";
-import { PageHeader, Card, EmptyState } from "@/components/ui";
-import { Users } from "lucide-react";
+import { PageHeader, Card, EmptyState, StatTile, Badge } from "@/components/ui";
+import { formatTokens, formatCost } from "@/lib/format";
+import { timeAgo } from "@/lib/notifications";
+import { Users, Power, BookOpen, Clock, Sparkles } from "lucide-react";
+
+interface ProfileGateway {
+  state: string | null;
+  pid: number | null;
+  pid_alive: boolean;
+}
+
+interface ProfileUsage {
+  sessions: number;
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+  cost: number;
+  last_activity: string | null;
+}
+
+interface Profile {
+  name: string;
+  is_default: boolean;
+  active: boolean;
+  description: string | null;
+  soul_exists: boolean;
+  skills_count: number;
+  cron_jobs: number;
+  gateway: ProfileGateway;
+  usage: ProfileUsage;
+}
+
+interface ProfilesResp {
+  profiles: Profile[];
+  active_profile: string | null;
+}
 
 export default function ProfilesPage() {
-  const res = useResource<{ profiles: { name: string }[] }>("/hermes/profiles");
-  const loading = !res.data;
-  const profiles = res.data?.profiles || [];
+  const { data, loading } = useResource<ProfilesResp>("/hermes/profiles", { pollMs: 60_000 });
+  const profiles = data?.profiles || [];
+  const named = profiles.filter((p) => !p.is_default);
+  const totals = profiles.reduce(
+    (acc, p) => ({
+      sessions: acc.sessions + p.usage.sessions,
+      tokens: acc.tokens + p.usage.total_tokens,
+      cost: acc.cost + p.usage.cost,
+    }),
+    { sessions: 0, tokens: 0, cost: 0 },
+  );
 
   return (
     <div className="px-8 py-8 max-w-[1200px] mx-auto space-y-6 pb-20">
@@ -16,22 +58,77 @@ export default function ProfilesPage() {
         icon={<div className="h-10 w-10 grid place-items-center rounded-[var(--tt-radius)] bg-blue-500/10 border border-blue-500/30"><Users className="text-blue-500" size={20} /></div>}
         eyebrow="Hermes Agent"
         title="Profiles"
-        description="Local agent profiles available in ~/.hermes/profiles"
+        description="Each profile is a full parallel agent home (own config, SOUL, sessions, cron, gateway). Hermes has no combined usage view across profiles — this is it."
       />
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <StatTile label="Profiles" value={loading ? "—" : String(profiles.length)} hint={named.length ? `${named.length} named + default` : "default only"} />
+        <StatTile label="Sessions" value={loading ? "—" : String(totals.sessions)} />
+        <StatTile label="Tokens" value={loading ? "—" : formatTokens(totals.tokens)} />
+        <StatTile label="Cost" value={loading ? "—" : formatCost(totals.cost)} />
+      </div>
+
       {loading ? (
         <div className="animate-pulse h-32 bg-[var(--tt-panel)] rounded-xl" />
       ) : profiles.length === 0 ? (
-        <EmptyState title="No profiles found" description="The agent is using the default global profile." />
+        <EmptyState title="Hermes not found" description="No ~/.hermes directory on this machine." />
       ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
-          {profiles.map(p => (
-            <Card key={p.name} className="p-4 flex items-center gap-3">
-              <div className="h-10 w-10 bg-[var(--tt-border)] text-[var(--tt-fg)] rounded-full flex items-center justify-center font-semibold text-lg uppercase">
-                {p.name.charAt(0)}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {profiles.map((p) => (
+            <Card key={p.name} className="p-5 space-y-3">
+              <div className="flex items-center gap-3">
+                <div className="h-10 w-10 bg-[var(--tt-border)] text-[var(--tt-fg)] rounded-full flex items-center justify-center font-semibold text-lg uppercase shrink-0">
+                  {p.name.charAt(0)}
+                </div>
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <span className="font-mono text-sm text-[var(--tt-fg)] truncate">{p.name}</span>
+                    {p.active && <Badge variant="brand" size="xs">active</Badge>}
+                    {p.is_default && <Badge variant="outline" size="xs">default home</Badge>}
+                  </div>
+                  <div className="text-[11px] text-[var(--tt-fg-muted)] truncate" title={p.description || undefined}>
+                    {p.description || (p.is_default ? "~/.hermes" : `~/.hermes/profiles/${p.name}`)}
+                  </div>
+                </div>
+                <div className="ml-auto shrink-0">
+                  <Badge variant={p.gateway.pid_alive ? "success" : "neutral"} size="xs" title={p.gateway.pid ? `PID ${p.gateway.pid}` : "no gateway"}>
+                    <Power size={10} /> {p.gateway.pid_alive ? "gateway up" : "gateway off"}
+                  </Badge>
+                </div>
               </div>
-              <div className="font-mono text-sm text-[var(--tt-fg)] truncate">{p.name}</div>
+
+              <div className="grid grid-cols-4 gap-2 text-center">
+                <div className="bg-[var(--tt-sunken)] border border-[var(--tt-border)] rounded-[var(--tt-radius)] p-2">
+                  <div className="text-[15px] tabular font-semibold text-[var(--tt-fg)]">{p.usage.sessions}</div>
+                  <div className="text-[9px] uppercase tracking-wider text-[var(--tt-fg-dim)]">Sessions</div>
+                </div>
+                <div className="bg-[var(--tt-sunken)] border border-[var(--tt-border)] rounded-[var(--tt-radius)] p-2">
+                  <div className="text-[15px] tabular font-semibold text-[var(--tt-fg)]">{formatTokens(p.usage.total_tokens)}</div>
+                  <div className="text-[9px] uppercase tracking-wider text-[var(--tt-fg-dim)]">Tokens</div>
+                </div>
+                <div className="bg-[var(--tt-sunken)] border border-[var(--tt-border)] rounded-[var(--tt-radius)] p-2">
+                  <div className="text-[15px] tabular font-semibold text-[var(--tt-fg)]">{formatCost(p.usage.cost)}</div>
+                  <div className="text-[9px] uppercase tracking-wider text-[var(--tt-fg-dim)]">Cost</div>
+                </div>
+                <div className="bg-[var(--tt-sunken)] border border-[var(--tt-border)] rounded-[var(--tt-radius)] p-2">
+                  <div className="text-[15px] tabular font-semibold text-[var(--tt-fg)]">{p.usage.last_activity ? timeAgo(p.usage.last_activity) : "—"}</div>
+                  <div className="text-[9px] uppercase tracking-wider text-[var(--tt-fg-dim)]">Last active</div>
+                </div>
+              </div>
+
+              <div className="flex items-center gap-3 text-[11px] text-[var(--tt-fg-muted)]">
+                <span className="inline-flex items-center gap-1"><BookOpen size={11} /> {p.skills_count} skills</span>
+                <span className="inline-flex items-center gap-1"><Clock size={11} /> {p.cron_jobs} cron jobs</span>
+                {p.soul_exists && <span className="inline-flex items-center gap-1"><Sparkles size={11} /> SOUL.md</span>}
+              </div>
             </Card>
           ))}
+        </div>
+      )}
+
+      {!loading && profiles.length > 0 && named.length === 0 && (
+        <div className="text-[11px] text-[var(--tt-fg-dim)]">
+          Only the default home is in use. Create isolated agent identities with <code className="font-mono text-[var(--tt-fg-muted)]">hermes profile create &lt;name&gt;</code> — their sessions and costs will show up here.
         </div>
       )}
     </div>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -15,6 +15,7 @@ import CopilotSourceBadge from "@/components/CopilotSourceBadge";
 import AntigravitySourceBadge from "@/components/AntigravitySourceBadge";
 import LocalPowerInsights from "@/components/insights/LocalPowerInsights";
 import { formatTokens, formatCost } from "@/lib/format";
+import { profileColor } from "@/lib/profileColor";
 import { costFraming, type BillingConfig } from "@/lib/billing";
 import {
   PageHeader, StatTile, Section, Card, CardHeader, CardTitle, CardEyebrow,
@@ -36,6 +37,7 @@ interface Session {
   antigravity_source?: string;
   /** Hermes-only: cli / telegram / cron / etc. */
   source_subtype?: string;
+  hermes_profile?: string;
 }
 
 interface AnalyticsResponse {
@@ -265,7 +267,21 @@ export default function Home() {
                       <TD className="font-mono text-[12px] text-[var(--tt-fg-muted)] max-w-[160px] truncate" title={s.agent === "hermes" ? `Hermes source: ${s.source_subtype || "unknown"}` : s.project}>
                         <Link href={`/sessions/${s.id}?agent=${s.agent}&from=${encodeURIComponent(pathname)}`} className="block truncate">
                           {s.agent === "hermes" ? (
-                            <SourceBadge source={s.source_subtype} size="xs" />
+                            <span className="inline-flex items-center gap-1.5">
+                              <SourceBadge source={s.source_subtype} size="xs" />
+                              {s.hermes_profile && (
+                                <span
+                                  className="font-mono text-[9px] px-1.5 rounded-full border"
+                                  style={{
+                                    color: profileColor(s.hermes_profile) ?? undefined,
+                                    borderColor: profileColor(s.hermes_profile) ?? undefined,
+                                  }}
+                                  title={`Profile: ${s.hermes_profile}`}
+                                >
+                                  {s.hermes_profile}
+                                </span>
+                              )}
+                            </span>
                           ) : (
                             s.project.split("/").pop()
                           )}

--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -5,7 +5,7 @@ import { createPortal } from "react-dom";
 import { useParams, useSearchParams, useRouter } from "next/navigation";
 import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { ArrowLeft, Brain, Code, MessageSquare, Terminal, User, FileText, Activity, Zap, Info, Sparkles, GitBranch, LayoutPanelLeft, ListMusic, ChevronRight, ChevronLeft, Play, Pause, Wrench, Cpu, Folder, AlertTriangle, Hash, Clock, FileCode, Settings2, ChevronDown, ChevronUp, Copy, Maximize2, X } from "lucide-react";
+import { ArrowLeft, Brain, Code, MessageSquare, Terminal, User, Users, FileText, Activity, Zap, Info, Sparkles, GitBranch, LayoutPanelLeft, ListMusic, ChevronRight, ChevronLeft, Play, Pause, Wrench, Cpu, Folder, AlertTriangle, Hash, Clock, FileCode, Settings2, ChevronDown, ChevronUp, Copy, Maximize2, X } from "lucide-react";
 import Link from "next/link";
 import { format } from "date-fns";
 import { AgentBadge, Badge, Button, Skeleton } from "@/components/ui";
@@ -45,6 +45,8 @@ interface Session {
   antigravity_source?: string;
   /** Hermes-only */
   source_subtype?: string;
+  /** Hermes-only: owning profile (~/.hermes/profiles/<name>); absent = default home */
+  hermes_profile?: string;
   parent_session_id?: string | null;
   end_reason?: string | null;
 }
@@ -567,6 +569,11 @@ export default function SessionDetailPage() {
                   {agent === "copilot" && <CopilotSourceBadge source={sessionInfo?.copilot_source} size="sm" />}
                   {agent === "antigravity" && <AntigravitySourceBadge source={sessionInfo?.antigravity_source} size="sm" />}
                   {agent === "hermes" && <SourceBadge source={sessionInfo?.source_subtype} size="sm" />}
+                  {agent === "hermes" && sessionInfo?.hermes_profile && (
+                    <Badge variant="outline" size="xs" className="font-mono normal-case" title={`Hermes profile: ~/.hermes/profiles/${sessionInfo.hermes_profile}`}>
+                      <Users size={10} /> {sessionInfo.hermes_profile}
+                    </Badge>
+                  )}
                   <button
                     onClick={() => navigator.clipboard?.writeText(id)}
                     title="Copy session id"

--- a/frontend/src/lib/budgets.ts
+++ b/frontend/src/lib/budgets.ts
@@ -22,6 +22,8 @@ export interface BudgetFilters {
   project?: string;
   agent?: string;
   model?: string;
+  /** Hermes profile scope; "default" matches sessions from the root home. */
+  hermes_profile?: string;
 }
 
 /** A stored budget definition (what the editor reads/writes). */

--- a/frontend/src/lib/profileColor.ts
+++ b/frontend/src/lib/profileColor.ts
@@ -1,0 +1,24 @@
+// Deterministic per-profile color, mirroring Hermes desktop's own idiom
+// (apps/desktop/src/lib/profile-color.ts): hue hashed from the profile name,
+// fixed saturation/lightness, so a profile keeps its color everywhere without
+// any stored state. The default home is intentionally neutral (null) — only
+// named profiles get an identity color, same as the desktop app.
+
+export function profileHue(name: string): number {
+  let h = 0;
+  for (let i = 0; i < name.length; i++) {
+    h = (h * 31 + name.charCodeAt(i)) >>> 0;
+  }
+  return h % 360;
+}
+
+export function profileColor(name: string | null | undefined): string | null {
+  if (!name || name === "default") return null;
+  return `hsl(${profileHue(name)} 68% 58%)`;
+}
+
+/** Soft translucent fill for backgrounds behind the solid color. */
+export function profileTint(name: string | null | undefined): string | null {
+  if (!name || name === "default") return null;
+  return `hsl(${profileHue(name)} 68% 58% / 0.15)`;
+}


### PR DESCRIPTION
## What

Hermes's profiles feature gives each profile a full parallel agent home under `~/.hermes/profiles/<name>/`. Hermes itself has no combined usage/cost view across profiles — its own dashboard's analytics carries no profile dimension, and GitHub asks track exactly this gap (#13547 +5, #45148, #58274). This PR makes TT the cross-profile cost layer, in two stages:

### Commit 1 — data layer (per-profile attribution)
- `_hermes_dbs_with_profiles()` pairs each `state.db` with its owning profile; scanned sessions carry `hermes_profile`.
- Bug fix: overlay/cwd/measured-tok-per-sec log parsing was root-home-only, so profile sessions silently got empty overlays. Now reads the owning profile's `agent.log`.
- `GET /hermes/profiles`: metadata (profile.yaml description, active marker, per-profile gateway/skills/cron/SOUL) + usage rollup from the shared scan. No secrets read (`.env`, `auth.json` untouched).

### Commit 3 — three UI features (evidence: Hermes issues #62535/#29034 runaway spend, #39250 per-goal cost, #45148 profile analytics)
- **Profile scope**: switcher pills on `/hermes` filter every stat and session list; sessions show a profile chip colored with the same deterministic name→hue Hermes desktop uses. All-profiles view groups by color.
- **Burn + budgets**: profile cards get a 14-local-day cost sparkline, 7d-vs-prior-7d burn trend, and an *unattended* split (cron/subagent/kanban/tool spend — the overnight-swarm surprise). Alerts-only monthly budget per profile via the existing budgets engine (new `hermes_profile` filter key; `default` matches the root home).
- **Kanban cost board**: `/hermes/kanban` reads every `kanban.db` (root + profiles + named boards; `immutable=1` fallback for WAL DBs in 0700 homes), joins `tasks.session_id` (schema-tolerant — column arrived via migration) to scanned session costs, rolls up per-worker lanes and failure burn. Hermes tracks swarm tasks but never prices them; this does.

Also: `fix(tests)` commit patches `PI_SESSIONS_DIR` into the scan fixtures — they predate Pi support, so real `~/.pi` sessions leaked project roots and broke the smallcode tests on any machine with Pi usage (fails identically on origin/main).

## Verification

- 12 tests in `backend/test_hermes_profiles.py` (attribution, resolver, profile logs, burn windows, budget filter, kanban join incl. pre-migration schema + named boards + empty install) — all pass.
- Full backend suite failure set is byte-identical to origin/main's pre-existing environmental failures; +12 passing, and the smallcode hermeticity fix removes a real flake.
- `tsc --noEmit` clean.
- Live against real `~/.hermes`: profiles rollup matches an independent raw-SQL recompute; kanban endpoint reads the real (empty) board via the immutable fallback; budget with `hermes_profile` filter round-trips; all three pages render 200 on the dev servers.

## Follow-ups (researched, not in scope)
`sessions/request_dump_*.json` failed-call telemetry · `models_dev_cache.json` pricing fallback · rotated `agent.log.1` parsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)