### PR TITLE
feat: /loop telemetry — detect, track & show recurring loops (re-land on main)

### DIFF
--- a/UPDATE.json
+++ b/UPDATE.json
@@ -1,6 +1,21 @@
 {
   "releases": [
     {
+      "tag": "2026-07-16",
+      "title": "See which sessions ran a loop",
+      "highlights": [
+        {
+          "title": "Loop badge on every session trace",
+          "description": "When a session scheduled a recurring or self-paced prompt (a /loop, a cron, or a self-perpetuating agent), its trace header now shows a Loop badge with the live state: active, expired, or cancelled. Open any past session to see which loop ran, its cadence and job id, and why it ended."
+        },
+        {
+          "title": "Recurring loops in Analytics",
+          "description": "A new Recurring loops section counts your active, expired and cancelled loops with their observed fire counts, cadence and cost, so a forgotten hourly loop quietly burning tokens is easy to spot. It's detected from the actual scheduling calls, so it catches loops even when the /loop command left no trace.",
+          "href": "/analytics"
+        }
+      ]
+    },
+    {
       "tag": "2026-07-13",
       "title": "Compare two Hermes profiles head-to-head",
       "highlights": [

--- a/backend/history_store.py
+++ b/backend/history_store.py
@@ -43,6 +43,7 @@ SCHEMA_VERSION = 2
 # core rollup columns.
 _ECOSYSTEM_KEYS = (
     "skills_used", "mcp_usage", "delegation", "subagent_info", "parent_session_id",
+    "loop",
 )
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -3740,6 +3740,9 @@ def _scan_sessions_sync():
                     loop_cancels: List[Dict[str, Any]] = []  # CronDelete / ScheduleWakeup stop
                     loop_prompts: set = set()                # loop prompt text, to count re-injected fires
                     loop_fires: List[str] = []               # ts of each re-injected fire
+                    in_loop_span = False                     # inside a loop-fire response turn right now
+                    loop_usage = {"input": 0, "output": 0, "cached": 0,
+                                  "cache_creation": 0, "cache_creation_1h": 0}  # loop's OWN footprint
                     try:
                         with open(session_file, "r", encoding="utf-8", errors="replace") as f:
                             for line in f:
@@ -3764,6 +3767,14 @@ def _scan_sessions_sync():
                                         sess["tokens"]["_cached_sum"] = sess["tokens"].get("_cached_sum", 0) + cr
                                         sess["tokens"]["cache_creation"] = sess["tokens"].get("cache_creation", 0) + cc
                                         sess["tokens"]["cache_creation_1h"] = sess["tokens"].get("cache_creation_1h", 0) + cc_1h
+                                        if in_loop_span:
+                                            # This assistant turn is answering a loop fire, so its
+                                            # usage is the loop's OWN footprint (not the whole session).
+                                            loop_usage["input"] += usage.get("input_tokens", 0) or 0
+                                            loop_usage["output"] += usage.get("output_tokens", 0) or 0
+                                            loop_usage["cached"] = max(loop_usage["cached"], cr)
+                                            loop_usage["cache_creation"] += cc
+                                            loop_usage["cache_creation_1h"] += cc_1h
                                     sess["tokens"]["total"] = sess["tokens"]["input"] + sess["tokens"]["output"] + sess["tokens"]["cached"]
                                     sess["cost"] = calculate_cost(sess.get("model"), sess["tokens"]["input"], sess["tokens"]["output"], sess["tokens"]["cached"], cache_creation_tokens=sess["tokens"].get("cache_creation", 0), cache_creation_1h_tokens=sess["tokens"].get("cache_creation_1h", 0))
                                     for item in msg.get("content", []):
@@ -3830,10 +3841,22 @@ def _scan_sessions_sync():
                                                 for sc in loop_sched:
                                                     if sc.get("tool_use_id") == tuid and not sc.get("job_id"):
                                                         sc["job_id"] = mjob.group(1)
-                                    if loop_prompts:
-                                        utext = str(u_content)
-                                        if any(lp and lp in utext for lp in loop_prompts):
-                                            loop_fires.append(data.get("timestamp"))
+                                    # Loop-fire attribution span. Match the loop prompt ONLY in
+                                    # TEXT content — a tool_result that echoes the prompt (e.g. a
+                                    # grep of the transcript) is NOT a fire. A fire opens the span;
+                                    # a genuine user message closes it; tool_result / injected
+                                    # context lines (no text) leave it open, so the whole
+                                    # fire-response turn is attributed to the loop.
+                                    u_text = u_content if isinstance(u_content, str) else (
+                                        " ".join(b.get("text", "") for b in u_content
+                                                 if isinstance(b, dict) and b.get("type") == "text")
+                                        if isinstance(u_content, list) else "")
+                                    is_fire = bool(loop_prompts) and any(lp and lp in u_text for lp in loop_prompts)
+                                    if is_fire:
+                                        loop_fires.append(data.get("timestamp"))
+                                        in_loop_span = True
+                                    elif _strip_context_tags(u_text).strip():
+                                        in_loop_span = False
                     except Exception: continue
                     if last_real_ts:
                         try:
@@ -3852,6 +3875,18 @@ def _scan_sessions_sync():
                         fire_ts = [t for t in loop_fires if t] + [sc.get("ts") for sc in loop_sched if sc.get("ts")]
                         last_fired = max([t for t in fire_ts if t], default=created_at)
                         prompt = str(primary.get("prompt") or "")
+                        # Loop's OWN footprint: usage from the fire-response turns only, NOT
+                        # the whole session (a session may do lots of non-loop work).
+                        lu = loop_usage
+                        # Cost uses the same basis as the session (cached=high-water-mark), so
+                        # footprint_cost is guaranteed <= the session's own cost.
+                        footprint_cost = calculate_cost(sess.get("model"), lu["input"], lu["output"],
+                            lu["cached"], cache_creation_tokens=lu["cache_creation"],
+                            cache_creation_1h_tokens=lu["cache_creation_1h"])
+                        # Billed tokens the loop's own turns produced/processed (input+output).
+                        # Cache read/write is session context overhead, excluded — so this is the
+                        # loop's actual work and is always <= the session's input+output.
+                        footprint_tokens = lu["input"] + lu["output"]
                         # Raw, cacheable facts only. Lifecycle (state/active/expires_at) is
                         # recomputed per request by _annotate_loop_lifecycle, never cached.
                         sess["loop"] = {
@@ -3868,6 +3903,8 @@ def _scan_sessions_sync():
                             "iterations": len(loop_fires),
                             "cancelled": bool(loop_cancels),
                             "cancelled_at": (loop_cancels[-1].get("ts") if loop_cancels else None),
+                            "footprint_tokens": footprint_tokens,
+                            "footprint_cost": footprint_cost,
                         }
                     _attach_tool_usage(sess, tool_counts, skill_counts)
                     deleg = _claude_subagent_usage(session_file, sid)
@@ -7287,16 +7324,20 @@ async def get_analytics(
             elif st == "expired": loops["expired_loops"] += 1
             elif st == "cancelled": loops["cancelled_loops"] += 1
             loops["total_iterations"] += lp.get("iterations", 0) or 0
-            tok = (s.get("tokens") or {}).get("total", 0) or 0
+            # Footprint = the loop's OWN fire-response turns, not the whole session.
+            tok = lp.get("footprint_tokens", 0) or 0
+            cost = lp.get("footprint_cost", 0) or 0
+            session_tok = (s.get("tokens") or {}).get("total", 0) or 0
             loops["loop_tokens"] += tok
-            loops["loop_cost"] = round(loops["loop_cost"] + (s.get("cost") or 0), 6)
+            loops["loop_cost"] = round(loops["loop_cost"] + cost, 6)
             key = lp.get("job_id") or s.get("id")
             by_loop[key] = {
                 "label": lp.get("prompt_preview") or "(loop)",
                 "mode": lp.get("mode"), "cadence": lp.get("cadence"),
                 "state": st, "expired_reason": lp.get("expired_reason"),
                 "iterations": lp.get("iterations", 0) or 0,
-                "tokens": tok, "cost": s.get("cost") or 0,
+                "tokens": tok, "cost": cost,
+                "session_tokens": session_tok, "session_cost": s.get("cost") or 0,
                 "agent": agent, "session_id": s.get("id"),
                 "job_id": lp.get("job_id"), "last_fired": lp.get("last_fired"),
                 "expires_at": lp.get("expires_at"),

--- a/backend/main.py
+++ b/backend/main.py
@@ -3421,9 +3421,94 @@ def _claude_subagent_usage(session_file: Path, sid: str) -> Optional[Dict[str, A
     }
 
 
+# --- /loop detection + lifecycle -------------------------------------------
+# A loop is a session that scheduled a recurring/self-paced prompt. We detect
+# it from the SCHEDULING TOOL CALLS, never the "/loop" marker: a /goal-launched
+# loop leaves no /loop breadcrumb but still self-perpetuates via ScheduleWakeup.
+# Claude: CronCreate (fixed cron) / ScheduleWakeup (dynamic) / CronDelete (stop).
+# The job id lives in the CronCreate tool_RESULT, not its input (verified).
+_LOOP_JOB_RE = re.compile(r"\bjob\s+([0-9a-fA-F]{6,})\b")
+
+
+def _loop_parse_ts(ts: Any) -> Optional[datetime]:
+    if not ts or not isinstance(ts, str):
+        return None
+    try:
+        d = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        return d if d.tzinfo else d.replace(tzinfo=timezone.utc)
+    except (ValueError, AttributeError):
+        return None
+
+
+def _cron_to_seconds(cron: Optional[str]) -> Optional[int]:
+    """Coarse cadence in seconds for the common 5-field cron shapes we emit.
+    Returns None when the expression isn't one we can bound (keeps lifecycle
+    honest: an unknown cadence never fakes an 'active' staleness window)."""
+    if not cron or not isinstance(cron, str):
+        return None
+    parts = cron.split()
+    if len(parts) != 5:
+        return None
+    minute, hour, dom, mon, dow = parts
+    try:
+        if minute.startswith("*/") and hour == "*":
+            return int(minute[2:]) * 60          # every N minutes
+        if hour.startswith("*/"):
+            return int(hour[2:]) * 3600           # every N hours
+        if minute.isdigit() and hour == "*":
+            return 3600                           # hourly at minute M
+        if minute.isdigit() and hour.isdigit() and dom == "*" and mon == "*":
+            return 604800 if dow != "*" else 86400  # weekly vs daily
+    except (ValueError, IndexError):
+        return None
+    return None
+
+
+def _annotate_loop_lifecycle(sessions: List[Dict[str, Any]], now: datetime) -> None:
+    """Recompute the VOLATILE loop lifecycle from now() for every loop session.
+
+    Detection writes only raw, cacheable facts (mode/cadence/job_id/iterations/
+    created_at/last_fired/cancelled). Liveness is wall-clock-derived and must be
+    recomputed per request, never cached — an idle loop writes nothing, so a
+    cached 'active' would stick forever. State machine, first match wins:
+    cancelled -> one-shot-done -> cron-7d-expired -> stale(session ended) ->
+    active -> unknown. "unknown" is only the never-fired case (no last_fired to
+    age against); an idle dynamic loop with a known last_fired ages into
+    "expired" via the cadence-relative grace, not "unknown". Claude crons are
+    in-memory and auto-expire 7 days after creation; that ceiling is Claude-only."""
+    for s in sessions:
+        lp = s.get("loop")
+        if not isinstance(lp, dict) or not lp.get("is_loop"):
+            continue
+        created = _loop_parse_ts(lp.get("created_at"))
+        last = _loop_parse_ts(lp.get("last_fired")) or created
+        cs = lp.get("cadence_seconds")
+        recurring = bool(lp.get("recurring", True))
+        expires_at = created + timedelta(days=7) if (recurring and lp.get("mode") == "fixed_cron" and created) else None
+        lp["expires_at"] = expires_at.isoformat() if expires_at else None
+        if lp.get("cancelled"):
+            state, reason = "cancelled", "cancelled"
+        elif not recurring and lp.get("iterations", 0) >= 1:
+            state, reason = "expired", "one_shot_completed"
+        elif expires_at and now > expires_at:
+            state, reason = "expired", "cron_expired_7d"
+        elif last:
+            grace = (cs or 3600) + max(900, int(0.10 * (cs or 3600)))
+            if (now - last).total_seconds() <= grace:
+                state, reason = "active", None
+            else:
+                state, reason = "expired", "stale_session_ended"
+        else:
+            state, reason = "unknown", None
+        lp["state"] = state
+        lp["active"] = (state == "active")
+        lp["expired_reason"] = reason
+
+
 _CLAUDE_CACHE_FIELDS = (
     "tokens", "model", "cost", "mcp_tools", "has_plan", "plans",
     "delegation", "delegated_cost", "tool_counts", "mcp_usage", "skills_used",
+    "loop",
 )
 
 
@@ -3651,6 +3736,10 @@ def _scan_sessions_sync():
                     tool_counts: Dict[str, int] = {}
                     skill_counts: Dict[str, int] = {}
                     last_real_ts = None
+                    loop_sched: List[Dict[str, Any]] = []   # scheduling tool calls (CronCreate/ScheduleWakeup)
+                    loop_cancels: List[Dict[str, Any]] = []  # CronDelete / ScheduleWakeup stop
+                    loop_prompts: set = set()                # loop prompt text, to count re-injected fires
+                    loop_fires: List[str] = []               # ts of each re-injected fire
                     try:
                         with open(session_file, "r", encoding="utf-8", errors="replace") as f:
                             for line in f:
@@ -3691,6 +3780,26 @@ def _scan_sessions_sync():
                                                 if plan_text:
                                                     sess["has_plan"] = True
                                                     sess["plans"].append({"session_id": sid, "agent": "claude", "timestamp": sess["timestamp"], "content": plan_text})
+                                            # /loop detection: scheduling tool calls (see _annotate_loop_lifecycle).
+                                            if tool == "CronCreate":
+                                                ip = item.get("input") or {}
+                                                loop_sched.append({"source": "CronCreate", "mode": "fixed_cron",
+                                                                   "cron": ip.get("cron"), "recurring": ip.get("recurring", True),
+                                                                   "prompt": ip.get("prompt"), "tool_use_id": item.get("id"),
+                                                                   "ts": data.get("timestamp")})
+                                                if ip.get("prompt"): loop_prompts.add(str(ip["prompt"])[:120])
+                                            elif tool == "ScheduleWakeup":
+                                                ip = item.get("input") or {}
+                                                if ip.get("stop"):
+                                                    loop_cancels.append({"ts": data.get("timestamp")})
+                                                else:
+                                                    loop_sched.append({"source": "ScheduleWakeup", "mode": "dynamic",
+                                                                       "delay": ip.get("delaySeconds"), "recurring": True,
+                                                                       "prompt": ip.get("prompt"), "ts": data.get("timestamp")})
+                                                    if ip.get("prompt"): loop_prompts.add(str(ip["prompt"])[:120])
+                                            elif tool in ("CronDelete", "CronStop"):
+                                                ip = item.get("input") or {}
+                                                loop_cancels.append({"job_id": ip.get("id") or ip.get("job_id"), "ts": data.get("timestamp")})
                                         if item.get("type") == "thinking":
                                             t_text = item.get("thinking", "")
                                             if "plan" in t_text.lower() and len(t_text) > 100:
@@ -3704,12 +3813,62 @@ def _scan_sessions_sync():
                                     for cmd in _COMMAND_NAME_RE.findall(str(u_content)):
                                         if cmd not in _BUILTIN_CLI_COMMANDS:
                                             skill_counts[cmd] = skill_counts.get(cmd, 0) + 1
+                                    # Loop: pull the CronCreate job id from its tool_result, and
+                                    # count each re-injected fire (Claude crons re-inject the prompt
+                                    # into THIS same file, verified — so iterations are same-file).
+                                    if loop_sched and isinstance(u_content, list):
+                                        for blk in u_content:
+                                            if not isinstance(blk, dict) or blk.get("type") != "tool_result":
+                                                continue
+                                            rc = blk.get("content")
+                                            rtext = rc if isinstance(rc, str) else (
+                                                " ".join(b.get("text", "") for b in rc if isinstance(b, dict))
+                                                if isinstance(rc, list) else "")
+                                            mjob = _LOOP_JOB_RE.search(rtext or "")
+                                            if mjob:
+                                                tuid = blk.get("tool_use_id")
+                                                for sc in loop_sched:
+                                                    if sc.get("tool_use_id") == tuid and not sc.get("job_id"):
+                                                        sc["job_id"] = mjob.group(1)
+                                    if loop_prompts:
+                                        utext = str(u_content)
+                                        if any(lp and lp in utext for lp in loop_prompts):
+                                            loop_fires.append(data.get("timestamp"))
                     except Exception: continue
                     if last_real_ts:
                         try:
                             sess["timestamp"] = datetime.fromisoformat(last_real_ts.replace("Z", "+00:00"))
                         except ValueError:
                             pass
+                    if loop_sched:
+                        primary = loop_sched[0]
+                        job_id = next((sc.get("job_id") for sc in loop_sched if sc.get("job_id")), None)
+                        mode = primary.get("mode")
+                        cron = primary.get("cron")
+                        delay = primary.get("delay")
+                        cadence = cron if mode == "fixed_cron" else (f"~{delay}s heartbeat" if delay else "self-paced")
+                        cadence_seconds = _cron_to_seconds(cron) if mode == "fixed_cron" else (int(delay) if isinstance(delay, (int, float)) else None)
+                        created_at = primary.get("ts")
+                        fire_ts = [t for t in loop_fires if t] + [sc.get("ts") for sc in loop_sched if sc.get("ts")]
+                        last_fired = max([t for t in fire_ts if t], default=created_at)
+                        prompt = str(primary.get("prompt") or "")
+                        # Raw, cacheable facts only. Lifecycle (state/active/expires_at) is
+                        # recomputed per request by _annotate_loop_lifecycle, never cached.
+                        sess["loop"] = {
+                            "is_loop": True,
+                            "mode": mode,
+                            "cadence": cadence,
+                            "cadence_seconds": cadence_seconds,
+                            "recurring": bool(primary.get("recurring", True)),
+                            "job_id": job_id,
+                            "source_signal": primary.get("source"),
+                            "prompt_preview": _strip_context_tags(prompt)[:160],
+                            "created_at": created_at,
+                            "last_fired": last_fired,
+                            "iterations": len(loop_fires),
+                            "cancelled": bool(loop_cancels),
+                            "cancelled_at": (loop_cancels[-1].get("ts") if loop_cancels else None),
+                        }
                     _attach_tool_usage(sess, tool_counts, skill_counts)
                     deleg = _claude_subagent_usage(session_file, sid)
                     sess["delegation"] = {
@@ -4823,6 +4982,10 @@ def _scan_sessions_sync():
     # still "supported", just not scanned yet.
     for s in sessions:
         s.setdefault("delegation", {"supported": s.get("agent") in _DELEGATION_CAPABLE_AGENTS})
+
+    # Loop lifecycle: recompute active/expired/cancelled from now() for every
+    # loop session (raw facts were parsed above; liveness is never cached).
+    _annotate_loop_lifecycle(sessions, datetime.now(timezone.utc))
 
     # Global sort by timestamp descending
     sessions.sort(key=lambda x: x["timestamp"], reverse=True)
@@ -7089,6 +7252,15 @@ async def get_analytics(
         "linked_children": 0, "linked_child_tokens": 0, "linked_child_cost": 0.0,
         "by_agent": {},
     }
+    # Recurring loops (/loop): attribution-only view. A loop session is already
+    # an ordinary session in by_agent/by_day/total, so loop_tokens/loop_cost are
+    # a VIEW, never re-summed into totals (same discipline as linked_child_*).
+    by_loop: Dict[str, Dict[str, Any]] = {}
+    loops: Dict[str, Any] = {
+        "total_loops": 0, "active_loops": 0, "expired_loops": 0, "cancelled_loops": 0,
+        "loop_sessions": 0, "total_iterations": 0, "loop_tokens": 0, "loop_cost": 0.0,
+    }
+
     # Child sessions are looked up per (agent, id) so grok by_type rows can
     # attribute each child's tokens to its subagent type.
     sess_by_key = {(s.get("agent"), s.get("id")): s for s in sessions}
@@ -7106,6 +7278,29 @@ async def get_analytics(
 
     for s in sessions:
         agent = s.get("agent")
+        lp = s.get("loop")
+        if isinstance(lp, dict) and lp.get("is_loop"):
+            st = lp.get("state")
+            loops["total_loops"] += 1
+            loops["loop_sessions"] += 1
+            if st == "active": loops["active_loops"] += 1
+            elif st == "expired": loops["expired_loops"] += 1
+            elif st == "cancelled": loops["cancelled_loops"] += 1
+            loops["total_iterations"] += lp.get("iterations", 0) or 0
+            tok = (s.get("tokens") or {}).get("total", 0) or 0
+            loops["loop_tokens"] += tok
+            loops["loop_cost"] = round(loops["loop_cost"] + (s.get("cost") or 0), 6)
+            key = lp.get("job_id") or s.get("id")
+            by_loop[key] = {
+                "label": lp.get("prompt_preview") or "(loop)",
+                "mode": lp.get("mode"), "cadence": lp.get("cadence"),
+                "state": st, "expired_reason": lp.get("expired_reason"),
+                "iterations": lp.get("iterations", 0) or 0,
+                "tokens": tok, "cost": s.get("cost") or 0,
+                "agent": agent, "session_id": s.get("id"),
+                "job_id": lp.get("job_id"), "last_fired": lp.get("last_fired"),
+                "expires_at": lp.get("expires_at"),
+            }
         for sk in s.get("skills_used") or []:
             row = by_skill.setdefault(sk["name"], {"invocations": 0, "session_count": 0, "agents": []})
             row["invocations"] += sk["count"]
@@ -7182,6 +7377,8 @@ async def get_analytics(
         "by_skill": by_skill,
         "by_mcp_server": by_mcp_server,
         "by_subagent_type": by_subagent_type,
+        "by_loop": by_loop,
+        "loops": loops,
         "delegation": delegation_totals,
         "total": {
             "input": total_input,

--- a/backend/scan_cache.py
+++ b/backend/scan_cache.py
@@ -34,7 +34,7 @@ logger = logging.getLogger("tokentelemetry.scan_cache")
 # update that affects cached costs. `_mtime` only detects source-transcript
 # changes; this detects code changes. A mismatch is a miss, so stale entries
 # are transparently reparsed and rewritten — never migrated in place.
-CACHE_VERSION = 2  # bumped: added per-session "loop" field (v2)
+CACHE_VERSION = 3  # v2: added "loop" field; v3: added loop footprint_tokens/footprint_cost
 
 
 def _require_safe_component(candidate: str) -> str:

--- a/backend/scan_cache.py
+++ b/backend/scan_cache.py
@@ -34,7 +34,7 @@ logger = logging.getLogger("tokentelemetry.scan_cache")
 # update that affects cached costs. `_mtime` only detects source-transcript
 # changes; this detects code changes. A mismatch is a miss, so stale entries
 # are transparently reparsed and rewritten — never migrated in place.
-CACHE_VERSION = 1
+CACHE_VERSION = 2  # bumped: added per-session "loop" field (v2)
 
 
 def _require_safe_component(candidate: str) -> str:

--- a/backend/test_loops.py
+++ b/backend/test_loops.py
@@ -1,0 +1,224 @@
+"""Tests for /loop telemetry — see backend/main.py loop detection + lifecycle.
+
+Covers:
+  - _cron_to_seconds(): coarse cadence for the 5-field cron shapes we emit.
+  - _annotate_loop_lifecycle(): the wall-clock state machine (cancelled ->
+    one-shot-done -> cron-7d-expired -> stale -> active -> unknown), asserting
+    state/active/expired_reason and that expires_at is set for recurring crons.
+  - Detection: a real Claude scan builds sess["loop"] from a CronCreate
+    tool_use, its job-id-carrying tool_result, and re-injected fires.
+
+Run: pytest backend/test_loops.py
+"""
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+import main  # noqa: E402
+
+UTC = timezone.utc
+
+
+# --- _cron_to_seconds -------------------------------------------------------
+
+@pytest.mark.parametrize("cron,expected", [
+    ("13 * * * *", 3600),     # hourly at minute 13
+    ("*/5 * * * *", 300),     # every 5 minutes
+    ("0 */2 * * *", 7200),    # every 2 hours
+    ("30 9 * * *", 86400),    # daily at 09:30
+    ("garbage", None),        # not a 5-field cron -> unknown cadence
+])
+def test_cron_to_seconds(cron, expected):
+    assert main._cron_to_seconds(cron) == expected
+
+
+# --- _annotate_loop_lifecycle state machine ---------------------------------
+
+NOW = datetime(2026, 7, 16, tzinfo=UTC)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+def _loop_session(**loop_kw):
+    loop = {"is_loop": True, "mode": "fixed_cron", "cadence": "* * * * *",
+            "cadence_seconds": 3600, "recurring": True, "job_id": "abc123",
+            "source_signal": "CronCreate", "prompt_preview": "do X",
+            "created_at": None, "last_fired": None, "iterations": 0,
+            "cancelled": False, "cancelled_at": None}
+    loop.update(loop_kw)
+    return {"id": loop_kw.get("_id", "s"), "agent": "claude", "loop": loop}
+
+
+def test_lifecycle_cancelled():
+    s = _loop_session(cancelled=True, cancelled_at=_iso(NOW - timedelta(hours=1)))
+    main._annotate_loop_lifecycle([s], NOW)
+    lp = s["loop"]
+    assert lp["state"] == "cancelled"
+    assert lp["active"] is False
+    assert lp["expired_reason"] == "cancelled"
+
+
+def test_lifecycle_cron_expired_7d():
+    # Recurring fixed_cron created 8 days ago: past the Claude 7-day ceiling.
+    created = NOW - timedelta(days=8)
+    s = _loop_session(mode="fixed_cron", recurring=True, created_at=_iso(created))
+    main._annotate_loop_lifecycle([s], NOW)
+    lp = s["loop"]
+    assert lp["state"] == "expired"
+    assert lp["active"] is False
+    assert lp["expired_reason"] == "cron_expired_7d"
+    # expires_at is set for recurring fixed_cron loops (created + 7d).
+    assert lp["expires_at"] == _iso(created + timedelta(days=7))
+
+
+def test_lifecycle_one_shot_completed():
+    # One-shot (recurring False) that has already fired once.
+    s = _loop_session(recurring=False, iterations=1,
+                      created_at=_iso(NOW - timedelta(hours=2)))
+    main._annotate_loop_lifecycle([s], NOW)
+    lp = s["loop"]
+    assert lp["state"] == "expired"
+    assert lp["active"] is False
+    assert lp["expired_reason"] == "one_shot_completed"
+    # Not a recurring fixed_cron -> no 7-day window.
+    assert lp["expires_at"] is None
+
+
+def test_lifecycle_active():
+    created = NOW - timedelta(minutes=10)
+    last = NOW - timedelta(minutes=5)
+    s = _loop_session(mode="fixed_cron", recurring=True, cadence_seconds=3600,
+                      created_at=_iso(created), last_fired=_iso(last))
+    main._annotate_loop_lifecycle([s], NOW)
+    lp = s["loop"]
+    assert lp["state"] == "active"
+    assert lp["active"] is True
+    assert lp["expired_reason"] is None
+    assert lp["expires_at"] == _iso(created + timedelta(days=7))
+
+
+def test_lifecycle_stale_session_ended():
+    # Recurring cron whose last fire is 3 days ago — well past the cadence
+    # grace window, but created recently enough not to hit the 7-day ceiling.
+    created = NOW - timedelta(days=3)
+    last = NOW - timedelta(days=3)
+    s = _loop_session(mode="fixed_cron", recurring=True, cadence_seconds=3600,
+                      created_at=_iso(created), last_fired=_iso(last))
+    main._annotate_loop_lifecycle([s], NOW)
+    lp = s["loop"]
+    assert lp["state"] == "expired"
+    assert lp["active"] is False
+    assert lp["expired_reason"] == "stale_session_ended"
+    assert lp["expires_at"] == _iso(created + timedelta(days=7))
+
+
+def test_lifecycle_unknown_dynamic():
+    # Dynamic loop, no bound cadence and no fires yet -> unknown (never faked
+    # active). No created_at, so no expires_at either.
+    s = _loop_session(mode="dynamic", cadence="self-paced", cadence_seconds=None,
+                      created_at=None, last_fired=None)
+    main._annotate_loop_lifecycle([s], NOW)
+    lp = s["loop"]
+    assert lp["state"] == "unknown"
+    assert lp["active"] is False
+    assert lp["expired_reason"] is None
+    assert lp["expires_at"] is None
+
+
+def test_lifecycle_skips_non_loop_sessions():
+    # Sessions without a loop dict are left untouched.
+    s = {"id": "x", "agent": "claude"}
+    main._annotate_loop_lifecycle([s, {"id": "y", "loop": {"is_loop": False}}], NOW)
+    assert "state" not in s.get("loop", {}) if s.get("loop") else True
+
+
+# --- detection via the real scan --------------------------------------------
+
+LOOP_SID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+PROJ = "-tmp-loop"
+
+
+@pytest.fixture
+def scan_env(tmp_path, monkeypatch):
+    """Point every agent store at empty tmp paths so the scan is hermetic —
+    only the Claude tree we build under tmp_path/.claude is discovered."""
+    missing = tmp_path / "missing"
+    for attr in ("CODEX_DIR", "GEMINI_DIR", "QWEN_DIR", "VIBE_DIR", "OLLAMA_DIR",
+                 "GROK_SESSIONS_DIR", "VSCODE_STORAGE", "CURSOR_STORAGE",
+                 "COPILOT_CLI_DIR", "ANTIGRAVITY_BRAIN_DIR", "ANTIGRAVITY_CLI_DIR",
+                 "HERMES_DIR", "PI_SESSIONS_DIR"):
+        monkeypatch.setattr(main, attr, missing / attr.lower())
+    monkeypatch.setattr(main, "ANTIGRAVITY_BRAIN_SOURCES", [])
+    monkeypatch.setattr(main, "ANTIGRAVITY_BRAIN_DIRS", [])
+    monkeypatch.setattr(main, "_antigravity_cli_meta", lambda *a, **k: {})
+    monkeypatch.setattr(main, "CLAUDE_DIR", tmp_path / ".claude")
+    monkeypatch.setattr(main, "CURSOR_DIR", tmp_path / ".cursor")
+    monkeypatch.setattr(main, "OPENCODE_DB", tmp_path / "opencode.db")
+    monkeypatch.setattr(main, "HERMES_DB", tmp_path / "hermes-state.db")
+    monkeypatch.setattr(main, "HERMES_PROFILES_DIR", missing / "hermes-profiles")
+    monkeypatch.setattr(main, "PROJECT_ALIASES_FILE", tmp_path / "aliases.json")
+    monkeypatch.setenv("TOKENTELEMETRY_DATA_DIR", str(tmp_path / "tt_data"))
+    return tmp_path
+
+
+def _make_loop_tree(claude_dir, sid=LOOP_SID):
+    """A Claude session that ran /loop: the user prompt, an assistant turn
+    whose content carries a CronCreate tool_use, the tool_result that reports
+    the scheduled job id, then one re-injected fire of the loop prompt."""
+    proj = claude_dir / "projects" / PROJ
+    proj.mkdir(parents=True, exist_ok=True)
+    lines = [
+        {"type": "user", "timestamp": "2026-07-16T00:00:00Z", "cwd": "/tmp/loop",
+         "message": {"role": "user", "content": "/loop 7 * * * * do X"}},
+        {"type": "assistant", "timestamp": "2026-07-16T00:00:01Z",
+         "message": {"model": "claude-opus-4-8",
+                     "usage": {"input_tokens": 10, "output_tokens": 5},
+                     "content": [{"type": "tool_use", "name": "CronCreate", "id": "tu1",
+                                  "input": {"cron": "7 * * * *", "recurring": True,
+                                            "prompt": "do X"}}]}},
+        {"type": "user", "timestamp": "2026-07-16T00:00:02Z",
+         "message": {"role": "user", "content": [
+             {"type": "tool_result", "tool_use_id": "tu1",
+              "content": "Scheduled recurring job abc123 (runs at 7 * * * *)"}]}},
+        {"type": "user", "timestamp": "2026-07-16T01:00:00Z",
+         "message": {"role": "user", "content": "do X"}},
+    ]
+    (proj / f"{sid}.jsonl").write_text(
+        "".join(json.dumps(x) + "\n" for x in lines), encoding="utf-8")
+    return proj / f"{sid}.jsonl"
+
+
+def test_scan_builds_loop_field(scan_env):
+    _make_loop_tree(scan_env / ".claude")
+    sessions = [s for s in main._scan_sessions_sync()
+                if s["agent"] == "claude" and s["id"] == LOOP_SID]
+    assert len(sessions) == 1
+    lp = sessions[0]["loop"]
+    assert lp["is_loop"] is True
+    assert lp["mode"] == "fixed_cron"
+    assert lp["cadence"] == "7 * * * *"
+    assert lp["job_id"] == "abc123"
+    assert lp["cadence_seconds"] == 3600
+    assert lp["recurring"] is True
+    assert lp["source_signal"] == "CronCreate"
+    # The re-injected "do X" user turn is counted as one fire.
+    assert lp["iterations"] >= 1
+
+
+def test_scan_non_loop_session_has_no_loop_field(scan_env):
+    proj = (scan_env / ".claude") / "projects" / PROJ
+    proj.mkdir(parents=True, exist_ok=True)
+    sid = "11111111-1111-1111-1111-111111111111"
+    (proj / f"{sid}.jsonl").write_text(
+        json.dumps({"type": "user", "timestamp": "2026-07-16T00:00:00Z",
+                    "cwd": "/tmp/loop",
+                    "message": {"role": "user", "content": "hi"}}) + "\n",
+        encoding="utf-8")
+    s = [s for s in main._scan_sessions_sync() if s["id"] == sid][0]
+    assert "loop" not in s

--- a/backend/test_loops.py
+++ b/backend/test_loops.py
@@ -222,3 +222,62 @@ def test_scan_non_loop_session_has_no_loop_field(scan_env):
         encoding="utf-8")
     s = [s for s in main._scan_sessions_sync() if s["id"] == sid][0]
     assert "loop" not in s
+
+
+FOOT_SID = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+
+
+def test_scan_loop_footprint_only_counts_fire_turns(scan_env):
+    """The loop's footprint = usage from its fire-response turns ONLY, never the
+    whole session. A tool_result echoing the prompt is not a fire; a genuine
+    non-loop turn's usage is excluded and must not be attributed to the loop."""
+    proj = (scan_env / ".claude") / "projects" / PROJ
+    proj.mkdir(parents=True, exist_ok=True)
+    lines = [
+        {"type": "user", "timestamp": "2026-07-16T00:00:00Z", "cwd": "/tmp/loop",
+         "message": {"role": "user", "content": "/loop 7 * * * * do X"}},
+        # Setup turn (usage 10/5) — span not open yet, must NOT be attributed.
+        {"type": "assistant", "timestamp": "2026-07-16T00:00:01Z",
+         "message": {"model": "claude-opus-4-8",
+                     "usage": {"input_tokens": 10, "output_tokens": 5},
+                     "content": [{"type": "tool_use", "name": "CronCreate", "id": "tu1",
+                                  "input": {"cron": "7 * * * *", "recurring": True,
+                                            "prompt": "do X"}}]}},
+        {"type": "user", "timestamp": "2026-07-16T00:00:02Z",
+         "message": {"role": "user", "content": [
+             {"type": "tool_result", "tool_use_id": "tu1",
+              "content": "Scheduled recurring job abc123 (runs at 7 * * * *)"}]}},
+        # A tool_result that ECHOES the prompt "do X" — must NOT be a fire.
+        {"type": "user", "timestamp": "2026-07-16T00:30:00Z",
+         "message": {"role": "user", "content": [
+             {"type": "tool_result", "tool_use_id": "tu9", "content": "grep found: do X"}]}},
+        # Real fire — opens the span.
+        {"type": "user", "timestamp": "2026-07-16T01:00:00Z",
+         "message": {"role": "user", "content": "do X"}},
+        # Fire response (usage 100/50) — MUST be attributed to the loop.
+        {"type": "assistant", "timestamp": "2026-07-16T01:00:01Z",
+         "message": {"model": "claude-opus-4-8",
+                     "usage": {"input_tokens": 100, "output_tokens": 50},
+                     "content": [{"type": "text", "text": "here is X"}]}},
+        # Genuine non-loop user turn — closes the span.
+        {"type": "user", "timestamp": "2026-07-16T02:00:00Z",
+         "message": {"role": "user", "content": "now do something completely unrelated"}},
+        # Non-loop response (usage 1000/500) — MUST NOT be attributed.
+        {"type": "assistant", "timestamp": "2026-07-16T02:00:01Z",
+         "message": {"model": "claude-opus-4-8",
+                     "usage": {"input_tokens": 1000, "output_tokens": 500},
+                     "content": [{"type": "text", "text": "done"}]}},
+    ]
+    (proj / f"{FOOT_SID}.jsonl").write_text(
+        "".join(json.dumps(x) + "\n" for x in lines), encoding="utf-8")
+    s = [s for s in main._scan_sessions_sync() if s["id"] == FOOT_SID][0]
+    lp = s["loop"]
+    # Footprint = ONLY the fire response's input+output (100+50), not the setup
+    # turn (10+5), not the unrelated turn (1000+500).
+    assert lp["footprint_tokens"] == 150
+    assert lp["footprint_cost"] > 0
+    # Always <= the whole session.
+    assert lp["footprint_tokens"] < s["tokens"]["total"]
+    assert lp["footprint_cost"] <= (s.get("cost") or 0) + 1e-9
+    # The tool_result echoing "do X" was NOT counted as a fire.
+    assert lp["iterations"] == 1

--- a/frontend/src/app/analytics/page.tsx
+++ b/frontend/src/app/analytics/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { cn } from "@/lib/cn";
 import {
   BarChart3, TrendingUp, ArrowDownToLine, ArrowUpFromLine,
-  Zap, DollarSign, Cpu, GitBranch,
+  Zap, DollarSign, Cpu, GitBranch, Repeat,
 } from "lucide-react";
 import {
   AreaChart, Area, BarChart, Bar, PieChart as RePieChart, Pie, Cell,
@@ -33,6 +33,25 @@ interface AnalyticsData {
     linked_children?: number; linked_child_tokens?: number; linked_child_cost?: number;
     by_agent?: Record<string, { parents: number; spawns: number; children: number; child_tokens: number; child_cost: number; delegated_tokens: number; delegated_cost: number }>;
   };
+  loops?: {
+    total_loops: number; active_loops: number; expired_loops: number; cancelled_loops: number;
+    loop_sessions: number; total_iterations: number; loop_tokens: number; loop_cost: number;
+  };
+  by_loop?: Record<string, {
+    label: string;
+    mode: "fixed_cron" | "dynamic" | string;
+    cadence: string;
+    state: "active" | "expired" | "cancelled" | "unknown" | string;
+    expired_reason: string | null;
+    iterations: number;
+    tokens: number;
+    cost: number;
+    agent: string;
+    session_id: string;
+    job_id: string | null;
+    last_fired: string;
+    expires_at: string | null;
+  }>;
   total: { input: number; output: number; cached: number; total: number; cost: number };
   coverage?: {
     earliest: string | null;
@@ -584,7 +603,105 @@ export default function AnalyticsPage() {
       )}
 
       <EcosystemSection data={data} />
+
+      <RecurringLoopsSection data={data} />
     </div>
+  );
+}
+
+/* Recurring loops — cron/heartbeat-driven sessions the agent scheduled for
+   itself. Distinct from the "doom-loop" concept elsewhere. Tokens/cost here are
+   an attribution view: they're already counted in the session totals above.
+   Self-hides when there are no loop sessions (no fake zeros). State colours:
+   active=emerald, expired=muted, cancelled=amber, unknown=outline. */
+const LOOP_STATE = {
+  active:    { dot: "bg-emerald-400",              label: "text-emerald-300" },
+  expired:   { dot: "bg-[var(--tt-fg-dim)]",       label: "text-[var(--tt-fg-dim)]" },
+  cancelled: { dot: "bg-amber-400",                label: "text-amber-300" },
+  unknown:   { dot: "bg-transparent border border-[var(--tt-border-strong)]", label: "text-[var(--tt-fg-muted)]" },
+} as const;
+
+function loopState(s: string) {
+  return LOOP_STATE[s as keyof typeof LOOP_STATE] ?? LOOP_STATE.unknown;
+}
+
+function RecurringLoopsSection({ data }: { data: AnalyticsData }) {
+  const loops = data.loops;
+  if (!loops || loops.total_loops === 0) return null;
+
+  const entries = Object.entries(data.by_loop || {})
+    .map(([key, l]) => ({ key, ...l }))
+    .sort((a, b) => b.iterations - a.iterations);
+
+  return (
+    <Section
+      title="Recurring loops"
+      description="Cron- and heartbeat-scheduled sessions an agent set up to re-run itself. Token and cost figures are an attribution view — they're already included in the session totals above."
+    >
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <StatTile
+          label="Active loops"
+          value={String(loops.active_loops)}
+          hint={`${loops.total_loops} loop${loops.total_loops === 1 ? "" : "s"} total`}
+          icon={<Repeat size={16} />}
+          accent="var(--tt-success)"
+        />
+        <StatTile
+          label="Expired"
+          value={String(loops.expired_loops)}
+          hint={`${loops.cancelled_loops} cancelled`}
+          icon={<Repeat size={16} />}
+          accent="var(--tt-fg-dim)"
+        />
+        <StatTile
+          label="Loop runs"
+          value={`≥${loops.total_iterations.toLocaleString()}`}
+          hint={`Observed fires (min) across ${loops.loop_sessions} loop session${loops.loop_sessions === 1 ? "" : "s"}`}
+          icon={<TrendingUp size={16} />}
+          accent="var(--tt-brand)"
+        />
+        <StatTile
+          label="Loop cost"
+          value={`$${loops.loop_cost.toFixed(2)}`}
+          hint={`${compact(loops.loop_tokens)} tok · already in session totals`}
+          icon={<DollarSign size={16} />}
+          accent="var(--tt-warn)"
+        />
+      </div>
+
+      {entries.length > 0 && (
+        <Card padding="lg">
+          <CardHeader>
+            <CardTitle><Repeat size={14} className="text-[var(--tt-brand)]" /> Loops by activity</CardTitle>
+            <CardEyebrow>{entries.length} loop{entries.length === 1 ? "" : "s"}</CardEyebrow>
+          </CardHeader>
+          <ul className="space-y-2 max-h-96 overflow-y-auto pr-1">
+            {entries.map((l) => {
+              const st = loopState(l.state);
+              return (
+                <li key={l.key} className="flex items-center justify-between gap-3 text-[11px]">
+                  <span className="min-w-0 flex items-start gap-2">
+                    <span className={cn("w-1.5 h-1.5 rounded-full shrink-0 mt-1.5", st.dot)} />
+                    <span className="min-w-0 flex flex-col">
+                      <span className="text-[var(--tt-fg)] truncate" title={l.label}>{l.label || "(no prompt)"}</span>
+                      <span className="text-[var(--tt-fg-dim)] truncate">
+                        <span className={cn("uppercase tracking-[0.1em] text-[10px]", st.label)}>{l.state}</span>
+                        {" · "}{l.cadence}{" · "}{l.mode}
+                        {l.expired_reason && <> · {l.expired_reason}</>}
+                      </span>
+                    </span>
+                  </span>
+                  <span className="text-right shrink-0">
+                    <span className="block tabular font-semibold text-[var(--tt-fg)]" title="observed fires (lower bound)">≥{l.iterations.toLocaleString()}</span>
+                    <span className="block tabular text-[var(--tt-fg-dim)]">{compact(l.tokens)} tok · ${l.cost.toFixed(2)}</span>
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        </Card>
+      )}
+    </Section>
   );
 }
 

--- a/frontend/src/app/analytics/page.tsx
+++ b/frontend/src/app/analytics/page.tsx
@@ -46,6 +46,8 @@ interface AnalyticsData {
     iterations: number;
     tokens: number;
     cost: number;
+    session_tokens?: number;
+    session_cost?: number;
     agent: string;
     session_id: string;
     job_id: string | null;
@@ -636,7 +638,7 @@ function RecurringLoopsSection({ data }: { data: AnalyticsData }) {
   return (
     <Section
       title="Recurring loops"
-      description="Cron- and heartbeat-scheduled sessions an agent set up to re-run itself. Token and cost figures are an attribution view — they're already included in the session totals above."
+      description="Cron- and heartbeat-scheduled sessions an agent set up to re-run itself. Token and cost here are the loop's OWN turns (its fire responses), not the whole session — a session may do plenty of non-loop work too. These are already part of the session totals above."
     >
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <StatTile
@@ -663,7 +665,7 @@ function RecurringLoopsSection({ data }: { data: AnalyticsData }) {
         <StatTile
           label="Loop cost"
           value={`$${loops.loop_cost.toFixed(2)}`}
-          hint={`${compact(loops.loop_tokens)} tok · already in session totals`}
+          hint={`${compact(loops.loop_tokens)} tok · loop turns only`}
           icon={<DollarSign size={16} />}
           accent="var(--tt-warn)"
         />
@@ -693,7 +695,10 @@ function RecurringLoopsSection({ data }: { data: AnalyticsData }) {
                   </span>
                   <span className="text-right shrink-0">
                     <span className="block tabular font-semibold text-[var(--tt-fg)]" title="observed fires (lower bound)">≥{l.iterations.toLocaleString()}</span>
-                    <span className="block tabular text-[var(--tt-fg-dim)]">{compact(l.tokens)} tok · ${l.cost.toFixed(2)}</span>
+                    <span className="block tabular text-[var(--tt-fg-dim)]" title="the loop's own fire-response turns">{compact(l.tokens)} tok · ${l.cost.toFixed(2)}</span>
+                    {l.session_cost != null && l.session_cost > l.cost + 0.005 && (
+                      <span className="block tabular text-[var(--tt-fg-dim)] text-[10px] opacity-70">of ${l.session_cost.toFixed(2)} session</span>
+                    )}
                   </span>
                 </li>
               );

--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -765,6 +765,8 @@ export default function SessionDetailPage() {
              {agent === "hermes" && hermesOverlay && <HermesOverlayCard overlay={hermesOverlay} />}
              {/* Grok Build forensics — token growth, permissions, tool lifecycle, plan mode */}
              {agent === "grok" && grokForensics && <GrokForensicsCard forensics={grokForensics} cost={sessionInfo?.tokens?.cost ?? sessionInfo?.cost} />}
+             {/* Recurring loop (/loop, cron, self-perpetuating agent) — full detail */}
+             {sessionInfo?.loop?.is_loop && <LoopCard loop={sessionInfo.loop} />}
              {/* Delegated work — subagent spawns and what they actually cost */}
              {delegation && agent && <DelegationCard delegation={delegation} agent={agent} sessionId={id} onOpenSubagent={setSubagentView} />}
              <div className={splitView ? "grid grid-cols-2 gap-8" : "space-y-8"}>
@@ -2221,6 +2223,105 @@ function ResponseBody({ text, tone = "default" }: { text: string; tone?: "defaul
     </div>
   );
 }
+
+function LoopCard({ loop }: { loop: any }) {
+  const state: string = loop.state ?? "unknown";
+  const tone =
+    state === "active"    ? { ring: "border-emerald-500/40", dot: "bg-emerald-400",       text: "text-emerald-400" } :
+    state === "cancelled" ? { ring: "border-amber-500/40",   dot: "bg-amber-400",         text: "text-amber-400" } :
+                            { ring: "border-[var(--tt-border)]", dot: "bg-[var(--tt-fg-dim)]", text: "text-[var(--tt-fg-dim)]" };
+
+  const interval = (() => {
+    const s = loop.cadence_seconds;
+    if (loop.mode === "fixed_cron") {
+      if (s && s % 86400 === 0) return `Every ${s / 86400}d`;
+      if (s && s % 3600 === 0)  return `Every ${s / 3600}h`;
+      if (s && s % 60 === 0)    return `Every ${s / 60}m`;
+      return s ? `Every ${s}s` : "Cron schedule";
+    }
+    return s ? `~${s}s heartbeat` : "Self-paced";
+  })();
+
+  const reasonLabel = (r: string | null | undefined) => ({
+    cron_expired_7d: "reached its 7-day auto-expiry",
+    one_shot_completed: "ran once and finished",
+    stale_session_ended: "session ended (no recent fire)",
+    cancelled: "cancelled",
+  } as Record<string, string>)[r || ""] || r || "";
+
+  const fmt = (iso?: string | null) => {
+    if (!iso) return "—";
+    const d = new Date(iso);
+    return isNaN(d.getTime()) ? String(iso) : d.toLocaleString();
+  };
+  const rel = (iso?: string | null) => {
+    if (!iso) return "";
+    const t = new Date(iso).getTime();
+    if (isNaN(t)) return "";
+    const diff = Date.now() - t, abs = Math.abs(diff);
+    const unit = abs >= 86400000 ? `${Math.round(abs / 86400000)}d`
+      : abs >= 3600000 ? `${Math.round(abs / 3600000)}h`
+      : `${Math.round(abs / 60000)}m`;
+    return diff >= 0 ? `${unit} ago` : `in ${unit}`;
+  };
+
+  const Row = ({ k, v, accent }: { k: string; v: React.ReactNode; accent?: string }) => (
+    <div className="flex justify-between gap-3">
+      <span className="text-[var(--tt-fg-dim)]">{k}</span>
+      <span className={accent || "text-[var(--tt-fg)]"}>{v}</span>
+    </div>
+  );
+
+  return (
+    <div className={`mb-8 bg-[var(--tt-panel)]/60 border ${tone.ring} rounded-[var(--tt-radius-lg)] p-5`}>
+      <div className="flex items-center justify-between mb-3">
+        <div className="text-[10px] font-black uppercase tracking-[0.2em] text-[var(--tt-fg)] flex items-center gap-2">
+          <Repeat size={12} strokeWidth={3} /> Recurring loop
+        </div>
+        <span className={`flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.1em] ${tone.text}`}>
+          <span className={`w-1.5 h-1.5 rounded-full ${tone.dot}`} /> {state}
+        </span>
+      </div>
+
+      {loop.prompt_preview && (
+        <div className="mb-3 bg-[var(--tt-sunken)] border border-[var(--tt-border)] rounded-[var(--tt-radius)] px-3 py-2">
+          <span className="text-[9px] uppercase tracking-[0.18em] text-[var(--tt-fg-dim)] block mb-1">Runs this prompt</span>
+          <span className="text-[12px] text-[var(--tt-fg-muted)] line-clamp-3">{loop.prompt_preview}</span>
+        </div>
+      )}
+
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-3">
+        <Stat label="Interval" value={interval} />
+        <Stat label="Fires (min)" value={`≥${(loop.iterations ?? 0).toLocaleString()}`} />
+        <Stat label="Job id" value={loop.job_id || "—"} />
+        <Stat label="Trigger" value={loop.source_signal || loop.mode || "—"} />
+      </div>
+
+      <div className="space-y-1 text-[11px] font-mono text-[var(--tt-fg-muted)]">
+        <Row k="Cadence" v={loop.cadence || "—"} />
+        <Row k="Created" v={<>{fmt(loop.created_at)} <span className="text-[var(--tt-fg-dim)]">({rel(loop.created_at)})</span></>} />
+        <Row k="Last fired" v={<>{fmt(loop.last_fired)} <span className="text-[var(--tt-fg-dim)]">({rel(loop.last_fired)})</span></>} />
+        {loop.expires_at && (
+          <Row k={state === "expired" ? "Expired" : "Expires"} v={<>{fmt(loop.expires_at)} <span className="text-[var(--tt-fg-dim)]">({rel(loop.expires_at)})</span></>} />
+        )}
+        {loop.cancelled_at && (
+          <Row k="Cancelled" v={<>{fmt(loop.cancelled_at)} <span className="text-[var(--tt-fg-dim)]">({rel(loop.cancelled_at)})</span></>} />
+        )}
+        {loop.expired_reason && <Row k="Reason" v={reasonLabel(loop.expired_reason)} accent={tone.text} />}
+      </div>
+
+      {state === "active" && loop.recurring && (
+        <div className="mt-3 text-[10px] text-[var(--tt-fg-dim)]">
+          Still scheduled — liveness is recomputed from its last fire and cadence on each load, never cached.
+        </div>
+      )}
+      <div className="mt-1 text-[10px] text-[var(--tt-fg-dim)]">
+        Fires is a lower bound (counted from re-injected prompts in this session).
+      </div>
+    </div>
+  );
+}
+
 
 function DelegationCard({ delegation, agent, sessionId, onOpenSubagent }: { delegation: any; agent: string; sessionId: string; onOpenSubagent?: (entry: any) => void }) {
   const subagents: any[] = delegation?.subagents || [];

--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -5,7 +5,7 @@ import { createPortal } from "react-dom";
 import { useParams, useSearchParams, useRouter } from "next/navigation";
 import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { ArrowLeft, Brain, Code, MessageSquare, Terminal, User, Users, FileText, Activity, Zap, Info, Sparkles, GitBranch, LayoutPanelLeft, ListMusic, ChevronRight, ChevronLeft, Play, Pause, Wrench, Cpu, Folder, AlertTriangle, Hash, Clock, FileCode, Settings2, ChevronDown, ChevronUp, Copy, Maximize2, X } from "lucide-react";
+import { ArrowLeft, Brain, Code, MessageSquare, Terminal, User, Users, FileText, Activity, Zap, Info, Sparkles, GitBranch, LayoutPanelLeft, ListMusic, ChevronRight, ChevronLeft, Play, Pause, Wrench, Cpu, Folder, AlertTriangle, Hash, Clock, FileCode, Settings2, ChevronDown, ChevronUp, Copy, Maximize2, X, Repeat } from "lucide-react";
 import Link from "next/link";
 import { format } from "date-fns";
 import { AgentBadge, Badge, Button, Skeleton } from "@/components/ui";
@@ -49,6 +49,8 @@ interface Session {
   hermes_profile?: string;
   parent_session_id?: string | null;
   end_reason?: string | null;
+  /** TRACE loop metadata; present only on loop sessions (see backend /sessions) */
+  loop?: any;
 }
 
 interface Event {
@@ -602,6 +604,21 @@ export default function SessionDetailPage() {
                 <StatPill icon={<User size={11} />}     label="Turns"  value={stats.userTurns} />
                 <StatPill icon={<Clock size={11} />}    label="Dur"    value={stats.duration} />
                 <StatPill icon={<AlertTriangle size={11} />} label="Err" value={stats.errors} tone={stats.errors > 0 ? "red" : undefined} />
+                {sessionInfo?.loop?.is_loop && (() => {
+                  const lp = sessionInfo.loop;
+                  const state: string = lp.state ?? "unknown";
+                  const variant =
+                    state === "active"    ? "success" :
+                    state === "expired"   ? "neutral" :
+                    state === "cancelled" ? "warn" :
+                    "outline";
+                  const tip = `${lp.mode} · ${lp.cadence} · ≥${lp.iterations} fires${lp.expired_reason ? " · " + lp.expired_reason : ""}`;
+                  return (
+                    <Badge variant={variant} size="sm" className="normal-case" title={tip}>
+                      <Repeat size={11} /> Loop · {state}
+                    </Badge>
+                  );
+                })()}
               </div>
               {sessionInfo?.tokens && (
                 <div className="hidden lg:flex items-center gap-3 bg-[var(--tt-sunken)] px-3 h-9 rounded-[var(--tt-radius)] border border-[var(--tt-border)]">


### PR DESCRIPTION
Re-lands the **/loop telemetry** feature on `main`. The original PR #167 was stacked on `fix/workflow-subagent-attribution` and merged into that branch (not main); that base was already squash-merged as #166 and then deleted, so the loop changes never reached `main`. This branch is the same loop work, rebased cleanly onto current `main` (loop-only, no workflow duplication).

## What it does
Detects when a session is running a loop (a scheduled recurring or self-paced prompt) and surfaces it in the trace and analytics with an honest active / expired / cancelled lifecycle.

- **Detection** keys on the scheduling tool calls (`CronCreate` / `ScheduleWakeup` / `CronDelete`), not the `/loop` marker, so it catches loops with no `/loop` breadcrumb. Job id comes from the CronCreate tool_result; fires re-inject into the same session file.
- **Lifecycle** (`_annotate_loop_lifecycle`) is recomputed from `now()` on every request, never cached — an idle loop can't serve a stale "active". State machine: cancelled → one-shot-done → cron-7d-expired → stale → active → unknown.
- **Footprint** — loop tokens/cost are attributed to the loop's OWN fire-response turns only, not the whole session (a 3-fire loop in a busy session no longer shows the session's full $631). `footprint_cost` ≤ session cost by construction.
- **Surfaces:** a state-colored Loop badge + full Loop details card in the trace; a self-hiding "Recurring loops" section in analytics (tiles + per-loop list showing footprint "of $X session").
- **Cost/cache:** `loop` cached as raw facts only; `scan_cache.CACHE_VERSION` 2→3; `history_store._ECOSYSTEM_KEYS` gains `loop`. Count-once preserved (loop tokens are an attribution view, never summed into totals).

## Verification
- Live data: this session's cron loop tracked active → cancelled; `loop_cost` $1,130 → $90.54 after the footprint fix; every loop's footprint ≤ its session.
- `backend/test_loops.py`: 15 tests (cron parsing, full state machine, detection, footprint-only-counts-fire-turns). All pass.
- tsc clean. Includes the `UPDATE.json` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)