### PR TITLE
feat: cost attribution — billing buckets, local-vs-cloud, cost per completed session

### DIFF
--- a/UPDATE.json
+++ b/UPDATE.json
@@ -1,6 +1,22 @@
 {
   "releases": [
     {
+      "tag": "2026-07-14",
+      "title": "Cost attribution: buckets & per-session cost",
+      "highlights": [
+        {
+          "title": "See which bucket actually pays for each session",
+          "description": "Analytics now splits cost three ways: subscription-covered (included in a flat plan you already pay), API-metered (billed per token), and local electricity. It tells you how much of your spend is a real marginal bill versus usage a subscription already covers, plus a local-vs-cloud split.",
+          "href": "/analytics"
+        },
+        {
+          "title": "Cost per completed session",
+          "description": "Alongside average cost per session, Analytics shows cost per session that ended cleanly. Codex, Claude Code and Cline report a completion signal; other agents show as unknown rather than guessing. Lets you weigh spend against runs that finished, not ones that errored out partway.",
+          "href": "/analytics"
+        }
+      ]
+    },
+    {
       "tag": "2026-07-13",
       "title": "Compare two Hermes profiles head-to-head",
       "highlights": [

--- a/backend/history_store.py
+++ b/backend/history_store.py
@@ -36,7 +36,7 @@ from tt_paths import data_dir
 
 _log = logging.getLogger("tokentelemetry.history")
 
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 # Sub-dicts folded into ``ecosystem_json`` and expanded back out on read. These
 # are the keys the analytics aggregation + delegation views consume beyond the
@@ -86,6 +86,8 @@ def _migrate(con: sqlite3.Connection) -> None:
                 total           INTEGER DEFAULT 0,
                 cost            REAL    DEFAULT 0.0,
                 tok_per_sec     REAL,
+                task_type       TEXT,
+                completed       TEXT,
                 ecosystem_json  TEXT,
                 first_seen_at   TEXT,
                 last_seen_at    TEXT,
@@ -130,6 +132,21 @@ def _migrate(con: sqlite3.Connection) -> None:
             con.execute("ALTER TABLE sessions ADD COLUMN cache_reads INTEGER DEFAULT 0")
         except sqlite3.OperationalError:
             pass
+        con.execute(f"PRAGMA user_version={SCHEMA_VERSION}")
+        con.commit()
+    if ver < 3:
+        # v3 adds the cost-attribution raw signals: `task_type`
+        # (interactive|programmatic|unknown) and `completed`
+        # (clean|errored|unknown), both log-derived at scan time and STORED
+        # verbatim. The config-dependent billing_bucket / marginal_cost_zero are
+        # deliberately NOT persisted — they're re-derived at read time from the
+        # live billing route (store-raw-derive-at-read). Fresh DBs already carry
+        # both columns from CREATE TABLE, so tolerate the duplicate-column error.
+        for _col in ("task_type", "completed"):
+            try:
+                con.execute(f"ALTER TABLE sessions ADD COLUMN {_col} TEXT")
+            except sqlite3.OperationalError:
+                pass
         con.execute(f"PRAGMA user_version={SCHEMA_VERSION}")
         con.commit()
 
@@ -216,6 +233,8 @@ def upsert_sessions(rows: Sequence[Dict[str, Any]]) -> int:
                             total=excluded.total,
                             cost=excluded.cost,
                             tok_per_sec=excluded.tok_per_sec,
+                            task_type=excluded.task_type,
+                            completed=excluded.completed,
                             ecosystem_json=excluded.ecosystem_json,
                             last_seen_at=excluded.last_seen_at,
                             source_present=1
@@ -225,9 +244,9 @@ def upsert_sessions(rows: Sequence[Dict[str, Any]]) -> int:
                     INSERT INTO sessions (
                         agent, id, project, model, provider, endpoint, billing_mode,
                         first_ts, last_ts, input, output, cached, cache_reads, total, cost,
-                        tok_per_sec, ecosystem_json, first_seen_at, last_seen_at,
-                        source_present
-                    ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,1)
+                        tok_per_sec, task_type, completed, ecosystem_json,
+                        first_seen_at, last_seen_at, source_present
+                    ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,1)
                     {conflict_clause}
                     """,
                     (
@@ -239,6 +258,7 @@ def upsert_sessions(rows: Sequence[Dict[str, Any]]) -> int:
                         int(tok.get("total", 0) or 0),
                         float(r.get("cost", 0.0) or 0.0),
                         r.get("tok_per_sec"),
+                        r.get("task_type"), r.get("completed"),
                         _ecosystem_blob(r), now, now,
                     ),
                 )
@@ -303,6 +323,10 @@ def _rehydrate(r: sqlite3.Row) -> Dict[str, Any]:
         },
         "cost": r["cost"],
         "tok_per_sec": r["tok_per_sec"],
+        # Cost-attribution raw signals (v3+). Rows persisted before v3 have no
+        # column / NULL here → "unknown", matching a scanner with no signal.
+        "task_type": (r["task_type"] if "task_type" in r.keys() else None) or "unknown",
+        "completed": (r["completed"] if "completed" in r.keys() else None) or "unknown",
         "source_present": bool(r["source_present"]),
         "transcript_archived": bool(r["transcript_archived"]),
         "summary_present": bool(r["summary_present"]),

--- a/backend/main.py
+++ b/backend/main.py
@@ -2616,6 +2616,10 @@ def _scan_cline_sessions() -> List[Dict[str, Any]]:
 
             is_subagent = bool(_row_get(row, "is_subagent"))
             parent_sid = _row_get(row, "parent_session_id")
+            # Cost-attribution raw signals: the CLI store's `interactive` flag
+            # (1/0) and `status` are first-class columns, not a guess.
+            _iv = _row_get(row, "interactive")
+            _task_type = "unknown" if _iv is None else ("interactive" if _iv else "programmatic")
             rec = {
                 "id": sid,
                 "agent": "cline",
@@ -2629,6 +2633,8 @@ def _scan_cline_sessions() -> List[Dict[str, Any]]:
                 "plans": [],
                 "artifacts": artifacts,
                 "cost": tokens["cost"],
+                "task_type": _task_type,
+                "completed": _cline_completed(_row_get(row, "status")),
                 "cline": {
                     "source": "cli",
                     "provider": row["provider"],
@@ -3334,6 +3340,7 @@ def _claude_subagent_usage(session_file: Path, sid: str) -> Optional[Dict[str, A
 _CLAUDE_CACHE_FIELDS = (
     "tokens", "model", "cost", "mcp_tools", "has_plan", "plans",
     "delegation", "delegated_cost", "tool_counts", "mcp_usage", "skills_used",
+    "task_type", "completed",
 )
 
 
@@ -3377,6 +3384,7 @@ _CODEX_CACHE_FIELDS = (
     "tokens", "model", "_provider", "cost", "mcp_tools", "has_plan", "plans",
     "text", "tokens_by_day", "tool_counts", "_skill_counts",
     "parent_session_id", "subagent_info", "_raw_cwd",
+    "task_type", "completed",
 )
 
 
@@ -3412,6 +3420,50 @@ def _apply_codex_cache_hit(sess: Dict[str, Any], cached: Dict[str, Any]) -> None
         {**p, "timestamp": datetime.fromisoformat(p["timestamp"]) if isinstance(p.get("timestamp"), str) else p.get("timestamp")}
         for p in (sess.get("plans") or [])
     ]
+
+
+# --- Cost-attribution raw signals (stored; billing bucket is derived at read) ---
+def _claude_task_type(entrypoint: Optional[str]) -> str:
+    """Map a Claude ``entrypoint`` (top-level on every transcript line) to a task
+    type: ``cli`` / ``claude-desktop`` are a human at a terminal/app
+    (interactive); ``sdk-cli`` is the Agent SDK / headless path (programmatic).
+    Anything unrecognized stays ``unknown`` — never guess."""
+    ep = (entrypoint or "").strip().lower()
+    if ep in ("cli", "claude-desktop"):
+        return "interactive"
+    if ep == "sdk-cli":
+        return "programmatic"
+    return "unknown"
+
+
+def _codex_task_type(originator: Optional[str]) -> str:
+    """Map a Codex session_meta ``originator`` to a task type. ``codex_exec``
+    (headless exec / app-server) and ``Claude Code`` (SDK-orchestrated over the
+    app-server) are programmatic; the TUI / editor / desktop originators are a
+    human driving it (interactive). Unrecognized → ``unknown``."""
+    o = (originator or "").strip().lower()
+    if not o:
+        return "unknown"
+    if "exec" in o or o == "claude code":
+        return "programmatic"
+    if o in ("codex-tui", "codex_vscode", "codex desktop") or "tui" in o or "vscode" in o or "desktop" in o:
+        return "interactive"
+    return "unknown"
+
+
+# Cline CLI ``status`` values that mean the run ended cleanly vs. with an error.
+_CLINE_CLEAN_STATUS = {"completed", "done", "finished", "success", "succeeded"}
+_CLINE_ERROR_STATUS = {"failed", "error", "errored", "cancelled", "canceled",
+                       "aborted", "crashed", "timeout", "timed_out", "killed"}
+
+
+def _cline_completed(status: Optional[str]) -> str:
+    s = (status or "").strip().lower()
+    if s in _CLINE_CLEAN_STATUS:
+        return "clean"
+    if s in _CLINE_ERROR_STATUS:
+        return "errored"
+    return "unknown"
 
 
 def _scan_sessions_sync():
@@ -3552,16 +3604,27 @@ def _scan_sessions_sync():
                     tool_counts: Dict[str, int] = {}
                     skill_counts: Dict[str, int] = {}
                     last_real_ts = None
+                    # Cost-attribution raw signals, derived in this single pass:
+                    # `entrypoint` (task type) is the same on every line; the last
+                    # assistant turn's stop_reason / isApiErrorMessage decide the
+                    # completed state.
+                    entrypoint = None
+                    last_stop_reason = None
+                    last_is_error = False
                     try:
                         with open(session_file, "r", encoding="utf-8", errors="replace") as f:
                             for line in f:
                                 try:
                                     data = json.loads(line)
                                 except Exception: continue
+                                if entrypoint is None and data.get("entrypoint"):
+                                    entrypoint = data["entrypoint"]
                                 if data.get("type") in ("user", "assistant") and data.get("timestamp"):
                                     last_real_ts = data["timestamp"]
                                 if data.get("type") == "assistant":
                                     msg = data.get("message", {})
+                                    last_stop_reason = msg.get("stop_reason")
+                                    last_is_error = bool(data.get("isApiErrorMessage"))
                                     m = msg.get("model")
                                     if m and m != "<synthetic>" and not sess.get("model"):
                                         sess["model"] = m
@@ -3611,6 +3674,13 @@ def _scan_sessions_sync():
                             sess["timestamp"] = datetime.fromisoformat(last_real_ts.replace("Z", "+00:00"))
                         except ValueError:
                             pass
+                    sess["task_type"] = _claude_task_type(entrypoint)
+                    if last_is_error:
+                        sess["completed"] = "errored"
+                    elif last_stop_reason == "end_turn":
+                        sess["completed"] = "clean"
+                    else:
+                        sess["completed"] = "unknown"
                     _attach_tool_usage(sess, tool_counts, skill_counts)
                     deleg = _claude_subagent_usage(session_file, sid)
                     sess["delegation"] = {
@@ -3699,6 +3769,10 @@ def _scan_sessions_sync():
                             if data.get("type") == "session_meta":
                                 sess["_raw_cwd"] = data["payload"].get("cwd", "unknown")
                                 sess["project"] = apply_alias(sess["_raw_cwd"])
+                                if sess.get("task_type", "unknown") == "unknown":
+                                    _tt = _codex_task_type(data["payload"].get("originator"))
+                                    if _tt != "unknown":
+                                        sess["task_type"] = _tt
                                 if not sess.get("model") and data["payload"].get("model"):
                                     sess["model"] = data["payload"].get("model")
                                 if not sess.get("_provider"):
@@ -3724,6 +3798,11 @@ def _scan_sessions_sync():
                             if data.get("type") == "turn_context" and not sess.get("model"):
                                 sess["model"] = data.get("payload", {}).get("model")
                             if data.get("type") == "event_msg":
+                                # A `task_complete` event means the turn agent
+                                # finished cleanly; presence anywhere in the
+                                # rollout marks the session clean.
+                                if (data.get("payload") or {}).get("type") == "task_complete":
+                                    sess["completed"] = "clean"
                                 ts_str = data.get("timestamp")
                                 event_day = None
                                 if ts_str:
@@ -4724,6 +4803,11 @@ def _scan_sessions_sync():
     # still "supported", just not scanned yet.
     for s in sessions:
         s.setdefault("delegation", {"supported": s.get("agent") in _DELEGATION_CAPABLE_AGENTS})
+        # Cost-attribution raw signals default to "unknown" for every scanner
+        # that couldn't derive them (never guess). Scanners that DID derive a
+        # value (Claude/Codex/Cline) already set it above.
+        s.setdefault("task_type", "unknown")
+        s.setdefault("completed", "unknown")
 
     # Global sort by timestamp descending
     sessions.sort(key=lambda x: x["timestamp"], reverse=True)
@@ -4863,15 +4947,62 @@ async def get_sessions_cached(fresh: bool = False) -> List[Dict[str, Any]]:
         return _sessions_cache["data"]
 
 
+# ---------------------------------------------------------------------------
+# Cost-attribution read-time derivation
+# ---------------------------------------------------------------------------
+# `task_type` / `completed` are STORED raw at scan time; the billing *bucket* a
+# session drains depends on the user's CURRENT billing mode + plan, so it's
+# re-derived here at read time (never persisted), mirroring how energy/savings
+# are re-derived from power config. Buckets: included | api_rate | electricity |
+# unknown (the last for agents whose billing we genuinely can't resolve).
+def _resolve_session_bucket(
+    sess: Dict[str, Any],
+    mode_cache: Dict[str, str],
+    plans: Dict[str, str],
+    today,
+) -> tuple:
+    """Return ``(bucket, marginal_cost_zero)`` for one session.
+
+    ``mode_cache`` memoizes ``billing_mode.get_mode`` per agent (it touches disk),
+    ``plans`` is ``billing_route.load_plans()`` (read once by the caller).
+    """
+    import billing_mode, billing_route
+    agent = sess.get("agent") or ""
+    mode = mode_cache.get(agent)
+    if mode is None:
+        mode = billing_mode.get_mode(agent).get("mode", "unknown")
+        mode_cache[agent] = mode
+    plan = plans.get(agent, billing_route.DEFAULT_PLAN)
+    route = billing_route.resolve_billing_route(
+        agent, sess.get("task_type") or "unknown", plan, mode, today)
+    active = route.get("active")
+    if not active or active.get("id") == "unknown":
+        return "unknown", False
+    return (active.get("charges") or "unknown"), bool(route.get("marginal_cost_zero"))
+
+
 @app.get("/sessions")
 async def get_sessions(fresh: bool = False):
     """Return the session list. Pass ?fresh=1 to force a re-scan."""
+    import datetime as _date_mod
     data = await get_sessions_cached(fresh=fresh)
     # `stub` is scan→persist plumbing (history_store.upsert_sessions keys its
     # conflict clause on it), not API surface. Strip it on shallow copies —
     # never mutate the cached dicts, which the async history persist may
-    # still be reading.
-    return [{k: v for k, v in s.items() if k != "stub"} for s in data]
+    # still be reading. While copying, attach the read-time-derived billing
+    # bucket + marginal_cost_zero (config-dependent, so never stored).
+    import billing_route
+    plans = billing_route.load_plans()
+    mode_cache: Dict[str, str] = {}
+    today = _date_mod.date.today()
+    out = []
+    for s in data:
+        c = {k: v for k, v in s.items() if k != "stub"}
+        bucket, mcz = _resolve_session_bucket(s, mode_cache, plans, today)
+        c["billing_bucket"] = bucket
+        c["marginal_cost_zero"] = mcz
+        out.append(c)
+    return out
 
 
 @app.get("/pricing")
@@ -7072,6 +7203,60 @@ async def get_analytics(
             arow["child_tokens"] += (s.get("tokens") or {}).get("total", 0)
             arow["child_cost"] = round(arow["child_cost"] + (s.get("cost") or 0), 6)
 
+    # Cost attribution (read-time, config-dependent — never stored). Buckets the
+    # SAME filtered `sessions` set the other keys use. `by_bucket` = which credit
+    # pool pays: included (subscription-covered → marginal $0), api_rate
+    # (metered/paygo), electricity (local power), unknown (billing unresolved).
+    # `local_vs_cloud` reuses is_local_session (the pricing branch, not a
+    # re-derivation). `per_session` reports cost per session and per *cleanly-
+    # completed* session (completed=="clean" only; unknown is its own bucket,
+    # never folded into clean).
+    import billing_route as _billing_route
+    _plans = _billing_route.load_plans()
+    _mode_cache: Dict[str, str] = {}
+    _ca_today = datetime.now().date()
+
+    def _ca_row() -> Dict[str, Any]:
+        return {"cost": 0.0, "tokens": 0, "sessions": 0}
+
+    ca_by_bucket = {b: _ca_row() for b in ("included", "api_rate", "electricity", "unknown")}
+    ca_local = {"local": _ca_row(), "cloud": _ca_row()}
+    ca_completed = {"clean": 0, "errored": 0, "unknown": 0}
+    ca_cost_all = 0.0
+    ca_cost_clean = 0.0
+    ca_clean_n = 0
+    for s in sessions:
+        st = s.get("tokens", {}) or {}
+        toks = st.get("total", 0) or 0
+        scost = s.get("cost", 0.0) or 0.0
+        bucket, _mcz = _resolve_session_bucket(s, _mode_cache, _plans, _ca_today)
+        row = ca_by_bucket.get(bucket) or ca_by_bucket["unknown"]
+        row["cost"] += scost; row["tokens"] += toks; row["sessions"] += 1
+        loc = "local" if is_local_session(
+            model_name=s.get("model"), endpoint=s.get("endpoint"),
+            provider=s.get("provider"), billing_mode=s.get("billing_mode"), config=pc,
+        ) else "cloud"
+        ca_local[loc]["cost"] += scost; ca_local[loc]["tokens"] += toks; ca_local[loc]["sessions"] += 1
+        comp = s.get("completed") or "unknown"
+        if comp not in ca_completed:
+            comp = "unknown"
+        ca_completed[comp] += 1
+        ca_cost_all += scost
+        if comp == "clean":
+            ca_cost_clean += scost; ca_clean_n += 1
+    n_sessions = len(sessions)
+    cost_attribution = {
+        "by_bucket": {b: {"cost": round(v["cost"], 6), "tokens": v["tokens"], "sessions": v["sessions"]}
+                      for b, v in ca_by_bucket.items()},
+        "local_vs_cloud": {k: {"cost": round(v["cost"], 6), "tokens": v["tokens"], "sessions": v["sessions"]}
+                           for k, v in ca_local.items()},
+        "per_session": {
+            "avg_cost_all": round(ca_cost_all / n_sessions, 6) if n_sessions else 0.0,
+            "avg_cost_completed": round(ca_cost_clean / ca_clean_n, 6) if ca_clean_n else None,
+            "completed_counts": ca_completed,
+        },
+    }
+
     return {
         "by_agent": by_agent,
         "by_day": sorted_days,
@@ -7080,6 +7265,7 @@ async def get_analytics(
         "by_mcp_server": by_mcp_server,
         "by_subagent_type": by_subagent_type,
         "delegation": delegation_totals,
+        "cost_attribution": cost_attribution,
         "total": {
             "input": total_input,
             "output": total_output,

--- a/frontend/src/app/analytics/page.tsx
+++ b/frontend/src/app/analytics/page.tsx
@@ -33,6 +33,7 @@ interface AnalyticsData {
     linked_children?: number; linked_child_tokens?: number; linked_child_cost?: number;
     by_agent?: Record<string, { parents: number; spawns: number; children: number; child_tokens: number; child_cost: number; delegated_tokens: number; delegated_cost: number }>;
   };
+  cost_attribution?: CostAttribution;
   total: { input: number; output: number; cached: number; total: number; cost: number };
   coverage?: {
     earliest: string | null;
@@ -45,6 +46,21 @@ interface AnalyticsData {
 
 interface AgentStats {
   input: number; output: number; cached: number; total: number; cost: number; session_count: number;
+}
+
+/* Cost attribution (additive /analytics key, discussion #49 v1). Every field is
+   optional-safe — an older backend omits the whole `cost_attribution` object and
+   the section simply doesn't render. */
+interface BucketStat { cost: number; tokens: number; sessions: number }
+type BillingBucket = "included" | "api_rate" | "electricity" | "unknown";
+interface CostAttribution {
+  by_bucket: Record<BillingBucket, BucketStat>;
+  local_vs_cloud: { local: BucketStat; cloud: BucketStat };
+  per_session: {
+    avg_cost_all: number;
+    avg_cost_completed: number | null;
+    completed_counts: { clean: number; errored: number; unknown: number };
+  };
 }
 
 /* ──────────────────────────────────────────────────────────────────────────
@@ -571,7 +587,155 @@ export default function AnalyticsPage() {
         </Section>
       )}
 
+      {data.cost_attribution && <CostAttributionSection ca={data.cost_attribution} />}
+
       <EcosystemSection data={data} />
+    </div>
+  );
+}
+
+/* Cost attribution — which layer actually pays: subscription-covered vs API
+   metered vs local electricity, local-vs-cloud, and cost per (completed) session.
+   Labels reuse the billing vocabulary from DrainOrder/BillingSettings. The
+   "subscription-covered" figure is an API-list-price equivalent, never a bill
+   (same framing as costFraming() in lib/billing.ts). */
+const BUCKET_META: Record<
+  BillingBucket,
+  { label: string; sub: string; dot: string; text: string }
+> = {
+  included:    { label: "Subscription-covered", sub: "$0 marginal — flat-fee plan",        dot: "var(--tt-success-fg)", text: "text-[var(--tt-success-fg)]" },
+  api_rate:    { label: "API metered",          sub: "Pay-per-token — approximates a bill", dot: "#f59e0b",              text: "text-amber-300" },
+  electricity: { label: "Electricity (local)",  sub: "Local model — power estimate",        dot: "var(--tt-info-fg)",    text: "text-[var(--tt-info-fg)]" },
+  unknown:     { label: "Unknown",              sub: "Billing mode not resolved",           dot: "var(--tt-fg-dim)",     text: "text-[var(--tt-fg-dim)]" },
+};
+const BUCKET_ORDER: BillingBucket[] = ["included", "api_rate", "electricity", "unknown"];
+
+function CostAttributionSection({ ca }: { ca: CostAttribution }) {
+  const buckets = BUCKET_ORDER
+    .map((k) => ({ key: k, ...(ca.by_bucket?.[k] ?? { cost: 0, tokens: 0, sessions: 0 }) }))
+    .filter((b) => b.sessions > 0 || b.cost > 0 || b.tokens > 0);
+  const totalCost = buckets.reduce((s, b) => s + b.cost, 0);
+  const hasIncluded = (ca.by_bucket?.included?.sessions ?? 0) > 0 || (ca.by_bucket?.included?.cost ?? 0) > 0;
+
+  const lc = ca.local_vs_cloud;
+  const cloud = lc?.cloud ?? { cost: 0, tokens: 0, sessions: 0 };
+  const local = lc?.local ?? { cost: 0, tokens: 0, sessions: 0 };
+  const cc = ca.per_session?.completed_counts ?? { clean: 0, errored: 0, unknown: 0 };
+  const avgCompleted = ca.per_session?.avg_cost_completed;
+
+  return (
+    <Section
+      title="Cost attribution"
+      description="Which layer actually pays — subscription plans, pay-per-token API, or local electricity — and what a session costs. All dollar figures are API list-price equivalents."
+      actions={<Badge variant="neutral" size="sm">{buckets.length} bucket{buckets.length === 1 ? "" : "s"}</Badge>}
+    >
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Bucket split */}
+        <Card className="lg:col-span-2" padding="none">
+          <div className="px-5 py-4 border-b border-[var(--tt-border)] flex items-center justify-between">
+            <CardTitle><DollarSign size={14} className="text-amber-300" /> By billing bucket</CardTitle>
+            <CardEyebrow>subscription vs metered vs local</CardEyebrow>
+          </div>
+          <div className="overflow-x-auto">
+            <Table>
+              <THead>
+                <TR>
+                  <TH className="pl-5">Bucket</TH>
+                  <TH className="text-right">Sessions</TH>
+                  <TH className="text-right">Tokens</TH>
+                  <TH className="text-right">Share</TH>
+                  <TH className="text-right pr-5 text-amber-300">API equiv.</TH>
+                </TR>
+              </THead>
+              <TBody>
+                {buckets.map((b) => {
+                  const meta = BUCKET_META[b.key];
+                  return (
+                    <TR key={b.key}>
+                      <TD className="pl-5">
+                        <span className="flex items-center gap-2">
+                          <span className="w-1.5 h-1.5 rounded-full shrink-0" style={{ backgroundColor: meta.dot }} />
+                          <span className="flex flex-col min-w-0">
+                            <span className={cn("text-[12px] font-medium", meta.text)}>{meta.label}</span>
+                            <span className="text-[10px] text-[var(--tt-fg-dim)]">{meta.sub}</span>
+                          </span>
+                        </span>
+                      </TD>
+                      <TD className="text-right tabular text-[var(--tt-fg-muted)]">{b.sessions.toLocaleString()}</TD>
+                      <TD className="text-right tabular text-[var(--tt-fg-muted)]">{compact(b.tokens)}</TD>
+                      <TD className="text-right tabular text-[var(--tt-fg-dim)]">{pct(b.cost, totalCost)}%</TD>
+                      <TD className="text-right pr-5 tabular font-semibold text-amber-300">${b.cost.toFixed(2)}</TD>
+                    </TR>
+                  );
+                })}
+              </TBody>
+            </Table>
+          </div>
+          {hasIncluded && (
+            <p className="px-5 py-3 text-[11px] leading-snug text-[var(--tt-fg-dim)] border-t border-[var(--tt-border)]">
+              <span className="text-[var(--tt-fg-muted)] font-medium">Subscription-covered is an API-list-price equivalent, not a bill.</span>{" "}
+              Flat-fee plans (Claude Pro/Max, Copilot and similar) charge a fixed
+              monthly price, so your actual spend on that usage is much lower — the
+              figure only re-prices it at API list rates so sessions are comparable.
+            </p>
+          )}
+        </Card>
+
+        {/* Local vs cloud + cost per session */}
+        <div className="space-y-6">
+          <Card padding="lg">
+            <CardHeader>
+              <CardTitle><Cpu size={14} className="text-[var(--tt-info-fg)]" /> Local vs cloud</CardTitle>
+            </CardHeader>
+            <div className="space-y-2.5 mt-1">
+              <SplitRow label="Cloud (hosted APIs)" stat={cloud} accentText="text-amber-300" dot="#f59e0b" />
+              <SplitRow label="Local (self-hosted)" stat={local} accentText="text-[var(--tt-info-fg)]" dot="var(--tt-info-fg)" />
+            </div>
+          </Card>
+
+          <div className="grid grid-cols-1 gap-4">
+            <StatTile
+              label="Cost per session"
+              value={`$${(ca.per_session?.avg_cost_all ?? 0).toFixed(3)}`}
+              hint="API equiv., averaged over every recorded session"
+              icon={<DollarSign size={16} />}
+              accent="var(--tt-brand)"
+            />
+            <StatTile
+              label="Cost per completed session"
+              value={avgCompleted == null ? "—" : `$${avgCompleted.toFixed(3)}`}
+              hint={
+                <>
+                  {cc.clean.toLocaleString()} ended cleanly · {cc.errored.toLocaleString()} errored · {cc.unknown.toLocaleString()} unknown
+                </>
+              }
+              icon={<DollarSign size={16} />}
+              accent="var(--tt-success)"
+            />
+          </div>
+        </div>
+      </div>
+
+      <p className="text-[11px] leading-snug text-[var(--tt-fg-dim)] px-0.5">
+        <span className="text-[var(--tt-fg-muted)]">Completed = &ldquo;ended cleanly&rdquo;</span> (no API/limit error at the
+        end), not &ldquo;the user was satisfied.&rdquo; Sessions we can&rsquo;t
+        classify are counted as <span className="text-[var(--tt-fg-muted)]">unknown</span> — never folded into clean.
+      </p>
+    </Section>
+  );
+}
+
+function SplitRow({ label, stat, accentText, dot }: { label: string; stat: BucketStat; accentText: string; dot: string }) {
+  return (
+    <div className="flex items-center justify-between gap-2 text-[11px]">
+      <span className="flex items-center gap-2 text-[var(--tt-fg-muted)] min-w-0">
+        <span className="w-1.5 h-1.5 rounded-full shrink-0" style={{ backgroundColor: dot }} />
+        <span className="truncate">{label}</span>
+      </span>
+      <span className="text-right whitespace-nowrap tabular">
+        <span className={cn("font-semibold", accentText)}>${stat.cost.toFixed(2)}</span>
+        <span className="text-[var(--tt-fg-dim)]"> · {stat.sessions.toLocaleString()} sess · {compact(stat.tokens)} tok</span>
+      </span>
     </div>
   );
 }

--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -5,7 +5,7 @@ import { createPortal } from "react-dom";
 import { useParams, useSearchParams, useRouter } from "next/navigation";
 import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { ArrowLeft, Brain, Code, MessageSquare, Terminal, User, Users, FileText, Activity, Zap, Info, Sparkles, GitBranch, LayoutPanelLeft, ListMusic, ChevronRight, ChevronLeft, Play, Pause, Wrench, Cpu, Folder, AlertTriangle, Hash, Clock, FileCode, Settings2, ChevronDown, ChevronUp, Copy, Maximize2, X } from "lucide-react";
+import { ArrowLeft, Brain, Code, MessageSquare, Terminal, User, Users, FileText, Activity, Zap, Info, Sparkles, GitBranch, LayoutPanelLeft, ListMusic, ChevronRight, ChevronLeft, Play, Pause, Wrench, Cpu, Folder, AlertTriangle, Hash, Clock, FileCode, Settings2, ChevronDown, ChevronUp, Copy, Maximize2, X, Wallet, Check } from "lucide-react";
 import Link from "next/link";
 import { format } from "date-fns";
 import { AgentBadge, Badge, Button, Skeleton } from "@/components/ui";
@@ -49,6 +49,13 @@ interface Session {
   hermes_profile?: string;
   parent_session_id?: string | null;
   end_reason?: string | null;
+  /* Cost attribution v1 — all optional (older backend omits them). task_type &
+     completed are stored raw at scan time; billing_bucket & marginal_cost_zero
+     are derived at read time from the user's current billing config. */
+  task_type?: "interactive" | "programmatic" | "unknown";
+  completed?: "clean" | "errored" | "unknown";
+  billing_bucket?: "included" | "api_rate" | "electricity" | "unknown";
+  marginal_cost_zero?: boolean;
 }
 
 interface Event {
@@ -589,6 +596,11 @@ export default function SessionDetailPage() {
                   {modelsUsed.length > 3 && (
                     <span className="text-[10px] font-mono text-[var(--tt-fg-dim)]">+{modelsUsed.length - 3}</span>
                   )}
+                  <BillingBucketChip
+                    bucket={sessionInfo?.billing_bucket}
+                    marginalZero={sessionInfo?.marginal_cost_zero}
+                  />
+                  <CompletedChip completed={sessionInfo?.completed} />
                 </div>
               </div>
             </div>
@@ -924,6 +936,52 @@ export default function SessionDetailPage() {
       )}
     </div>
   );
+}
+
+/* Cost-attribution metadata chips (discussion #49 v1). Both degrade to nothing
+   when the field is absent or carries only "unknown" noise — an "unknown"
+   completed chip on every legacy session would be clutter, so we show it only
+   for a decisive clean/errored end. Labels reuse the billing vocabulary from
+   Settings → Billing (DrainOrder/BillingSettings). */
+function BillingBucketChip({
+  bucket,
+  marginalZero,
+}: {
+  bucket?: "included" | "api_rate" | "electricity" | "unknown";
+  marginalZero?: boolean;
+}) {
+  if (!bucket || bucket === "unknown") return null;
+  const meta = {
+    included:    { variant: "success" as const, label: "Subscription-covered" },
+    api_rate:    { variant: "warn" as const,    label: "API metered" },
+    electricity: { variant: "info" as const,    label: "Electricity" },
+  }[bucket];
+  return (
+    <Badge variant={meta.variant} size="xs" title="How this session's usage is billed">
+      <Wallet size={10} /> {meta.label}
+      {marginalZero && <span className="opacity-70">· $0 marginal</span>}
+    </Badge>
+  );
+}
+
+function CompletedChip({ completed }: { completed?: "clean" | "errored" | "unknown" }) {
+  // Only show a decisive end — "unknown" is the default for most harnesses and
+  // adds no signal, so it's omitted rather than shown as a chip on every session.
+  if (completed === "clean") {
+    return (
+      <Badge variant="success" size="xs" title='Ended cleanly (no API/limit error at the end) — not a measure of whether you were satisfied'>
+        <Check size={10} /> Completed
+      </Badge>
+    );
+  }
+  if (completed === "errored") {
+    return (
+      <Badge variant="danger" size="xs" title="Ended on an API or rate-limit error">
+        <AlertTriangle size={10} /> Errored
+      </Badge>
+    );
+  }
+  return null;
 }
 
 /* Sidebar list of this session's subagents — the at-a-glance "what was

--- a/website/content/docs/features/cost-attribution.mdx
+++ b/website/content/docs/features/cost-attribution.mdx
@@ -1,0 +1,73 @@
+---
+title: Cost Attribution
+description: Split cost by billing bucket (subscription-covered, API-metered, local electricity), see a local-vs-cloud split, and cost per completed session.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+The **Cost attribution** section on the [Analytics](/docs/features/analytics) page breaks your spend down by *what actually pays for it*, not by token count. It answers a different question than the totals: of everything you ran, how much was a real marginal bill, how much was already covered by a subscription, and how much was electricity.
+
+All of it is derived on your machine from agent logs plus your billing configuration. Nothing leaves your machine.
+
+## The three billing buckets
+
+Every session's cost is placed in one of three buckets, derived at read time from your per-agent [billing configuration](/docs/configuration/billing):
+
+| Bucket | Meaning |
+| --- | --- |
+| **Included** | Covered by a flat subscription you already pay for (Claude Pro/Max, ChatGPT Plus, Copilot). No extra charge for this session. |
+| **API rate** | Metered per token against an API key. This is a real marginal cost; every token adds to a bill. |
+| **Electricity** | A local model (Ollama, llama.cpp, LM Studio, vLLM). Cost is power draw, not an API charge. |
+
+The split tells you which part of your usage you'd stop paying for if you stopped running it, versus usage a subscription already covers whether you use it or not.
+
+<Callout title="Included is an API-equivalent, not your bill">
+The dollar figure in the **Included** bucket is what the same tokens *would* cost at API list rates. It is a comparison number, not an invoice. On a flat plan your actual spend for those sessions is your monthly fee, regardless of how many tokens you ran (within plan limits). Use it to judge how much value you're getting from the subscription, not as money owed.
+</Callout>
+
+## Local means electricity
+
+Sessions in the **Electricity** bucket are priced by power draw and your kWh rate, not by a per-token charge, because a model you host yourself has no API bill. If you haven't set your wattage and electricity rate, configure them on the [Local Models & Power Cost](/docs/configuration/local-models) page so the estimate reflects your hardware.
+
+## Local vs cloud split
+
+Separately from the three buckets, Cost attribution shows a **local vs cloud** split: total cost and share for models you run yourself versus models called over a provider's API. This is the same local/cloud classification the pricing engine already uses, so it lines up with the energy and savings figures elsewhere in the app.
+
+## Cost per session and per completed session
+
+Two averages sit alongside the buckets:
+
+- **Cost per session**: total cost divided by every session in the range.
+- **Cost per completed session**: total cost divided by only the sessions that ended cleanly.
+
+Splitting them out lets you compare spend against work that actually ran to the end, instead of letting runs that errored or hit a limit partway drag the average in either direction.
+
+### What "completed" means, and what it doesn't
+
+A session is marked **completed** when its log shows it ended cleanly. That is a mechanical signal from the transcript, not a judgment about the result:
+
+- **Completed means** the run reached a normal end (the agent finished its turn or reported a done state).
+- **Completed does not mean** the output was correct, the task was accepted, or you were satisfied. A session can end cleanly and still be wrong.
+
+### Per-agent signal coverage
+
+Not every agent records whether a session finished. TokenTelemetry only marks completion where the harness leaves an honest signal in its logs, and shows the rest as `unknown` rather than guessing:
+
+| Agent | Completion signal |
+| --- | --- |
+| Codex | `task_complete` event in the session log |
+| Claude Code | Final turn ends with a clean stop (not an API error or limit) |
+| Cline | Its own `status` field |
+| All other agents | `unknown`; no completion signal in the logs |
+
+Sessions with `unknown` completion are kept as their own group. They are never folded into the completed count, so "cost per completed session" is computed only from sessions we can actually confirm ended cleanly. For agents in the `unknown` row, treat that average as covering the agents that do report a signal.
+
+<Callout type="info">
+Cost attribution depends on durable history being on, like the rest of Analytics. Sessions captured before you enabled durable history won't carry the completion signal or appear in these splits. See [History & Retention](/docs/configuration/retention).
+</Callout>
+
+## Related
+
+- [Billing & Cost Modes](/docs/configuration/billing): how each agent's bucket is detected and how to override it.
+- [Local Models & Power Cost](/docs/configuration/local-models): set the wattage and rate behind the electricity bucket.
+- [Analytics](/docs/features/analytics): the page this section lives on.

--- a/website/content/docs/features/meta.json
+++ b/website/content/docs/features/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "dashboard",
     "analytics",
+    "cost-attribution",
     "projects",
     "budgets",
     "traces",


### PR DESCRIPTION
## What

Layered cost attribution, from richardchen874-sys's request on discussion #49. `/analytics` gains an additive `cost_attribution` key and the analytics page a matching section:

- **Subscription-covered vs API-metered vs electricity** — per-session billing bucket derived at read time from the existing `billing_route` resolver (store raw, derive at read; config changes retroactively re-bucket, same as power settings).
- **Local vs cloud split** via the existing `is_local_session` partition.
- **Cost per session / per completed session** — new scan-time `completed` enum: Codex `task_complete`, Claude last `stop_reason` + `isApiErrorMessage`, Cline `status`; every other harness reports `unknown`, never guessed.
- New scan-time `task_type` (interactive/programmatic) from Claude `entrypoint`, Codex `originator`, Cline `interactive` column.
- `history_store` v2→v3: additive nullable `task_type`/`completed` columns.
- Session detail: billing-bucket and completed chips; `marginal_cost_zero` shows a "$0 marginal" hint.
- Website docs page (`features/cost-attribution.mdx`) + UPDATE.json entry.

In-UI caveats are mandatory and shipped: included-$ is an API-list-price equivalent (not a bill), completed means "ended cleanly" (not "user satisfied"), unknown is its own bucket and never folded into clean.

## Explicitly not in v1 (honest limits of post-hoc log scanning)

- Retry cost in dollars: ≈0 by construction (failed/429 calls bill ~0 output tokens). Follow-up: retry-friction count (Claude+Codex logs carry the signals).
- Fallback-triggered cost: no harness logs requested-vs-served model. Follow-up: intra-session model-mix cost delta, labeled a proxy.
- Cost per accepted task: no acceptance signal exists in any harness's logs.

## Verification

- `cost_attribution` exactly partitions the endpoint's own totals: $2160.66 / 1064 sessions / 349.4M tokens identical across by_bucket, local_vs_cloud, completed_counts, and equal to the by_agent sums.
- Independent recompute from `/sessions` agrees on the live subset (958 rows; the 106-row delta is exactly the history-only rows `/analytics` merges in).
- Migration tested on a copy of the real 1064-row DB (never the live one): user_version 2→3, all rows survive, old rows rehydrate as `unknown`.
- `completed` spot-checked against raw JSONL: 3 Codex `task_complete`→clean, 2 Claude errored with `isApiErrorMessage` on the last assistant turn.
- Field names confirmed on real logs before parsing (Claude `entrypoint`: cli 56.7k / sdk-cli 2.1k / claude-desktop 89 lines; Codex `session_meta.payload.originator`; Cline `sessions.db` columns).
- `tsc --noEmit` exit 0; `import main` / `import history_store` clean; billing_route (20), billing_mode (15), history_store (7), cline_smallcode (11), local_power (24) tests pass in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V6BwHfY2NxYHJ6T32y3yKn