### PR TITLE
fix: Codex Desktop session crash on structured reasoning summaries (#181)

### DIFF
--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -16,6 +16,7 @@ import SummaryPanel from "@/components/summarizer/SummaryPanel";
 import { apiFetch, artifactUrl } from "@/lib/api";
 import { formatTokens, formatCost } from "@/lib/format";
 import { resolveSessionBackTarget } from "@/lib/navigation";
+import { coerceReasoningText } from "@/lib/reasoning";
 
 interface Artifact {
   name: string;
@@ -2007,9 +2008,7 @@ function EventCard({ event, mode = "all", agent, tokens }: { event: any, mode?: 
               {renderTimestamp()}
             </div>
             <div className="text-[var(--tt-fg-muted)] whitespace-pre-wrap italic text-xs leading-relaxed font-mono opacity-80">{
-              Array.isArray(payload.content)
-                ? payload.content.map((c: any) => c?.text ?? c?.summary ?? c?.content ?? (typeof c === 'string' ? c : "")).filter(Boolean).join("\n\n")
-                : (typeof payload.content === 'string' ? payload.content : (payload.summary ?? payload.text ?? ""))
+              coerceReasoningText(payload.content ?? payload.summary ?? payload.text)
             }</div>
           </div>
        );

--- a/frontend/src/lib/reasoning.test.ts
+++ b/frontend/src/lib/reasoning.test.ts
@@ -1,0 +1,54 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { coerceReasoningText } from "./reasoning";
+
+test("plain string passes through", () => {
+  assert.equal(coerceReasoningText("Planning the client"), "Planning the client");
+});
+
+// Regression for issue #181: Codex Desktop reasoning summaries arrive as an
+// array of { type, text } objects. Passing that array to React as a child
+// crashes the whole session detail page ("Objects are not valid as a React
+// child"). It must be flattened to the joined text instead.
+test("structured Codex summary array is flattened to text", () => {
+  const summary = [
+    { type: "summary_text", text: "Planning custom HTTP client logging handler" },
+    { type: "summary_text", text: "Wiring the retry path" },
+  ];
+  assert.equal(
+    coerceReasoningText(summary),
+    "Planning custom HTTP client logging handler\n\nWiring the retry path",
+  );
+});
+
+test("single-element summary array yields just its text", () => {
+  assert.equal(
+    coerceReasoningText([{ type: "summary_text", text: "one step" }]),
+    "one step",
+  );
+});
+
+test("nested object with a text field is unwrapped", () => {
+  assert.equal(coerceReasoningText({ type: "reasoning", text: "hi" }), "hi");
+});
+
+test("alternate text-bearing keys are honored", () => {
+  assert.equal(coerceReasoningText({ thinking: "t" }), "t");
+  assert.equal(coerceReasoningText({ content: "c" }), "c");
+  assert.equal(coerceReasoningText({ value: "v" }), "v");
+});
+
+test("empty/unknown shapes degrade to empty string, never throw", () => {
+  assert.equal(coerceReasoningText(null), "");
+  assert.equal(coerceReasoningText(undefined), "");
+  assert.equal(coerceReasoningText([]), "");
+  assert.equal(coerceReasoningText({}), "");
+  assert.equal(coerceReasoningText({ type: "summary_text" }), "");
+});
+
+test("mixed string and object array items both render", () => {
+  assert.equal(
+    coerceReasoningText(["raw", { text: "obj" }]),
+    "raw\n\nobj",
+  );
+});

--- a/frontend/src/lib/reasoning.ts
+++ b/frontend/src/lib/reasoning.ts
@@ -1,0 +1,19 @@
+// Coerce a reasoning/content value of unknown shape into a display string.
+//
+// Agent session payloads represent reasoning inconsistently. Codex Desktop can
+// send it as a plain string, an array of `{ type, text }` summary objects, or a
+// nested object. React crashes ("Objects are not valid as a React child") if any
+// of these object shapes reaches JSX as a child directly, so every reasoning
+// value must pass through here before it is rendered.
+export function coerceReasoningText(value: unknown): string {
+  if (value == null) return "";
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) {
+    return value.map((item) => coerceReasoningText(item)).filter(Boolean).join("\n\n");
+  }
+  if (typeof value === "object") {
+    const o = value as Record<string, unknown>;
+    return coerceReasoningText(o.text ?? o.thinking ?? o.summary ?? o.content ?? o.value ?? "");
+  }
+  return String(value);
+}


### PR DESCRIPTION
## What

Fixes #181 — opening a Codex Desktop session with structured reasoning summaries crashed the entire session detail page with:

> Objects are not valid as a React child (found: object with keys {type, text})

## Cause

Newer Codex Desktop reasoning events carry `payload.summary` as an array of `{ type, text }` objects. In `EventCard`'s `response_item` reasoning branch, when `payload.content` was absent the code fell back to `payload.summary` and passed that raw array of objects straight to React as a child, crashing the page.

## Fix

- Added `coerceReasoningText` (`frontend/src/lib/reasoning.ts`) — flattens any reasoning value shape (plain string, array of `{type,text}` summary objects, nested object) into a display string. Unknown/empty shapes degrade to `""` instead of throwing.
- Routed the Codex reasoning branch through it, replacing the ad-hoc inline extraction.
- Added `reasoning.test.ts` (`node:test`, same pattern as `navigation.test.ts`) covering the reported array-of-summaries shape, single/mixed arrays, nested objects, alternate keys, and graceful degradation.

## Verification

- `node --test` on the new suite: 7/7 pass (exercised against the real module).
- `tsc --noEmit`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)