### PR TITLE
fix: attribute dynamic-workflow subagent tokens in Claude traces

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -3225,24 +3225,153 @@ def _attach_tool_usage(sess: Dict[str, Any], tool_counts: Dict[str, int],
         ]
 
 
-def _claude_subagent_usage(session_file: Path, sid: str) -> Optional[Dict[str, Any]]:
-    """Roll up subagent (Task/Agent tool) usage for one Claude Code session.
+def _rollup_agent_transcript(f: Path, agent_type: Optional[str] = None,
+                             description: Optional[str] = None,
+                             tool_use_id: Optional[str] = None,
+                             extra: Optional[Dict[str, Any]] = None) -> Optional[Dict[str, Any]]:
+    """Parse ONE Claude subagent/workflow transcript file into a usage entry.
 
-    Claude Code writes each spawned subagent's full transcript to
-      <project-dir>/<sessionId>/subagents/agent-<agentId>.jsonl
-    with a sibling agent-<agentId>.meta.json {agentType, description, toolUseId}.
-    These files are NOT sessions — their usage is counted nowhere else, so this
-    rollup is the only place it surfaces (count-once invariant: the parent's own
-    token fields stay untouched; delegated usage is a separate bucket).
-
-    Each subagent runs its own context and often a DIFFERENT model than the
+    Each transcript runs its own context and often a DIFFERENT model than the
     parent (e.g. Explore on Haiku under an Opus session), so cost is computed
     per file with that file's model. Cache semantics match the main scanner:
     cached = high-water-mark of cache_read per transcript, cache writes are
-    billed per event and accumulate.
+    billed per event and accumulate. Returns None if the file can't be read.
 
