### PR TITLE
feat(loops): project loop tabs + Grok & Cline detection

### DIFF
--- a/UPDATE.json
+++ b/UPDATE.json
@@ -18,8 +18,8 @@
           "description": "Open any project and its Config tab now lists every recurring loop set up there — state, cadence, fire count and job id — so you can see at a glance which automations are still running in that repo. The Insights tab adds the numbers: active/expired/cancelled counts and the token & cost footprint of the loops' own fire turns, scoped to that project."
         },
         {
-          "title": "Grok Build loops, not just Claude",
-          "description": "Recurring loops set up in Grok Build (its `/loop` scheduler / Grok Tasks) are now detected too — the task's cadence, fire count and cancelled/expired state show up in the trace and the loop views alongside Claude's, tagged Grok Build. Grok reports only a whole-session token total, so its loops show cadence and fires with cost marked n/a rather than a made-up number."
+          "title": "Loops from other agents, not just Claude",
+          "description": "Recurring loops set up in Grok Build (its `/loop` scheduler / Grok Tasks) and Cline (Scheduled Agents) are now detected too — each schedule's cadence, fire count and cancelled/expired state show up in the trace and the loop views alongside Claude's, tagged with the agent that ran it. Where an agent reports only a whole-session token total (Grok) or fires each run as its own session (Cline), the loop shows cadence and fires with cost marked n/a rather than a made-up number."
         }
       ]
     },

--- a/UPDATE.json
+++ b/UPDATE.json
@@ -16,6 +16,10 @@
         {
           "title": "Per-project loop view",
           "description": "Open any project and its Config tab now lists every recurring loop set up there — state, cadence, fire count and job id — so you can see at a glance which automations are still running in that repo. The Insights tab adds the numbers: active/expired/cancelled counts and the token & cost footprint of the loops' own fire turns, scoped to that project."
+        },
+        {
+          "title": "Grok Build loops, not just Claude",
+          "description": "Recurring loops set up in Grok Build (its `/loop` scheduler / Grok Tasks) are now detected too — the task's cadence, fire count and cancelled/expired state show up in the trace and the loop views alongside Claude's, tagged Grok Build. Grok reports only a whole-session token total, so its loops show cadence and fires with cost marked n/a rather than a made-up number."
         }
       ]
     },

--- a/UPDATE.json
+++ b/UPDATE.json
@@ -12,6 +12,10 @@
           "title": "Recurring loops in Analytics",
           "description": "A new Recurring loops section counts your active, expired and cancelled loops with their observed fire counts, cadence and cost, so a forgotten hourly loop quietly burning tokens is easy to spot. It's detected from the actual scheduling calls, so it catches loops even when the /loop command left no trace.",
           "href": "/analytics"
+        },
+        {
+          "title": "Per-project loop view",
+          "description": "Open any project and its Config tab now lists every recurring loop set up there — state, cadence, fire count and job id — so you can see at a glance which automations are still running in that repo. The Insights tab adds the numbers: active/expired/cancelled counts and the token & cost footprint of the loops' own fire turns, scoped to that project."
         }
       ]
     },

--- a/backend/main.py
+++ b/backend/main.py
@@ -2141,6 +2141,157 @@ async def get_available_agents():
 #     return status
 
 
