### PR TITLE
fix(hermes): re-price custom/proxy-endpoint sessions reported as $0.00 (#176)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -5142,11 +5142,13 @@ def _scan_sessions_sync():
                 # schemas (the outer try/except would otherwise drop all sessions).
                 _cols = {r[1] for r in conn.execute("PRAGMA table_info(sessions)").fetchall()}
                 _base_url_col = "billing_base_url" if "billing_base_url" in _cols else "NULL AS billing_base_url"
+                _cost_status_col = "cost_status" if "cost_status" in _cols else "NULL AS cost_status"
+                _cost_source_col = "cost_source" if "cost_source" in _cols else "NULL AS cost_source"
                 srows = conn.execute(
                     "SELECT id, source, model, parent_session_id, started_at, ended_at, "
                     "input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, "
                     "reasoning_tokens, estimated_cost_usd, actual_cost_usd, title, "
-                    f"billing_provider, {_base_url_col}, end_reason "
+                    f"billing_provider, {_base_url_col}, {_cost_status_col}, {_cost_source_col}, end_reason "
                     "FROM sessions"
                 ).fetchall()
                 for srow in srows:
@@ -5173,6 +5175,14 @@ def _scan_sessions_sync():
                     model = srow["model"]
                     # Prefer Hermes's own cost (it knows exotic models we may not price)
                     cost = srow["actual_cost_usd"] if srow["actual_cost_usd"] is not None else srow["estimated_cost_usd"]
+                    # Hermes stores estimated_cost_usd=0.0 (not NULL) with cost_status='unknown'
+                    # / cost_source='none' when it couldn't price the session itself (proxied or
+                    # unrecognized endpoint, subscription-included model). Don't take that 0.0 at
+                    # face value — fall through to calculate_cost() below, which prices from the
+                    # model + token counts and lets TT's own subscription config (not Hermes's)
+                    # decide the framing. Only override the *estimate*; a real actual_cost_usd wins.
+                    if srow["actual_cost_usd"] is None and (srow["cost_status"] == "unknown" or srow["cost_source"] == "none"):
+                        cost = None
                     # Bind before the branch: it's referenced unconditionally in the
                     # session dict below, but only computed when cost must be derived.
                     _measured_tps = None
@@ -6907,7 +6917,7 @@ async def get_power_config():
 
 @app.put("/config/power")
 async def put_power_config(payload: dict = Body(...)):
-    """Persist power config. Body: {loadWatts?, costPerKwh?, subscriptionEndpoints?}.
+    """Persist power config. Body: {loadWatts?, costPerKwh?, subscriptionEndpoints?, subscriptionModels?}.
 
     Validation happens in power_config.save_power_config (bad values are skipped,
     never surfaced as raw errors). Returns the full saved config.

--- a/backend/power_config.py
+++ b/backend/power_config.py
@@ -56,6 +56,10 @@ DEFAULT_CARBON_INTENSITY = 400
 # Sane upper bound for carbon intensity.
 MAX_CARBON_INTENSITY = 2000
 DEFAULT_SUBSCRIPTION_ENDPOINTS: List[str] = []
+# Specific model ids billed under a flat monthly subscription regardless of which
+# endpoint served them (one proxy can front both subscription and pay-per-token
+# models). Opt-in; empty by default. Matched by exact case-insensitive model id.
+DEFAULT_SUBSCRIPTION_MODELS: List[str] = []
 # Extra endpoints (beyond loopback) the user runs models on locally, e.g. a LAN
 # box at http://192.168.1.50:11434. Loopback is always treated as local.
 DEFAULT_LOCAL_ENDPOINTS: List[str] = []
@@ -65,6 +69,7 @@ DEFAULTS: Dict[str, Any] = {
     "costPerKwh": DEFAULT_COST_PER_KWH,
     "gridCarbonIntensity": DEFAULT_CARBON_INTENSITY,
     "subscriptionEndpoints": list(DEFAULT_SUBSCRIPTION_ENDPOINTS),
+    "subscriptionModels": list(DEFAULT_SUBSCRIPTION_MODELS),
     "localEndpoints": list(DEFAULT_LOCAL_ENDPOINTS),
     "referenceCloudModel": "claude-sonnet-4-6",
 }
@@ -165,6 +170,7 @@ def load_power_config() -> Dict[str, Any]:
     """
     config = dict(DEFAULTS)
     config["subscriptionEndpoints"] = list(DEFAULT_SUBSCRIPTION_ENDPOINTS)
+    config["subscriptionModels"] = list(DEFAULT_SUBSCRIPTION_MODELS)
     # Baseline wattage is device-aware (chip estimate) — an explicit value in
     # power.json below still overrides it.
     config["loadWatts"] = device_default_watts()
@@ -196,6 +202,12 @@ def load_power_config() -> Dict[str, Any]:
     if isinstance(eps, list):
         config["subscriptionEndpoints"] = [
             e.strip() for e in eps if isinstance(e, str) and e.strip()
+        ]
+
+    sms = raw.get("subscriptionModels")
+    if isinstance(sms, list):
+        config["subscriptionModels"] = [
+            m.strip() for m in sms if isinstance(m, str) and m.strip()
         ]
 
     leps = raw.get("localEndpoints")
@@ -235,6 +247,12 @@ def save_power_config(updates: Dict[str, Any]) -> Dict[str, Any]:
     if isinstance(eps, list):
         config["subscriptionEndpoints"] = [
             e.strip() for e in eps if isinstance(e, str) and e.strip()
+        ]
+
+    sms = updates.get("subscriptionModels")
+    if isinstance(sms, list):
+        config["subscriptionModels"] = [
+            m.strip() for m in sms if isinstance(m, str) and m.strip()
         ]
 
     leps = updates.get("localEndpoints")
@@ -277,6 +295,18 @@ def is_subscription_endpoint(
         if s in ep or ep in s:
             return True
     return False
+
+
+def is_subscription_model(
+    model_name: Optional[str], config: Optional[Dict[str, Any]] = None
+) -> bool:
+    """True if model_name exactly matches a configured flat-subscription model id (case-insensitive)."""
+    if not model_name:
+        return False
+    if config is None:
+        config = load_power_config()
+    m = str(model_name).lower().strip()
+    return any(m == s.lower().strip() for s in config.get("subscriptionModels", []) if s and s.strip())
 
 
 _LOOPBACK_HOSTS = ("localhost", "127.0.0.1", "0.0.0.0", "::1", "[::1]")

--- a/backend/pricing.py
+++ b/backend/pricing.py
@@ -322,6 +322,16 @@ def calculate_cost(
         except Exception:
             pass
 
+    # Model-level flat subscription: a specific model billed monthly regardless of
+    # which endpoint served it (one proxy can front both subscription and
+    # pay-per-token models). Opt-in via power.json subscriptionModels; empty by default.
+    try:
+        from power_config import is_subscription_model
+        if is_subscription_model(model_name):
+            return 0.0
+    except Exception:
+        pass
+
     # Confirmed-local sessions (loopback/local endpoint, a local provider id, or
     # the agent set to `local` billing mode) are priced by electricity and WIN
     # over the pricing table — so a local llama-3.3-70b isn't billed at cloud

--- a/backend/test_hermes_profiles.py
+++ b/backend/test_hermes_profiles.py
@@ -47,9 +47,8 @@ def _make_hermes_db(path: Path, sid: str, tokens=(100, 40)):
     con.close()
 
 
-@pytest.fixture
-def hermes_env(tmp_path, monkeypatch):
-    """Hermetic Hermes home: root state.db plus one 'coder' profile."""
+def _isolate_other_agents(tmp_path, monkeypatch):
+    """Point every non-Hermes source at empty paths so a scan sees Hermes only."""
     missing = tmp_path / "missing"
     for attr in ("CODEX_DIR", "GEMINI_DIR", "QWEN_DIR", "VIBE_DIR", "OLLAMA_DIR",
                  "GROK_SESSIONS_DIR", "VSCODE_STORAGE", "CURSOR_STORAGE",
@@ -65,6 +64,12 @@ def hermes_env(tmp_path, monkeypatch):
     monkeypatch.setattr(main, "PROJECT_ALIASES_FILE", tmp_path / "aliases.json")
     monkeypatch.setenv("TOKENTELEMETRY_DATA_DIR", str(tmp_path / "tt_data"))
 
+
+@pytest.fixture
+def hermes_env(tmp_path, monkeypatch):
+    """Hermetic Hermes home: root state.db plus one 'coder' profile."""
+    _isolate_other_agents(tmp_path, monkeypatch)
+
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setattr(main, "HERMES_DIR", home)
@@ -74,6 +79,59 @@ def hermes_env(tmp_path, monkeypatch):
     _make_hermes_db(home / "profiles" / "coder" / "state.db",
                     "20260102_000000_bbbb2222", tokens=(50, 20))
     return home
+
+
+def _make_hermes_db_costcols(path: Path):
+    """Hermes DB on the NEWER schema that carries cost_status / cost_source.
+
+    Two rows:
+      - a BUG row (issue #176): estimated_cost_usd=0.0, actual_cost_usd=NULL,
+        cost_status='unknown', cost_source='none', a priceable model + real
+        tokens. TT must NOT take the 0.0 at face value; it re-prices.
+      - a CONTROL row: cost_source='api' with a real estimated cost preserved
+        as-is (TT must not touch a trustworthy Hermes estimate).
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    con = sqlite3.connect(path)
+    con.execute("CREATE TABLE sessions (id TEXT, source TEXT, model TEXT, "
+                "parent_session_id TEXT, started_at INT, ended_at INT, "
+                "input_tokens INT, output_tokens INT, cache_read_tokens INT, "
+                "cache_write_tokens INT, reasoning_tokens INT, "
+                "estimated_cost_usd REAL, actual_cost_usd REAL, title TEXT, "
+                "billing_provider TEXT, billing_base_url TEXT, "
+                "cost_status TEXT, cost_source TEXT, end_reason TEXT)")
+    con.execute("CREATE TABLE messages (session_id TEXT, role TEXT, content TEXT, "
+                "timestamp INT, tool_name TEXT)")
+    # Bug row: proxied endpoint, Hermes couldn't price it → stored 0.0/'unknown'/'none'.
+    con.execute(
+        "INSERT INTO sessions VALUES ('bug_20260101', 'cli', 'claude-haiku-4.5', NULL, "
+        "1750000000, 1750000100, 115184, 21102, 0, 0, 0, 0.0, NULL, 'bug', "
+        "'openai', 'https://myproxy.example/v1', 'unknown', 'none', 'done')")
+    # Control row: Hermes priced it itself (cost_source='api'), estimate is trustworthy.
+    con.execute(
+        "INSERT INTO sessions VALUES ('ctrl_20260101', 'cli', 'claude-sonnet-4-6', NULL, "
+        "1750000000, 1750000100, 1000, 500, 0, 0, 0, 0.42, NULL, 'ctrl', "
+        "'anthropic', NULL, 'ok', 'api', 'done')")
+    con.commit()
+    con.close()
+
+
+def test_scan_reprices_untrustworthy_hermes_zero(tmp_path, monkeypatch):
+    """Issue #176: a Hermes estimated_cost_usd=0.0 with cost_status='unknown' /
+    cost_source='none' is re-priced from tokens; a trustworthy estimate is kept."""
+    _isolate_other_agents(tmp_path, monkeypatch)
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(main, "HERMES_DIR", home)
+    monkeypatch.setattr(main, "HERMES_DB", home / "state.db")
+    monkeypatch.setattr(main, "HERMES_PROFILES_DIR", home / "profiles")
+    _make_hermes_db_costcols(home / "state.db")
+
+    by_id = {s["id"]: s for s in main._scan_sessions_sync() if s["agent"] == "hermes"}
+    # Bug row: TT fell through to calculate_cost() and priced it > 0.
+    assert by_id["bug_20260101"]["cost"] > 0
+    # Control row: a trustworthy Hermes estimate is preserved verbatim.
+    assert by_id["ctrl_20260101"]["cost"] == 0.42
 
 
 def test_dbs_with_profiles(hermes_env):

--- a/backend/test_power_config.py
+++ b/backend/test_power_config.py
@@ -217,6 +217,66 @@ def test_no_config_file_preserves_per_token_behaviour():
         assert with_ep > 0
 
 
+# --------------------------------------------------------------------------
+# Model-level subscriptions (per-model flat billing)
+# --------------------------------------------------------------------------
+def test_is_subscription_model_exact_match():
+    with tempfile.TemporaryDirectory() as home:
+        _write_power_json(home, {"subscriptionModels": ["gpt-5", "claude-opus-4-7"]})
+        pc, _ = _fresh_modules(home)
+        assert pc.is_subscription_model("gpt-5") is True
+        assert pc.is_subscription_model("claude-opus-4-7") is True
+
+
+def test_is_subscription_model_case_insensitive():
+    with tempfile.TemporaryDirectory() as home:
+        _write_power_json(home, {"subscriptionModels": ["GPT-5"]})
+        pc, _ = _fresh_modules(home)
+        assert pc.is_subscription_model("gpt-5") is True
+        assert pc.is_subscription_model("  GpT-5  ") is True
+
+
+def test_is_subscription_model_no_substring_false_positive():
+    # Model ids are short; substring matching would over-match. gpt-5 must NOT
+    # match gpt-5-mini (a distinct, separately-billed model).
+    with tempfile.TemporaryDirectory() as home:
+        _write_power_json(home, {"subscriptionModels": ["gpt-5"]})
+        pc, _ = _fresh_modules(home)
+        assert pc.is_subscription_model("gpt-5-mini") is False
+        assert pc.is_subscription_model("gpt-5.4") is False
+
+
+def test_is_subscription_model_empty_and_none():
+    with tempfile.TemporaryDirectory() as home:
+        pc, _ = _fresh_modules(home)  # no config → empty subscriptionModels
+        assert pc.is_subscription_model("gpt-5") is False
+        assert pc.is_subscription_model(None) is False
+        assert pc.is_subscription_model("") is False
+
+
+def test_subscription_models_load_save_roundtrip():
+    with tempfile.TemporaryDirectory() as home:
+        pc, _ = _fresh_modules(home)
+        assert pc.load_power_config()["subscriptionModels"] == []
+        saved = pc.save_power_config({
+            "subscriptionModels": ["gpt-5", "", 5, "  claude-x  "],
+        })
+        # Nonempty stripped strings only.
+        assert saved["subscriptionModels"] == ["gpt-5", "claude-x"]
+        assert pc.load_power_config()["subscriptionModels"] == ["gpt-5", "claude-x"]
+
+
+def test_subscription_model_returns_zero_in_calculate_cost():
+    with tempfile.TemporaryDirectory() as home:
+        _write_power_json(home, {"subscriptionModels": ["some-model"]})
+        _, pricing = _fresh_modules(home)
+        # Real token counts, no endpoint hint → still 0.0 because the model is
+        # billed monthly regardless of which endpoint served it.
+        assert pricing.calculate_cost("some-model", 1000, 1000) == 0.0
+        # A non-subscription model is unaffected.
+        assert pricing.calculate_cost("some-model-mini", 1000, 1000) > 0
+
+
 if __name__ == "__main__":
     import traceback
     funcs = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]

--- a/backend/test_pricing.py
+++ b/backend/test_pricing.py
@@ -6,6 +6,11 @@ rate). These tests pin that behaviour and guard backward compatibility of the
 positional signature.
 """
 
+import json
+import os
+import tempfile
+from pathlib import Path
+
 from pricing import calculate_cost
 
 
@@ -80,6 +85,29 @@ def test_cache_write_uses_input_rate_even_without_cached_read_config():
     write = calculate_cost(model, 0, 0, 0, provider="groq", cache_creation_tokens=MTOK)
     assert write == in_rate * 1.25
 
+def test_subscription_model_returns_zero():
+    """A model listed in power.json subscriptionModels prices to 0.0 regardless
+    of endpoint (issue #176: model-level flat subscription)."""
+    prev = os.environ.get("TOKENTELEMETRY_HOME")
+    with tempfile.TemporaryDirectory() as home:
+        d = Path(home) / ".tokentelemetry"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "power.json").write_text(
+            json.dumps({"subscriptionModels": ["some-model"]}), encoding="utf-8"
+        )
+        os.environ["TOKENTELEMETRY_HOME"] = home
+        try:
+            # load_power_config resolves the path lazily on each call, so no reload.
+            assert calculate_cost("some-model", 1000, 1000) == 0.0
+            # A non-subscription model is still priced normally.
+            assert calculate_cost("some-model-mini", 1000, 1000) > 0
+        finally:
+            if prev is None:
+                os.environ.pop("TOKENTELEMETRY_HOME", None)
+            else:
+                os.environ["TOKENTELEMETRY_HOME"] = prev
+
+
 if __name__ == "__main__":
     test_cache_write_priced_at_1_25x_input()
     test_cache_write_1h_priced_at_2x_input()
