### PR TITLE
feat(org): self-hosted org mode MVP — collector, shipper, Team page

### DIFF
--- a/UPDATE.json
+++ b/UPDATE.json
@@ -2,6 +2,21 @@
   "releases": [
     {
       "tag": "2026-07-18",
+      "title": "Org mode: see your whole team's usage in one place",
+      "highlights": [
+        {
+          "title": "Team dashboard (early preview)",
+          "description": "A new Team page rolls up sessions, tokens and cost across every machine that ships metrics to your own self-hosted collector — split by machine, agent and project. Only metric rollups travel; prompts, code and file paths never leave a dev's machine.",
+          "href": "/team"
+        },
+        {
+          "title": "Ship metrics from each dev machine",
+          "description": "A small stdlib-only shipper (backend/org_ship.py) reads your local session list and posts rollups to the collector on a schedule, authenticated by a per-machine token. Re-sends are idempotent, so nothing double-counts. Setup steps live on the Team page until data arrives."
+        }
+      ]
+    },
+    {
+      "tag": "2026-07-18",
       "title": "See which experimental features each agent has on",
       "highlights": [
         {

--- a/backend/main.py
+++ b/backend/main.py
@@ -9,7 +9,7 @@ import yaml
 import sqlite3
 from pathlib import Path
 from typing import List, Optional, Dict, Any, Set, Iterable, Tuple
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from datetime import datetime, timezone, timedelta, time as _dtime
 from urllib.parse import unquote, quote
 
@@ -227,6 +227,12 @@ def _presented_token(request: Request) -> str:
 
 class RemoteAuthMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
+        # /org/ingest is exempt from the TT_AUTH_TOKEN gate: shipping machines
+        # hold a per-machine token from org.json, not the dashboard token. The
+        # endpoint enforces its own X-TT-Machine-Token check on EVERY request,
+        # loopback included, so this bypass never opens an unauthenticated path.
+        if request.url.path == "/org/ingest":
+            return await call_next(request)
         token = os.environ.get("TT_AUTH_TOKEN", "").strip()
         if not token:
             return await call_next(request)  # gate disabled (local default)
@@ -7003,6 +7009,69 @@ async def put_billing_config(payload: dict = Body(...)):
         raise HTTPException(status_code=500, detail="Could not save billing config to disk.")
     _invalidate_sessions_cache()
     return {"agents": get_all(_list_available_agents()), "modes": list(MODES)}
+
+
+# --- Org mode (self-hosted collector) ----------------------------------------
+# Metrics-only rollups shipped from teammate machines (see org_store docstring).
+import org_store
+
+
+class OrgTokenUsage(BaseModel):
+    input: int = 0
+    output: int = 0
+    cached: int = 0
+    total: int = 0
+
+
+# A machine token is lower-privilege than the dashboard token but writes to
+# org.db, so the request shape is bounded: string fields are capped and a batch
+# tops out at 1000 sessions (the shipper defaults to 200 per POST).
+class OrgSessionRollup(BaseModel):
+    id: str = Field(max_length=256)
+    agent: str = Field(max_length=128)
+    project: str = Field(max_length=512)
+    timestamp: str = Field(max_length=64)
+    tokens: OrgTokenUsage = OrgTokenUsage()
+    model: Optional[str] = Field(default=None, max_length=256)
+    cost: Optional[float] = None
+
+
+class OrgIngestRequest(BaseModel):
+    sessions: List[OrgSessionRollup] = Field(max_length=1000)
+
+
+@app.post("/org/ingest")
+async def org_ingest(payload: OrgIngestRequest, request: Request):
+    """Accept a batch of session rollups from one machine's shipping agent.
+
+    Auth is the X-TT-Machine-Token header, required on EVERY request (loopback
+    included; RemoteAuthMiddleware deliberately skips this path). The machine
+    label comes from the matching org.json entry, never from the body, so a
+    machine can only ever write under its own label. Upsert keyed on
+    (machine, session_id) keeps re-sends idempotent.
+    """
+    machine = org_store.resolve_machine(request.headers.get("X-TT-Machine-Token", ""))
+    if machine is None:
+        return JSONResponse(
+            status_code=401,
+            content={"detail": "A valid X-TT-Machine-Token header is required."},
+        )
+    accepted, updated = org_store.upsert_sessions(
+        machine, [s.model_dump() for s in payload.sessions]
+    )
+    return {"accepted": accepted, "updated": updated}
+
+
+@app.get("/org/status")
+async def org_status():
+    """Whether org mode is configured (org.json has machines) plus row counts."""
+    return org_store.status()
+
+
+@app.get("/org/summary")
+async def org_summary():
+    """Org-wide rollup: totals plus by-machine/agent/project and recent sessions."""
+    return org_store.summary()
 
 
 # Feature/experimental flags each agent persists in its own local config. There

--- a/backend/org_ship.py
+++ b/backend/org_ship.py
@@ -1,0 +1,117 @@
+"""Org mode shipping agent: push this machine's session rollups to a collector.
+
+Runs on each teammate's machine, reads sessions from the LOCAL TokenTelemetry
+backend, and POSTs metrics-only rollups (id, agent, project, timestamp, token
+counts) to the team's self-hosted collector at /org/ingest. Prompt content
+never leaves the machine, and the only outbound call is to the collector URL
+you configure. Model and cost are shipped as null in this MVP.
+
+Designed for cron/launchd scheduling: it is a one-shot run, idempotent on the
+collector side (re-sending the same sessions upserts, never double-counts),
+prints a single summary line on success, and exits non-zero with a plain
+message when the local backend or the collector is unreachable.
+
+Usage:
+    python backend/org_ship.py --central-url https://tt.example.com --token <hex>
+        [--source-url http://127.0.0.1:8000] [--batch-size 200]
+
+TT_CENTRAL_URL and TT_MACHINE_TOKEN work as env fallbacks for --central-url
+and --token, keeping the token out of the crontab line if preferred.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+
+def _fetch_local_sessions(source_url: str) -> list:
+    url = source_url.rstrip("/") + "/sessions"
+    try:
+        with urllib.request.urlopen(url, timeout=60) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, OSError, ValueError) as e:
+        sys.exit(f"Could not read sessions from the local backend at {url}. "
+                 f"Is TokenTelemetry running? ({e})")
+    if not isinstance(data, list):
+        sys.exit(f"Unexpected response from {url}: expected a session list.")
+    return data
+
+
+def _to_rollup(session: dict) -> dict:
+    tokens = session.get("tokens") or {}
+    return {
+        "id": str(session.get("id", "")),
+        "agent": str(session.get("agent", "")),
+        "project": str(session.get("project", "")),
+        "timestamp": str(session.get("timestamp", "")),
+        "tokens": {
+            "input": int(tokens.get("input") or 0),
+            "output": int(tokens.get("output") or 0),
+            "cached": int(tokens.get("cached") or 0),
+            "total": int(tokens.get("total") or 0),
+        },
+        "model": None,
+        "cost": None,
+    }
+
+
+def _post_batch(central_url: str, token: str, batch: list) -> dict:
+    url = central_url.rstrip("/") + "/org/ingest"
+    req = urllib.request.Request(
+        url,
+        data=json.dumps({"sessions": batch}).encode("utf-8"),
+        headers={
+            "Content-Type": "application/json",
+            "X-TT-Machine-Token": token,
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        if e.code == 401:
+            sys.exit("The collector rejected the machine token (401). "
+                     "Check the token against the collector's org.json.")
+        sys.exit(f"The collector at {url} returned HTTP {e.code}.")
+    except (urllib.error.URLError, OSError, ValueError) as e:
+        sys.exit(f"Could not reach the collector at {url}. ({e})")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Ship this machine's session rollups to an org-mode collector."
+    )
+    parser.add_argument("--central-url", default=os.environ.get("TT_CENTRAL_URL", ""),
+                        help="Collector base URL (env: TT_CENTRAL_URL)")
+    parser.add_argument("--token", default=os.environ.get("TT_MACHINE_TOKEN", ""),
+                        help="This machine's token from the collector's org.json (env: TT_MACHINE_TOKEN)")
+    parser.add_argument("--source-url", default="http://127.0.0.1:8000",
+                        help="Local TokenTelemetry backend to read sessions from")
+    parser.add_argument("--batch-size", type=int, default=200,
+                        help="Sessions per POST to /org/ingest")
+    args = parser.parse_args()
+
+    if not args.central_url.strip():
+        sys.exit("A collector URL is required (--central-url or TT_CENTRAL_URL).")
+    if not args.token.strip():
+        sys.exit("A machine token is required (--token or TT_MACHINE_TOKEN).")
+    if args.batch_size < 1:
+        sys.exit("--batch-size must be at least 1.")
+
+    rollups = [_to_rollup(s) for s in _fetch_local_sessions(args.source_url)]
+    accepted = updated = 0
+    for i in range(0, len(rollups), args.batch_size):
+        result = _post_batch(args.central_url.strip(), args.token.strip(),
+                             rollups[i:i + args.batch_size])
+        accepted += int(result.get("accepted") or 0)
+        updated += int(result.get("updated") or 0)
+    print(f"Shipped {len(rollups)} sessions: {accepted} accepted, {updated} updated.")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/org_store.py
+++ b/backend/org_store.py
@@ -1,0 +1,259 @@
+"""Org mode: the self-hosted collector's config + store.
+
+Org mode lets a small team aggregate usage across machines without any
+third-party service: one TokenTelemetry instance acts as the collector, and
+each teammate's machine ships metrics-only session rollups to it (session id,
+agent, project, timestamp, token counts, optional model/cost). Prompt content,
+transcripts, and file paths never leave the source machine, and the collector
+never reaches out to anything.
+
+Config lives at ``<data_dir()>/org.json``:
+
+    {"machines": [{"label": "kyle-laptop", "token": "<random hex>"}]}
+
+Org mode is "enabled" when that file exists and lists at least one machine.
+Rollups are stored in SQLite at ``<data_dir()>/org.db``, one row per
+(machine, session_id), so re-shipping the same sessions upserts instead of
+double-counting. Both paths resolve through ``tt_paths.data_dir()`` and are
+created lazily on first write.
+"""
+from __future__ import annotations
+
+import hmac
+import json
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from tt_paths import data_dir
+
+
+def _config_path() -> Path:
+    return data_dir() / "org.json"
+
+
+def _db_path() -> Path:
+    return data_dir() / "org.db"
+
+
+def read_org_config() -> Dict[str, Any]:
+    """Load org.json. Missing or corrupt config means org mode is disabled, so
+    both cases return ``{"machines": []}`` rather than raising."""
+    try:
+        raw = json.loads(_config_path().read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {"machines": []}
+    machines = raw.get("machines") if isinstance(raw, dict) else None
+    if not isinstance(machines, list):
+        return {"machines": []}
+    clean = [
+        m for m in machines
+        if isinstance(m, dict)
+        and isinstance(m.get("label"), str) and m["label"].strip()
+        and isinstance(m.get("token"), str) and m["token"]
+    ]
+    return {"machines": clean}
+
+
+def resolve_machine(token: str) -> Optional[str]:
+    """Map a presented machine token to its configured label, or None.
+
+    Every configured token is compared with hmac.compare_digest and the loop
+    never exits early, so response timing does not reveal which (if any) entry
+    matched or how far down the list it sits. Comparison is on bytes: header
+    values reach us latin-1 decoded and compare_digest raises TypeError on a
+    non-ASCII str, which would turn a garbage token into a 500 instead of 401.
+    """
+    if not token:
+        return None
+    token_bytes = token.encode("utf-8")
+    matched: Optional[str] = None
+    for m in read_org_config()["machines"]:
+        if hmac.compare_digest(token_bytes, m["token"].encode("utf-8")) and matched is None:
+            matched = m["label"]
+    return matched
+
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS org_sessions (
+    machine        TEXT NOT NULL,
+    session_id     TEXT NOT NULL,
+    agent          TEXT NOT NULL,
+    project        TEXT NOT NULL,
+    timestamp      TEXT NOT NULL,
+    input_tokens   INTEGER NOT NULL DEFAULT 0,
+    output_tokens  INTEGER NOT NULL DEFAULT 0,
+    cached_tokens  INTEGER NOT NULL DEFAULT 0,
+    total_tokens   INTEGER NOT NULL DEFAULT 0,
+    model          TEXT,
+    cost           REAL,
+    received_at    TEXT NOT NULL,
+    PRIMARY KEY (machine, session_id)
+)
+"""
+
+
+def _connect() -> sqlite3.Connection:
+    """Open org.db, creating the directory and schema on first use."""
+    path = _db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    conn.execute(_SCHEMA)
+    return conn
+
+
+def upsert_sessions(machine: str, sessions: List[Dict[str, Any]]) -> Tuple[int, int]:
+    """Upsert one machine's rollups; returns (accepted, updated).
+
+    accepted = rows new to the store, updated = rows that already existed and
+    were re-upserted. Keyed on (machine, session_id) so re-shipping the same
+    batch is idempotent: totals never double-count.
+    """
+    now = datetime.now(timezone.utc).isoformat()
+    conn = _connect()
+    try:
+        existing: set = set()
+        ids = [str(s.get("id", "")) for s in sessions]
+        # SQLite caps bound parameters (999 in older builds); chunk the
+        # existence probe so arbitrarily large batches still work.
+        for i in range(0, len(ids), 500):
+            chunk = ids[i:i + 500]
+            marks = ",".join("?" * len(chunk))
+            rows = conn.execute(
+                f"SELECT session_id FROM org_sessions WHERE machine = ? AND session_id IN ({marks})",
+                [machine, *chunk],
+            ).fetchall()
+            existing.update(r[0] for r in rows)
+        accepted = updated = 0
+        for s in sessions:
+            tokens = s.get("tokens") or {}
+            conn.execute(
+                """
+                INSERT INTO org_sessions (machine, session_id, agent, project, timestamp,
+                    input_tokens, output_tokens, cached_tokens, total_tokens,
+                    model, cost, received_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(machine, session_id) DO UPDATE SET
+                    agent = excluded.agent,
+                    project = excluded.project,
+                    timestamp = excluded.timestamp,
+                    input_tokens = excluded.input_tokens,
+                    output_tokens = excluded.output_tokens,
+                    cached_tokens = excluded.cached_tokens,
+                    total_tokens = excluded.total_tokens,
+                    model = excluded.model,
+                    cost = excluded.cost,
+                    received_at = excluded.received_at
+                """,
+                (
+                    machine, str(s.get("id", "")), str(s.get("agent", "")),
+                    str(s.get("project", "")), str(s.get("timestamp", "")),
+                    int(tokens.get("input") or 0), int(tokens.get("output") or 0),
+                    int(tokens.get("cached") or 0), int(tokens.get("total") or 0),
+                    s.get("model"), s.get("cost"), now,
+                ),
+            )
+            if str(s.get("id", "")) in existing:
+                updated += 1
+            else:
+                accepted += 1
+                existing.add(str(s.get("id", "")))
+        conn.commit()
+        return accepted, updated
+    finally:
+        conn.close()
+
+
+def _enabled() -> bool:
+    return len(read_org_config()["machines"]) > 0
+
+
+def status() -> Dict[str, Any]:
+    cfg = read_org_config()
+    sessions = 0
+    if _db_path().exists():
+        conn = _connect()
+        try:
+            sessions = conn.execute("SELECT COUNT(*) FROM org_sessions").fetchone()[0]
+        finally:
+            conn.close()
+    return {
+        "enabled": len(cfg["machines"]) > 0,
+        "machines": len(cfg["machines"]),
+        "sessions": sessions,
+    }
+
+
+def _empty_summary(enabled: bool) -> Dict[str, Any]:
+    return {
+        "enabled": enabled,
+        "totals": {"sessions": 0, "tokens": 0, "cost": 0.0},
+        "by_machine": [],
+        "by_agent": [],
+        "by_project": [],
+        "recent": [],
+    }
+
+
+def summary() -> Dict[str, Any]:
+    """Org-wide rollup for the dashboard. Always returns every key (zeros and
+    empty lists when disabled or empty) so the frontend never branches on
+    missing fields."""
+    if not _enabled() or not _db_path().exists():
+        return _empty_summary(_enabled())
+    conn = _connect()
+    try:
+        total_row = conn.execute(
+            "SELECT COUNT(*), COALESCE(SUM(total_tokens), 0), COALESCE(SUM(cost), 0.0) FROM org_sessions"
+        ).fetchone()
+        by_machine = [
+            {"machine": r[0], "sessions": r[1], "tokens": r[2], "cost": r[3], "last_seen": r[4]}
+            for r in conn.execute(
+                """
+                SELECT machine, COUNT(*), COALESCE(SUM(total_tokens), 0),
+                       COALESCE(SUM(cost), 0.0), MAX(received_at)
+                FROM org_sessions GROUP BY machine
+                ORDER BY COALESCE(SUM(total_tokens), 0) DESC
+                """
+            ).fetchall()
+        ]
+        def _grouped(col: str, key: str) -> List[Dict[str, Any]]:
+            return [
+                {key: r[0], "sessions": r[1], "tokens": r[2], "cost": r[3]}
+                for r in conn.execute(
+                    f"""
+                    SELECT {col}, COUNT(*), COALESCE(SUM(total_tokens), 0),
+                           COALESCE(SUM(cost), 0.0)
+                    FROM org_sessions GROUP BY {col}
+                    ORDER BY COALESCE(SUM(total_tokens), 0) DESC
+                    """
+                ).fetchall()
+            ]
+        # Timestamps are stored verbatim with each machine's own UTC offset, so
+        # lexical order misranks mixed offsets; datetime() normalizes to UTC
+        # (unparseable values become NULL and sort last under DESC).
+        recent = [
+            {"id": r[0], "machine": r[1], "agent": r[2], "project": r[3],
+             "timestamp": r[4], "tokens_total": r[5], "cost": r[6]}
+            for r in conn.execute(
+                """
+                SELECT session_id, machine, agent, project, timestamp, total_tokens, cost
+                FROM org_sessions ORDER BY datetime(timestamp) DESC LIMIT 20
+                """
+            ).fetchall()
+        ]
+        return {
+            "enabled": True,
+            "totals": {
+                "sessions": total_row[0],
+                "tokens": total_row[1],
+                "cost": float(total_row[2]),
+            },
+            "by_machine": by_machine,
+            "by_agent": _grouped("agent", "agent"),
+            "by_project": _grouped("project", "project"),
+            "recent": recent,
+        }
+    finally:
+        conn.close()

--- a/backend/test_org_mode.py
+++ b/backend/test_org_mode.py
@@ -1,0 +1,306 @@
+"""Tests for org mode (self-hosted collector): /org/ingest, /org/status,
+/org/summary and the org_store SQLite layer.
+
+Pins the API contract both sides depend on:
+
+  * /org/ingest requires a valid X-TT-Machine-Token on EVERY request, even
+    loopback, and resolves the machine label server-side (body can't spoof it);
+  * re-sending the same batch upserts (accepted 0, updated N) and totals in
+    /org/summary do not move — idempotency is proven by the numbers;
+  * /org/status flips `enabled` on org.json presence;
+  * summary rollups (by_machine / by_agent / by_project, tokens desc) are exact;
+  * the RemoteAuthMiddleware bypass: a remote machine WITHOUT TT_AUTH_TOKEN can
+    still reach /org/ingest when it holds a machine token.
+
+Follows test_remote_auth.py: no httpx — the real ASGI app is driven with
+constructed scopes, which also lets us set the client IP. State is isolated by
+pointing TOKENTELEMETRY_DATA_DIR at a temp dir BEFORE importing main, so
+org.json / org.db never touch the real ~/.tokentelemetry.
+Run directly:  python backend/test_org_mode.py
+"""
+import asyncio
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+# Must be set before main (and org_store) resolve any paths.
+_TMP = tempfile.mkdtemp(prefix="tt-org-test-")
+os.environ["TOKENTELEMETRY_DATA_DIR"] = _TMP
+
+import main  # noqa: E402
+from main import app  # noqa: E402
+import org_store  # noqa: E402
+
+
+async def _request(method, path, *, headers=None, body=None, client=("127.0.0.1", 5555)):
+    """Send one request through the real ASGI app; return (status, json_or_none)."""
+    payload = json.dumps(body).encode() if body is not None else b""
+    raw_headers = [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()]
+    if body is not None:
+        raw_headers.append((b"content-type", b"application/json"))
+        raw_headers.append((b"content-length", str(len(payload)).encode()))
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": method,
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": b"",
+        "headers": raw_headers,
+        "client": client,
+        "server": ("testserver", 80),
+        "scheme": "http",
+    }
+    status = {"code": None}
+    body_parts: list = []
+    pending = [{"type": "http.request", "body": payload, "more_body": False}]
+
+    async def receive():
+        return pending.pop(0) if pending else {"type": "http.disconnect"}
+
+    async def send(message):
+        if message["type"] == "http.response.start":
+            status["code"] = message["status"]
+        elif message["type"] == "http.response.body":
+            body_parts.append(message.get("body", b""))
+
+    await app(scope, receive, send)
+    raw = b"".join(body_parts)
+    try:
+        data = json.loads(raw) if raw else None
+    except ValueError:
+        data = None
+    return status["code"], data
+
+
+def _call(method, path, **kw):
+    return asyncio.run(_request(method, path, **kw))
+
+
+REMOTE = ("203.0.113.7", 5555)
+TOKEN_A = "aaaa1111aaaa1111"
+TOKEN_B = "bbbb2222bbbb2222"
+
+
+def _reset(machines=None):
+    """Reset org state: fresh org.json (or none) and no org.db."""
+    os.environ.pop("TT_AUTH_TOKEN", None)
+    cfg = Path(_TMP) / "org.json"
+    db = Path(_TMP) / "org.db"
+    if db.exists():
+        db.unlink()
+    if machines is None:
+        if cfg.exists():
+            cfg.unlink()
+    else:
+        cfg.parent.mkdir(parents=True, exist_ok=True)
+        cfg.write_text(json.dumps({"machines": machines}), encoding="utf-8")
+
+
+def _two_machines():
+    _reset([
+        {"label": "kyle-laptop", "token": TOKEN_A},
+        {"label": "maria-desktop", "token": TOKEN_B},
+    ])
+
+
+def _session(sid, agent="claude", project="tt", total=100, ts="2026-07-01T10:00:00+05:30"):
+    return {
+        "id": sid, "agent": agent, "project": project, "timestamp": ts,
+        "tokens": {"input": total // 2, "output": total // 2, "cached": 0, "total": total},
+        "model": None, "cost": None,
+    }
+
+
+def test_ingest_valid_token_accepts():
+    _two_machines()
+    status, data = _call("POST", "/org/ingest",
+                         headers={"X-TT-Machine-Token": TOKEN_A},
+                         body={"sessions": [_session("s1"), _session("s2")]})
+    assert status == 200, (status, data)
+    assert data == {"accepted": 2, "updated": 0}, data
+
+
+def test_ingest_resend_is_idempotent():
+    _two_machines()
+    payload = {"sessions": [_session("s1", total=100), _session("s2", total=200)]}
+    _call("POST", "/org/ingest", headers={"X-TT-Machine-Token": TOKEN_A}, body=payload)
+    _, before = _call("GET", "/org/summary")
+    status, data = _call("POST", "/org/ingest",
+                         headers={"X-TT-Machine-Token": TOKEN_A}, body=payload)
+    assert status == 200, status
+    assert data == {"accepted": 0, "updated": 2}, data
+    _, after = _call("GET", "/org/summary")
+    assert before["totals"] == after["totals"] == {"sessions": 2, "tokens": 300, "cost": 0.0}, (before, after)
+
+
+def test_ingest_resend_with_changed_values_overwrites():
+    """Re-sending a known session_id with new values must replace the old row
+    (DO UPDATE), not skip it: totals reflect the new numbers, not old, not sum."""
+    _two_machines()
+    _call("POST", "/org/ingest", headers={"X-TT-Machine-Token": TOKEN_A},
+          body={"sessions": [_session("s1", agent="claude", total=100)]})
+    changed = _session("s1", agent="codex", total=999)
+    changed["cost"] = 1.25
+    status, data = _call("POST", "/org/ingest",
+                         headers={"X-TT-Machine-Token": TOKEN_A},
+                         body={"sessions": [changed]})
+    assert status == 200 and data == {"accepted": 0, "updated": 1}, (status, data)
+    _, summ = _call("GET", "/org/summary")
+    assert summ["totals"] == {"sessions": 1, "tokens": 999, "cost": 1.25}, summ["totals"]
+    assert [(a["agent"], a["tokens"]) for a in summ["by_agent"]] == [("codex", 999)], summ["by_agent"]
+
+
+def test_ingest_bad_or_missing_token_is_401():
+    _two_machines()
+    body = {"sessions": [_session("s1")]}
+    status_wrong, _ = _call("POST", "/org/ingest",
+                            headers={"X-TT-Machine-Token": "not-a-token"}, body=body)
+    assert status_wrong == 401, status_wrong
+    status_missing, _ = _call("POST", "/org/ingest", body=body)
+    assert status_missing == 401, status_missing
+    _, summ = _call("GET", "/org/summary")
+    assert summ["totals"]["sessions"] == 0, summ
+
+
+def test_ingest_machine_field_in_body_is_ignored():
+    """The label always comes from the token's config entry, never the body."""
+    _two_machines()
+    s = _session("s1")
+    s["machine"] = "spoofed-label"
+    status, _ = _call("POST", "/org/ingest",
+                      headers={"X-TT-Machine-Token": TOKEN_B}, body={"sessions": [s]})
+    assert status == 200, status
+    _, summ = _call("GET", "/org/summary")
+    assert [m["machine"] for m in summ["by_machine"]] == ["maria-desktop"], summ
+
+
+def test_status_enabled_flips_on_config_presence():
+    _reset(None)
+    status, data = _call("GET", "/org/status")
+    assert status == 200 and data == {"enabled": False, "machines": 0, "sessions": 0}, data
+    _two_machines()
+    status, data = _call("GET", "/org/status")
+    assert status == 200 and data == {"enabled": True, "machines": 2, "sessions": 0}, data
+
+
+def test_summary_disabled_shape_has_all_keys():
+    _reset(None)
+    status, data = _call("GET", "/org/summary")
+    assert status == 200, status
+    assert data == {
+        "enabled": False,
+        "totals": {"sessions": 0, "tokens": 0, "cost": 0.0},
+        "by_machine": [], "by_agent": [], "by_project": [], "recent": [],
+    }, data
+
+
+def test_summary_rollup_math_two_machines():
+    _two_machines()
+    _call("POST", "/org/ingest", headers={"X-TT-Machine-Token": TOKEN_A}, body={"sessions": [
+        _session("a1", agent="claude", project="tt", total=100, ts="2026-07-01T10:00:00+05:30"),
+        _session("a2", agent="codex", project="web", total=300, ts="2026-07-02T10:00:00+05:30"),
+    ]})
+    _call("POST", "/org/ingest", headers={"X-TT-Machine-Token": TOKEN_B}, body={"sessions": [
+        _session("b1", agent="claude", project="tt", total=500, ts="2026-07-03T10:00:00+05:30"),
+    ]})
+    status, data = _call("GET", "/org/summary")
+    assert status == 200, status
+    assert data["enabled"] is True
+    assert data["totals"] == {"sessions": 3, "tokens": 900, "cost": 0.0}, data["totals"]
+    machines = [(m["machine"], m["sessions"], m["tokens"], m["cost"]) for m in data["by_machine"]]
+    assert machines == [("maria-desktop", 1, 500, 0.0), ("kyle-laptop", 2, 400, 0.0)], machines
+    assert all(m["last_seen"] for m in data["by_machine"]), data["by_machine"]
+    agents = [(a["agent"], a["sessions"], a["tokens"]) for a in data["by_agent"]]
+    assert agents == [("claude", 2, 600), ("codex", 1, 300)], agents
+    projects = [(p["project"], p["tokens"]) for p in data["by_project"]]
+    assert projects == [("tt", 600), ("web", 300)], projects
+    assert [r["id"] for r in data["recent"]] == ["b1", "a2", "a1"], data["recent"]
+    assert data["recent"][0]["tokens_total"] == 500, data["recent"][0]
+
+
+def test_recent_orders_by_instant_across_offsets():
+    """'2026-07-01T20:00:00+05:30' is 14:30 UTC, EARLIER than 16:00 UTC even
+    though the string sorts higher; recent must order by instant, not text."""
+    _two_machines()
+    _call("POST", "/org/ingest", headers={"X-TT-Machine-Token": TOKEN_A}, body={"sessions": [
+        _session("ist", ts="2026-07-01T20:00:00+05:30"),
+        _session("utc", ts="2026-07-01T16:00:00+00:00"),
+    ]})
+    _, summ = _call("GET", "/org/summary")
+    assert [r["id"] for r in summ["recent"]] == ["utc", "ist"], summ["recent"]
+
+
+def test_ingest_non_ascii_token_is_401():
+    """Header bytes outside ASCII reach the handler latin-1 decoded; the token
+    lookup must answer 401, not crash in hmac.compare_digest with a 500."""
+    _two_machines()
+    status, _ = _call("POST", "/org/ingest",
+                      headers={"X-TT-Machine-Token": "caf\xe9-token"},
+                      body={"sessions": []})
+    assert status == 401, status
+
+
+def test_ingest_oversized_batch_is_422():
+    _two_machines()
+    sessions = [_session(f"s{i}") for i in range(1001)]
+    status, _ = _call("POST", "/org/ingest",
+                      headers={"X-TT-Machine-Token": TOKEN_A},
+                      body={"sessions": sessions})
+    assert status == 422, status
+    _, summ = _call("GET", "/org/summary")
+    assert summ["totals"]["sessions"] == 0, summ
+
+
+def test_ingest_bypasses_remote_auth_gate():
+    """A remote shipper without TT_AUTH_TOKEN reaches /org/ingest; its machine
+    token is still mandatory. Every other path stays gated for that client."""
+    _two_machines()
+    os.environ["TT_AUTH_TOKEN"] = "dashboard-secret"
+    try:
+        status, data = _call("POST", "/org/ingest", client=REMOTE,
+                             headers={"X-TT-Machine-Token": TOKEN_A},
+                             body={"sessions": [_session("s1")]})
+        assert status == 200, (status, data)
+        status_no_machine_token, _ = _call("POST", "/org/ingest", client=REMOTE,
+                                           body={"sessions": [_session("s2")]})
+        assert status_no_machine_token == 401, status_no_machine_token
+        status_other, _ = _call("GET", "/org/summary", client=REMOTE)
+        assert status_other == 401, status_other
+    finally:
+        os.environ.pop("TT_AUTH_TOKEN", None)
+
+
+def test_corrupt_org_json_means_disabled():
+    _reset(None)
+    (Path(_TMP) / "org.json").write_text("{not json", encoding="utf-8")
+    assert org_store.read_org_config() == {"machines": []}
+    assert org_store.resolve_machine(TOKEN_A) is None
+    status, data = _call("GET", "/org/status")
+    assert status == 200 and data["enabled"] is False, data
+
+
+def test_malformed_body_is_422():
+    _two_machines()
+    status, _ = _call("POST", "/org/ingest",
+                      headers={"X-TT-Machine-Token": TOKEN_A},
+                      body={"sessions": [{"id": "x"}]})
+    assert status == 422, status
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except Exception as e:  # noqa: BLE001
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    sys.exit(1 if failed else 0)

--- a/frontend/src/app/team/page.tsx
+++ b/frontend/src/app/team/page.tsx
@@ -1,0 +1,308 @@
+"use client";
+
+import { Users, Server, TrendingUp, DollarSign, Cpu, Folder } from "lucide-react";
+import { useResource } from "@/lib/api";
+import { timeAgo } from "@/lib/notifications";
+import { formatTokens, formatCost } from "@/lib/format";
+import type { OrgSummary } from "@/lib/org";
+import {
+  PageHeader, StatTile, Section, Card, CardEyebrow, CardTitle,
+  Table, THead, TBody, TR, TH, TD, AgentBadge, EmptyState, Skeleton,
+} from "@/components/ui";
+
+export default function TeamPage() {
+  const { data, loading, error } = useResource<OrgSummary>("/org/summary", { pollMs: 30_000 });
+
+  if (loading && !data) return <TeamLoading />;
+
+  if (error) {
+    return (
+      <div className="px-8 py-8 max-w-[1200px] mx-auto">
+        <EmptyState
+          icon={<Users size={20} />}
+          title="Couldn't load team data"
+          description={`The collector didn't respond (${error.message}). If you're running org mode on a separate host, make sure this dashboard points at it.`}
+        />
+      </div>
+    );
+  }
+
+  if (!data || !data.enabled) {
+    return <TeamSetup />;
+  }
+
+  return (
+    <div className="px-8 py-8 max-w-[1200px] mx-auto space-y-10 pb-20">
+      <PageHeader
+        eyebrow="Team"
+        title="Team usage"
+        description="Token consumption and cost rolled up across every machine reporting to this collector."
+        icon={<Users size={20} strokeWidth={2.25} />}
+      />
+
+      <Section title="Totals" description="Across all reporting machines, all time.">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <StatTile
+            label="Sessions"
+            value={data.totals.sessions.toLocaleString()}
+            hint={`${data.by_machine.length} machine${data.by_machine.length === 1 ? "" : "s"} reporting`}
+            icon={<Server size={16} />}
+            accent="var(--tt-brand)"
+          />
+          <StatTile
+            label="Tokens"
+            value={formatTokens(data.totals.tokens)}
+            hint={`${data.totals.tokens.toLocaleString()} total`}
+            icon={<TrendingUp size={16} />}
+            accent="var(--tt-info)"
+          />
+          <StatTile
+            label="Cost"
+            value={formatCost(data.totals.cost)}
+            hint="Sum of priced sessions"
+            icon={<DollarSign size={16} />}
+            accent="var(--tt-warn)"
+          />
+        </div>
+      </Section>
+
+      {/* By machine */}
+      <Card padding="none">
+        <div className="px-5 py-4 border-b border-[var(--tt-border)] flex items-center justify-between">
+          <CardTitle><Server size={14} className="text-[var(--tt-brand)]" /> By machine</CardTitle>
+          <CardEyebrow>{data.by_machine.length} machine{data.by_machine.length === 1 ? "" : "s"}</CardEyebrow>
+        </div>
+        <div className="overflow-x-auto">
+          <Table>
+            <THead>
+              <TR>
+                <TH className="pl-5">Machine</TH>
+                <TH className="text-right">Sessions</TH>
+                <TH className="text-right">Tokens</TH>
+                <TH className="text-right">Cost</TH>
+                <TH className="text-right pr-5">Last seen</TH>
+              </TR>
+            </THead>
+            <TBody>
+              {data.by_machine.length === 0 ? (
+                <TR><TD className="pl-5 text-[var(--tt-fg-dim)]" colSpan={5}>No sessions ingested yet.</TD></TR>
+              ) : (
+                data.by_machine.map((m) => (
+                  <TR key={m.machine} interactive>
+                    <TD className="pl-5">
+                      <span className="flex items-center gap-2 font-medium text-[var(--tt-fg)]">
+                        <Server size={12} className="text-[var(--tt-fg-dim)]" /> {m.machine}
+                      </span>
+                    </TD>
+                    <TD className="text-right tabular text-[var(--tt-fg-muted)]">{m.sessions.toLocaleString()}</TD>
+                    <TD className="text-right tabular font-semibold text-[var(--tt-fg)]">{formatTokens(m.tokens)}</TD>
+                    <TD className="text-right tabular font-semibold text-amber-300">{formatCost(m.cost)}</TD>
+                    <TD className="text-right pr-5 tabular text-[var(--tt-fg-dim)]">
+                      {m.last_seen ? timeAgo(m.last_seen) : "never"}
+                    </TD>
+                  </TR>
+                ))
+              )}
+            </TBody>
+          </Table>
+        </div>
+      </Card>
+
+      {/* By agent + by project side by side */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <Card padding="none">
+          <div className="px-5 py-4 border-b border-[var(--tt-border)] flex items-center justify-between">
+            <CardTitle><Cpu size={14} className="text-emerald-400" /> By agent</CardTitle>
+            <CardEyebrow>{data.by_agent.length} agent{data.by_agent.length === 1 ? "" : "s"}</CardEyebrow>
+          </div>
+          <div className="overflow-x-auto">
+            <Table>
+              <THead>
+                <TR>
+                  <TH className="pl-5">Agent</TH>
+                  <TH className="text-right">Sessions</TH>
+                  <TH className="text-right">Tokens</TH>
+                  <TH className="text-right pr-5">Cost</TH>
+                </TR>
+              </THead>
+              <TBody>
+                {data.by_agent.length === 0 ? (
+                  <TR><TD className="pl-5 text-[var(--tt-fg-dim)]" colSpan={4}>No data.</TD></TR>
+                ) : (
+                  data.by_agent.map((a) => (
+                    <TR key={a.agent} interactive>
+                      <TD className="pl-5"><AgentBadge agent={a.agent} /></TD>
+                      <TD className="text-right tabular text-[var(--tt-fg-muted)]">{a.sessions.toLocaleString()}</TD>
+                      <TD className="text-right tabular font-semibold text-[var(--tt-fg)]">{formatTokens(a.tokens)}</TD>
+                      <TD className="text-right pr-5 tabular font-semibold text-amber-300">{formatCost(a.cost)}</TD>
+                    </TR>
+                  ))
+                )}
+              </TBody>
+            </Table>
+          </div>
+        </Card>
+
+        <Card padding="none">
+          <div className="px-5 py-4 border-b border-[var(--tt-border)] flex items-center justify-between">
+            <CardTitle><Folder size={14} className="text-[var(--tt-brand)]" /> By project</CardTitle>
+            <CardEyebrow>{data.by_project.length} project{data.by_project.length === 1 ? "" : "s"}</CardEyebrow>
+          </div>
+          <div className="overflow-x-auto">
+            <Table>
+              <THead>
+                <TR>
+                  <TH className="pl-5">Project</TH>
+                  <TH className="text-right">Sessions</TH>
+                  <TH className="text-right">Tokens</TH>
+                  <TH className="text-right pr-5">Cost</TH>
+                </TR>
+              </THead>
+              <TBody>
+                {data.by_project.length === 0 ? (
+                  <TR><TD className="pl-5 text-[var(--tt-fg-dim)]" colSpan={4}>No data.</TD></TR>
+                ) : (
+                  data.by_project.map((p) => (
+                    <TR key={p.project} interactive>
+                      <TD className="pl-5">
+                        <span className="font-mono text-[12px] text-[var(--tt-fg)] truncate block max-w-[220px]" title={p.project}>
+                          {p.project || "(unknown)"}
+                        </span>
+                      </TD>
+                      <TD className="text-right tabular text-[var(--tt-fg-muted)]">{p.sessions.toLocaleString()}</TD>
+                      <TD className="text-right tabular font-semibold text-[var(--tt-fg)]">{formatTokens(p.tokens)}</TD>
+                      <TD className="text-right pr-5 tabular font-semibold text-amber-300">{formatCost(p.cost)}</TD>
+                    </TR>
+                  ))
+                )}
+              </TBody>
+            </Table>
+          </div>
+        </Card>
+      </div>
+
+      {/* Recent sessions */}
+      <Card padding="none">
+        <div className="px-5 py-4 border-b border-[var(--tt-border)] flex items-center justify-between">
+          <CardTitle><TrendingUp size={14} className="text-[var(--tt-brand)]" /> Recent sessions</CardTitle>
+          <CardEyebrow>newest {data.recent.length}</CardEyebrow>
+        </div>
+        <div className="overflow-x-auto">
+          <Table>
+            <THead>
+              <TR>
+                <TH className="pl-5">When</TH>
+                <TH>Machine</TH>
+                <TH>Agent</TH>
+                <TH>Project</TH>
+                <TH className="text-right">Tokens</TH>
+                <TH className="text-right pr-5">Cost</TH>
+              </TR>
+            </THead>
+            <TBody>
+              {data.recent.length === 0 ? (
+                <TR><TD className="pl-5 text-[var(--tt-fg-dim)]" colSpan={6}>No sessions ingested yet.</TD></TR>
+              ) : (
+                data.recent.map((s) => (
+                  <TR key={`${s.machine}:${s.id}`} interactive>
+                    <TD className="pl-5 tabular text-[var(--tt-fg-dim)] whitespace-nowrap">{timeAgo(s.timestamp)}</TD>
+                    <TD className="text-[var(--tt-fg-muted)] whitespace-nowrap">{s.machine}</TD>
+                    <TD><AgentBadge agent={s.agent} /></TD>
+                    <TD>
+                      <span className="font-mono text-[12px] text-[var(--tt-fg-muted)] truncate block max-w-[220px]" title={s.project}>
+                        {s.project || "(unknown)"}
+                      </span>
+                    </TD>
+                    <TD className="text-right tabular font-semibold text-[var(--tt-fg)]">{formatTokens(s.tokens_total)}</TD>
+                    <TD className="text-right pr-5 tabular text-amber-300">{s.cost == null ? "—" : formatCost(s.cost)}</TD>
+                  </TR>
+                ))
+              )}
+            </TBody>
+          </Table>
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+/* Empty state shown when org mode isn't configured. Explains what org mode is
+   and how to turn it on. The snippet is illustrative setup, not live values. */
+function TeamSetup() {
+  return (
+    <div className="px-8 py-8 max-w-[900px] mx-auto space-y-10 pb-20">
+      <PageHeader
+        eyebrow="Team"
+        title="Team usage"
+        description="Roll up token usage across your whole team on a collector you host yourself."
+        icon={<Users size={20} strokeWidth={2.25} />}
+      />
+
+      <Section title="What org mode is">
+        <div className="rounded-[var(--tt-radius-lg)] border border-[var(--tt-border)] bg-[var(--tt-sunken)] p-6 space-y-4 text-sm text-[var(--tt-fg-dim)]">
+          <p>
+            Org mode lets several developers report their agent usage to one
+            TokenTelemetry instance you run as a central collector. Each machine
+            keeps working locally as usual and, on a schedule, sends its session
+            totals (agent, project, tokens, cost) to the collector over a
+            token-authenticated endpoint. Nothing else leaves the machine, and no
+            prompt or transcript content is sent. This page then shows the
+            combined picture: usage by machine, by agent, and by project.
+          </p>
+          <p>
+            It&apos;s off until you configure at least one machine on the collector.
+          </p>
+        </div>
+      </Section>
+
+      <Section title="Turn it on" description="Two steps: register machines on the collector, then run the shipper on each dev box.">
+        <div className="rounded-[var(--tt-radius-lg)] border border-[var(--tt-border)] bg-[var(--tt-sunken)] p-6 space-y-5 text-sm text-[var(--tt-fg-dim)]">
+          <ol className="list-decimal list-inside space-y-4 text-[var(--tt-fg)]">
+            <li>
+              <span className="font-medium">On the collector,</span> create an{" "}
+              <code className="font-mono text-[12px] text-[var(--tt-fg-muted)] bg-[var(--tt-panel)] border border-[var(--tt-border)] rounded px-1 py-0.5">org.json</code>{" "}
+              in your data directory with one entry per machine and a random token for each:
+              <pre className="mt-2 text-[11px] font-mono text-[var(--tt-fg-muted)] whitespace-pre-wrap bg-[var(--tt-panel)] border border-[var(--tt-border)] rounded-lg p-3 overflow-x-auto">
+{`{
+  "machines": [
+    { "label": "kyle-laptop", "token": "` + `<random hex>` + `" }
+  ]
+}`}
+              </pre>
+            </li>
+            <li>
+              <span className="font-medium">On each dev machine,</span> run the shipper,
+              pointing it at the collector with that machine&apos;s token:
+              <pre className="mt-2 text-[11px] font-mono text-[var(--tt-fg-muted)] whitespace-pre-wrap bg-[var(--tt-panel)] border border-[var(--tt-border)] rounded-lg p-3 overflow-x-auto">
+{`python backend/org_ship.py \\
+  --central-url https://collector.example:8000 \\
+  --token <this machine's token>`}
+              </pre>
+            </li>
+          </ol>
+          <p>
+            Re-running the shipper is safe: ingestion is idempotent per machine and
+            session, so the same sessions never double-count. Once a machine
+            reports, this page fills in automatically.
+          </p>
+        </div>
+      </Section>
+    </div>
+  );
+}
+
+function TeamLoading() {
+  return (
+    <div className="px-8 py-8 max-w-[1200px] mx-auto space-y-10">
+      <Skeleton className="h-12 w-72" />
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {Array.from({ length: 3 }).map((_, i) => <Skeleton key={i} className="h-28 w-full" />)}
+      </div>
+      <Skeleton className="h-64 w-full" />
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <Skeleton className="h-64" />
+        <Skeleton className="h-64" />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import {
   LayoutDashboard, Folder, BarChart3, Activity, Settings2,
-  PanelLeftOpen, PanelLeftClose, Zap,
+  PanelLeftOpen, PanelLeftClose, Zap, Users,
 } from "lucide-react";
 import { useResource } from "@/lib/api";
 import { ALL_AGENT_KEYS, getAgent } from "@/lib/agents";
@@ -23,6 +23,7 @@ const LINKS = [
   { name: "Projects",  href: "/projects", icon: Folder },
   { name: "Analytics", href: "/analytics", icon: BarChart3 },
   { name: "Local Models", href: "/local-models", icon: Zap },
+  { name: "Team", href: "/team", icon: Users },
 ];
 
 export default function Navigation({ isCollapsed, setIsCollapsed }: NavigationProps) {

--- a/frontend/src/lib/org.ts
+++ b/frontend/src/lib/org.ts
@@ -1,0 +1,64 @@
+// Org mode (self-hosted team roll-up) response shapes. These mirror the backend
+// /org/status and /org/summary endpoints exactly; keep field names in sync with
+// backend/main.py or the two sides silently drift (tsc can't see the backend).
+//
+// The summary arrays and totals are ALWAYS present, even when org mode is off:
+// the backend returns empty totals/arrays so the frontend never branches on
+// missing keys — only on `enabled`.
+
+import { api } from "./api";
+
+export interface OrgStatus {
+  enabled: boolean;
+  machines: number; // count of configured machine entries
+  sessions: number; // total sessions ingested across all machines
+}
+
+export interface OrgMachineRow {
+  machine: string;
+  sessions: number;
+  tokens: number;
+  cost: number;
+  last_seen: string | null; // ISO8601, or null if nothing ingested yet
+}
+
+export interface OrgAgentRow {
+  agent: string;
+  sessions: number;
+  tokens: number;
+  cost: number;
+}
+
+export interface OrgProjectRow {
+  project: string;
+  sessions: number;
+  tokens: number;
+  cost: number;
+}
+
+export interface OrgRecentSession {
+  id: string;
+  machine: string;
+  agent: string;
+  project: string;
+  timestamp: string; // ISO8601
+  tokens_total: number;
+  cost: number | null;
+}
+
+export interface OrgSummary {
+  enabled: boolean;
+  totals: { sessions: number; tokens: number; cost: number };
+  by_machine: OrgMachineRow[];
+  by_agent: OrgAgentRow[];
+  by_project: OrgProjectRow[];
+  recent: OrgRecentSession[]; // newest 20
+}
+
+export function getOrgStatus(): Promise<OrgStatus> {
+  return api<OrgStatus>("/org/status");
+}
+
+export function getOrgSummary(): Promise<OrgSummary> {
+  return api<OrgSummary>("/org/summary");
+}


### PR DESCRIPTION
## What this is

First slice of org mode: teams run their own central collector, each dev machine ships metric rollups to it, and a new Team page shows the aggregate. Nothing changes for single-user local use; without an org.json the endpoints report disabled and the page shows setup instructions.

## Pieces

- **`POST /org/ingest`** — accepts session rollups (id, agent, project, timestamp, token counts, optional model/cost). Auth is a per-machine token (`X-TT-Machine-Token`) resolved against `<data_dir>/org.json`, compared constant-time against every configured token. The endpoint is exempt from the `TT_AUTH_TOKEN` dashboard gate (remote agents don't hold that token) but its own machine-token check is mandatory even from loopback. Batch capped at 1000 sessions; string fields length-capped; malformed bodies 422 before any write.
- **`backend/org_store.py`** — SQLite at `<data_dir>/org.db`, PRIMARY KEY `(machine, session_id)`, upsert returns (accepted, updated) so re-scans never double-count. `summary()` rolls up totals, by-machine/by-agent/by-project, and the 20 most recent sessions ordered by `datetime(timestamp)` so mixed UTC offsets sort by real instant.
- **`backend/org_ship.py`** — stdlib-only shipper for cron/launchd: reads the local backend's `/sessions`, maps to rollups, posts in batches. `--central-url` / `--token` flags or `TT_CENTRAL_URL` / `TT_MACHINE_TOKEN` envs.
- **Frontend `/team`** — totals cards, per-machine (with last-seen), per-agent and per-project tables, recent sessions; empty state walks through collector + shipper setup. Nav entry added.
- **`backend/test_org_mode.py`** — 14 tests: valid/invalid/missing token, idempotent re-send, re-send with changed values must overwrite (kills a DO NOTHING regression), mixed-offset recent ordering, non-ASCII token answers 401 not 500, oversize batch 422, body-label spoof ignored, corrupt org.json treated as disabled, remote-client ingest with TT_AUTH_TOKEN set.

## Verification

- `pytest backend/test_org_mode.py backend/test_remote_auth.py` — 27 passed.
- `tsc --noEmit` in `frontend/` — clean.
- Independent recompute: seeded two machines with known counts via `org_store` directly; hand-computed totals (3 sessions / 600 tokens / $2.00), per-machine and per-agent splits, and instant-ordering of `recent` across `+05:30`/`+00:00` offsets all match `summary()` exactly. Re-ingest of an identical batch returned accepted 0 / updated 2 with totals unchanged.
- Built with a multi-agent workflow; three adversarial review passes (auth, data correctness, FE/BE contract) surfaced four real issues — unbounded ingest batch, non-ASCII token crash, lexical timestamp ordering, and an upsert-blind test suite — all fixed and covered by new tests.

## Not in this PR (deliberate)

Docker Compose packaging for the collector, machine-token management CLI, cost/model enrichment in the shipper, per-team grouping, and any managed-cloud/multi-tenant layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019aPyCUWq54vgUopuZnZww7