### PR TITLE
fix(opencode): resolve data dir across platforms/env, not just ~/.local/share (#170)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -286,7 +286,57 @@ OLLAMA_DIR = HOME / ".ollama"
 PI_DIR = HOME / ".pi" / "agent"
 PI_SESSIONS_DIR = PI_DIR / "sessions"
 HF_DIR = HOME / ".cache/huggingface"
-OPENCODE_DB = HOME / ".local/share/opencode/opencode.db"
+def _opencode_db_candidates() -> List[Path]:
+    """OpenCode SQLite DB locations to probe, highest-priority first.
+
+    OpenCode does NOT use one fixed path: it resolves a data dir honoring
+    ``$OPENCODE_DATA_DIR`` and ``$XDG_DATA_HOME`` with a per-OS default. We used
+    to look only at ``~/.local/share/opencode`` and so silently missed relocated
+    or non-Linux installs — the scan is gated on ``.exists()`` inside a bare
+    ``try/except``, so a wrong path means the whole agent vanishes with no error
+    (discussion #170). Probe every place the agent could have written; the scan
+    uses the first that exists. Extra non-existent candidates are harmless.
+    """
+    c: List[Path] = []
+    env = os.environ.get("OPENCODE_DATA_DIR")
+    if env:
+        c.append(Path(env).expanduser() / "opencode.db")
+    xdg = os.environ.get("XDG_DATA_HOME")
+    if xdg:
+        c.append(Path(xdg).expanduser() / "opencode" / "opencode.db")
+    if sys.platform == "win32":
+        for var in ("APPDATA", "LOCALAPPDATA"):
+            base = os.environ.get(var)
+            if base:
+                c.append(Path(base) / "opencode" / "opencode.db")
+    # Standard XDG data dir — the confirmed default on BOTH Linux and macOS
+    # (OpenCode does not use ~/Library/Application Support, verified on 1.15.13).
+    c.append(HOME / ".local/share/opencode/opencode.db")
+    # macOS env-paths-style location, in case a build ever used it.
+    if sys.platform == "darwin":
+        c.append(HOME / "Library/Application Support/opencode/opencode.db")
+    seen: set = set()
+    out: List[Path] = []
+    for p in c:
+        if p not in seen:
+            seen.add(p)
+            out.append(p)
+    return out
+
+
+def _opencode_db_path() -> Path:
+    """First existing OpenCode DB among the candidates, else the canonical XDG
+    default (so a not-yet-created DB still has a stable path to display)."""
+    for p in _opencode_db_candidates():
+        try:
+            if p.exists():
+                return p
+        except OSError:
+            continue
+    return HOME / ".local/share/opencode/opencode.db"
+
+
+OPENCODE_DB = _opencode_db_path()
 # Hermes installs to ~/.hermes by default, but the agent honors HERMES_HOME for
 # users who relocate their data dir (shared hosts, containerized setups, etc.).
 # Mirror that contract so we read from wherever the agent actually writes.
@@ -4958,11 +5008,24 @@ def _scan_sessions_sync():
     # 8. OpenCode (SQLite: session / message / part)
     if OPENCODE_DB.exists():
         try:
-            # immutable=1 so we don't block the live TUI process's write lock
+            # mode=ro (via _sqlite_ro_uri) so we never take a write lock on the
+            # live TUI's DB. It's a WAL database, so a read can still time out if
+            # OpenCode is mid-write — that lands in the outer except, which now
+            # logs instead of silently dropping the whole agent.
             uri = _sqlite_ro_uri(OPENCODE_DB)
             conn = sqlite3.connect(uri, uri=True, timeout=1.0)
             conn.row_factory = sqlite3.Row
             try:
+                # OpenCode's schema drifts across versions (tables get added and
+                # renamed). Detect which tables exist so one missing *peripheral*
+                # table (e.g. `todo`) can't throw into the outer except and wipe
+                # out every session — the failure mode behind discussion #170's
+                # neighbours.
+                try:
+                    _tables = {r[0] for r in conn.execute(
+                        "SELECT name FROM sqlite_master WHERE type='table'")}
+                except Exception:
+                    _tables = set()
                 # Some OpenCode versions added a session-level `model` column
                 # (e.g. the github-copilot provider stores the model only there,
                 # not on assistant messages — see issue #39). Detect it so we can
@@ -5070,8 +5133,10 @@ def _scan_sessions_sync():
                     project_path = srow["directory"] or "unknown"
                     title = srow["title"] or ""
                     display = (first_user or title)[:100]
-                    # Todos (opencode's plan-like artifact)
-                    todo_rows = conn.execute("SELECT content, status FROM todo WHERE session_id=? ORDER BY position", (sid,)).fetchall()
+                    # Todos (opencode's plan-like artifact). Optional table —
+                    # absent on older/newer schemas, so gate on its presence.
+                    todo_rows = (conn.execute("SELECT content, status FROM todo WHERE session_id=? ORDER BY position", (sid,)).fetchall()
+                                 if "todo" in _tables else [])
                     if todo_rows:
                         has_plan = True
                         plan_text = "\n".join(f"- [{r['status']}] {r['content']}" for r in todo_rows)
@@ -5104,8 +5169,13 @@ def _scan_sessions_sync():
                                                  "linked_children": len(kids)}
             finally:
                 conn.close()