+# Grok Build recurring loop ("Grok Tasks" / the `/loop <interval> <prompt>`
+# command). A firing re-injects the prompt into the SAME session, tagged in
+# chat_history.jsonl with synthetic_reason="scheduler_fired" and a reminder of
+# the form: "scheduled task execution (task <id>, every <interval>, recurring)".
+# This is the Grok analog of Claude's CronCreate/ScheduleWakeup loop.
+_GROK_LOOP_RE = re.compile(
+    r"scheduled task execution \(task\s+([0-9a-fA-F]+),\s*([^,]+?),\s*(recurring|once)\)",
+    re.IGNORECASE,
+)
+
+
+def _grok_interval_to_seconds(text: Optional[str]) -> Optional[int]:
+    """Parse a Grok scheduler interval to seconds.
+
+    Handles both the expanded reminder form ("every 2 hours", "30 minutes",
+    "45 seconds", "1 day") and Grok's compact input grammar ("2h", "5m", "60s",
+    "1d"). Returns None when unparseable so lifecycle falls back to defaults.
+    """
+    if not text:
+        return None
+    t = text.strip().lower()
+    if t.startswith("every"):
+        t = t[len("every"):].strip()
+    m = re.fullmatch(r"(\d+)\s*([smhd])", t)
+    if m:
+        return int(m.group(1)) * {"s": 1, "m": 60, "h": 3600, "d": 86400}[m.group(2)]
+    m = re.fullmatch(r"(\d+)\s*(second|minute|hour|day)s?", t)
+    if m:
+        return int(m.group(1)) * {"second": 1, "minute": 60, "hour": 3600, "day": 86400}[m.group(2)]
+    return None
+
+
+def _grok_record_text(rec: Dict[str, Any]) -> str:
+    """Flatten a Grok chat_history.jsonl record's content to plain text."""
+    c = rec.get("content")
+    if isinstance(c, str):
+        return c
+    if isinstance(c, list):
+        return "\n".join(
+            b.get("text", "") for b in c if isinstance(b, dict) and b.get("type") == "text"
+        )
+    return ""
+
+
+def _grok_strip_reminder(text: str) -> str:
+    """Strip the <user_query>/<system-reminder> scheduler wrapper, leaving the
+    actual prompt the loop runs each fire."""
+    t = re.sub(r"<system-reminder>.*?</system-reminder>", "", text, flags=re.DOTALL)
+    t = t.replace("<user_query>", "").replace("</user_query>", "")
+    return t.strip()
+
+
+def _grok_loop_detect(
+    sess_dir: Path, tools_used: List[str], created_iso: Optional[str], updated_iso: Optional[str]
+) -> Optional[Dict[str, Any]]:
+    """Detect a Grok Build recurring scheduler loop for one session.
+
+    Gated on `scheduler_create` appearing in signals.toolsUsed (cheap — already
+    loaded) so the fuller chat_history/events scan only runs for the rare
+    session that actually set up a loop. Recurrence signature: scheduler_fired
+    records in chat_history.jsonl whose reminder text names the task id +
+    interval + "recurring". created_at and cancellation come from the
+    timestamped scheduler_create / scheduler_delete events in events.jsonl.
+
+    Grok exposes only a session-level context-token total (no per-turn split),
+    so a per-fire footprint isn't computable — footprint_tokens/cost are 0 and
+    the loop surfaces its cadence + fire count without a fabricated cost.
+    Requires at least one firing (that's where the task id + interval live); a
+    created-but-never-fired Grok task isn't detected.
+    """
+    if "scheduler_create" not in (tools_used or []):
+        return None
+    chat_path = sess_dir / GROK_CHAT_HISTORY
+    if not chat_path.exists():
+        return None
+
+    task_id: Optional[str] = None
+    interval_text: Optional[str] = None
+    prompt_preview: Optional[str] = None
+    iterations = 0
+    try:
+        with open(chat_path, "r", encoding="utf-8", errors="ignore") as f:
+            for line in f:
+                if "scheduler_fired" not in line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except Exception:
+                    continue
+                if rec.get("synthetic_reason") != "scheduler_fired":
+                    continue
+                text = _grok_record_text(rec)
+                m = _GROK_LOOP_RE.search(text or "")
+                if not m or m.group(3).lower() != "recurring":
+                    continue
+                iterations += 1
+                if task_id is None:
+                    task_id = m.group(1)
+                    interval_text = (m.group(2) or "").strip()
+                    prompt_preview = _grok_strip_reminder(text)
+    except Exception:
+        return None
+
+    if iterations == 0 or not task_id:
+        return None
+
+    # created_at + cancellation from the timestamped scheduler_* tool events.
+    created_at: Optional[str] = None
+    cancelled = False
+    cancelled_at: Optional[str] = None
+    events_path = sess_dir / GROK_EVENTS
+    if events_path.exists():
+        try:
+            with open(events_path, "r", encoding="utf-8", errors="ignore") as f:
+                for line in f:
+                    if "scheduler_" not in line:
+                        continue
+                    try:
+                        ev = json.loads(line)
+                    except Exception:
+                        continue
+                    name = ev.get("tool_name")
+                    ets = ev.get("ts")
+                    if name == "scheduler_create" and created_at is None:
+                        created_at = ets
+                    elif (name == "scheduler_delete" and ev.get("type") == "tool_completed"
+                          and ev.get("outcome") == "success"):
+                        cancelled = True
+                        cancelled_at = ets
+        except Exception:
+            pass
+
+    return {
+        "is_loop": True,
+        "mode": "scheduler",                 # Grok Tasks scheduler (fixed interval)
+        "cadence": interval_text or "",
+        "cadence_seconds": _grok_interval_to_seconds(interval_text),
+        "recurring": True,
+        "job_id": task_id,
+        "source_signal": "grok_scheduler",
+        "prompt_preview": (prompt_preview or "")[:160],
+        "created_at": created_at or created_iso,
+        "last_fired": updated_iso,           # grok fires carry no per-record ts; session's last activity ≈ last fire
+        "iterations": iterations,
+        "cancelled": cancelled,
+        "cancelled_at": cancelled_at,
+        "footprint_tokens": 0,               # grok has no per-turn token split
+        "footprint_cost": 0,
+    }
+
+
 def _scan_grok_sessions() -> List[Dict[str, Any]]:
     """Scan Grok Build sessions under ~/.grok/sessions/.
 
@@ -2335,6 +2486,17 @@ def _scan_grok_sessions() -> List[Dict[str, Any]]:
                     "last_active_at": summary.get("last_active_at"),
                 },
             }
+            # Recurring loop (/loop / Grok Tasks scheduler). Gated on
+            # scheduler_create in signals.toolsUsed so the deeper scan is skipped
+            # for the vast majority of sessions.
+            loop = _grok_loop_detect(
+                sess_id_dir,
+                tools_used if isinstance(tools_used, list) else [],
+                created, updated,
+            )
+            if loop:
+                sess["loop"] = loop
+
             if grok_spawns:
                 by_type: Dict[str, Dict[str, Any]] = {}
                 for sp in grok_spawns:

--- a/backend/main.py
+++ b/backend/main.py
@@ -2638,6 +2638,74 @@ def _scan_smallcode_sessions(roots: Iterable[str]) -> List[Dict[str, Any]]:
     return out
 
 
+def _cline_loop_specs(db_path: Path) -> Dict[str, Dict[str, Any]]:
+    """Read Cline "Scheduled Agents" from cron.db and return {anchor_session_id:
+    loop_dict} for each genuinely recurring schedule.
+
+    Cline's model differs from Claude/Grok: a recurring schedule is a row in
+    `cron_specs` (trigger_kind='schedule'), and every firing spawns its OWN
+    Cline session, recorded in `cron_runs` with a session_id. To reuse the
+    session-based loop UI we anchor the loop to the LATEST run's session (the
+    most recent fire) — the same "loop lives in the session that ran it" model
+    Grok uses. A schedule that has never fired (no run with a session_id) has no
+    anchor and isn't surfaced. one_off/event triggers are not loops.
+
+    Cline's per-run sessions are each counted on their own, so the loop's
+    footprint is left at 0 here (iterations + cadence carry the signal) rather
+    than re-summing already-counted child sessions.
+    """
+    out: Dict[str, Dict[str, Any]] = {}
+    if not db_path.exists():
+        return out
+    try:
+        uri = _sqlite_ro_uri(db_path)
+        conn = sqlite3.connect(uri, uri=True, timeout=1.0)
+        conn.row_factory = sqlite3.Row
+        try:
+            specs = conn.execute(
+                "SELECT * FROM cron_specs WHERE trigger_kind='schedule'"
+            ).fetchall()
+            for spec in specs:
+                spec_id = spec["spec_id"]
+                runs = conn.execute(
+                    "SELECT session_id, status, completed_at, created_at FROM cron_runs "
+                    "WHERE spec_id=? ORDER BY created_at DESC",
+                    (spec_id,),
+                ).fetchall()
+                # Anchor to the most recent run that actually has a session.
+                anchor = next((r["session_id"] for r in runs if r["session_id"]), None)
+                if not anchor:
+                    continue
+                fired = [r for r in runs if r["status"] in ("done", "failed", "cancelled")]
+                schedule_expr = spec["schedule_expr"]
+                removed = bool(spec["removed"]) if "removed" in spec.keys() else False
+                enabled = bool(spec["enabled"]) if "enabled" in spec.keys() else True
+                cancelled = removed or not enabled
+                out[anchor] = {
+                    "is_loop": True,
+                    "mode": "cron",                       # cron/interval schedule, NOT a Claude 7-day cron
+                    "cadence": schedule_expr or "",
+                    "cadence_seconds": _cron_to_seconds(schedule_expr) if schedule_expr else None,
+                    "recurring": True,
+                    "job_id": spec["external_id"] or spec_id,
+                    "source_signal": "cline_schedule",
+                    "prompt_preview": ((spec["prompt"] if "prompt" in spec.keys() else None)
+                                       or spec["title"] or "")[:160],
+                    "created_at": spec["created_at"] if "created_at" in spec.keys() else None,
+                    "last_fired": (spec["last_run_at"] if "last_run_at" in spec.keys() else None),
+                    "iterations": len(fired),
+                    "cancelled": cancelled,
+                    "cancelled_at": (spec["updated_at"] if cancelled and "updated_at" in spec.keys() else None),
+                    "footprint_tokens": 0,                # each fire is its own already-counted session
+                    "footprint_cost": 0,
+                }
+        finally:
+            conn.close()
+    except Exception:
+        return out
+    return out
+
+
 def _scan_cline_sessions() -> List[Dict[str, Any]]:
     """Scan Cline sessions from BOTH stores it writes to, deduping by session id
     (the CLI row wins when a session id appears in both).
@@ -2873,6 +2941,15 @@ def _scan_cline_sessions() -> List[Dict[str, Any]]:
                     },
                 })
                 seen_ids.add(sid)
+
+    # Recurring "Scheduled Agents" (cron.db) — anchor each schedule's loop to its
+    # latest run session. Gated on the file existing; cheap SQLite read.
+    loop_by_sid = _cline_loop_specs(CLINE_DIR / "data" / "db" / "cron.db")
+    if loop_by_sid:
+        for rec in out:
+            lp = loop_by_sid.get(rec["id"])
+            if lp:
+                rec["loop"] = lp
 
     return out
 

--- a/backend/test_loops.py
+++ b/backend/test_loops.py
@@ -386,3 +386,147 @@ def test_grok_loop_lifecycle_no_7day_cap(tmp_path):
     assert lp["expires_at"] is None                 # no 7-day cap for scheduler mode
     assert lp["state"] == "expired"
     assert lp["expired_reason"] == "stale_session_ended"
