### PR TITLE
fix(ui): label total-tokens/cost scope (dashboard all-time vs analytics window)

### DIFF
--- a/frontend/src/app/analytics/page.tsx
+++ b/frontend/src/app/analytics/page.tsx
@@ -128,6 +128,18 @@ export default function AnalyticsPage() {
   const ct = useChartTheme();
   const AXIS = { stroke: ct.axisStroke, fontSize: 10, tickLine: false, axisLine: false, tick: { fill: ct.tickFill } } as const;
 
+  // Human label for the active window — the dashboard KPI strip is all-time,
+  // so spelling out the analytics window here keeps the two totals from
+  // reading as a mismatch (they measure different scopes).
+  const rangeLabel = (() => {
+    const m: Record<string, string> = {
+      "7d": "Last 7 days", "30d": "Last 30 days", "90d": "Last 90 days",
+      "month": "This month", "year": "This year", "all": "All time",
+    };
+    if (range === "custom") return (customFrom || customTo) ? `${customFrom || "…"} → ${customTo || "…"}` : "Custom range";
+    return m[range] || range;
+  })();
+
   // Accumulate every model we've seen so selecting one doesn't collapse the
   // option list (the response only carries models in the current window).
   const [allModels, setAllModels] = useState<string[]>([]);
@@ -297,12 +309,12 @@ export default function AnalyticsPage() {
       )}
 
       {/* KPI strip */}
-      <Section title="Totals">
+      <Section title="Totals" description={`${rangeLabel} · all agents. The dashboard shows all-time totals, so these differ by window.`}>
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
           <StatTile
             label="Total tokens"
             value={data.total.total.toLocaleString()}
-            hint="Across all agents"
+            hint={rangeLabel}
             icon={<TrendingUp size={16} />}
             accent="var(--tt-brand)"
           />

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -117,12 +117,14 @@ export default function Home() {
           <StatTile
             label="Sessions"
             value={loading ? <Skeleton className="h-8 w-20" /> : sessions.length.toLocaleString()}
+            hint="All time"
             icon={<Clock size={16} />}
             accent="var(--tt-brand)"
           />
           <StatTile
             label="Tokens"
             value={loading ? <Skeleton className="h-8 w-20" /> : formatTokens(totalTokens)}
+            hint="All time"
             icon={<TrendingUp size={16} />}
             accent="var(--tt-success)"
           />
@@ -135,7 +137,7 @@ export default function Home() {
           <StatTile
             label="API equiv. (est.)"
             value={loading ? <Skeleton className="h-8 w-20" /> : formatCost(totalCost)}
-            hint={framing.hint}
+            hint={framing.hint ? `${framing.hint} · all time` : "All time"}
             icon={<DollarSign size={16} />}
             accent="var(--tt-warn)"
           />


### PR DESCRIPTION
## Why
Users saw the dashboard show **Tokens 349.8M / $2,276** while Analytics showed **43.3M / $2,135** and assumed one was broken. A validated diagnosis (3-investigator workflow with live numbers) showed **it's not a bug** — it's a window-scope mismatch:

| Source | Window | Tokens | Cost |
|---|---|---:|---:|
| Dashboard (sums all `/sessions`) | all-time | 349.8M | $2,276.27 |
| Analytics (`total`) | 30d default | 43.3M | $2,134.77 |
| Analytics (matched to all-time) | all-time | 351.6M | $2,288.54 |

Both compute per-session tokens/cost identically (delegation excluded on both) and reconcile to within **0.5%** when windows match. The 30-day window holds only **12% of all-time tokens but 94% of all-time cost**, so the token axis looks ~8× off while cost barely moves. The only defect is the tiles carry no scope label.

## Fix (frontend-only, no backend change)
- **Dashboard** (`page.tsx`): "All time" hint on the Sessions and Tokens tiles; "… · all time" appended to the cost tile's existing billing hint.
- **Analytics** (`analytics/page.tsx`): a `rangeLabel` ("Last 30 days" / "All time" / custom range) on the Totals section description and the Total-tokens tile hint, noting the dashboard is all-time.

The 30-day analytics default is a deliberate product choice and is left unchanged.

## Notes
- tsc clean.
- One known residual (not addressed here, flagged in the diagnosis): analytics unions the durable history store with the live scan, so it counts ~0.5% pruned/rotated sessions the dashboard's live-only scan can't see. Making them bit-identical would require the dashboard to read the history store too (a larger, separate change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)