### PR TITLE
feat(projects): recurring loops in a project's Config & Insights tabs

### DIFF
--- a/UPDATE.json
+++ b/UPDATE.json
@@ -12,6 +12,10 @@
           "title": "Recurring loops in Analytics",
           "description": "A new Recurring loops section counts your active, expired and cancelled loops with their observed fire counts, cadence and cost, so a forgotten hourly loop quietly burning tokens is easy to spot. It's detected from the actual scheduling calls, so it catches loops even when the /loop command left no trace.",
           "href": "/analytics"
+        },
+        {
+          "title": "Per-project loop view",
+          "description": "Open any project and its Config tab now lists every recurring loop set up there — state, cadence, fire count and job id — so you can see at a glance which automations are still running in that repo. The Insights tab adds the numbers: active/expired/cancelled counts and the token & cost footprint of the loops' own fire turns, scoped to that project."
         }
       ]
     },

--- a/frontend/src/app/projects/[path]/_lib/loops.ts
+++ b/frontend/src/app/projects/[path]/_lib/loops.ts
@@ -1,0 +1,177 @@
+/* Project-scoped /loop derivation.
+ *
+ * The project tabs already hold this project's session rows (project-context),
+ * and each row carries the full `loop` field the backend scan annotated
+ * (lifecycle state + fire-turn footprint). So the per-project loop breakdown is
+ * a pure client-side fold over those rows — no extra fetch, and it stays in
+ * lockstep with the project filter for free.
+ *
+ * This deliberately mirrors backend/main.py's /analytics `loops`/`by_loop`
+ * aggregation so the numbers match the global Analytics tab exactly:
+ *   - footprint tokens/cost are the loop's OWN fire-response turns, never the
+ *     whole session (a loop session does plenty of non-loop work too);
+ *   - the per-loop map is keyed by job_id || session_id (last write wins, same
+ *     as the backend dict), while the summary counters count every loop session.
+ * Loop tokens/cost are an attribution VIEW — already part of session totals,
+ * never re-summed into them.
+ */
+import type { SessionLoop, SessionRow } from "./project-context";
+
+export interface LoopRow {
+  key: string;
+  sessionId: string;
+  agent: string;
+  label: string;
+  state: LoopState;
+  mode: string;
+  cadence: string;
+  cadenceSeconds?: number;
+  recurring: boolean;
+  iterations: number;
+  tokens: number;         // footprint (loop fire turns only)
+  cost: number;           // footprint
+  sessionTokens: number;
+  sessionCost: number;
+  jobId?: string | null;
+  sourceSignal?: string;
+  createdAt?: string | null;
+  lastFired?: string | null;
+  expiresAt?: string | null;
+  expiredReason?: string | null;
+  cancelledAt?: string | null;
+}
+
+export interface LoopSummary {
+  total: number;
+  active: number;
+  expired: number;
+  cancelled: number;
+  unknown: number;
+  loopSessions: number;
+  totalIterations: number;
+  loopTokens: number;
+  loopCost: number;
+}
+
+export type LoopState = "active" | "expired" | "cancelled" | "unknown";
+
+function normState(s?: string): LoopState {
+  return s === "active" || s === "expired" || s === "cancelled" ? s : "unknown";
+}
+
+export interface ProjectLoops {
+  rows: LoopRow[];
+  summary: LoopSummary;
+}
+
+export function deriveProjectLoops(sessions: SessionRow[]): ProjectLoops {
+  const summary: LoopSummary = {
+    total: 0, active: 0, expired: 0, cancelled: 0, unknown: 0,
+    loopSessions: 0, totalIterations: 0, loopTokens: 0, loopCost: 0,
+  };
+  const byKey = new Map<string, LoopRow>();
+
+  for (const s of sessions) {
+    const lp: SessionLoop | undefined = s.loop;
+    if (!lp || !lp.is_loop) continue;
+
+    const state = normState(lp.state);
+    summary.total += 1;
+    summary.loopSessions += 1;
+    if (state === "active") summary.active += 1;
+    else if (state === "expired") summary.expired += 1;
+    else if (state === "cancelled") summary.cancelled += 1;
+    else summary.unknown += 1;
+
+    const iterations = lp.iterations || 0;
+    const tokens = lp.footprint_tokens || 0;
+    const cost = lp.footprint_cost || 0;
+    summary.totalIterations += iterations;
+    summary.loopTokens += tokens;
+    summary.loopCost += cost;
+
+    const key = lp.job_id || s.id;
+    byKey.set(key, {
+      key,
+      sessionId: s.id,
+      agent: s.agent,
+      label: lp.prompt_preview || "",
+      state,
+      mode: lp.mode || "",
+      cadence: lp.cadence || "",
+      cadenceSeconds: lp.cadence_seconds,
+      recurring: lp.recurring !== false,
+      iterations,
+      tokens,
+      cost,
+      sessionTokens: s.tokens?.total || 0,
+      sessionCost: s.cost || 0,
+      jobId: lp.job_id,
+      sourceSignal: lp.source_signal,
+      createdAt: lp.created_at,
+      lastFired: lp.last_fired,
+      expiresAt: lp.expires_at,
+      expiredReason: lp.expired_reason,
+      cancelledAt: lp.cancelled_at,
+    });
+  }
+
+  const rows = [...byKey.values()].sort((a, b) => b.iterations - a.iterations);
+  summary.loopCost = Number(summary.loopCost.toFixed(6));
+  return { rows, summary };
+}
+
+/* ── Presentation helpers (shared by config + insights tabs) ── */
+
+export const LOOP_STATE: Record<LoopState, { dot: string; label: string; ring: string }> = {
+  active:    { dot: "bg-emerald-400",                                          label: "text-emerald-300",       ring: "border-emerald-500/40" },
+  expired:   { dot: "bg-[var(--tt-fg-dim)]",                                   label: "text-[var(--tt-fg-dim)]", ring: "border-[var(--tt-border)]" },
+  cancelled: { dot: "bg-amber-400",                                           label: "text-amber-300",         ring: "border-amber-500/40" },
+  unknown:   { dot: "bg-transparent border border-[var(--tt-border-strong)]", label: "text-[var(--tt-fg-muted)]", ring: "border-[var(--tt-border)]" },
+};
+
+export function loopStateTone(s: LoopState) {
+  return LOOP_STATE[s] ?? LOOP_STATE.unknown;
+}
+
+/** Human interval from cadence_seconds + mode (matches the trace LoopCard). */
+export function loopInterval(row: Pick<LoopRow, "cadenceSeconds" | "mode">): string {
+  const s = row.cadenceSeconds;
+  if (row.mode === "fixed_cron") {
+    if (s && s % 86400 === 0) return `Every ${s / 86400}d`;
+    if (s && s % 3600 === 0) return `Every ${s / 3600}h`;
+    if (s && s % 60 === 0) return `Every ${s / 60}m`;
+    return s ? `Every ${s}s` : "Cron schedule";
+  }
+  return s ? `~${s}s heartbeat` : "Self-paced";
+}
+
+export function loopReasonLabel(r?: string | null): string {
+  return (
+    {
+      cron_expired_7d: "reached its 7-day auto-expiry",
+      one_shot_completed: "ran once and finished",
+      stale_session_ended: "session ended (no recent fire)",
+      cancelled: "cancelled",
+    } as Record<string, string>
+  )[r || ""] || r || "";
+}
+
+export function loopRel(iso?: string | null): string {
+  if (!iso) return "";
+  const t = new Date(iso).getTime();
+  if (isNaN(t)) return "";
+  const diff = Date.now() - t;
+  const abs = Math.abs(diff);
+  const unit =
+    abs >= 86400000 ? `${Math.round(abs / 86400000)}d`
+    : abs >= 3600000 ? `${Math.round(abs / 3600000)}h`
+    : `${Math.round(abs / 60000)}m`;
+  return diff >= 0 ? `${unit} ago` : `in ${unit}`;
+}
+
+export function loopFmtNum(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}