+
+
+# --- Cline "Scheduled Agents" (cron.db) -------------------------------------
+
+def _cline_cron_db(path, *, specs, runs):
+    """Build a cron.db with the real (subset) Cline schema and seed rows."""
+    import sqlite3 as _sq
+    conn = _sq.connect(str(path))
+    conn.execute("""CREATE TABLE cron_specs (
+        spec_id TEXT PRIMARY KEY, external_id TEXT, source_path TEXT,
+        trigger_kind TEXT, enabled INTEGER DEFAULT 1, removed INTEGER DEFAULT 0,
+        title TEXT, prompt TEXT, schedule_expr TEXT, last_run_at TEXT,
+        next_run_at TEXT, created_at TEXT, updated_at TEXT)""")
+    conn.execute("""CREATE TABLE cron_runs (
+        run_id TEXT PRIMARY KEY, spec_id TEXT, trigger_kind TEXT, status TEXT,
+        session_id TEXT, completed_at TEXT, created_at TEXT)""")
+    conn.executemany(
+        "INSERT INTO cron_specs (spec_id,external_id,source_path,trigger_kind,enabled,"
+        "removed,title,prompt,schedule_expr,last_run_at,next_run_at,created_at,updated_at) "
+        "VALUES (:spec_id,:external_id,:source_path,:trigger_kind,:enabled,:removed,:title,"
+        ":prompt,:schedule_expr,:last_run_at,:next_run_at,:created_at,:updated_at)", specs)
+    conn.executemany(
+        "INSERT INTO cron_runs (run_id,spec_id,trigger_kind,status,session_id,completed_at,created_at) "
+        "VALUES (:run_id,:spec_id,:trigger_kind,:status,:session_id,:completed_at,:created_at)", runs)
+    conn.commit()
+    conn.close()
+
+
+def test_cline_loop_specs_schedule(tmp_path):
+    db = tmp_path / "cron.db"
+    _cline_cron_db(
+        db,
+        specs=[{"spec_id": "spec-1", "external_id": "nightly-audit", "source_path": "/w/a.md",
+                "trigger_kind": "schedule", "enabled": 1, "removed": 0, "title": "Nightly audit",
+                "prompt": "Audit the repo for new TODOs", "schedule_expr": "0 9 * * *",
+                "last_run_at": "2026-07-16T09:00:00Z", "next_run_at": "2026-07-17T09:00:00Z",
+                "created_at": "2026-07-10T09:00:00Z", "updated_at": "2026-07-16T09:00:00Z"}],
+        runs=[
+            {"run_id": "r1", "spec_id": "spec-1", "trigger_kind": "schedule", "status": "done",
+             "session_id": "sess-old", "completed_at": "2026-07-15T09:00:00Z", "created_at": "2026-07-15T09:00:00Z"},
+            {"run_id": "r2", "spec_id": "spec-1", "trigger_kind": "schedule", "status": "done",
+             "session_id": "sess-latest", "completed_at": "2026-07-16T09:00:00Z", "created_at": "2026-07-16T09:00:00Z"},
+        ],
+    )
+    loops = main._cline_loop_specs(db)
+    # Anchored to the LATEST run's session, not the older one.
+    assert set(loops.keys()) == {"sess-latest"}
+    lp = loops["sess-latest"]
+    assert lp["is_loop"] is True
+    assert lp["mode"] == "cron"
+    assert lp["job_id"] == "nightly-audit"
+    assert lp["cadence"] == "0 9 * * *"
+    assert lp["cadence_seconds"] == 86400          # daily
+    assert lp["iterations"] == 2                    # both done runs
+    assert lp["prompt_preview"].startswith("Audit the repo")
+    assert lp["cancelled"] is False
+    assert lp["footprint_tokens"] == 0             # each fire is its own counted session
+
+
+def test_cline_loop_specs_ignores_one_off_and_disabled(tmp_path):
+    db = tmp_path / "cron.db"
+    _cline_cron_db(
+        db,
+        specs=[
+            {"spec_id": "one", "external_id": "x", "source_path": "/w/1.md", "trigger_kind": "one_off",
+             "enabled": 1, "removed": 0, "title": "once", "prompt": "p", "schedule_expr": None,
+             "last_run_at": None, "next_run_at": None, "created_at": "2026-07-16T00:00:00Z",
+             "updated_at": "2026-07-16T00:00:00Z"},
+            {"spec_id": "disabled", "external_id": "y", "source_path": "/w/2.md", "trigger_kind": "schedule",
+             "enabled": 0, "removed": 0, "title": "paused", "prompt": "p", "schedule_expr": "0 * * * *",
+             "last_run_at": "2026-07-16T00:00:00Z", "next_run_at": None, "created_at": "2026-07-10T00:00:00Z",
+             "updated_at": "2026-07-16T00:00:00Z"},
+        ],
+        runs=[
+            {"run_id": "a", "spec_id": "one", "trigger_kind": "one_off", "status": "done",
+             "session_id": "s-oneoff", "completed_at": "2026-07-16T00:00:00Z", "created_at": "2026-07-16T00:00:00Z"},
+            {"run_id": "b", "spec_id": "disabled", "trigger_kind": "schedule", "status": "done",
+             "session_id": "s-disabled", "completed_at": "2026-07-16T00:00:00Z", "created_at": "2026-07-16T00:00:00Z"},
+        ],
+    )
+    loops = main._cline_loop_specs(db)
+    # one_off is not a loop; the disabled schedule IS surfaced but marked cancelled.
+    assert "s-oneoff" not in loops
+    assert "s-disabled" in loops
+    assert loops["s-disabled"]["cancelled"] is True
+
+
+def test_cline_loop_specs_never_fired_has_no_anchor(tmp_path):
+    db = tmp_path / "cron.db"
+    _cline_cron_db(
+        db,
+        specs=[{"spec_id": "spec-nf", "external_id": "z", "source_path": "/w/3.md", "trigger_kind": "schedule",
+                "enabled": 1, "removed": 0, "title": "never fired", "prompt": "p", "schedule_expr": "0 9 * * *",
+                "last_run_at": None, "next_run_at": "2026-07-20T09:00:00Z", "created_at": "2026-07-16T00:00:00Z",
+                "updated_at": "2026-07-16T00:00:00Z"}],
+        runs=[],
+    )
+    assert main._cline_loop_specs(db) == {}
+
+
+def test_cline_loop_specs_missing_db(tmp_path):
+    assert main._cline_loop_specs(tmp_path / "nope.db") == {}
+
+
+def test_cline_scan_attaches_loop_to_anchor_session(tmp_path, monkeypatch):
+    """End-to-end: a schedule in cron.db attaches its loop to the matching
+    session row from sessions.db, and only that one."""
+    import sqlite3 as _sq
+    db_dir = tmp_path / "data" / "db"
+    db_dir.mkdir(parents=True)
+    # Minimal sessions.db with the columns the scanner reads.
+    sdb = _sq.connect(str(db_dir / "sessions.db"))
+    sdb.execute("""CREATE TABLE sessions (
+        session_id TEXT, model TEXT, workspace_root TEXT, cwd TEXT, started_at TEXT,
+        metadata_json TEXT, messages_path TEXT, prompt TEXT, provider TEXT, status TEXT,
+        is_subagent INTEGER, parent_session_id TEXT, agent_id TEXT, team_name TEXT)""")
+    for sid in ("sess-latest", "sess-plain"):
+        sdb.execute(
+            "INSERT INTO sessions (session_id,model,workspace_root,cwd,started_at,metadata_json,"
+            "messages_path,prompt,provider,status,is_subagent,parent_session_id,agent_id,team_name) "
+            "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+            (sid, "claude-opus-4-8", "/w", "/w", "2026-07-16T09:00:00Z",
+             '{"usage":{"inputTokens":100,"outputTokens":50}}', None, "hi", "anthropic",
+             "done", 0, None, None, None))
+    sdb.commit(); sdb.close()
+
+    _cline_cron_db(
+        db_dir / "cron.db",
+        specs=[{"spec_id": "spec-1", "external_id": "nightly", "source_path": "/w/a.md",
+                "trigger_kind": "schedule", "enabled": 1, "removed": 0, "title": "Nightly",
+                "prompt": "Do the nightly thing", "schedule_expr": "0 9 * * *",
+                "last_run_at": "2026-07-16T09:00:00Z", "next_run_at": "2026-07-17T09:00:00Z",
+                "created_at": "2026-07-10T09:00:00Z", "updated_at": "2026-07-16T09:00:00Z"}],
+        runs=[{"run_id": "r2", "spec_id": "spec-1", "trigger_kind": "schedule", "status": "done",
+               "session_id": "sess-latest", "completed_at": "2026-07-16T09:00:00Z",
+               "created_at": "2026-07-16T09:00:00Z"}],
+    )
+
+    monkeypatch.setattr(main, "CLINE_DIR", tmp_path)
+    monkeypatch.setattr(main, "CLINE_VSCODE_DIR", tmp_path / "no_vscode")
+    monkeypatch.setattr(main, "_load_project_aliases", lambda: {})
+    sessions = {s["id"]: s for s in main._scan_cline_sessions()}
+    assert "loop" in sessions["sess-latest"] and sessions["sess-latest"]["loop"]["job_id"] == "nightly"
+    assert "loop" not in sessions["sess-plain"]