-        except Exception:
-            pass
+        except Exception as e:
+            # Don't let a schema/lock hiccup silently erase the whole agent —
+            # log it at debug so "no OpenCode sessions" is diagnosable instead
+            # of invisible (discussion #170).
+            import logging
+            logging.getLogger("tokentelemetry.opencode").debug(
+                "OpenCode scan skipped (%s): %r", OPENCODE_DB, e)
 
     # 8. Grok Build (xAI) — rich per-session directory with events, updates, chat history
     sessions.extend(_scan_grok_sessions())

--- a/backend/test_opencode_paths.py
+++ b/backend/test_opencode_paths.py
@@ -1,0 +1,95 @@
+"""Tests for OpenCode data-dir resolution (discussion #170).
+
+Before this, TokenTelemetry only ever looked at ``~/.local/share/opencode/
+opencode.db``, so a relocated or non-Linux OpenCode install was silently
+invisible. These tests pin the candidate-probing behaviour: env override,
+``$XDG_DATA_HOME``, per-OS defaults, priority, and the fall-back-to-canonical
+when nothing exists yet.
+"""
+
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+import main  # noqa: E402
+
+
+def _clear_oc_env(monkeypatch):
+    monkeypatch.delenv("OPENCODE_DATA_DIR", raising=False)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+
+
+def _mk_db(path: Path):
+    """Create a minimal opencode.db with a session table at ``path``."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path))
+    conn.execute("CREATE TABLE session(id TEXT)")
+    conn.commit()
+    conn.close()
+
+
+def test_candidates_always_include_xdg_default(monkeypatch):
+    _clear_oc_env(monkeypatch)
+    cands = main._opencode_db_candidates()
+    assert main.HOME / ".local/share/opencode/opencode.db" in cands
+
+
+def test_env_override_is_first_candidate(monkeypatch):
+    _clear_oc_env(monkeypatch)
+    monkeypatch.setenv("OPENCODE_DATA_DIR", "/opt/oc-data")
+    cands = main._opencode_db_candidates()
+    assert cands[0] == Path("/opt/oc-data/opencode.db")
+
+
+def test_xdg_data_home_is_probed(monkeypatch):
+    _clear_oc_env(monkeypatch)
+    monkeypatch.setenv("XDG_DATA_HOME", "/xdg")
+    cands = main._opencode_db_candidates()
+    assert Path("/xdg/opencode/opencode.db") in cands
+
+
+def test_windows_probes_appdata_and_localappdata(monkeypatch):
+    _clear_oc_env(monkeypatch)
+    monkeypatch.setattr(main.sys, "platform", "win32")
+    monkeypatch.setenv("APPDATA", r"C:\\Users\\dev\\AppData\\Roaming")
+    monkeypatch.setenv("LOCALAPPDATA", r"C:\\Users\\dev\\AppData\\Local")
+    cands = main._opencode_db_candidates()
+    assert Path(r"C:\\Users\\dev\\AppData\\Roaming") / "opencode" / "opencode.db" in cands
+    assert Path(r"C:\\Users\\dev\\AppData\\Local") / "opencode" / "opencode.db" in cands
+
+
+def test_candidates_are_deduped(monkeypatch):
+    _clear_oc_env(monkeypatch)
+    cands = main._opencode_db_candidates()
+    assert len(cands) == len(set(cands))
+
+
+def test_path_picks_existing_env_db(monkeypatch, tmp_path):
+    _clear_oc_env(monkeypatch)
+    db = tmp_path / "custom" / "opencode.db"
+    _mk_db(db)
+    monkeypatch.setenv("OPENCODE_DATA_DIR", str(tmp_path / "custom"))
+    assert main._opencode_db_path() == db
+
+
+def test_env_override_wins_over_xdg(monkeypatch, tmp_path):
+    _clear_oc_env(monkeypatch)
+    env_db = tmp_path / "env" / "opencode.db"
+    xdg_db = tmp_path / "xdg" / "opencode" / "opencode.db"
+    _mk_db(env_db)
+    _mk_db(xdg_db)
+    monkeypatch.setenv("OPENCODE_DATA_DIR", str(tmp_path / "env"))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
+    assert main._opencode_db_path() == env_db
+
+
+def test_path_falls_back_to_canonical_when_nothing_exists(monkeypatch, tmp_path):
+    _clear_oc_env(monkeypatch)
+    # Point HOME at an empty dir so no candidate exists on disk.
+    monkeypatch.setattr(main, "HOME", tmp_path)
+    got = main._opencode_db_path()
+    assert got == tmp_path / ".local/share/opencode/opencode.db"


### PR DESCRIPTION
Refs #170 (OpenCode 1.15.13 sessions not showing up).

## Root cause
TT only ever looked for OpenCode's DB at `~/.local/share/opencode/opencode.db` (`backend/main.py`). The scan is gated on `.exists()` inside a bare `try/except: pass`, so when OpenCode wrote its DB anywhere else, **the whole agent vanished with no error, no log, no partial data** — matching the "no OpenCode sessions at all" report.

OpenCode resolves its data dir honoring `$OPENCODE_DATA_DIR` and `$XDG_DATA_HOME` with a per-OS default (Windows → `%APPDATA%`/`%LOCALAPPDATA%`). We never followed that.

## Fix
- **Path resolution** — probe every location OpenCode could have written, first-existing wins, mirroring the platform branching TT already does for VSCode/Cursor and the env override it honors for Hermes (`HERMES_HOME`). Order: `$OPENCODE_DATA_DIR` → `$XDG_DATA_HOME/opencode` → (Windows) `%APPDATA%`/`%LOCALAPPDATA%\opencode` → `~/.local/share/opencode` → (macOS fallback) `~/Library/Application Support/opencode`. macOS stays on the XDG path — a live 1.15.13 install stores the DB at `~/.local/share`, **not** `~/Library/Application Support`.
- **Hardening** — detect which tables exist and gate the optional `todo` query on its presence, and log the swallowed exception at debug instead of a bare `pass`, so the next schema drift can't silently erase the agent again. Fixed a stale `immutable=1` comment (code uses `mode=ro`, correct for a live WAL DB).

## Verification
- Env-override + XDG resolution picks relocated DBs with correct priority (`OPENCODE_DATA_DIR` > `XDG_DATA_HOME` > default); no-env behavior unchanged.
- The live 38-session DB still scans clean (all tables present, no regression).
- `test_opencode_paths.py` — 8 new tests (candidate probing, env priority, Windows paths, dedupe, fall-back-to-canonical).

## Note
This resolves the most likely cause (relocated/non-Linux DB). Since the reporter is on the same 1.15.13 that works here at the standard path, I've asked them (on #170) to confirm their DB location vs. a same-path WAL/lock issue — the second layer this PR also hardens against either way.

Unrelated: `test_delegation.py::test_analytics_ecosystem_aggregates` fails on `main` too (pre-existing, `Query` object reaching `.strip()`) — not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UDo8qcPJDhxphuy4Cfskrn