### PR TITLE
feat(settings): show each agent's experimental / feature flags

### DIFF
--- a/UPDATE.json
+++ b/UPDATE.json
@@ -1,6 +1,17 @@
 {
   "releases": [
     {
+      "tag": "2026-07-18",
+      "title": "See which experimental features each agent has on",
+      "highlights": [
+        {
+          "title": "Agent feature flags in Settings",
+          "description": "Settings now shows the experimental and preview features each coding agent has enabled in its own local config — at a glance whether Copilot's experimental mode (the one that unlocks /every and /loop), Codex's per-feature flags, or Claude Code's feature toggles are on or off. It's read-only and local-first; agents that gate features server-side aren't listed rather than faked.",
+          "href": "/settings"
+        }
+      ]
+    },
+    {
       "tag": "2026-07-16",
       "title": "See which sessions ran a loop",
       "highlights": [

--- a/UPDATE.json
+++ b/UPDATE.json
@@ -6,7 +6,7 @@
       "highlights": [
         {
           "title": "Agent feature flags in Settings",
-          "description": "Settings now shows the experimental and preview features each coding agent has enabled in its own local config — at a glance whether Copilot's experimental mode (the one that unlocks /every and /loop), Codex's per-feature flags, or Claude Code's feature toggles are on or off. It's read-only and local-first; agents that gate features server-side aren't listed rather than faked.",
+          "description": "Settings now shows the experimental and preview features each coding agent has enabled in its own local config — at a glance whether Copilot's experimental mode (the one that unlocks /every and /loop), Codex's per-feature flags, or Claude Code's feature toggles are on or off, plus the exact command and a docs link to turn each on in the agent itself. It's read-only and local-first; agents that gate features server-side aren't listed rather than faked.",
           "href": "/settings"
         }
       ]

--- a/backend/main.py
+++ b/backend/main.py
@@ -6766,6 +6766,100 @@ async def put_billing_config(payload: dict = Body(...)):
     return {"agents": get_all(_list_available_agents()), "modes": list(MODES)}
 
 
+# Feature/experimental flags each agent persists in its own local config. There
+# is no shared "experimental mode" across harnesses — each exposes it
+# differently (or server-side, or not at all), so we read only the agents with a
+# clean, secret-free local signal and surface an allowlist of scalar flags. This
+# is read-only and informational; TokenTelemetry never writes these back.
+def _scalar(v: Any) -> bool:
+    return isinstance(v, (bool, int, float, str)) and not isinstance(v, bytes)
+
+
+def _agent_feature_flags() -> List[Dict[str, Any]]:
+    """Per-agent experimental/feature flags, read from each agent's own config.
+
+    Best-effort and read-only: a missing/corrupt config is simply omitted, never
+    raised. Only allowlisted, scalar, non-secret keys are surfaced (no auth
+    tokens, no whole-file dumps). Bool flags carry kind="bool" so the UI can show
+    an on/off pill; everything else is kind="value".
+    """
+    out: List[Dict[str, Any]] = []
+
+    def _flag(name: str, value: Any) -> Dict[str, Any]:
+        return {"name": name, "value": value,
+                "kind": "bool" if isinstance(value, bool) else "value"}
+
+    # Copilot — ~/.copilot/settings.json: a single `experimental` boolean that
+    # gates preview features incl. the /every, /loop and /after scheduled prompts.
+    cp = HOME / ".copilot" / "settings.json"
+    if cp.exists():
+        try:
+            d = json.loads(cp.read_text(encoding="utf-8"))
+            if isinstance(d, dict):
+                flags = [_flag(k, d[k]) for k in ("experimental",) if k in d and _scalar(d[k])]
+                out.append({
+                    "agent": "copilot", "detected": True,
+                    "source": "~/.copilot/settings.json",
+                    "flags": flags,
+                    "note": "Turns on preview features, including the /every, /loop and /after scheduled prompts.",
+                })
+        except Exception:
+            pass
+
+    # Codex — ~/.codex/config.toml [features]: per-feature booleans (e.g. js_repl).
+    cx = CODEX_DIR / "config.toml"
+    if cx.exists():
+        try:
+            import tomllib
+            with open(cx, "rb") as f:
+                t = tomllib.load(f)
+            feats = t.get("features") if isinstance(t, dict) else None
+            if isinstance(feats, dict):
+                flags = [_flag(k, v) for k, v in feats.items() if _scalar(v)]
+                out.append({
+                    "agent": "codex", "detected": True,
+                    "source": "~/.codex/config.toml  [features]",
+                    "flags": flags,
+                    "note": "Experimental Codex capabilities, toggled per feature.",
+                })
+        except Exception:
+            pass
+
+    # Claude Code — ~/.claude/settings.json: no single experimental switch, so we
+    # surface an allowlist of its individual feature toggles.
+    CLAUDE_KEYS = ("enableWorkflows", "effortLevel", "editorMode",
+                   "voiceEnabled", "agentPushNotifEnabled")
+    cl = CLAUDE_DIR / "settings.json"
+    if cl.exists():
+        try:
+            d = json.loads(cl.read_text(encoding="utf-8"))
+            if isinstance(d, dict):
+                flags = [_flag(k, d[k]) for k in CLAUDE_KEYS if k in d and _scalar(d[k])]
+                if flags:
+                    out.append({
+                        "agent": "claude", "detected": True,
+                        "source": "~/.claude/settings.json",
+                        "flags": flags,
+                        "note": "Claude Code has no single experimental switch; these are its individual feature toggles.",
+                    })
+        except Exception:
+            pass
+
+    return out
+
+
+@app.get("/config/agent-features")
+async def get_agent_features():
+    """Experimental/feature flags each agent stores in its own local config.
+
+    Covers the agents with a clean, locally-readable signal (Copilot, Codex,
+    Claude Code). Agents that gate features server-side or in opaque stores
+    (Cursor, cloud harnesses) aren't listed — an absent agent means "not exposed
+    locally", never "off". Read-only.
+    """
+    return {"agents": _agent_feature_flags()}
+
+
 @app.get("/config/billing-route")
 async def get_billing_route_config():
     """Drain-priority billing routes per agent: which credit *bucket* pays, and

--- a/backend/main.py
+++ b/backend/main.py
@@ -6802,6 +6802,9 @@ def _agent_feature_flags() -> List[Dict[str, Any]]:
                     "source": "~/.copilot/settings.json",
                     "flags": flags,
                     "note": "Turns on preview features, including the /every, /loop and /after scheduled prompts.",
+                    "how_to_enable": "In the Copilot CLI, run /experimental to toggle it (or start it with --experimental). Copilot restarts to apply.",
+                    "enable_command": "/experimental",
+                    "docs_url": "https://docs.github.com/en/copilot/how-tos/copilot-cli/automate-copilot-cli/schedule-prompts",
                 })
         except Exception:
             pass
@@ -6821,6 +6824,9 @@ def _agent_feature_flags() -> List[Dict[str, Any]]:
                     "source": "~/.codex/config.toml  [features]",
                     "flags": flags,
                     "note": "Experimental Codex capabilities, toggled per feature.",
+                    "how_to_enable": "Edit ~/.codex/config.toml and set a flag under [features] (e.g. js_repl = true), then restart Codex.",
+                    "enable_command": "~/.codex/config.toml  →  [features]",
+                    "docs_url": "https://learn.chatgpt.com/docs/config-file/config-reference",
                 })
         except Exception:
             pass
@@ -6841,6 +6847,9 @@ def _agent_feature_flags() -> List[Dict[str, Any]]:
                         "source": "~/.claude/settings.json",
                         "flags": flags,
                         "note": "Claude Code has no single experimental switch; these are its individual feature toggles.",
+                        "how_to_enable": "In Claude Code run /config (or /config <key>=<value> on v2.1.181+), or edit ~/.claude/settings.json.",
+                        "enable_command": "/config",
+                        "docs_url": "https://code.claude.com/docs/en/settings",
                     })
         except Exception:
             pass

--- a/backend/main.py
+++ b/backend/main.py
@@ -6857,16 +6857,32 @@ def _agent_feature_flags() -> List[Dict[str, Any]]:
     return out
 
 
+# Agents that DO have experimental/preview features but store the toggle
+# somewhere TokenTelemetry can't honestly read (an opaque local state store or
+# server-side), so we name them explicitly rather than silently omitting them —
+# absence would otherwise read as "we forgot", not "not exposed locally".
+_FEATURES_NOT_DETECTABLE = [
+    {"agent": "antigravity",
+     "reason": "Its Scheduled Tasks and preview features live in an opaque local state store (state.vscdb) / server-side, not a readable flag."},
+    {"agent": "cursor",
+     "reason": "Automations and preview features are gated in Cursor's cloud / opaque store, with no local flag."},
+]
+
+
 @app.get("/config/agent-features")
 async def get_agent_features():
     """Experimental/feature flags each agent stores in its own local config.
 
-    Covers the agents with a clean, locally-readable signal (Copilot, Codex,
-    Claude Code). Agents that gate features server-side or in opaque stores
-    (Cursor, cloud harnesses) aren't listed — an absent agent means "not exposed
-    locally", never "off". Read-only.
+    `agents` are the ones with a clean, locally-readable signal (Copilot, Codex,
+    Claude Code). `not_detectable` names agents that HAVE such features but gate
+    them where we can't honestly read them (Antigravity, Cursor). Any other agent
+    simply has no experimental/feature-flag concept in local config. An absent or
+    not_detectable agent means "not exposed locally", never "off". Read-only.
     """
-    return {"agents": _agent_feature_flags()}
+    detected = _agent_feature_flags()
+    present = {a["agent"] for a in detected}
+    not_detectable = [x for x in _FEATURES_NOT_DETECTABLE if x["agent"] not in present]
+    return {"agents": detected, "not_detectable": not_detectable}
 
 
 @app.get("/config/billing-route")

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/cn";
 import { PageHeader, Section, Card, CardHeader, CardTitle, Button, Badge, Skeleton } from "@/components/ui";
 import { BackendPicker } from "@/components/summarizer/BackendPicker";
 import { BillingSettings } from "@/components/settings/BillingSettings";
+import { AgentFeatureFlags } from "@/components/settings/AgentFeatureFlags";
 import { RetentionSettings } from "@/components/settings/RetentionSettings";
 import UsagePrivacySettings from "@/components/settings/UsagePrivacySettings";
 import { ConnectDevice } from "@/components/ConnectDevice";
@@ -213,6 +214,13 @@ export default function SettingsPage() {
         <div className="space-y-4">
           <BillingSettings />
         </div>
+      </Section>
+
+      <Section
+        title="Agent feature flags"
+        description="Experimental and preview features each agent has enabled in its own local config — read-only. There's no shared 'experimental mode' across harnesses, so this covers the agents that expose it on disk (Copilot, Codex, Claude Code); agents that gate features server-side or in opaque stores aren't listed."
+      >
+        <AgentFeatureFlags />
       </Section>
 
       <Section

--- a/frontend/src/components/settings/AgentFeatureFlags.tsx
+++ b/frontend/src/components/settings/AgentFeatureFlags.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { FlaskConical, Check, X } from "lucide-react";
+
+import { apiFetch } from "@/lib/api";
+import { Card, Badge, AgentBadge, Skeleton, EmptyState } from "@/components/ui";
+import { cn } from "@/lib/cn";
+
+interface Flag {
+  name: string;
+  value: boolean | string | number;
+  kind: "bool" | "value";
+}
+interface AgentFeatures {
+  agent: string;
+  detected: boolean;
+  source: string;
+  flags: Flag[];
+  note?: string;
+}
+
+export function AgentFeatureFlags() {
+  const [data, setData] = useState<AgentFeatures[] | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    apiFetch("/config/agent-features")
+      .then((r) => r.json())
+      .then((d) => { if (!cancelled) setData(d.agents ?? []); })
+      .catch(() => { if (!cancelled) setData([]); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="space-y-3">
+        <Skeleton className="h-24 w-full" />
+        <Skeleton className="h-24 w-full" />
+      </div>
+    );
+  }
+
+  if (!data || data.length === 0) {
+    return (
+      <Card>
+        <EmptyState
+          icon={<FlaskConical size={18} />}
+          title="No local feature flags found"
+          description="None of the agents that expose experimental flags on disk (Copilot, Codex, Claude Code) are set up on this machine."
+        />
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {data.map((a) => <AgentFlagsCard key={a.agent} a={a} />)}
+    </div>
+  );
+}
+
+function AgentFlagsCard({ a }: { a: AgentFeatures }) {
+  return (
+    <Card padding="md">
+      <div className="flex items-start justify-between gap-4 mb-3">
+        <div className="flex items-center gap-2.5 min-w-0">
+          <AgentBadge agent={a.agent} />
+          {a.note && (
+            <p className="text-[12px] text-[var(--tt-fg-dim)] leading-relaxed">{a.note}</p>
+          )}
+        </div>
+        <span
+          className="shrink-0 text-[10px] font-mono text-[var(--tt-fg-faint)] truncate max-w-[280px]"
+          title={a.source}
+        >
+          {a.source}
+        </span>
+      </div>
+
+      {a.flags.length === 0 ? (
+        <p className="text-[12px] text-[var(--tt-fg-dim)] italic">
+          Config present, but no known feature flags are set.
+        </p>
+      ) : (
+        <div className="flex flex-wrap gap-2">
+          {a.flags.map((f) => <FlagPill key={f.name} flag={f} />)}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+function FlagPill({ flag }: { flag: Flag }) {
+  // Boolean flags read as on/off with an icon; value flags show "name: value".
+  if (flag.kind === "bool") {
+    const on = flag.value === true;
+    return (
+      <span
+        className={cn(
+          "inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-[11px] font-medium",
+          on
+            ? "border-[color:var(--tt-success)]/30 bg-[color:var(--tt-success)]/10 text-[var(--tt-success-fg)]"
+            : "border-[var(--tt-border)] bg-[var(--tt-sunken)] text-[var(--tt-fg-dim)]",
+        )}
+      >
+        {on ? <Check size={11} /> : <X size={11} />}
+        <span className="font-mono normal-case">{flag.name}</span>
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-md border border-[var(--tt-border)] bg-[var(--tt-sunken)] px-2 py-1 text-[11px]">
+      <span className="font-mono text-[var(--tt-fg-muted)]">{flag.name}</span>
+      <Badge variant="neutral" size="xs" className="font-mono normal-case">{String(flag.value)}</Badge>
+    </span>
+  );
+}

--- a/frontend/src/components/settings/AgentFeatureFlags.tsx
+++ b/frontend/src/components/settings/AgentFeatureFlags.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { FlaskConical, Check, X } from "lucide-react";
+import { FlaskConical, Check, X, ExternalLink } from "lucide-react";
 
 import { apiFetch } from "@/lib/api";
 import { Card, Badge, AgentBadge, Skeleton, EmptyState } from "@/components/ui";
@@ -18,6 +18,9 @@ interface AgentFeatures {
   source: string;
   flags: Flag[];
   note?: string;
+  how_to_enable?: string;
+  enable_command?: string;
+  docs_url?: string;
 }
 
 export function AgentFeatureFlags() {
@@ -89,7 +92,45 @@ function AgentFlagsCard({ a }: { a: AgentFeatures }) {
           {a.flags.map((f) => <FlagPill key={f.name} flag={f} />)}
         </div>
       )}
+
+      {(a.how_to_enable || a.docs_url) && (
+        <div className="mt-3 pt-3 border-t border-[var(--tt-border)] flex items-start justify-between gap-4">
+          {a.how_to_enable && (
+            <p className="text-[11px] text-[var(--tt-fg-dim)] leading-relaxed min-w-0">
+              <span className="text-[var(--tt-fg-muted)] font-medium">Change it in the agent — </span>
+              {renderWithCommand(a.how_to_enable, a.enable_command)}
+            </p>
+          )}
+          {a.docs_url && (
+            <a
+              href={a.docs_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="shrink-0 inline-flex items-center gap-1 text-[11px] font-medium text-[var(--tt-brand)] hover:underline"
+            >
+              Docs <ExternalLink size={11} />
+            </a>
+          )}
+        </div>
+      )}
     </Card>
+  );
+}
+
+// Render the how-to text, styling the enable_command substring as a code chip
+// wherever it appears (robust: if the command isn't found, plain text is shown).
+function renderWithCommand(text: string, cmd?: string): React.ReactNode {
+  if (!cmd) return text;
+  const i = text.indexOf(cmd);
+  if (i === -1) return text;
+  return (
+    <>
+      {text.slice(0, i)}
+      <code className="font-mono text-[var(--tt-brand)] bg-[var(--tt-sunken)] border border-[var(--tt-border)] rounded px-1 py-0.5">
+        {cmd}
+      </code>
+      {text.slice(i + cmd.length)}
+    </>
   );
 }
 

--- a/frontend/src/components/settings/AgentFeatureFlags.tsx
+++ b/frontend/src/components/settings/AgentFeatureFlags.tsx
@@ -22,16 +22,25 @@ interface AgentFeatures {
   enable_command?: string;
   docs_url?: string;
 }
+interface NotDetectable {
+  agent: string;
+  reason: string;
+}
 
 export function AgentFeatureFlags() {
   const [data, setData] = useState<AgentFeatures[] | null>(null);
+  const [notDetectable, setNotDetectable] = useState<NotDetectable[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     let cancelled = false;
     apiFetch("/config/agent-features")
       .then((r) => r.json())
-      .then((d) => { if (!cancelled) setData(d.agents ?? []); })
+      .then((d) => {
+        if (cancelled) return;
+        setData(d.agents ?? []);
+        setNotDetectable(d.not_detectable ?? []);
+      })
       .catch(() => { if (!cancelled) setData([]); })
       .finally(() => { if (!cancelled) setLoading(false); });
     return () => { cancelled = true; };
@@ -46,7 +55,7 @@ export function AgentFeatureFlags() {
     );
   }
 
-  if (!data || data.length === 0) {
+  if ((!data || data.length === 0) && notDetectable.length === 0) {
     return (
       <Card>
         <EmptyState
@@ -60,8 +69,33 @@ export function AgentFeatureFlags() {
 
   return (
     <div className="space-y-3">
-      {data.map((a) => <AgentFlagsCard key={a.agent} a={a} />)}
+      {(data ?? []).map((a) => <AgentFlagsCard key={a.agent} a={a} />)}
+      {notDetectable.length > 0 && <NotDetectableNote items={notDetectable} />}
     </div>
+  );
+}
+
+// Agents that have experimental features but keep the toggle where we can't
+// read it — named so their absence reads as "not exposed", not "forgotten".
+function NotDetectableNote({ items }: { items: NotDetectable[] }) {
+  return (
+    <Card padding="md" className="bg-transparent border-dashed">
+      <div className="flex items-center gap-2 mb-2.5 text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--tt-fg-muted)]">
+        <FlaskConical size={12} /> Not exposed locally
+      </div>
+      <div className="space-y-2">
+        {items.map((x) => (
+          <div key={x.agent} className="flex items-start gap-2.5">
+            <AgentBadge agent={x.agent} />
+            <p className="text-[11px] text-[var(--tt-fg-dim)] leading-relaxed min-w-0">{x.reason}</p>
+          </div>
+        ))}
+      </div>
+      <p className="mt-3 pt-3 border-t border-[var(--tt-border)] text-[11px] text-[var(--tt-fg-faint)] leading-relaxed">
+        Other agents (Gemini, Qwen, Grok, OpenCode, Pi, Hermes…) don&apos;t expose an experimental or
+        feature-flag toggle in local config, so there&apos;s nothing to read.
+      </p>
+    </Card>
   );
 }
 


### PR DESCRIPTION
Adds a read-only **Agent feature flags** section to Settings — at a glance, which experimental/preview features each agent has enabled in its own local config. Answers "is Copilot's experimental mode on?" without digging through dotfiles.

## Why
There is **no shared "experimental mode"** across coding agents — each exposes it differently (a boolean, a feature table, individual toggles) or server-side, or not at all. This surfaces the three with a clean, secret-free, locally-readable signal:

| Agent | Source | Flag(s) |
|---|---|---|
| **Copilot** | `~/.copilot/settings.json` | `experimental` — the boolean that unlocks `/every`, `/loop`, `/after` scheduled prompts |
| **Codex** | `~/.codex/config.toml [features]` | per-feature booleans (`js_repl`, …) |
| **Claude Code** | `~/.claude/settings.json` | `enableWorkflows`, `effortLevel`, `editorMode`, `voiceEnabled`, `agentPushNotifEnabled` |

## Design
- **Backend** `GET /config/agent-features` + `_agent_feature_flags()` — best-effort, read-only. A missing/corrupt config is omitted (never raised), and only an **allowlist of scalar, non-secret keys** is surfaced — no auth tokens, no whole-file dumps. An absent agent means *"not exposed locally"*, never *"off"*; server-side/opaque-store agents (Cursor, cloud harnesses) aren't listed rather than faked (same honesty rule as the billing/loop views).
- **Frontend** `AgentFeatureFlags` — per-agent card with on/off pills (green ✓ / muted ✗), the config path, and a one-line note.
- Local-first, no new outbound calls.

## Verification
Live against real config: Copilot `experimental` **on**, Codex `js_repl` **off**, Claude `enableWorkflows` on / `effortLevel` high / … (screenshot captured). `tsc --noEmit` clean. Independent of the loop PRs — branches off `main`, merges on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UDo8qcPJDhxphuy4Cfskrn