@@ -89,4 +117,5 @@ if __name__ == "__main__":
     test_backward_compat_positional_provider_still_works()
     test_combined_read_and_write()
     test_cache_write_uses_input_rate_even_without_cached_read_config()
+    test_subscription_model_returns_zero()
     print("All tests passed!")


### PR DESCRIPTION
Fixes #176.

## The bug
Hermes stores `estimated_cost_usd = 0.0` (**not** `NULL`) alongside `cost_status = "unknown"` / `cost_source = "none"` when it can't price a session itself — a proxied/unrecognized OpenAI-compatible endpoint, or a subscription-included model. The Hermes scan trusted that `0.0` because `0.0 is not None`, so real, priceable spend showed as **$0.00**.

## The fix
**Part 1 — core (`backend/main.py`)**
- SELECT `cost_status` / `cost_source` with the same legacy-schema `NULL AS …` fallback already used for `billing_base_url`.
- When `actual_cost_usd IS NULL` **and** Hermes flags `cost_status='unknown'` or `cost_source='none'`, drop the untrustworthy estimate and fall through to the existing `calculate_cost()` path. A real `actual_cost_usd` still wins; genuine Hermes-priced estimates (`cost_source != 'none'`) are preserved.

**Part 2 — related gap (`backend/power_config.py`, `backend/pricing.py`)**
- New `subscriptionModels` (exact case-insensitive model-id match), checked in `calculate_cost()` **independent of endpoint**, so one proxy fronting a mix of subscription and pay-per-token models can be costed per-model instead of the endpoint-level `subscriptionEndpoints` zeroing everything behind that gateway. Config-only, opt-in, empty by default (no UI yet). Wired through the `PUT /config/power` payload.

## Verification
Independent recompute against a live `~/.hermes/state.db`: **11 sessions that reported $0.00 now price to $0.89 total** from the pricing table (e.g. `claude-haiku-4.5` 115k/21k → $0.238). No fabricated rates — every value comes from the existing `PRICING` table.

Tests: **73 passed** across `test_power_config.py`, `test_pricing.py`, `test_hermes_profiles.py`, `test_local_power.py`, `test_pricing_data.py`. New coverage:
- `test_hermes_profiles.py`: a bug row (`unknown`/`none`, 0.0 estimate, priceable model) re-prices > 0; a control row with a real estimate is preserved verbatim.
- `test_power_config.py`: `is_subscription_model` exact/case-insensitive match, no-substring false positive (`gpt-5` must not match `gpt-5-mini`), load/save round-trip.
- `test_pricing.py`: `calculate_cost` returns 0.0 for a configured subscription model.

Thanks to the reporter for the precise root-cause and repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UDo8qcPJDhxphuy4Cfskrn