--- a/frontend/src/app/projects/[path]/_lib/project-context.tsx
+++ b/frontend/src/app/projects/[path]/_lib/project-context.tsx
@@ -38,6 +38,37 @@ export interface SessionRow {
   subagent_info?: { role?: string; nickname?: string; depth?: number };
   skills_used?: { name: string; count: number }[];
   mcp_usage?: Record<string, Record<string, number>>;
+  /* /loop telemetry; present only on sessions that scheduled a recurring loop.
+     Lifecycle (state/active/expires_at/expired_reason) is annotated by the
+     backend scan; footprint_* are the loop's own fire-turn tokens, not the
+     whole session. See SessionLoop and _lib/loops.ts. */
+  loop?: SessionLoop;
+}
+
+/* Mirror of backend sess["loop"] (backend/main.py) — raw facts plus the
+   per-request lifecycle annotation. All fields optional/loose because the
+   shape is owned by the scanner; consumers guard on `is_loop`. */
+export interface SessionLoop {
+  is_loop?: boolean;
+  mode?: string;                // "fixed_cron" | "dynamic"
+  cadence?: string;             // human cadence, e.g. "every 1h"
+  cadence_seconds?: number;
+  recurring?: boolean;
+  job_id?: string | null;
+  source_signal?: string;
+  prompt_preview?: string;
+  created_at?: string | null;
+  last_fired?: string | null;
+  iterations?: number;
+  cancelled?: boolean;
+  cancelled_at?: string | null;
+  footprint_tokens?: number;
+  footprint_cost?: number;
+  // lifecycle (recomputed per scan, never cached)
+  state?: "active" | "expired" | "cancelled" | "unknown";
+  active?: boolean;
+  expires_at?: string | null;
+  expired_reason?: string | null;
 }
 
 export interface WorktreeSummary {

--- a/frontend/src/app/projects/[path]/config/page.tsx
+++ b/frontend/src/app/projects/[path]/config/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
 import {
   Settings2, Folder, Puzzle, Users, BookOpen, Terminal, Wrench, FileText,
-  Globe, Package,
+  Globe, Package, Repeat, ChevronRight,
 } from "lucide-react";
 
 import { apiFetch } from "@/lib/api";
@@ -11,8 +12,13 @@ import {
   Card, CardHeader, CardTitle, CardEyebrow, Section, Badge, AgentBadge,
   EmptyState, Skeleton,
 } from "@/components/ui";
+import { cn } from "@/lib/cn";
 import BudgetEditor from "@/components/budgets/BudgetEditor";
 import { useProject } from "../_lib/project-context";
+import {
+  deriveProjectLoops, loopStateTone, loopInterval, loopRel, loopFmtNum,
+  type LoopRow,
+} from "../_lib/loops";
 
 interface ConfigItem { name: string; agent: string; scope: "project" | "user"; description?: string; source?: string; pluginRef?: string; [k: string]: unknown }
 interface SubagentItem extends ConfigItem { model?: string; tools?: string }
@@ -39,8 +45,9 @@ interface UsageData {
 }
 
 export default function ConfigTab() {
-  const { decodedPath, project } = useProject();
+  const { decodedPath, project, sessions } = useProject();
   const projectAgents = project?.agents ?? [];
+  const loops = useMemo(() => deriveProjectLoops(sessions), [sessions]);
   const [config, setConfig] = useState<ProjectConfig | null>(null);
   const [usage, setUsage] = useState<UsageData | null>(null);
   const [loading, setLoading] = useState(true);
@@ -106,6 +113,12 @@ export default function ConfigTab() {
     <div className="space-y-7">
       {/* Budgets — set spend limits for this project (overall + per agent) */}
       <BudgetEditor projectPath={decodedPath} agents={projectAgents} />
+
+      {/* Recurring loops set up in this project — the automations a session
+          scheduled to re-run itself (/loop, cron, self-pacing heartbeat).
+          Sits with the rest of the project's configured surface; the Insights
+          tab carries the token/cost breakdown. Self-hides when there are none. */}
+      <ProjectLoopsInventory rows={loops.rows} decodedPath={decodedPath} />
 
       {/* Summary tiles */}
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3">
@@ -386,5 +399,73 @@ function CountChip({ color, label, value }: { color: string; label: string; valu
       <span className="font-semibold tabular" style={{ color }}>{value}</span>
       <span>{label}</span>
     </span>
+  );
+}
+
+/* ─────────────────── Recurring loops (config inventory) ─────────────────── */
+
+function ProjectLoopsInventory({ rows, decodedPath }: { rows: LoopRow[]; decodedPath: string }) {
+  if (rows.length === 0) return null;
+  const active = rows.filter((r) => r.state === "active").length;
+  return (
+    <Section
+      title={<span className="flex items-center gap-2"><Repeat size={12} className="text-[var(--tt-brand)]" /> Recurring loops</span>}
+      description="Sessions in this project that scheduled themselves to re-run — /loop, cron, or a self-pacing heartbeat. Liveness is recomputed from each loop's last fire and cadence; token & cost economics live on the Insights tab."
+      actions={<Badge variant={active > 0 ? "success" : "neutral"} size="sm">{active} active · {rows.length} total</Badge>}
+    >
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        {rows.map((r) => <LoopInventoryCard key={r.key} row={r} decodedPath={decodedPath} />)}
+      </div>
+    </Section>
+  );
+}
+
+function LoopInventoryCard({ row, decodedPath }: { row: LoopRow; decodedPath: string }) {
+  const tone = loopStateTone(row.state);
+  const href = `/sessions/${encodeURIComponent(row.sessionId)}?agent=${encodeURIComponent(row.agent)}&back=${encodeURIComponent(`/projects/${encodeURIComponent(decodedPath)}/config`)}`;
+  return (
+    <Link
+      href={href}
+      className={cn(
+        "group block rounded-[var(--tt-radius-lg)] border bg-[var(--tt-panel)] p-4 transition-colors hover:tt-tint-1",
+        tone.ring,
+      )}
+    >
+      <div className="flex items-start justify-between gap-3 mb-2">
+        <span className="flex items-center gap-1.5 min-w-0">
+          <Repeat size={12} className="text-[var(--tt-brand)] shrink-0" />
+          <span className="text-[11px] font-semibold uppercase tracking-[0.14em] flex items-center gap-1.5" >
+            <span className={cn("w-1.5 h-1.5 rounded-full shrink-0", tone.dot)} />
+            <span className={tone.label}>{row.state}</span>
+          </span>
+        </span>
+        <span className="flex items-center gap-1.5 shrink-0">
+          <AgentBadge agent={row.agent} />
+          <ChevronRight size={13} className="text-[var(--tt-fg-faint)] group-hover:text-[var(--tt-brand)] group-hover:translate-x-0.5 transition-all" />
+        </span>
+      </div>
+
+      {row.label ? (
+        <p className="text-[12px] text-[var(--tt-fg)] leading-relaxed line-clamp-2 mb-2.5" title={row.label}>{row.label}</p>
+      ) : (
+        <p className="text-[12px] text-[var(--tt-fg-dim)] italic mb-2.5">(no prompt captured)</p>
+      )}
+
+      <div className="flex flex-wrap items-center gap-1.5">
+        <Badge variant="brand" size="xs" className="normal-case">{loopInterval(row)}</Badge>
+        <Badge variant="neutral" size="xs" className="normal-case">≥{row.iterations.toLocaleString()} fires</Badge>
+        {row.mode && <Badge variant="neutral" size="xs" className="font-mono normal-case">{row.mode}</Badge>}
+        {row.jobId && <Badge variant="neutral" size="xs" className="font-mono normal-case">{row.jobId}</Badge>}
+      </div>
+
+      {(row.lastFired || row.expiresAt) && (
+        <div className="mt-2.5 flex flex-wrap gap-x-4 gap-y-0.5 text-[10px] text-[var(--tt-fg-dim)] tabular">
+          {row.lastFired && <span>last fired {loopRel(row.lastFired)}</span>}
+          {row.state === "active" && row.expiresAt && <span>expires {loopRel(row.expiresAt)}</span>}
+          {row.state === "expired" && row.expiredReason && <span className="text-[var(--tt-fg-muted)]">{row.expiredReason}</span>}
+          {row.tokens > 0 && <span>{loopFmtNum(row.tokens)} tok · ${row.cost.toFixed(2)} loop turns</span>}
+        </div>
+      )}
+    </Link>
   );
 }

--- a/frontend/src/app/projects/[path]/insights/page.tsx
+++ b/frontend/src/app/projects/[path]/insights/page.tsx
@@ -1,15 +1,23 @@
 "use client";
 
 import { Fragment, useMemo, useState } from "react";
-import { Sparkles, Activity, Flame, Clock4, Wrench, GitBranch, Zap, Cpu } from "lucide-react";
+import Link from "next/link";
+import {
+  Sparkles, Activity, Flame, Clock4, Wrench, GitBranch, Zap, Cpu,
+  Repeat, TrendingUp, DollarSign,
+} from "lucide-react";
 
 import { getAgent } from "@/lib/agents";
 import { cn } from "@/lib/cn";
 import {
-  Card, CardHeader, CardTitle, StatTile, EmptyState,
+  Card, CardHeader, CardTitle, CardEyebrow, StatTile, EmptyState,
 } from "@/components/ui";
 import BudgetCard from "@/components/budgets/BudgetCard";
 import { useProject } from "../_lib/project-context";
+import {
+  deriveProjectLoops, loopStateTone, loopInterval, loopRel, loopFmtNum,
+  type LoopRow, type LoopSummary,
+} from "../_lib/loops";
 
 const DOW_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
@@ -179,6 +187,11 @@ export default function InsightsTab() {
       any: sessionsWithSpawns > 0 || Object.keys(skills).length > 0 || Object.keys(mcp).length > 0,
     };
   }, [sessions]);
+
+  // Recurring loops in this project — same fold the global Analytics tab does,
+  // but scoped to these sessions. Footprint tokens/cost are the loop's own fire
+  // turns, already part of the totals above (an attribution view).
+  const loops = useMemo(() => deriveProjectLoops(sessions), [sessions]);
 
   const totalTokens = insights.agents.reduce((a, [, x]) => a + x.tokens, 0);
   const totalSessions = insights.agents.reduce((a, [, x]) => a + x.count, 0);
@@ -395,6 +408,10 @@ export default function InsightsTab() {
         </Card>
       )}
 