--- a/backend/test_loops.py
+++ b/backend/test_loops.py
@@ -281,3 +281,108 @@ def test_scan_loop_footprint_only_counts_fire_turns(scan_env):
     assert lp["footprint_cost"] <= (s.get("cost") or 0) + 1e-9
     # The tool_result echoing "do X" was NOT counted as a fire.
     assert lp["iterations"] == 1
+
+
+# --- Grok Build scheduler loop (~/.grok/sessions/.../chat_history.jsonl) -----
+
+@pytest.mark.parametrize("text,expected", [
+    ("every 2 hours", 7200),
+    ("2h", 7200),
+    ("every 30 minutes", 1800),
+    ("30 minutes", 1800),
+    ("60s", 60),
+    ("45 seconds", 45),
+    ("1 day", 86400),
+    ("1d", 86400),
+    ("every 5 minutes", 300),
+    ("garbage", None),
+    (None, None),
+])
+def test_grok_interval_to_seconds(text, expected):
+    assert main._grok_interval_to_seconds(text) == expected
+
+
+def _grok_fire(prompt="Run /tt-hot-topics-post for Reddit.", task="019f6409a0a1",
+               interval="every 2 hours", recurring=True):
+    reminder = (f"<user_query>\n<system-reminder>\nThis is a scheduled task execution "
+                f"(task {task}, {interval}, {'recurring' if recurring else 'once'}).\n"
+                f"</system-reminder>\n\n{prompt}")
+    return {"type": "user", "synthetic_reason": "scheduler_fired",
+            "content": [{"type": "text", "text": reminder}]}
+
+
+def _grok_session_dir(tmp_path, *, fires, events=None):
+    d = tmp_path / "grok_sess"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / main.GROK_CHAT_HISTORY).write_text(
+        "".join(json.dumps(x) + "\n" for x in fires), encoding="utf-8")
+    if events is not None:
+        (d / main.GROK_EVENTS).write_text(
+            "".join(json.dumps(x) + "\n" for x in events), encoding="utf-8")
+    return d
+
+
+def test_grok_loop_detect_happy_path(tmp_path):
+    fires = [_grok_fire() for _ in range(8)]
+    events = [
+        {"ts": "2026-07-15T04:29:40.384Z", "type": "tool_completed",
+         "tool_name": "scheduler_create", "outcome": "success"},
+        {"ts": "2026-07-17T18:31:46.026Z", "type": "tool_completed",
+         "tool_name": "scheduler_delete", "outcome": "success"},
+    ]
+    d = _grok_session_dir(tmp_path, fires=fires, events=events)
+    lp = main._grok_loop_detect(d, ["scheduler_create", "scheduler_delete"],
+                                "2026-07-15T04:00:00Z", "2026-07-15T20:00:00Z")
+    assert lp is not None
+    assert lp["is_loop"] is True
+    assert lp["mode"] == "scheduler"
+    assert lp["job_id"] == "019f6409a0a1"
+    assert lp["cadence"] == "every 2 hours"
+    assert lp["cadence_seconds"] == 7200
+    assert lp["iterations"] == 8
+    assert lp["recurring"] is True
+    assert lp["source_signal"] == "grok_scheduler"
+    assert lp["prompt_preview"].startswith("Run /tt-hot-topics-post")
+    # created_at comes from the scheduler_create event; cancel from scheduler_delete.
+    assert lp["created_at"] == "2026-07-15T04:29:40.384Z"
+    assert lp["cancelled"] is True
+    assert lp["cancelled_at"] == "2026-07-17T18:31:46.026Z"
+    # Grok exposes no per-turn token split -> honest zero footprint (no fabrication).
+    assert lp["footprint_tokens"] == 0
+    assert lp["footprint_cost"] == 0
+
+
+def test_grok_loop_detect_gated_on_scheduler_create(tmp_path):
+    """No scheduler_create in signals.toolsUsed -> the deeper scan never runs."""
+    d = _grok_session_dir(tmp_path, fires=[_grok_fire()])
+    assert main._grok_loop_detect(d, ["read_file", "grep"], None, None) is None
+
+
+def test_grok_loop_detect_ignores_one_shot(tmp_path):
+    """A scheduled run marked 'once' (not recurring) is not a loop."""
+    d = _grok_session_dir(tmp_path, fires=[_grok_fire(recurring=False)])
+    assert main._grok_loop_detect(d, ["scheduler_create"], None, None) is None
+
+
+def test_grok_loop_detect_requires_a_fire(tmp_path):
+    """scheduler_create present but zero firings -> not detected (task id +
+    interval only exist in the fire reminder)."""
+    d = _grok_session_dir(tmp_path, fires=[
+        {"type": "user", "content": [{"type": "text", "text": "ordinary prompt"}]}])
+    assert main._grok_loop_detect(d, ["scheduler_create"], None, None) is None
+
+
+def test_grok_loop_lifecycle_no_7day_cap(tmp_path):
+    """A Grok 'scheduler' loop is a fixed interval but NOT a Claude cron, so the
+    7-day auto-expiry must not apply — an old, uncancelled one ages to expired
+    via cadence staleness, not the cron ceiling."""
+    fires = [_grok_fire() for _ in range(3)]
+    d = _grok_session_dir(tmp_path, fires=fires)
+    lp = main._grok_loop_detect(d, ["scheduler_create"],
+                                _iso(NOW - timedelta(days=10)),
+                                _iso(NOW - timedelta(days=9)))
+    s = {"id": "g", "agent": "grok", "loop": lp}
+    main._annotate_loop_lifecycle([s], NOW)
+    assert lp["expires_at"] is None                 # no 7-day cap for scheduler mode
+    assert lp["state"] == "expired"
+    assert lp["expired_reason"] == "stale_session_ended"