-    Returns None when the session has no subagents/ dir; otherwise
-    {spawn_count, subagents: [...], totals: {...}, cost}.
+    Shared by _claude_subagent_usage (flat Task/Agent transcripts) and
+    _claude_workflow_entries (dynamic-workflow agents) so the token/cost math
+    can't drift between the two.
+    """
+    tokens = {"input": 0, "output": 0, "cached": 0, "cache_creation": 0,
+              "cache_creation_1h": 0, "total": 0}
+    model = None
+    try:
+        with open(f, "r", encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                try:
+                    data = json.loads(line)
+                except Exception:
+                    continue
+                if data.get("type") != "assistant":
+                    continue
+                msg = data.get("message", {}) if isinstance(data.get("message"), dict) else {}
+                m = msg.get("model")
+                if m and m != "<synthetic>" and not model:
+                    model = m
+                # Fallback identity when meta.json is missing/corrupt.
+                if not agent_type and data.get("attributionAgent"):
+                    agent_type = data.get("attributionAgent")
+                usage = msg.get("usage", {}) if isinstance(msg.get("usage"), dict) else {}
+                if not usage:
+                    continue
+                cr = usage.get("cache_read_input_tokens", 0) or 0
+                cc = usage.get("cache_creation_input_tokens", 0) or 0
+                cc_1h = (usage.get("cache_creation", {}) or {}).get("ephemeral_1h_input_tokens", 0) or 0
+                tokens["input"] += usage.get("input_tokens", 0) or 0
+                tokens["output"] += usage.get("output_tokens", 0) or 0
+                tokens["cached"] = max(tokens["cached"], cr)
+                tokens["cache_creation"] += cc
+                tokens["cache_creation_1h"] += cc_1h
+    except Exception:
+        return None
+    tokens["total"] = tokens["input"] + tokens["output"] + tokens["cached"]
+    cost = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"],
+                          cache_creation_tokens=tokens["cache_creation"],
+                          cache_creation_1h_tokens=tokens["cache_creation_1h"])
+    entry = {
+        "agent_id": f.stem[len("agent-"):],
+        "agent_type": agent_type or "unknown",
+        "description": description,
+        "tool_use_id": tool_use_id,
+        "model": model,
+        "tokens": tokens,
+        "cost": cost,
+    }
+    if extra:
+        entry.update(extra)
+    return entry
+
+
+def _claude_workflow_entries(sub_dir: Path) -> List[Dict[str, Any]]:
+    """Dynamic-workflow (Workflow tool) subagent usage for one Claude session.
+
+    The Workflow tool writes each spawned agent one level deeper than a normal
+    Task subagent:
+      <sid>/subagents/workflows/wf_<id>/agent-<agentId>.jsonl
+    with a sibling journal.jsonl whose {"type":"result", agentId, result} lines
+    map an agent to a human label (its phase/area). These files are NEVER
+    discovered as sessions (the session glob is non-recursive), and the flat
+    subagents/ scanner only globs agent-*.jsonl one directory shallower, so
+    without this pass their tokens and cost are counted NOWHERE — the parent
+    trace, delegation overlay, and analytics all undercount by the full
+    workflow. Count-once still holds: these are files inside the parent's dir,
+    not sessions.
+    """
+    out: List[Dict[str, Any]] = []
+    wf_root = sub_dir / "workflows"
+    try:
+        if not wf_root.is_dir():
+            return out
+    except Exception:
+        return out
+    for wf_dir in sorted(wf_root.glob("wf_*")):
+        # journal maps agentId -> a human label. result is usually a dict
+        # ({area, summary, ...}) but is a plain string for some agents, so
+        # guard the type before .get() or it raises.
+        labels: Dict[str, str] = {}
+        try:
+            with open(wf_dir / "journal.jsonl", "r", encoding="utf-8", errors="replace") as jf:
+                for line in jf:
+                    try:
+                        j = json.loads(line)
+                    except Exception:
+                        continue
+                    if j.get("type") != "result":
+                        continue
+                    aid = j.get("agentId")
+                    res = j.get("result")
+                    if isinstance(res, dict):
+                        # Structured agent output — pull whatever human label the
+                        # agent's schema happens to carry. Some (e.g. verify agents
+                        # returning {results:[...]}) have none; that's fine, the row
+                        # falls back to the agent id.
+                        label = (res.get("area") or res.get("summary") or res.get("label")
+                                 or res.get("title") or res.get("name"))
+                    elif isinstance(res, str):
+                        label = res[:80]
+                    else:
+                        label = None
+                    if aid and label and aid not in labels:
+                        labels[aid] = str(label)[:120]
+        except Exception:
+            pass
+        wf_id = wf_dir.name
+        for f in sorted(wf_dir.glob("agent-*.jsonl")):
+            phase = labels.get(f.stem[len("agent-"):])
+            e = _rollup_agent_transcript(
+                f, agent_type="workflow-subagent", description=phase,
+                extra={"kind": "workflow", "workflow_id": wf_id, "phase": phase},
+            )
+            if e:
+                out.append(e)
+    return out
+
+
+def _claude_subagent_usage(session_file: Path, sid: str) -> Optional[Dict[str, Any]]:
+    """Roll up subagent usage (Task/Agent tool AND dynamic workflows) for one
+    Claude Code session.
+
+    Claude Code writes each spawned Task subagent's full transcript to
+      <project-dir>/<sessionId>/subagents/agent-<agentId>.jsonl
+    with a sibling agent-<agentId>.meta.json {agentType, description, toolUseId},
+    and each dynamic-workflow agent one level deeper under
+      <sessionId>/subagents/workflows/wf_<id>/agent-<agentId>.jsonl.
+    None of these are sessions — their usage is counted nowhere else, so this
+    rollup is the only place it surfaces (count-once invariant: the parent's own
+    token fields stay untouched; delegated usage is a separate bucket).
+
+    Returns None when the session has no subagents/ dir and no workflow agents;
+    otherwise {spawn_count, subagents: [...], totals: {...}, by_type, cost,
+    workflow_count}.
     """
     sub_dir = session_file.parent / sid / "subagents"
     try:
@@ -3252,7 +3381,6 @@ def _claude_subagent_usage(session_file: Path, sid: str) -> Optional[Dict[str, A
         return None
     entries: List[Dict[str, Any]] = []
     for f in sorted(sub_dir.glob("agent-*.jsonl")):
-        agent_id = f.stem[len("agent-"):]
         agent_type = None
         description = None
         tool_use_id = None
@@ -3265,51 +3393,12 @@ def _claude_subagent_usage(session_file: Path, sid: str) -> Optional[Dict[str, A
                 tool_use_id = meta.get("toolUseId")
         except Exception:
             pass
-        tokens = {"input": 0, "output": 0, "cached": 0, "cache_creation": 0,
-                  "cache_creation_1h": 0, "total": 0}
-        model = None
-        try:
-            with open(f, "r", encoding="utf-8", errors="replace") as fh:
-                for line in fh:
-                    try:
-                        data = json.loads(line)
-                    except Exception:
-                        continue
-                    if data.get("type") != "assistant":
-                        continue
-                    msg = data.get("message", {}) if isinstance(data.get("message"), dict) else {}
-                    m = msg.get("model")
-                    if m and m != "<synthetic>" and not model:
-                        model = m
-                    # Fallback identity when meta.json is missing/corrupt.
-                    if not agent_type and data.get("attributionAgent"):
-                        agent_type = data.get("attributionAgent")
-                    usage = msg.get("usage", {}) if isinstance(msg.get("usage"), dict) else {}
-                    if not usage:
-                        continue
-                    cr = usage.get("cache_read_input_tokens", 0) or 0
-                    cc = usage.get("cache_creation_input_tokens", 0) or 0
-                    cc_1h = (usage.get("cache_creation", {}) or {}).get("ephemeral_1h_input_tokens", 0) or 0
-                    tokens["input"] += usage.get("input_tokens", 0) or 0
-                    tokens["output"] += usage.get("output_tokens", 0) or 0
-                    tokens["cached"] = max(tokens["cached"], cr)
-                    tokens["cache_creation"] += cc
-                    tokens["cache_creation_1h"] += cc_1h
-        except Exception:
-            continue
-        tokens["total"] = tokens["input"] + tokens["output"] + tokens["cached"]
-        cost = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"],
-                              cache_creation_tokens=tokens["cache_creation"],
-                              cache_creation_1h_tokens=tokens["cache_creation_1h"])
-        entries.append({
-            "agent_id": agent_id,
-            "agent_type": agent_type or "unknown",
-            "description": description,
-            "tool_use_id": tool_use_id,
-            "model": model,
-            "tokens": tokens,
-            "cost": cost,
-        })
+        e = _rollup_agent_transcript(f, agent_type=agent_type, description=description,
+                                     tool_use_id=tool_use_id, extra={"kind": "task"})
+        if e:
+            entries.append(e)
+    # Dynamic-workflow agents live under subagents/workflows/wf_*/ (see above).
+    entries.extend(_claude_workflow_entries(sub_dir))
     if not entries:
         return None
     totals = {"input": 0, "output": 0, "cached": 0, "cache_creation": 0,
@@ -3324,6 +3413,7 @@ def _claude_subagent_usage(session_file: Path, sid: str) -> Optional[Dict[str, A
         bt["cost"] = round(bt["cost"] + (e["cost"] or 0), 6)
     return {
         "spawn_count": len(entries),
+        "workflow_count": sum(1 for e in entries if e.get("kind") == "workflow"),
         "subagents": entries,
         "totals": totals,
         "by_type": by_type,
@@ -3537,6 +3627,15 @@ def _scan_sessions_sync():
                     sub_dir = session_file.parent / sid / "subagents"
                     if sub_dir.is_dir():
                         for sub_f in sub_dir.glob("agent-*.jsonl"):
+                            try:
+                                source_mtime = max(source_mtime, sub_f.stat().st_mtime)
+                            except OSError:
+                                continue
+                        # Dynamic-workflow agents (subagents/workflows/wf_*/) run in
+                        # the background and often finish AFTER the parent's last
+                        # write; without them here the cache serves a stale
+                        # undercount of delegated tokens forever.
+                        for sub_f in sub_dir.glob("workflows/wf_*/agent-*.jsonl"):
                             try:
                                 source_mtime = max(source_mtime, sub_f.stat().st_mtime)
                             except OSError:
@@ -5708,8 +5807,12 @@ async def session_subagent_trace(session_id: str, agent_id: str, agent: str):
         files = list(CLAUDE_DIR.glob(f"projects/**/{session_id}.jsonl"))
         if not files:
             return {"error": "Not found"}
-        t = files[0].parent / session_id / "subagents" / f"agent-{agent_id}.jsonl"
+        sub_dir = files[0].parent / session_id / "subagents"
+        t = sub_dir / f"agent-{agent_id}.jsonl"
         if not t.exists():
+            # Dynamic-workflow agents live one level deeper, under workflows/wf_*/.
+            t = next((sub_dir / "workflows").glob(f"wf_*/agent-{agent_id}.jsonl"), None)
+        if not t or not t.exists():
             return {"error": "Not found"}
         return _jsonl_events(t)
     if agent == "cursor":

--- a/backend/test_delegation.py
+++ b/backend/test_delegation.py
@@ -105,6 +105,74 @@ def make_claude_tree(claude_dir: Path, sid: str = SID, with_subagents: bool = Tr
     return session_file
 
 
+def add_workflow_agents(session_file: Path, sid: str = SID, wf_id: str = "wf_test") -> Path:
+    """Add dynamic-workflow (Workflow tool) agents under
+    <sid>/subagents/workflows/<wf_id>/ — a journal.jsonl mapping agentId->label
+    plus per-agent transcripts. Mirrors what the Workflow tool writes on disk."""
+    wf = session_file.parent / sid / "subagents" / "workflows" / wf_id
+    wf.mkdir(parents=True, exist_ok=True)
+    # Journal: a labelled result (dict), a string result, and an unlabelled
+    # result ({results:[...]}, e.g. a verify agent) that must degrade to no phase.
+    (wf / "journal.jsonl").write_text(
+        _jl(type="started", key="v2:aaa", agentId="wfa")
+        + _jl(type="result", key="v2:aaa", agentId="wfa", result={"area": "Phase A"})
+        + _jl(type="result", key="v2:bbb", agentId="wfb", result="a plain string summary")
+        + _jl(type="result", key="v2:ccc", agentId="wfc", result={"results": [1, 2]}),
+        encoding="utf-8",
+    )
+    (wf / "agent-wfa.jsonl").write_text(
+        _assistant_line(model="claude-opus-4-8", inp=100, out=200,
+                        cache_read=1000, cache_creation=500), encoding="utf-8")
+    (wf / "agent-wfb.jsonl").write_text(
+        _assistant_line(model="claude-haiku-4-5-20251001", inp=10, out=20,
+                        cache_read=100, cache_creation=50), encoding="utf-8")
+    (wf / "agent-wfc.jsonl").write_text(
+        _assistant_line(model="claude-opus-4-8", inp=5, out=5), encoding="utf-8")
+    return wf
+
+
+def test_workflow_agents_attributed(tmp_path):
+    """Dynamic-workflow agents (subagents/workflows/wf_*/) are rolled into
+    delegation, tagged kind='workflow' with their workflow id and journal
+    label, and counted ON TOP of the flat Task subagents (not instead of)."""
+    sf = make_claude_tree(tmp_path / ".claude")
+    add_workflow_agents(sf)
+    deleg = main._claude_subagent_usage(sf, SID)
+    tasks = [e for e in deleg["subagents"] if e.get("kind") == "task"]
+    wf = [e for e in deleg["subagents"] if e.get("kind") == "workflow"]
+    assert len(tasks) == 3          # the flat Task subagents still present
+    assert len(wf) == 3             # the three workflow agents newly attributed
+    assert deleg["workflow_count"] == 3
+    assert deleg["spawn_count"] == 6
+    by_id = {e["agent_id"]: e for e in wf}
+    assert by_id["wfa"]["workflow_id"] == "wf_test"
+    assert by_id["wfa"]["agent_type"] == "workflow-subagent"
+    assert by_id["wfa"]["phase"] == "Phase A"                 # dict label
+    assert by_id["wfb"]["phase"] == "a plain string summary"  # string label
+    assert by_id["wfc"]["phase"] is None                     # no label -> None
+    assert by_id["wfa"]["description"] == "Phase A"          # description carries the phase
+    # Per-file model-correct: wfb rolled up under Haiku, wfa under Opus.
+    assert by_id["wfb"]["model"] == "claude-haiku-4-5-20251001"
+    # Tokens fold into the by_type bucket and totals.
+    assert "workflow-subagent" in deleg["by_type"]
+    assert deleg["by_type"]["workflow-subagent"]["count"] == 3
+    # wfa: in100+out200+cached1000 = 1300; wfb: 10+20+100=130; wfc: 5+5+0=10
+    assert by_id["wfa"]["tokens"]["total"] == 1300
+    wf_total = sum(e["tokens"]["total"] for e in wf)
+    assert wf_total == 1440
+    # Count-once: the workflow tokens are additive on top of the flat totals.
+    task_total = sum(e["tokens"]["total"] for e in tasks)
+    assert deleg["totals"]["total"] == task_total + wf_total
+
+
+def test_no_workflow_dir_is_harmless(tmp_path):
+    """A session with flat subagents but no workflows/ dir is unchanged."""
+    sf = make_claude_tree(tmp_path / ".claude")
+    deleg = main._claude_subagent_usage(sf, SID)
+    assert deleg["workflow_count"] == 0
+    assert all(e.get("kind") == "task" for e in deleg["subagents"])
+
+
 # --- helper unit tests ------------------------------------------------------
 
 def test_sqlite_ro_uri_cross_platform():

--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -2247,8 +2247,14 @@ function DelegationCard({ delegation, agent, sessionId, onOpenSubagent }: { dele
               className={`flex items-center justify-between gap-3 text-[11px] font-mono text-[var(--tt-fg-muted)] py-1.5 px-2 rounded ${onOpenSubagent ? "cursor-pointer hover:bg-[var(--tt-sunken)] hover:text-[var(--tt-fg)]" : "hover:bg-[var(--tt-sunken)]"}`}
             >
               <span className="flex items-center gap-2 min-w-0">
+                {s.kind === "workflow" && (
+                  <span
+                    title={s.workflow_id ? `dynamic workflow ${s.workflow_id}` : "dynamic workflow"}
+                    className="text-[9px] font-bold uppercase tracking-wider px-1 py-0.5 rounded bg-[var(--tt-cyan-fg)]/15 text-[var(--tt-cyan-fg)] shrink-0"
+                  >wf</span>
+                )}
                 <Badge>{s.agent_type || s.agent_role || "subagent"}</Badge>
-                <span className="truncate text-[var(--tt-fg)]">{s.description || s.nickname || s.agent_id}</span>
+                <span className="truncate text-[var(--tt-fg)]">{s.description || s.phase || s.nickname || s.agent_id}</span>
               </span>
               <span className="flex items-center gap-3 shrink-0">
                 {s.model && <span className="text-[var(--tt-fg-dim)]">{s.model.replace(/-\d{8}$/, "")}</span>}


### PR DESCRIPTION
## The bug

Claude Code's **Workflow tool** (dynamic workflows) writes each spawned agent one level deeper than a normal Task subagent:

```
<sid>/subagents/workflows/wf_<id>/agent-<agentId>.jsonl   (+ journal.jsonl)
```

TT's scanners only globbed the flat `<sid>/subagents/agent-*.jsonl`, so these agents' tokens and cost were **counted nowhere** — missing from the trace, the `/delegation` overlay, `by_subagent_type`, and analytics delegation totals. In one real session this hid **17 workflow agents totalling ~1,018,981 tokens** (54.9K in / 170.8K out / 793.3K cached / 2.79M cache-creation). It's also the direct cause of the "my workflow subagents don't show in the trace" observation.

## The fix

- **`_rollup_agent_transcript`** — extracted the per-file token/cost rollup so the flat and workflow paths share one implementation and can't drift.
- **`_claude_workflow_entries`** — parses `subagents/workflows/wf_*/`, reads `journal.jsonl` for each agent's human label (guarding the dict-vs-string `result` shape), and merges the agents into `_claude_subagent_usage` tagged `kind="workflow"` with `workflow_id` + `phase`. The scan fold-in, the `/delegation` endpoint, the sidecar cache, and analytics all pick them up with **no further edits**.
- **Freshness** — the source-mtime scan now includes `workflows/wf_*/agent-*.jsonl`, so a background workflow agent that finishes after the parent's last write invalidates the cache instead of serving a stale undercount.
- **Trace drill-in** — `/sessions/{id}/subagents/{id}/trace` falls back to the workflows path, so a workflow agent's transcript opens instead of 404.
- **Frontend** — `DelegationCard` rows show a `wf` chip + the phase for `kind="workflow"` entries.

## Count-once invariant preserved

These transcripts live inside the parent's directory and are never discovered as sessions (the session glob is non-recursive), so the parent's own token fields are untouched — delegated usage stays a separate bucket, exactly as for Task subagents.

## Verification

- **Independent recompute:** a throwaway stdlib script summed the 17 workflow transcripts → **1,018,981 tokens**, matching `_claude_subagent_usage` to the token. `spawn_count` 17 → 34; `by_type` gains a `workflow-subagent` bucket; delegated cost $33.85.
- **Trace drill-in:** resolves a real workflow agent (49 events); a bogus id still 404s.
- **Tests:** added `test_workflow_agents_attributed` + `test_no_workflow_dir_is_harmless`. Delegation suite: **55 passed**. The one failing test (`test_analytics_ecosystem_aggregates`, a FastAPI Query-default issue) fails identically on `origin/main` — pre-existing and unrelated.
- **Frontend:** `tsc --noEmit` clean.

Labeled `fix:` (recovers lost token attribution). Not gated on UPDATE.json, but it is user-visible — happy to add an UPDATE.json entry if you'd like it announced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)