+      {/* Recurring loops — this project's /loop automations, broken down by
+          state and by the token/cost footprint of their own fire turns. */}
+      <RecurringLoopsBreakdown rows={loops.rows} summary={loops.summary} decodedPath={decodedPath} />
+
       {/* Leaderboard + migration ribbon */}
       <Card padding="lg">
         <CardHeader>
@@ -511,6 +528,96 @@ export default function InsightsTab() {
         </Card>
       </div>
     </div>
+  );
+}
+
+/* Recurring loops, scoped to this project. Tiles mirror the global Analytics
+   tab; the list breaks each loop down by its own fire-turn footprint and puts
+   that in context of the whole session ("of $X session"). Self-hides at zero. */
+function RecurringLoopsBreakdown({
+  rows, summary, decodedPath,
+}: { rows: LoopRow[]; summary: LoopSummary; decodedPath: string }) {
+  if (summary.total === 0) return null;
+  return (
+    <Card padding="lg">
+      <CardHeader>
+        <div>
+          <CardTitle><Repeat size={14} className="text-[var(--tt-brand)]" /> Recurring loops</CardTitle>
+          <p className="text-[11px] text-[var(--tt-fg-dim)] mt-0.5">
+            /loop, cron and heartbeat-scheduled sessions that re-run themselves. Token & cost are the loop&apos;s OWN
+            fire turns — a fraction of the session, and already part of the totals above.
+          </p>
+        </div>
+        <CardEyebrow>{rows.length} loop{rows.length === 1 ? "" : "s"}</CardEyebrow>
+      </CardHeader>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-5">
+        <StatTile
+          label="Active loops"
+          value={String(summary.active)}
+          hint={`${summary.total} loop${summary.total === 1 ? "" : "s"} total`}
+          icon={<Repeat size={16} />}
+          accent="var(--tt-success)"
+        />
+        <StatTile
+          label="Expired / cancelled"
+          value={`${summary.expired} / ${summary.cancelled}`}
+          hint={summary.unknown > 0 ? `${summary.unknown} never fired` : "no longer running"}
+          icon={<Repeat size={16} />}
+          accent="var(--tt-fg-dim)"
+        />
+        <StatTile
+          label="Loop runs"
+          value={`≥${summary.totalIterations.toLocaleString()}`}
+          hint={`observed fires (min) across ${summary.loopSessions} session${summary.loopSessions === 1 ? "" : "s"}`}
+          icon={<TrendingUp size={16} />}
+          accent="var(--tt-brand)"
+        />
+        <StatTile
+          label="Loop cost"
+          value={`$${summary.loopCost.toFixed(2)}`}
+          hint={`${loopFmtNum(summary.loopTokens)} tok · loop turns only`}
+          icon={<DollarSign size={16} />}
+          accent="var(--tt-warn)"
+        />
+      </div>
+
+      <div className="space-y-2 max-h-[420px] overflow-y-auto pr-1">
+        {rows.map((r) => {
+          const tone = loopStateTone(r.state);
+          const href = `/sessions/${encodeURIComponent(r.sessionId)}?agent=${encodeURIComponent(r.agent)}&back=${encodeURIComponent(`/projects/${encodeURIComponent(decodedPath)}/insights`)}`;
+          const meta = getAgent(r.agent);
+          return (
+            <Link
+              key={r.key}
+              href={href}
+              className="group flex items-center justify-between gap-3 rounded-[var(--tt-radius)] border border-transparent hover:border-[var(--tt-border)] hover:tt-tint-1 px-2 py-1.5 -mx-1 transition-colors"
+            >
+              <span className="min-w-0 flex items-start gap-2">
+                <span className={cn("w-1.5 h-1.5 rounded-full shrink-0 mt-1.5", tone.dot)} />
+                <span className="min-w-0 flex flex-col">
+                  <span className="text-[12px] text-[var(--tt-fg)] truncate" title={r.label}>{r.label || "(no prompt captured)"}</span>
+                  <span className="text-[10px] text-[var(--tt-fg-dim)] truncate flex items-center gap-1.5">
+                    <span className={cn("uppercase tracking-[0.1em]", tone.label)}>{r.state}</span>
+                    <span>· {loopInterval(r)}</span>
+                    <span className="hidden sm:inline" style={{ color: meta.hex }}>· {meta.label}</span>
+                    {r.state === "active" && r.lastFired && <span className="hidden md:inline">· last fired {loopRel(r.lastFired)}</span>}
+                    {r.state === "expired" && r.expiredReason && <span className="hidden md:inline">· {r.expiredReason}</span>}
+                  </span>
+                </span>
+              </span>
+              <span className="text-right shrink-0">
+                <span className="block tabular font-semibold text-[12px] text-[var(--tt-fg)]" title="observed fires (lower bound)">≥{r.iterations.toLocaleString()}</span>
+                <span className="block tabular text-[10px] text-[var(--tt-fg-dim)]" title="the loop's own fire-response turns">{loopFmtNum(r.tokens)} tok · ${r.cost.toFixed(2)}</span>
+                {r.sessionCost > r.cost + 0.005 && (
+                  <span className="block tabular text-[10px] text-[var(--tt-fg-faint)]">of ${r.sessionCost.toFixed(2)} session</span>
+                )}
+              </span>
+            </Link>
+          );
+        })}
+      </div>
+    </Card>
   );
 }
 


