### PR TITLE
Enterprise/VDI ergonomics: private-registry installs, off-PATH summarizer CLIs, local-models crash guard

### DIFF
--- a/backend/summarizers/base.py
+++ b/backend/summarizers/base.py
@@ -11,6 +11,8 @@ text back out. Heavy lifting (condensing, prompting, caching) lives in
 """
 from __future__ import annotations
 
+import os
+import re
 import shutil
 import subprocess
 from abc import ABC, abstractmethod
@@ -39,6 +41,28 @@ def _ensure_cwd() -> str:
     return str(SUMMARIZER_CWD)
 
 
+def _looks_like_path(s: str) -> bool:
+    """True when ``s`` is a path (has a separator), not a bare command name."""
+    return os.sep in s or (os.altsep is not None and os.altsep in s)
+
+
+def _binary_override(binary: str) -> str:
+    """Location override for a CLI, via env ``TT_<BINARY>_BIN``. "" when unset.
+
+    Enterprise / locked-down VDI installs often can't put the coding CLI on PATH
+    (redirected profile, per-user install under Documents, an npm shim in a
+    non-PATH dir) even though the binary runs fine when launched by full path.
+    Setting e.g. ``TT_CLAUDE_BIN=C:\\Users\\me\\Documents\\claude.exe`` (or
+    ``TT_OLLAMA_BIN`` / ``TT_CODEX_BIN`` / …, keyed on the adapter's ``binary``)
+    makes both the availability probe and the actual summarize call use that
+    path. A bare name is still PATH-resolved; a full/relative path is used as-is.
+    """
+    if not binary:
+        return ""
+    key = "TT_" + re.sub(r"[^A-Z0-9]+", "_", binary.upper()) + "_BIN"
+    return os.environ.get(key, "").strip()
+
+
 def _resolve_executable(name: str) -> str:
     """Resolve a bare CLI name to its full path on PATH, honouring PATHEXT.
 
@@ -54,7 +78,14 @@ def _resolve_executable(name: str) -> str:
 
     Falls back to the original name when nothing is found, so the existing
     "failed to launch" error still surfaces with the same wording.
+
+    A ``TT_<NAME>_BIN`` override wins over PATH resolution — a full/relative path
+    is launched as-is (CreateProcess runs ``.exe``/``.cmd`` by full path), a bare
+    override name is still PATH-resolved.
     """
+    override = _binary_override(name)
+    if override:
+        return override if _looks_like_path(override) else (shutil.which(override) or override)
     return shutil.which(name) or name
 
 
@@ -114,8 +145,20 @@ class BaseSummarizer(ABC):
     binary: str = ""
 
     def is_available(self) -> bool:
-        """True iff the CLI is installed and on PATH."""
-        return self.binary != "" and shutil.which(self.binary) is not None
+        """True iff the CLI can be launched — on PATH, or via a TT_<BIN>_BIN override.
+
+        The override lets a locked-down install expose a CLI that works but isn't
+        on PATH (see ``_binary_override``); a path override must point at an
+        existing file, a bare-name override must resolve on PATH.
+        """
+        if not self.binary:
+            return False
+        override = _binary_override(self.binary)
+        if override:
+            if _looks_like_path(override):
+                return Path(override).is_file()
+            return shutil.which(override) is not None
+        return shutil.which(self.binary) is not None
 
     @abstractmethod
     def summarize(self, prompt: str, *, timeout: int = 120) -> str:

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -133,7 +133,47 @@ function printHelp() {
   ].join('\n'));
 }
 
-function run(cmd, args, opts = {}) {
+// Print actionable guidance when a dependency install fails. stdio is inherited
+// so pip/npm's real error is already on screen — but behind a private registry
+// the cause (auth, TLS, hash pinning) is rarely obvious from that output, so we
+// spell out the usual suspects instead of leaving the user with a bare exit
+// code. `tool` is 'pip' or 'npm'.
+function printInstallFailureHelp(tool) {
+  const bar = '─'.repeat(64);
+  const usingMirror = tool === 'pip' ? Boolean(pipIndexUrl) : Boolean(npmRegistry);
+  console.error('\n' + bar);
+  console.error(`The ${tool} dependency install above failed.`);
+  console.error('If this machine reaches packages through a private registry or');
+  console.error('proxy (e.g. JFrog Artifactory, Nexus), the usual causes are:');
+  console.error('');
+  console.error('  • Auth — the registry needs an identity token. The URL alone');
+  if (tool === 'npm') {
+    console.error('    is not enough; add it to ~/.npmrc:');
+    console.error('        //<host>/<repo>/:_authToken=<token>');
+  } else {
+    console.error('    is not enough; use pip.conf or embed it in the URL:');
+    console.error('        https://<user>:<token>@<host>/.../simple');
+  }
+  console.error('  • TLS — the internal CA cert must be trusted, else the');
+  console.error('    download fails cert verification:');
+  console.error(tool === 'npm'
+    ? '        set NODE_EXTRA_CA_CERTS=/path/to/corp-ca.pem'
+    : '        set PIP_CERT=/path/to/corp-ca.pem (or add to the OS trust store)');
+  if (tool === 'pip') {
+    console.error('  • Hash mismatch — requirements.lock pins exact wheel hashes.');
+    console.error('    A read-through PyPI proxy serves the real upstream files so');
+    console.error('    hashes match; only a mirror that REPACKAGES wheels breaks it.');
+  }
+  if (!usingMirror) {
+    console.error(`  • Registry — point the install at your mirror with`);
+    console.error(tool === 'npm'
+      ? '        TT_NPM_REGISTRY=<url>'
+      : '        TT_PIP_INDEX_URL=<url>');
+  }
+  console.error(bar + '\n');
+}
+
+function run(cmd, args, opts = {}, hintOnFail = null) {
   // On Windows we spawn through the shell so PATH-resolved commands (`py`, the
   // python launcher, etc.) work — but cmd.exe re-parses the line and does NOT
   // quote for us. When the repo lives in a path with spaces (e.g.
@@ -151,7 +191,10 @@ function run(cmd, args, opts = {}) {
     useShell ? args.map(quote) : args,
     { stdio: 'inherit', shell: useShell, ...opts },
   );
-  if (res.status !== 0) die(`"${cmd} ${args.join(' ')}" exited with ${res.status}`);
+  if (res.status !== 0) {
+    if (hintOnFail) hintOnFail();
+    die(`"${cmd} ${args.join(' ')}" exited with ${res.status}`);
+  }
 }
 
 function canConnect(host, port, timeoutMs = 300) {
@@ -273,9 +316,9 @@ function ensureBackend() {
   if (cachedSha === currentSha) return;
   console.log('→ installing backend dependencies…');
   if (useLock) {
-    run(venvPython, ['-m', 'pip', 'install', '--quiet', '--require-hashes', ...pipIndexArgs, '-r', 'requirements.lock'], { cwd: backendDir });
+    run(venvPython, ['-m', 'pip', 'install', '--quiet', '--require-hashes', ...pipIndexArgs, '-r', 'requirements.lock'], { cwd: backendDir }, () => printInstallFailureHelp('pip'));
   } else {
-    run(venvPython, ['-m', 'pip', 'install', '--quiet', ...pipIndexArgs, '-r', 'requirements.txt'], { cwd: backendDir });
+    run(venvPython, ['-m', 'pip', 'install', '--quiet', ...pipIndexArgs, '-r', 'requirements.txt'], { cwd: backendDir }, () => printInstallFailureHelp('pip'));
   }
   try { fs.writeFileSync(stampPath, currentSha); } catch {}
 }
@@ -306,9 +349,9 @@ function ensureFrontend() {
   // checkouts predating the committed lockfile (or a repo where it was deleted)
   // fall back to `npm install` so those users aren't broken.
   if (fs.existsSync(lockPath)) {
-    run('npm', ['ci', ...npmRegistryArgs], { cwd: frontendDir });
+    run('npm', ['ci', ...npmRegistryArgs], { cwd: frontendDir }, () => printInstallFailureHelp('npm'));
   } else {
-    run('npm', ['install', ...npmRegistryArgs], { cwd: frontendDir });
+    run('npm', ['install', ...npmRegistryArgs], { cwd: frontendDir }, () => printInstallFailureHelp('npm'));
   }
   try { fs.writeFileSync(stampPath, currentSha); } catch {}
 }

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -30,6 +30,17 @@ const venvPython = isWindows
   ? path.join(venvDir, 'Scripts', 'python.exe')
   : path.join(venvDir, 'bin', 'python3');
 
+// Enterprise / air-gapped installs: route the two first-run dependency installs
+// (pip + npm) through a private mirror such as JFrog Artifactory or Nexus,
+// without needing to edit global pip.conf / .npmrc — which a locked-down VDI may
+// not permit. When unset, nothing changes. Note pip already reads PIP_INDEX_URL
+// and npm reads npm_config_registry from the inherited environment, so an org
+// that configures those globally needs neither of these.
+const pipIndexUrl = (process.env.TT_PIP_INDEX_URL || '').trim();
+const npmRegistry = (process.env.TT_NPM_REGISTRY || '').trim();
+const pipIndexArgs = pipIndexUrl ? ['--index-url', pipIndexUrl] : [];
+const npmRegistryArgs = npmRegistry ? ['--registry', npmRegistry] : [];
+
 function die(msg) {
   console.error('\nERROR: ' + msg + '\n');
   process.exit(1);
@@ -262,9 +273,9 @@ function ensureBackend() {
   if (cachedSha === currentSha) return;
   console.log('→ installing backend dependencies…');
   if (useLock) {
-    run(venvPython, ['-m', 'pip', 'install', '--quiet', '--require-hashes', '-r', 'requirements.lock'], { cwd: backendDir });
+    run(venvPython, ['-m', 'pip', 'install', '--quiet', '--require-hashes', ...pipIndexArgs, '-r', 'requirements.lock'], { cwd: backendDir });
   } else {
-    run(venvPython, ['-m', 'pip', 'install', '--quiet', '-r', 'requirements.txt'], { cwd: backendDir });
+    run(venvPython, ['-m', 'pip', 'install', '--quiet', ...pipIndexArgs, '-r', 'requirements.txt'], { cwd: backendDir });
   }
   try { fs.writeFileSync(stampPath, currentSha); } catch {}
 }
@@ -295,9 +306,9 @@ function ensureFrontend() {
   // checkouts predating the committed lockfile (or a repo where it was deleted)
   // fall back to `npm install` so those users aren't broken.
   if (fs.existsSync(lockPath)) {
-    run('npm', ['ci'], { cwd: frontendDir });
+    run('npm', ['ci', ...npmRegistryArgs], { cwd: frontendDir });
   } else {
-    run('npm', ['install'], { cwd: frontendDir });
+    run('npm', ['install', ...npmRegistryArgs], { cwd: frontendDir });
   }
   try { fs.writeFileSync(stampPath, currentSha); } catch {}
 }

--- a/frontend/src/app/local-models/page.tsx
+++ b/frontend/src/app/local-models/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Cpu } from "lucide-react";
 import { PageHeader, Section } from "@/components/ui";
 import { PowerSettings } from "@/components/settings/PowerSettings";

--- a/frontend/src/components/insights/LocalPowerInsights.tsx
+++ b/frontend/src/components/insights/LocalPowerInsights.tsx
@@ -50,8 +50,12 @@ export default function LocalPowerInsights({ forceShow = false }: { forceShow?: 
     return null;
   }
 
-  let totalEnergyWh: number | undefined = analytics?.total?.energy_wh;
-  let savingsUsd: number | undefined = analytics?.total?.savings_usd;
+  // `?? undefined` folds a null (some backend versions send null rather than 0)
+  // into the same path as a missing value: energy falls back to the estimate,
+  // savings hides its card — instead of a `null.toFixed()` crash that would take
+  // the whole page down when the field is null.
+  let totalEnergyWh: number | undefined = analytics?.total?.energy_wh ?? undefined;
+  let savingsUsd: number | undefined = analytics?.total?.savings_usd ?? undefined;
   let isEstimate = false;
 
   if (totalEnergyWh === undefined) {


### PR DESCRIPTION
Four changes for locked-down / enterprise (JFrog Artifactory, Nexus, corporate VDI) setups. All are no-ops on a normal machine. These apply to the documented launch paths (one-line installer / `git clone` → `./start.sh` → `node bin/cli.js`); no global-install workflow is promoted.

### 1. Route first-run installs through a private registry (`build:`)
`TT_PIP_INDEX_URL` → `pip install --index-url` (works with the `--require-hashes` lock); `TT_NPM_REGISTRY` → `npm ci/install --registry`. For VDIs where editing global `pip.conf` / `.npmrc` isn't allowed. pip/npm still honour `PIP_INDEX_URL` / `npm_config_registry` from the inherited env, so orgs that configure those globally need nothing.

### 2. Explain auth/TLS/hash causes on install failure (`build:`)
On a non-zero exit from the pip/npm bootstrap, print the usual private-registry causes (missing auth token, untrusted internal CA, `requirements.lock` hash mismatch against a repackaging mirror) with concrete fixes, instead of a bare exit code. This is the diagnosis for first-run bootstrap failures behind a firewall — the app source ships fine; it's the runtime dependency install that couldn't reach public registries.

### 3. Summarizer CLIs usable when off-PATH (`fix:`)
`is_available()` gated the summarizer picker on `shutil.which(binary)`, so a `claude.exe` that runs by full path but isn't on PATH (redirected profile / per-user install) never appeared. `TT_CLAUDE_BIN` (and `TT_CODEX_BIN` / `TT_GEMINI_BIN` / `TT_OLLAMA_BIN` / …, keyed on the adapter's binary) now overrides both the availability probe and the launch path.

### 4. Local-models page crash (`fix:`)
`/local-models` crashed on every visit with `createContext only works in Client Components` — `page.tsx` was the only route missing the `"use client"` directive (analytics, settings, home all have it) while importing the ui barrel / providers that call `createContext`. Added the directive. Also folds a backend `null` in `analytics.total.energy_wh` / `savings_usd` into the missing-value path so a null can't reach `.toFixed()`.

## Test
- `node --check bin/cli.js` passes; verified arg injection (pip/npm get `--index-url`/`--registry` only when the env is set) and the failure-hint output for both tools.
- `backend/summarizers/base.py` compiles; functionally verified: off-PATH `TT_CLAUDE_BIN` → available + launches via that path; bad path → stays hidden; unset → PATH behaviour unchanged.
- Local-models: `"use client"` matches the pattern every other route uses; verified `local-models` was the only page missing it. Frontend null edit is type-preserving; tsc not run in the fresh worktree (no node_modules).

## Follow-ups (not in this PR)
- `NEXT_TELEMETRY_DISABLED` unset (Next phones home on dev/build); `findPython` doesn't try the Windows `py` launcher. TT's own telemetry + update-check already have first-run opt-out + env kill-switches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)