--- a/frontend/src/app/analytics/page.tsx
+++ b/frontend/src/app/analytics/page.tsx
@@ -695,9 +695,15 @@ function RecurringLoopsSection({ data }: { data: AnalyticsData }) {
                   </span>
                   <span className="text-right shrink-0">
                     <span className="block tabular font-semibold text-[var(--tt-fg)]" title="observed fires (lower bound)">≥{l.iterations.toLocaleString()}</span>
-                    <span className="block tabular text-[var(--tt-fg-dim)]" title="the loop's own fire-response turns">{compact(l.tokens)} tok · ${l.cost.toFixed(2)}</span>
-                    {l.session_cost != null && l.session_cost > l.cost + 0.005 && (
-                      <span className="block tabular text-[var(--tt-fg-dim)] text-[10px] opacity-70">of ${l.session_cost.toFixed(2)} session</span>
+                    {l.tokens > 0 ? (
+                      <>
+                        <span className="block tabular text-[var(--tt-fg-dim)]" title="the loop's own fire-response turns">{compact(l.tokens)} tok · ${l.cost.toFixed(2)}</span>
+                        {l.session_cost != null && l.session_cost > l.cost + 0.005 && (
+                          <span className="block tabular text-[var(--tt-fg-dim)] text-[10px] opacity-70">of ${l.session_cost.toFixed(2)} session</span>
+                        )}
+                      </>
+                    ) : (
+                      <span className="block tabular text-[var(--tt-fg-dim)] text-[10px] opacity-70" title="this agent exposes no per-turn token split">tokens n/a</span>
                     )}
                   </span>
                 </li>

--- a/frontend/src/app/projects/[path]/_lib/loops.ts
+++ b/frontend/src/app/projects/[path]/_lib/loops.ts
@@ -134,16 +134,17 @@ export function loopStateTone(s: LoopState) {
   return LOOP_STATE[s] ?? LOOP_STATE.unknown;
 }
 
-/** Human interval from cadence_seconds + mode (matches the trace LoopCard). */
+/** Human interval from cadence_seconds + mode (matches the trace LoopCard).
+    Only Claude's dynamic ScheduleWakeup loop is a self-pacing heartbeat; every
+    other mode (Claude fixed_cron, Grok's "scheduler") is a fixed interval. */
 export function loopInterval(row: Pick<LoopRow, "cadenceSeconds" | "mode">): string {
   const s = row.cadenceSeconds;
-  if (row.mode === "fixed_cron") {
-    if (s && s % 86400 === 0) return `Every ${s / 86400}d`;
-    if (s && s % 3600 === 0) return `Every ${s / 3600}h`;
-    if (s && s % 60 === 0) return `Every ${s / 60}m`;
-    return s ? `Every ${s}s` : "Cron schedule";
-  }
-  return s ? `~${s}s heartbeat` : "Self-paced";
+  if (row.mode === "dynamic") return s ? `~${s}s heartbeat` : "Self-paced";
+  if (s && s % 86400 === 0) return `Every ${s / 86400}d`;
+  if (s && s % 3600 === 0) return `Every ${s / 3600}h`;
+  if (s && s % 60 === 0) return `Every ${s / 60}m`;
+  if (s) return `Every ${s}s`;
+  return row.mode === "fixed_cron" ? "Cron schedule" : "Self-paced";
 }
 
 export function loopReasonLabel(r?: string | null): string {

--- a/frontend/src/app/projects/[path]/_lib/loops.ts
+++ b/frontend/src/app/projects/[path]/_lib/loops.ts
@@ -1,0 +1,177 @@
+/* Project-scoped /loop derivation.
+ *
+ * The project tabs already hold this project's session rows (project-context),
+ * and each row carries the full `loop` field the backend scan annotated
+ * (lifecycle state + fire-turn footprint). So the per-project loop breakdown is
+ * a pure client-side fold over those rows — no extra fetch, and it stays in
+ * lockstep with the project filter for free.
+ *
+ * This deliberately mirrors backend/main.py's /analytics `loops`/`by_loop`
+ * aggregation so the numbers match the global Analytics tab exactly:
+ *   - footprint tokens/cost are the loop's OWN fire-response turns, never the
+ *     whole session (a loop session does plenty of non-loop work too);
+ *   - the per-loop map is keyed by job_id || session_id (last write wins, same
+ *     as the backend dict), while the summary counters count every loop session.
+ * Loop tokens/cost are an attribution VIEW — already part of session totals,
+ * never re-summed into them.
+ */
+import type { SessionLoop, SessionRow } from "./project-context";
+
+export interface LoopRow {
+  key: string;
+  sessionId: string;
+  agent: string;
+  label: string;
+  state: LoopState;
+  mode: string;
+  cadence: string;
+  cadenceSeconds?: number;
+  recurring: boolean;
+  iterations: number;
+  tokens: number;         // footprint (loop fire turns only)
+  cost: number;           // footprint
+  sessionTokens: number;
+  sessionCost: number;
+  jobId?: string | null;
+  sourceSignal?: string;
+  createdAt?: string | null;
+  lastFired?: string | null;
+  expiresAt?: string | null;
+  expiredReason?: string | null;
+  cancelledAt?: string | null;
+}
+
+export interface LoopSummary {
+  total: number;
+  active: number;
+  expired: number;
+  cancelled: number;
+  unknown: number;
+  loopSessions: number;
+  totalIterations: number;
+  loopTokens: number;
+  loopCost: number;
+}
+
+export type LoopState = "active" | "expired" | "cancelled" | "unknown";
+
+function normState(s?: string): LoopState {
+  return s === "active" || s === "expired" || s === "cancelled" ? s : "unknown";
+}
+
+export interface ProjectLoops {
+  rows: LoopRow[];
+  summary: LoopSummary;
+}
+
+export function deriveProjectLoops(sessions: SessionRow[]): ProjectLoops {
+  const summary: LoopSummary = {
+    total: 0, active: 0, expired: 0, cancelled: 0, unknown: 0,
+    loopSessions: 0, totalIterations: 0, loopTokens: 0, loopCost: 0,
+  };
+  const byKey = new Map<string, LoopRow>();
+
+  for (const s of sessions) {
+    const lp: SessionLoop | undefined = s.loop;
+    if (!lp || !lp.is_loop) continue;
+
+    const state = normState(lp.state);
+    summary.total += 1;
+    summary.loopSessions += 1;
+    if (state === "active") summary.active += 1;
+    else if (state === "expired") summary.expired += 1;
+    else if (state === "cancelled") summary.cancelled += 1;
+    else summary.unknown += 1;
+
+    const iterations = lp.iterations || 0;
+    const tokens = lp.footprint_tokens || 0;
+    const cost = lp.footprint_cost || 0;
+    summary.totalIterations += iterations;
+    summary.loopTokens += tokens;
+    summary.loopCost += cost;
+
+    const key = lp.job_id || s.id;
+    byKey.set(key, {
+      key,
+      sessionId: s.id,
+      agent: s.agent,
+      label: lp.prompt_preview || "",
+      state,
+      mode: lp.mode || "",
+      cadence: lp.cadence || "",
+      cadenceSeconds: lp.cadence_seconds,
+      recurring: lp.recurring !== false,
+      iterations,
+      tokens,
+      cost,
+      sessionTokens: s.tokens?.total || 0,
+      sessionCost: s.cost || 0,
+      jobId: lp.job_id,
+      sourceSignal: lp.source_signal,
+      createdAt: lp.created_at,
+      lastFired: lp.last_fired,
+      expiresAt: lp.expires_at,
+      expiredReason: lp.expired_reason,
+      cancelledAt: lp.cancelled_at,
+    });
+  }
+
+  const rows = [...byKey.values()].sort((a, b) => b.iterations - a.iterations);
+  summary.loopCost = Number(summary.loopCost.toFixed(6));
+  return { rows, summary };
+}
+
+/* ── Presentation helpers (shared by config + insights tabs) ── */
+
+export const LOOP_STATE: Record<LoopState, { dot: string; label: string; ring: string }> = {
+  active:    { dot: "bg-emerald-400",                                          label: "text-emerald-300",       ring: "border-emerald-500/40" },
+  expired:   { dot: "bg-[var(--tt-fg-dim)]",                                   label: "text-[var(--tt-fg-dim)]", ring: "border-[var(--tt-border)]" },
+  cancelled: { dot: "bg-amber-400",                                           label: "text-amber-300",         ring: "border-amber-500/40" },
+  unknown:   { dot: "bg-transparent border border-[var(--tt-border-strong)]", label: "text-[var(--tt-fg-muted)]", ring: "border-[var(--tt-border)]" },
+};
+
+export function loopStateTone(s: LoopState) {
+  return LOOP_STATE[s] ?? LOOP_STATE.unknown;
+}
+
+/** Human interval from cadence_seconds + mode (matches the trace LoopCard). */
+export function loopInterval(row: Pick<LoopRow, "cadenceSeconds" | "mode">): string {
+  const s = row.cadenceSeconds;
+  if (row.mode === "fixed_cron") {
+    if (s && s % 86400 === 0) return `Every ${s / 86400}d`;
+    if (s && s % 3600 === 0) return `Every ${s / 3600}h`;
+    if (s && s % 60 === 0) return `Every ${s / 60}m`;
+    return s ? `Every ${s}s` : "Cron schedule";
+  }
+  return s ? `~${s}s heartbeat` : "Self-paced";
+}
+
+export function loopReasonLabel(r?: string | null): string {
+  return (
+    {
+      cron_expired_7d: "reached its 7-day auto-expiry",
+      one_shot_completed: "ran once and finished",
+      stale_session_ended: "session ended (no recent fire)",
+      cancelled: "cancelled",
+    } as Record<string, string>
+  )[r || ""] || r || "";
+}
+
+export function loopRel(iso?: string | null): string {
+  if (!iso) return "";
+  const t = new Date(iso).getTime();
+  if (isNaN(t)) return "";
+  const diff = Date.now() - t;
+  const abs = Math.abs(diff);
+  const unit =
+    abs >= 86400000 ? `${Math.round(abs / 86400000)}d`
+    : abs >= 3600000 ? `${Math.round(abs / 3600000)}h`
+    : `${Math.round(abs / 60000)}m`;
+  return diff >= 0 ? `${unit} ago` : `in ${unit}`;
+}
+
+export function loopFmtNum(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}

--- a/frontend/src/app/projects/[path]/_lib/project-context.tsx
+++ b/frontend/src/app/projects/[path]/_lib/project-context.tsx
@@ -38,6 +38,37 @@ export interface SessionRow {
   subagent_info?: { role?: string; nickname?: string; depth?: number };
   skills_used?: { name: string; count: number }[];
   mcp_usage?: Record<string, Record<string, number>>;
+  /* /loop telemetry; present only on sessions that scheduled a recurring loop.
+     Lifecycle (state/active/expires_at/expired_reason) is annotated by the
+     backend scan; footprint_* are the loop's own fire-turn tokens, not the
+     whole session. See SessionLoop and _lib/loops.ts. */
+  loop?: SessionLoop;
+}
+
+/* Mirror of backend sess["loop"] (backend/main.py) — raw facts plus the
+   per-request lifecycle annotation. All fields optional/loose because the
+   shape is owned by the scanner; consumers guard on `is_loop`. */
+export interface SessionLoop {
+  is_loop?: boolean;
+  mode?: string;                // "fixed_cron" | "dynamic"
+  cadence?: string;             // human cadence, e.g. "every 1h"
+  cadence_seconds?: number;
+  recurring?: boolean;
+  job_id?: string | null;
+  source_signal?: string;
+  prompt_preview?: string;
+  created_at?: string | null;
+  last_fired?: string | null;
+  iterations?: number;
+  cancelled?: boolean;
+  cancelled_at?: string | null;
+  footprint_tokens?: number;
+  footprint_cost?: number;
+  // lifecycle (recomputed per scan, never cached)
+  state?: "active" | "expired" | "cancelled" | "unknown";
+  active?: boolean;
+  expires_at?: string | null;
+  expired_reason?: string | null;
 }
 
 export interface WorktreeSummary {

--- a/frontend/src/app/projects/[path]/config/page.tsx
+++ b/frontend/src/app/projects/[path]/config/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
 import {
   Settings2, Folder, Puzzle, Users, BookOpen, Terminal, Wrench, FileText,
-  Globe, Package,
+  Globe, Package, Repeat, ChevronRight,
 } from "lucide-react";
 
 import { apiFetch } from "@/lib/api";
@@ -11,8 +12,13 @@ import {
   Card, CardHeader, CardTitle, CardEyebrow, Section, Badge, AgentBadge,
   EmptyState, Skeleton,
 } from "@/components/ui";
+import { cn } from "@/lib/cn";
 import BudgetEditor from "@/components/budgets/BudgetEditor";
 import { useProject } from "../_lib/project-context";
+import {
+  deriveProjectLoops, loopStateTone, loopInterval, loopRel, loopFmtNum,
+  type LoopRow,
+} from "../_lib/loops";
 
 interface ConfigItem { name: string; agent: string; scope: "project" | "user"; description?: string; source?: string; pluginRef?: string; [k: string]: unknown }
 interface SubagentItem extends ConfigItem { model?: string; tools?: string }
@@ -39,8 +45,9 @@ interface UsageData {
 }
 
 export default function ConfigTab() {
-  const { decodedPath, project } = useProject();
+  const { decodedPath, project, sessions } = useProject();
   const projectAgents = project?.agents ?? [];
+  const loops = useMemo(() => deriveProjectLoops(sessions), [sessions]);
   const [config, setConfig] = useState<ProjectConfig | null>(null);
   const [usage, setUsage] = useState<UsageData | null>(null);
   const [loading, setLoading] = useState(true);
@@ -106,6 +113,12 @@ export default function ConfigTab() {
     <div className="space-y-7">
       {/* Budgets — set spend limits for this project (overall + per agent) */}
       <BudgetEditor projectPath={decodedPath} agents={projectAgents} />
+
+      {/* Recurring loops set up in this project — the automations a session
+          scheduled to re-run itself (/loop, cron, self-pacing heartbeat).
+          Sits with the rest of the project's configured surface; the Insights
+          tab carries the token/cost breakdown. Self-hides when there are none. */}
+      <ProjectLoopsInventory rows={loops.rows} decodedPath={decodedPath} />
 
       {/* Summary tiles */}
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3">
@@ -386,5 +399,73 @@ function CountChip({ color, label, value }: { color: string; label: string; valu
       <span className="font-semibold tabular" style={{ color }}>{value}</span>
       <span>{label}</span>
     </span>
+  );
+}
+
+/* ─────────────────── Recurring loops (config inventory) ─────────────────── */
+
+function ProjectLoopsInventory({ rows, decodedPath }: { rows: LoopRow[]; decodedPath: string }) {
+  if (rows.length === 0) return null;
+  const active = rows.filter((r) => r.state === "active").length;
+  return (
+    <Section
+      title={<span className="flex items-center gap-2"><Repeat size={12} className="text-[var(--tt-brand)]" /> Recurring loops</span>}
+      description="Sessions in this project that scheduled themselves to re-run — /loop, cron, or a self-pacing heartbeat. Liveness is recomputed from each loop's last fire and cadence; token & cost economics live on the Insights tab."
+      actions={<Badge variant={active > 0 ? "success" : "neutral"} size="sm">{active} active · {rows.length} total</Badge>}
+    >
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        {rows.map((r) => <LoopInventoryCard key={r.key} row={r} decodedPath={decodedPath} />)}
+      </div>
+    </Section>
+  );
+}
+
+function LoopInventoryCard({ row, decodedPath }: { row: LoopRow; decodedPath: string }) {
+  const tone = loopStateTone(row.state);
+  const href = `/sessions/${encodeURIComponent(row.sessionId)}?agent=${encodeURIComponent(row.agent)}&back=${encodeURIComponent(`/projects/${encodeURIComponent(decodedPath)}/config`)}`;
+  return (
+    <Link
+      href={href}
+      className={cn(
+        "group block rounded-[var(--tt-radius-lg)] border bg-[var(--tt-panel)] p-4 transition-colors hover:tt-tint-1",
+        tone.ring,
+      )}
+    >
+      <div className="flex items-start justify-between gap-3 mb-2">
+        <span className="flex items-center gap-1.5 min-w-0">
+          <Repeat size={12} className="text-[var(--tt-brand)] shrink-0" />
+          <span className="text-[11px] font-semibold uppercase tracking-[0.14em] flex items-center gap-1.5" >
+            <span className={cn("w-1.5 h-1.5 rounded-full shrink-0", tone.dot)} />
+            <span className={tone.label}>{row.state}</span>
+          </span>
+        </span>
+        <span className="flex items-center gap-1.5 shrink-0">
+          <AgentBadge agent={row.agent} />
+          <ChevronRight size={13} className="text-[var(--tt-fg-faint)] group-hover:text-[var(--tt-brand)] group-hover:translate-x-0.5 transition-all" />
+        </span>
+      </div>
+
+      {row.label ? (
+        <p className="text-[12px] text-[var(--tt-fg)] leading-relaxed line-clamp-2 mb-2.5" title={row.label}>{row.label}</p>
+      ) : (
+        <p className="text-[12px] text-[var(--tt-fg-dim)] italic mb-2.5">(no prompt captured)</p>
+      )}
+
+      <div className="flex flex-wrap items-center gap-1.5">
+        <Badge variant="brand" size="xs" className="normal-case">{loopInterval(row)}</Badge>
+        <Badge variant="neutral" size="xs" className="normal-case">≥{row.iterations.toLocaleString()} fires</Badge>
+        {row.mode && <Badge variant="neutral" size="xs" className="font-mono normal-case">{row.mode}</Badge>}
+        {row.jobId && <Badge variant="neutral" size="xs" className="font-mono normal-case">{row.jobId}</Badge>}
+      </div>
+
+      {(row.lastFired || row.expiresAt) && (
+        <div className="mt-2.5 flex flex-wrap gap-x-4 gap-y-0.5 text-[10px] text-[var(--tt-fg-dim)] tabular">
+          {row.lastFired && <span>last fired {loopRel(row.lastFired)}</span>}
+          {row.state === "active" && row.expiresAt && <span>expires {loopRel(row.expiresAt)}</span>}
+          {row.state === "expired" && row.expiredReason && <span className="text-[var(--tt-fg-muted)]">{row.expiredReason}</span>}
+          {row.tokens > 0 && <span>{loopFmtNum(row.tokens)} tok · ${row.cost.toFixed(2)} loop turns</span>}
+        </div>
+      )}
+    </Link>
   );
 }

--- a/frontend/src/app/projects/[path]/insights/page.tsx
+++ b/frontend/src/app/projects/[path]/insights/page.tsx
@@ -1,15 +1,23 @@
 "use client";
 
 import { Fragment, useMemo, useState } from "react";
-import { Sparkles, Activity, Flame, Clock4, Wrench, GitBranch, Zap, Cpu } from "lucide-react";
+import Link from "next/link";
+import {
+  Sparkles, Activity, Flame, Clock4, Wrench, GitBranch, Zap, Cpu,
+  Repeat, TrendingUp, DollarSign,
+} from "lucide-react";
 
 import { getAgent } from "@/lib/agents";
 import { cn } from "@/lib/cn";
 import {
-  Card, CardHeader, CardTitle, StatTile, EmptyState,
+  Card, CardHeader, CardTitle, CardEyebrow, StatTile, EmptyState,
 } from "@/components/ui";
 import BudgetCard from "@/components/budgets/BudgetCard";
 import { useProject } from "../_lib/project-context";
+import {
+  deriveProjectLoops, loopStateTone, loopInterval, loopRel, loopFmtNum,
+  type LoopRow, type LoopSummary,
+} from "../_lib/loops";
 
 const DOW_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
@@ -179,6 +187,11 @@ export default function InsightsTab() {
       any: sessionsWithSpawns > 0 || Object.keys(skills).length > 0 || Object.keys(mcp).length > 0,
     };
   }, [sessions]);
+
+  // Recurring loops in this project — same fold the global Analytics tab does,
+  // but scoped to these sessions. Footprint tokens/cost are the loop's own fire
+  // turns, already part of the totals above (an attribution view).
+  const loops = useMemo(() => deriveProjectLoops(sessions), [sessions]);
 
   const totalTokens = insights.agents.reduce((a, [, x]) => a + x.tokens, 0);
   const totalSessions = insights.agents.reduce((a, [, x]) => a + x.count, 0);
@@ -395,6 +408,10 @@ export default function InsightsTab() {
         </Card>
       )}
 
+      {/* Recurring loops — this project's /loop automations, broken down by
+          state and by the token/cost footprint of their own fire turns. */}
+      <RecurringLoopsBreakdown rows={loops.rows} summary={loops.summary} decodedPath={decodedPath} />
+
       {/* Leaderboard + migration ribbon */}
       <Card padding="lg">
         <CardHeader>
@@ -511,6 +528,96 @@ export default function InsightsTab() {
         </Card>
       </div>
     </div>
+  );
+}
+
+/* Recurring loops, scoped to this project. Tiles mirror the global Analytics
+   tab; the list breaks each loop down by its own fire-turn footprint and puts
+   that in context of the whole session ("of $X session"). Self-hides at zero. */
+function RecurringLoopsBreakdown({
+  rows, summary, decodedPath,
+}: { rows: LoopRow[]; summary: LoopSummary; decodedPath: string }) {
+  if (summary.total === 0) return null;
+  return (
+    <Card padding="lg">
+      <CardHeader>
+        <div>
+          <CardTitle><Repeat size={14} className="text-[var(--tt-brand)]" /> Recurring loops</CardTitle>
+          <p className="text-[11px] text-[var(--tt-fg-dim)] mt-0.5">
+            /loop, cron and heartbeat-scheduled sessions that re-run themselves. Token & cost are the loop&apos;s OWN
+            fire turns — a fraction of the session, and already part of the totals above.
+          </p>
+        </div>
+        <CardEyebrow>{rows.length} loop{rows.length === 1 ? "" : "s"}</CardEyebrow>
+      </CardHeader>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-5">
+        <StatTile
+          label="Active loops"
+          value={String(summary.active)}
+          hint={`${summary.total} loop${summary.total === 1 ? "" : "s"} total`}
+          icon={<Repeat size={16} />}
+          accent="var(--tt-success)"
+        />
+        <StatTile
+          label="Expired / cancelled"
+          value={`${summary.expired} / ${summary.cancelled}`}
+          hint={summary.unknown > 0 ? `${summary.unknown} never fired` : "no longer running"}
+          icon={<Repeat size={16} />}
+          accent="var(--tt-fg-dim)"
+        />
+        <StatTile
+          label="Loop runs"
+          value={`≥${summary.totalIterations.toLocaleString()}`}
+          hint={`observed fires (min) across ${summary.loopSessions} session${summary.loopSessions === 1 ? "" : "s"}`}
+          icon={<TrendingUp size={16} />}
+          accent="var(--tt-brand)"
+        />
+        <StatTile
+          label="Loop cost"
+          value={`$${summary.loopCost.toFixed(2)}`}
+          hint={`${loopFmtNum(summary.loopTokens)} tok · loop turns only`}
+          icon={<DollarSign size={16} />}
+          accent="var(--tt-warn)"
+        />
+      </div>
+
+      <div className="space-y-2 max-h-[420px] overflow-y-auto pr-1">
+        {rows.map((r) => {
+          const tone = loopStateTone(r.state);
+          const href = `/sessions/${encodeURIComponent(r.sessionId)}?agent=${encodeURIComponent(r.agent)}&back=${encodeURIComponent(`/projects/${encodeURIComponent(decodedPath)}/insights`)}`;
+          const meta = getAgent(r.agent);
+          return (
+            <Link
+              key={r.key}
+              href={href}
+              className="group flex items-center justify-between gap-3 rounded-[var(--tt-radius)] border border-transparent hover:border-[var(--tt-border)] hover:tt-tint-1 px-2 py-1.5 -mx-1 transition-colors"
+            >
+              <span className="min-w-0 flex items-start gap-2">
+                <span className={cn("w-1.5 h-1.5 rounded-full shrink-0 mt-1.5", tone.dot)} />
+                <span className="min-w-0 flex flex-col">
+                  <span className="text-[12px] text-[var(--tt-fg)] truncate" title={r.label}>{r.label || "(no prompt captured)"}</span>
+                  <span className="text-[10px] text-[var(--tt-fg-dim)] truncate flex items-center gap-1.5">
+                    <span className={cn("uppercase tracking-[0.1em]", tone.label)}>{r.state}</span>
+                    <span>· {loopInterval(r)}</span>
+                    <span className="hidden sm:inline" style={{ color: meta.hex }}>· {meta.label}</span>
+                    {r.state === "active" && r.lastFired && <span className="hidden md:inline">· last fired {loopRel(r.lastFired)}</span>}
+                    {r.state === "expired" && r.expiredReason && <span className="hidden md:inline">· {r.expiredReason}</span>}
+                  </span>
+                </span>
+              </span>
+              <span className="text-right shrink-0">
+                <span className="block tabular font-semibold text-[12px] text-[var(--tt-fg)]" title="observed fires (lower bound)">≥{r.iterations.toLocaleString()}</span>
+                <span className="block tabular text-[10px] text-[var(--tt-fg-dim)]" title="the loop's own fire-response turns">{loopFmtNum(r.tokens)} tok · ${r.cost.toFixed(2)}</span>
+                {r.sessionCost > r.cost + 0.005 && (
+                  <span className="block tabular text-[10px] text-[var(--tt-fg-faint)]">of ${r.sessionCost.toFixed(2)} session</span>
+                )}
+              </span>
+            </Link>
+          );
+        })}
+      </div>
+    </Card>
   );
 }
 

--- a/frontend/src/app/projects/[path]/insights/page.tsx
+++ b/frontend/src/app/projects/[path]/insights/page.tsx
@@ -608,9 +608,15 @@ function RecurringLoopsBreakdown({
               </span>
               <span className="text-right shrink-0">
                 <span className="block tabular font-semibold text-[12px] text-[var(--tt-fg)]" title="observed fires (lower bound)">≥{r.iterations.toLocaleString()}</span>
-                <span className="block tabular text-[10px] text-[var(--tt-fg-dim)]" title="the loop's own fire-response turns">{loopFmtNum(r.tokens)} tok · ${r.cost.toFixed(2)}</span>
-                {r.sessionCost > r.cost + 0.005 && (
-                  <span className="block tabular text-[10px] text-[var(--tt-fg-faint)]">of ${r.sessionCost.toFixed(2)} session</span>
+                {r.tokens > 0 ? (
+                  <>
+                    <span className="block tabular text-[10px] text-[var(--tt-fg-dim)]" title="the loop's own fire-response turns">{loopFmtNum(r.tokens)} tok · ${r.cost.toFixed(2)}</span>
+                    {r.sessionCost > r.cost + 0.005 && (
+                      <span className="block tabular text-[10px] text-[var(--tt-fg-faint)]">of ${r.sessionCost.toFixed(2)} session</span>
+                    )}
+                  </>
+                ) : (
+                  <span className="block tabular text-[10px] text-[var(--tt-fg-faint)]" title="this agent exposes no per-turn token split">tokens n/a</span>
                 )}
               </span>
             </Link>

--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -2233,13 +2233,14 @@ function LoopCard({ loop }: { loop: any }) {
 
   const interval = (() => {
     const s = loop.cadence_seconds;
-    if (loop.mode === "fixed_cron") {
-      if (s && s % 86400 === 0) return `Every ${s / 86400}d`;
-      if (s && s % 3600 === 0)  return `Every ${s / 3600}h`;
-      if (s && s % 60 === 0)    return `Every ${s / 60}m`;
-      return s ? `Every ${s}s` : "Cron schedule";
-    }
-    return s ? `~${s}s heartbeat` : "Self-paced";
+    // Only Claude's dynamic ScheduleWakeup loop self-paces; fixed_cron and
+    // Grok's "scheduler" mode are fixed intervals.
+    if (loop.mode === "dynamic") return s ? `~${s}s heartbeat` : "Self-paced";
+    if (s && s % 86400 === 0) return `Every ${s / 86400}d`;
+    if (s && s % 3600 === 0)  return `Every ${s / 3600}h`;
+    if (s && s % 60 === 0)    return `Every ${s / 60}m`;
+    if (s) return `Every ${s}s`;
+    return loop.mode === "fixed_cron" ? "Cron schedule" : "Self-paced";
   })();
 
   const reasonLabel = (r: string | null | undefined) => ({


### PR DESCRIPTION
Consolidates the two stacked loop follow-up PRs (**#173** project tabs, **#174** Grok+Cline) into one clean branch off `main`. The loop base landed via **#169** (already merged); this is everything built on top of it, rebased so the diff is only the net-new work — no re-applied #169 commits, no conflicts.

Replaces #173 and #174 (both closed).

## What's here (3 commits, 9 files)
1. **Project loop tabs** — a project's Config tab lists its recurring loops (state, cadence, fires, job id); the Insights tab breaks down active/expired/cancelled counts + the token/cost footprint of loop turns. New `_lib/loops.ts` folds the project's sessions into the same shape `/analytics` produces (verified to match exactly).
2. **Grok Build detection** — parses `~/.grok/sessions/*/chat_history.jsonl` `scheduler_fired` reminders (validated against 8 real firings: task `019f6409a0a1`, every 2h, cancelled). Grok has no per-turn token split, so footprint is 0 and the UI shows "tokens n/a".
3. **Cline detection** — reads `~/.cline/data/db/cron.db` (`cron_specs` where `trigger_kind='schedule'`), anchoring each schedule's loop to its latest run session. Validated against the real DB schema.

Both new agents reuse the agent-agnostic loop field; the interval helper now shows "Every Nh" for any non-`dynamic` mode.

## Verification
- **36 loop tests pass** (interval parsing + Grok/Cline detection + lifecycle); frontend `tsc` clean; `UPDATE.json` valid.
- Grok loop verified live end-to-end (Config, Insights, session trace); quirky-borg analytics: 5 loops, 2 expired / 3 cancelled, 83 runs.

Independent of #175 (agent feature flags) — merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UDo8qcPJDhxphuy4Cfskrn