### PR DESCRIPTION
Surfaces `/loop` automations at the **project** level — the Config tab lists the loops set up in a project, the Insights tab breaks down their token/cost economics.

## Stacked on #169
This builds on the loop `loop` field that **#169** adds to every session. **Merge #169 first, then this.** The PR is based on `feat/loop-telemetry-rebased` (the #169 head) so the diff below is only this feature's changes; retarget it to `main` once #169 lands.

## What's here
- **`_lib/loops.ts`** — a pure client-side fold over the project's session rows into the same `loops`/`by_loop` shape the `/analytics` endpoint produces. No backend change, no extra fetch: the scan already annotates each session's `loop` field (lifecycle state + fire-turn footprint), and the project tabs already hold the project-scoped session list. Footprint = the loop's own fire-response turns, keyed by `job_id || session_id`.
- **Config tab** — a *Recurring loops* inventory: every loop set up in the project with its state, interval, fire count, mode and job id, each card linking to its session trace. Shown as soon as the project opens; self-hides when there are none.
- **Insights tab** — a *Recurring loops* breakdown: active / expired / cancelled tiles, observed fire counts, and the token & cost footprint of loop turns in context of the whole session (`of $X session`).

## Verification
- `tsc --noEmit` clean.
- Client fold cross-checked against `/analytics?projects=<path>` for a project with 4 loops — **exact match**: total 4, expired 2, cancelled 2, ≥75 iterations, 805,100 loop tokens, \$85.995473 loop cost.
- Both routes render 200 with real data (screenshots captured live against the loop backend).

Loop tokens/cost stay an **attribution view** — already part of the session totals, never re-summed into them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UDo8qcPJDhxphuy4Cfskrn