### PR TITLE
feat(sessions): show model reasoning effort for every agent that records one

### DIFF
--- a/UPDATE.json
+++ b/UPDATE.json
@@ -1,6 +1,17 @@
 {
   "releases": [
     {
+      "tag": "2026-07-19",
+      "title": "See the reasoning effort Codex ran at",
+      "highlights": [
+        {
+          "title": "Reasoning effort on Codex sessions",
+          "description": "A Codex session's context panel now shows the model reasoning effort it actually ran at (minimal / low / medium / high / xhigh). Because Codex can change effort between turns, sessions that shifted show the progression (e.g. \"medium → xhigh\") rather than a single value. The Sandbox and Approval Policy rows, which were silently blank for Codex before, now populate too.",
+          "href": "/sessions"
+        }
+      ]
+    },
+    {
       "tag": "2026-07-18",
       "title": "See which experimental features each agent has on",
       "highlights": [

--- a/UPDATE.json
+++ b/UPDATE.json
@@ -2,11 +2,11 @@
   "releases": [
     {
       "tag": "2026-07-19",
-      "title": "See the reasoning effort Codex ran at",
+      "title": "See the reasoning effort each session ran at",
       "highlights": [
         {
-          "title": "Reasoning effort on Codex sessions",
-          "description": "A Codex session's context panel now shows the model reasoning effort it actually ran at (minimal / low / medium / high / xhigh). Because Codex can change effort between turns, sessions that shifted show the progression (e.g. \"medium → xhigh\") rather than a single value. The Sandbox and Approval Policy rows, which were silently blank for Codex before, now populate too.",
+          "title": "Reasoning effort across agents",
+          "description": "A session's context panel now shows the model reasoning effort it actually ran at — for every agent that records one: Claude, Codex, Copilot, Grok, Hermes and Pi (values like minimal / low / medium / high / xhigh, or Pi's off). When the effort changed mid-session, the progression is shown (e.g. \"medium → xhigh\") instead of a single value. Agents that don't record a discrete effort setting simply don't show the row.",
           "href": "/sessions"
         }
       ]

--- a/backend/main.py
+++ b/backend/main.py
@@ -5604,6 +5604,12 @@ async def get_session_detail(session_id: str, agent: str):
                                 })
                             if content_blocks:
                                 norm = {"type": "assistant", "message": {"role": "assistant", "content": content_blocks}}
+                                # Surface the reasoning-effort setting so the
+                                # session context panel can show it (grok records
+                                # it per assistant turn; low/medium/high/xhigh).
+                                _re = entry.get("reasoning_effort")
+                                if isinstance(_re, str) and _re:
+                                    norm["reasoning_effort"] = _re
 
                         elif etype == "reasoning":
                             summ = entry.get("summary") or []
@@ -5662,6 +5668,21 @@ async def get_session_detail(session_id: str, agent: str):
                 try:
                     evt = json.loads(line)
                 except Exception:
+                    continue
+                # pi records the thinking-level setting (off/medium/high) as
+                # dedicated events; pass them through so the context panel can
+                # show the reasoning effort the session ran at.
+                if evt.get("type") == "thinking_level_change":
+                    _tl = evt.get("thinkingLevel")
+                    if isinstance(_tl, str) and _tl:
+                        _tle = {"type": "thinking_level_change", "thinkingLevel": _tl}
+                        _tlts = evt.get("timestamp")
+                        if _tlts:
+                            try:
+                                _tle["normalized_timestamp"] = _aware(datetime.fromisoformat(str(_tlts).replace("Z", "+00:00"))).timestamp() * 1000
+                            except Exception:
+                                pass
+                        events.append(_tle)
                     continue
                 if evt.get("type") != "message":
                     continue
@@ -5930,6 +5951,13 @@ async def get_session_detail(session_id: str, agent: str):
                             "tool": tr.get("name"), "callID": tr.get("toolCallId"),
                             "arguments": tr.get("arguments"),
                         }, **base})
+                elif et == "session.model_change":
+                    # Copilot records the reasoning-effort setting on model-change
+                    # events (null on Claude models, which have no effort enum);
+                    # surface it so the context panel can show it.
+                    _ce = d.get("reasoningEffort")
+                    if isinstance(_ce, str) and _ce:
+                        events.append({"type": "reasoning_effort", "payload": {"effort": _ce}, **base})
             return events
         # VS Code ~1.100+ stores sessions as <id>.jsonl (delta log) instead of
         # <id>.json (single object); match both and reconstruct the .jsonl form.
@@ -6005,10 +6033,20 @@ async def get_session_detail(session_id: str, agent: str):
                 conn = sqlite3.connect(uri, uri=True, timeout=1.0)
                 conn.row_factory = sqlite3.Row
                 try:
-                    srow = conn.execute("SELECT id FROM sessions WHERE id=?", (session_id,)).fetchone()
+                    srow = conn.execute("SELECT id, model_config FROM sessions WHERE id=?", (session_id,)).fetchone()
                     if not srow:
                         continue
                     events: List[Dict[str, Any]] = []
+                    # Surface the reasoning-effort setting (model_config.
+                    # reasoning_config.effort) as a session-level meta event so the
+                    # context panel can show it, mirroring the codex session_meta shape.
+                    try:
+                        _mc = json.loads(srow["model_config"] or "{}")
+                        _rc = _mc.get("reasoning_config") or {}
+                        if _rc.get("enabled") and isinstance(_rc.get("effort"), str) and _rc.get("effort"):
+                            events.append({"type": "session_meta", "payload": {"effort": _rc["effort"]}})
+                    except Exception:
+                        pass
                     for mrow in conn.execute(
                         "SELECT role, content, tool_calls, tool_call_id, tool_name, "
                         "timestamp, reasoning_content FROM messages WHERE session_id=? "

--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -508,6 +508,8 @@ export default function SessionDetailPage() {
       })(),
       approvalPolicy: meta?.approval_policy || turnCtx?.approval_policy,
       reasoningEffort: reasoningEfforts.length ? reasoningEfforts.join(" → ") : undefined,
+      // pi calls it "thinking level" (off/medium/high); label its row to match.
+      reasoningEffortLabel: agent === "pi" ? "Thinking Level" : "Reasoning Effort",
       instructions: meta?.instructions || turnCtx?.instructions,
       env: meta?.env,
       systemPrompt: typeof firstSystem === "string" ? firstSystem : undefined,
@@ -1294,7 +1296,7 @@ function ContextPanel({ ctx }: { ctx: any }) {
 
       <Row k="Sandbox" v={ctx.sandbox} />
       <Row k="Approval Policy" v={ctx.approvalPolicy} />
-      <Row k="Reasoning Effort" v={ctx.reasoningEffort} />
+      <Row k={ctx.reasoningEffortLabel ?? "Reasoning Effort"} v={ctx.reasoningEffort} />
       {ctx.instructions && (
         <details>
           <summary className="text-[9px] font-semibold uppercase tracking-[0.16em] text-[var(--tt-fg-dim)] cursor-pointer hover:text-[var(--tt-fg)]">Instructions ▸</summary>

--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -190,6 +190,38 @@ function normalizeTraceEvents(agent: string | null, data: any): Event[] {
   return evts;
 }
 
+/* Extract the model reasoning-effort setting an agent ran at, as ordered-distinct
+   enum strings (e.g. ["medium","xhigh"]). Each supported agent records it in its
+   own place in the raw (pre-normalization) detail events; agents that don't
+   record a discrete effort/level setting return []. The caller joins the result
+   with " → " so a session that changed effort mid-run shows the progression.
+   Only agents with a real signal are listed — see the reasoning-effort audit. */
+function extractReasoningEfforts(agent: string | null, rawEvents: any[]): string[] {
+  const out: string[] = [];
+  const push = (v: any) => { if (typeof v === "string" && v && !out.includes(v)) out.push(v); };
+  switch (agent) {
+    case "codex": // per-turn turn_context; newer builds mirror under collaboration_mode
+      for (const e of rawEvents) if (e.type === "turn_context") push(e.payload?.effort ?? e.payload?.collaboration_mode?.settings?.reasoning_effort);
+      break;
+    case "claude": // top-level `effort` on assistant records (CLI 2.1.212+; absent = unknown)
+      for (const e of rawEvents) if (e.type === "assistant") push(e.effort);
+      break;
+    case "grok": // top-level reasoning_effort on assistant turns
+      for (const e of rawEvents) if (e.type === "assistant") push(e.reasoning_effort);
+      break;
+    case "copilot": // model_change events surfaced as reasoning_effort by the backend
+      for (const e of rawEvents) if (e.type === "reasoning_effort") push(e.payload?.effort);
+      break;
+    case "hermes": // session-level reasoning_config.effort surfaced on session_meta
+      push(rawEvents.find((e) => e.type === "session_meta")?.payload?.effort);
+      break;
+    case "pi": // dedicated thinking_level_change events (off/medium/high)
+      for (const e of rawEvents) if (e.type === "thinking_level_change") push(e.thinkingLevel);
+      break;
+  }
+  return out;
+}
+
 function normalizeTs(evt: Event): number | undefined {
   if (typeof evt.normalized_timestamp === "number") return evt.normalized_timestamp;
   if (evt.timestamp) {
@@ -458,16 +490,9 @@ export default function SessionDetailPage() {
     const meta = events.find((e) => e.type === "session_meta")?.payload;
     const turnCtx = rawEvents.find((e) => e.type === "turn_context")?.payload;
     const firstSystem = events.find((e) => e.type === "user" && typeof e.message?.content === "string")?.message?.content;
-    // Codex records the model reasoning effort per turn in
-    // turn_context.payload.effort (newer builds also mirror it under
-    // collaboration_mode.settings.reasoning_effort). It can change across
-    // turns, so collect the distinct values in order rather than showing one.
-    const reasoningEfforts: string[] = [];
-    for (const e of rawEvents) {
-      if (e.type !== "turn_context") continue;
-      const eff = e.payload?.effort ?? e.payload?.collaboration_mode?.settings?.reasoning_effort;
-      if (typeof eff === "string" && eff && !reasoningEfforts.includes(eff)) reasoningEfforts.push(eff);
-    }
+    // Reasoning effort the agent ran at, per agent (see extractReasoningEfforts).
+    // Dispatch on the `agent` the trace was fetched with, so it agrees with rawEvents.
+    const reasoningEfforts = extractReasoningEfforts(agent, rawEvents);
     return {
       sessionId: id,
       agent: sessionInfo?.agent,
@@ -488,7 +513,7 @@ export default function SessionDetailPage() {
       systemPrompt: typeof firstSystem === "string" ? firstSystem : undefined,
       projectConfig,
     };
-  }, [events, rawEvents, sessionInfo, modelsUsed, projectConfig, id]);
+  }, [agent, events, rawEvents, sessionInfo, modelsUsed, projectConfig, id]);
 
   // Fetch per-project config (skills + MCPs) once we know the cwd
   useEffect(() => {

--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -196,29 +196,39 @@ function normalizeTraceEvents(agent: string | null, data: any): Event[] {
    record a discrete effort/level setting return []. The caller joins the result
    with " → " so a session that changed effort mid-run shows the progression.
    Only agents with a real signal are listed — see the reasoning-effort audit. */
+function reasoningEffortTimeline(agent: string | null, rawEvents: any[]): { ts: number; effort: string }[] {
+  const pts: { ts: number; effort: string }[] = [];
+  const add = (e: any, v: any) => { if (typeof v === "string" && v) pts.push({ ts: normalizeTs(e) ?? 0, effort: v }); };
+  for (const e of rawEvents) {
+    switch (agent) {
+      case "codex": // per-turn turn_context; newer builds mirror under collaboration_mode
+        if (e.type === "turn_context") add(e, e.payload?.effort ?? e.payload?.collaboration_mode?.settings?.reasoning_effort);
+        break;
+      case "claude": // top-level `effort` on assistant records (CLI 2.1.212+; absent = unknown)
+        if (e.type === "assistant") add(e, e.effort);
+        break;
+      case "grok": // top-level reasoning_effort on assistant turns
+        if (e.type === "assistant") add(e, e.reasoning_effort);
+        break;
+      case "copilot": // model_change events surfaced as reasoning_effort by the backend
+        if (e.type === "reasoning_effort") add(e, e.payload?.effort);
+        break;
+      case "hermes": // session-level reasoning_config.effort surfaced on session_meta
+        if (e.type === "session_meta") add(e, e.payload?.effort);
+        break;
+      case "pi": // dedicated thinking_level_change events (off/medium/high)
+        if (e.type === "thinking_level_change") add(e, e.thinkingLevel);
+        break;
+    }
+  }
+  return pts;
+}
+
+/* Ordered-distinct effort values across the session (e.g. ["medium","xhigh"]),
+   for the single context-panel row; the caller joins them with " → ". */
 function extractReasoningEfforts(agent: string | null, rawEvents: any[]): string[] {
   const out: string[] = [];
-  const push = (v: any) => { if (typeof v === "string" && v && !out.includes(v)) out.push(v); };
-  switch (agent) {
-    case "codex": // per-turn turn_context; newer builds mirror under collaboration_mode
-      for (const e of rawEvents) if (e.type === "turn_context") push(e.payload?.effort ?? e.payload?.collaboration_mode?.settings?.reasoning_effort);
-      break;
-    case "claude": // top-level `effort` on assistant records (CLI 2.1.212+; absent = unknown)
-      for (const e of rawEvents) if (e.type === "assistant") push(e.effort);
-      break;
-    case "grok": // top-level reasoning_effort on assistant turns
-      for (const e of rawEvents) if (e.type === "assistant") push(e.reasoning_effort);
-      break;
-    case "copilot": // model_change events surfaced as reasoning_effort by the backend
-      for (const e of rawEvents) if (e.type === "reasoning_effort") push(e.payload?.effort);
-      break;
-    case "hermes": // session-level reasoning_config.effort surfaced on session_meta
-      push(rawEvents.find((e) => e.type === "session_meta")?.payload?.effort);
-      break;
-    case "pi": // dedicated thinking_level_change events (off/medium/high)
-      for (const e of rawEvents) if (e.type === "thinking_level_change") push(e.thinkingLevel);
-      break;
-  }
+  for (const { effort } of reasoningEffortTimeline(agent, rawEvents)) if (!out.includes(effort)) out.push(effort);
   return out;
 }
 
@@ -418,6 +428,22 @@ export default function SessionDetailPage() {
     });
     return out;
   }, [events]);
+
+  // The reasoning effort in effect at each step, so a reasoning card can show it
+  // and a mid-session change is visible where it happened. Built from the raw
+  // (pre-normalization) events because some agents record effort on events that
+  // normalizeTraceEvents strips from the step view (e.g. codex turn_context).
+  const stepReasoningEffort = useMemo(() => {
+    const timeline = reasoningEffortTimeline(agent, rawEvents);
+    if (!timeline.length) return new Array(events.length).fill(undefined);
+    const sorted = [...timeline].sort((a, b) => a.ts - b.ts);
+    const effortAt = (ts: number) => {
+      let cur: string | undefined = sorted[0].effort; // before the first change → first known effort
+      for (const p of sorted) { if (p.ts <= ts) cur = p.effort; else break; }
+      return cur;
+    };
+    return events.map((e) => effortAt(normalizeTs(e) ?? 0));
+  }, [agent, rawEvents, events]);
 
   // Steps for left index
   const steps: Step[] = useMemo(
@@ -843,7 +869,7 @@ export default function SessionDetailPage() {
 
                       return (
                          <div key={idx} ref={(el) => { stepRefs.current[idx] = el; }} className={activeStep === idx ? `${stepRingClass[kind]} rounded-[var(--tt-radius-lg)]` : ""}>
-                            <EventCard event={event} mode={splitView ? "dialogue" : "all"} agent={agent} tokens={stepTokens[idx]} />
+                            <EventCard event={event} mode={splitView ? "dialogue" : "all"} agent={agent} tokens={stepTokens[idx]} reasoningEffort={stepReasoningEffort[idx]} />
                          </div>
                       );
                    })}
@@ -1251,6 +1277,9 @@ function ContextPanel({ ctx }: { ctx: any }) {
           </div>
         </div>
       )}
+      <Row k="Sandbox" v={ctx.sandbox} />
+      <Row k="Approval Policy" v={ctx.approvalPolicy} />
+      <Row k={ctx.reasoningEffortLabel ?? "Reasoning Effort"} v={ctx.reasoningEffort} />
       <Row k="CWD" v={ctx.cwd} />
 
       {ctx.projectConfig && (ctx.projectConfig.counts?.skills > 0 || ctx.projectConfig.counts?.mcps > 0) && (
@@ -1294,9 +1323,6 @@ function ContextPanel({ ctx }: { ctx: any }) {
         </div>
       )}
 
-      <Row k="Sandbox" v={ctx.sandbox} />
-      <Row k="Approval Policy" v={ctx.approvalPolicy} />
-      <Row k={ctx.reasoningEffortLabel ?? "Reasoning Effort"} v={ctx.reasoningEffort} />
       {ctx.instructions && (
         <details>
           <summary className="text-[9px] font-semibold uppercase tracking-[0.16em] text-[var(--tt-fg-dim)] cursor-pointer hover:text-[var(--tt-fg)]">Instructions ▸</summary>
@@ -1533,8 +1559,21 @@ function ArtifactViewer({ path }: { path: string }) {
   );
 }
 
-function EventCard({ event, mode = "all", agent, tokens }: { event: any, mode?: "dialogue" | "brain" | "all", agent?: string | null, tokens?: StepTokens | null }) {
+function EventCard({ event, mode = "all", agent, tokens, reasoningEffort }: { event: any, mode?: "dialogue" | "brain" | "all", agent?: string | null, tokens?: StepTokens | null, reasoningEffort?: string }) {
   const { type, timestamp, message, attachment, toolUseResult, payload, content, thoughts, toolCalls } = event;
+
+  // Small badge showing the model reasoning effort in effect for this reasoning
+  // step, so a mid-session effort change is visible on the card where it happened
+  // (constant effort just repeats the same value on every reasoning card).
+  const effortLabel = agent === "pi" ? "thinking level" : "effort";
+  const effortBadge = reasoningEffort ? (
+    <span
+      title={`Model reasoning ${effortLabel} in effect for this step`}
+      className="ml-2 px-1.5 py-0.5 rounded text-[9px] font-mono normal-case tracking-normal text-[var(--tt-warn-fg)] bg-amber-500/10 border border-amber-500/30"
+    >
+      {effortLabel}: {reasoningEffort}
+    </span>
+  ) : null;
 
   // Render a tiny timestamp badge if available
   const renderTimestamp = () => {
@@ -1600,7 +1639,7 @@ function EventCard({ event, mode = "all", agent, tokens }: { event: any, mode?: 
         <div className="bg-indigo-500/5 border border-indigo-500/20 rounded-[var(--tt-radius)] p-6 ml-4 border-l-4 border-l-indigo-500/50 group">
           <div className="flex justify-between items-start mb-3">
             <div className="flex items-center gap-2 text-[var(--tt-violet-fg)] font-bold text-xs uppercase tracking-widest">
-              <Brain size={16} /> Copilot Reasoning
+              <Brain size={16} /> Copilot Reasoning{effortBadge}
             </div>
             {renderTimestamp()}
           </div>
@@ -1619,7 +1658,7 @@ function EventCard({ event, mode = "all", agent, tokens }: { event: any, mode?: 
              <div key={`copilot-think-${i}`} className="bg-indigo-500/5 border border-indigo-500/20 rounded-[var(--tt-radius)] p-6 ml-4 border-l-4 border-l-indigo-500/50 group">
                <div className="flex justify-between items-start mb-3">
                  <div className="flex items-center gap-2 text-[var(--tt-violet-fg)] font-bold text-xs uppercase tracking-widest">
-                   <Brain size={16} /> Reasoning
+                   <Brain size={16} /> Reasoning{effortBadge}
                  </div>
                  {renderTimestamp()}
                </div>
@@ -1928,7 +1967,7 @@ function EventCard({ event, mode = "all", agent, tokens }: { event: any, mode?: 
         <div className={`${bg} border ${border} rounded-[var(--tt-radius)] p-6 ml-4 border-l-4 ${accent} group`}>
           <div className="flex justify-between items-start mb-3">
             <div className={`flex items-center gap-2 ${textColor} font-bold text-xs uppercase tracking-widest`}>
-              <Brain size={16} /> Reasoning
+              <Brain size={16} /> Reasoning{effortBadge}
             </div>
             {renderTimestamp()}
           </div>
@@ -1992,7 +2031,7 @@ function EventCard({ event, mode = "all", agent, tokens }: { event: any, mode?: 
             <div key={`think-${i}`} className="bg-amber-500/5 border border-amber-500/20 rounded-[var(--tt-radius)] p-6 ml-4 border-l-4 border-l-amber-500/50 group">
               <div className="flex justify-between items-start mb-3">
                 <div className="flex items-center gap-2 text-[var(--tt-warn-fg)] font-bold text-xs uppercase tracking-widest">
-                  <Brain size={16} /> Reasoning {isEncrypted && <span className="text-[9px] font-mono normal-case tracking-normal text-[var(--tt-warn-fg)]/70 bg-amber-500/10 px-1.5 py-0.5 rounded border border-amber-500/30">encrypted</span>}
+                  <Brain size={16} /> Reasoning{effortBadge} {isEncrypted && <span className="text-[9px] font-mono normal-case tracking-normal text-[var(--tt-warn-fg)]/70 bg-amber-500/10 px-1.5 py-0.5 rounded border border-amber-500/30">encrypted</span>}
                 </div>
                 {renderTimestamp()}
               </div>
@@ -2053,7 +2092,7 @@ function EventCard({ event, mode = "all", agent, tokens }: { event: any, mode?: 
           <div className="bg-purple-500/5 border border-purple-500/20 rounded-[var(--tt-radius)] p-6 ml-4 border-l-4 border-l-purple-500/50 group">
             <div className="flex justify-between items-start mb-3">
               <div className="flex items-center gap-2 text-[var(--tt-violet-fg)] font-bold mb-3 text-xs uppercase tracking-widest">
-                <Brain size={16} /> Reasoning
+                <Brain size={16} /> Reasoning{effortBadge}
               </div>
               {renderTimestamp()}
             </div>
@@ -2151,7 +2190,7 @@ function EventCard({ event, mode = "all", agent, tokens }: { event: any, mode?: 
         <div className="bg-purple-500/5 border border-purple-500/20 rounded-[var(--tt-radius)] p-6 ml-4 border-l-4 border-l-purple-500/50 group">
           <div className="flex justify-between items-start mb-3">
             <div className="flex items-center gap-2 text-[var(--tt-violet-fg)] font-bold text-xs uppercase tracking-widest">
-              <Brain size={16} /> Reasoning
+              <Brain size={16} /> Reasoning{effortBadge}
             </div>
             {renderTimestamp()}
           </div>

--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -245,6 +245,11 @@ export default function SessionDetailPage() {
   })();
 
   const [events, setEvents] = useState<Event[]>([]);
+  // Raw, un-normalized trace events. normalizeTraceEvents drops `turn_context`
+  // (and token_count) for Codex so they don't clutter the step view, but the
+  // Session Context panel still needs turn_context (sandbox / approval policy /
+  // reasoning effort). Keep the raw array so the context reads survive.
+  const [rawEvents, setRawEvents] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
   const [sessionInfo, setSessionInfo] = useState<Session | null>(null);
   const [hermesOverlay, setHermesOverlay] = useState<any | null>(null);
@@ -285,6 +290,7 @@ export default function SessionDetailPage() {
         .then((res) => res.json())
         .then((data) => {
           const evts = normalizeTraceEvents(agent, data);
+          setRawEvents(Array.isArray(data) ? data : []);
           setEvents(evts);
           setPlaybackIndex(evts.length);
           setLoading(false)
@@ -447,9 +453,21 @@ export default function SessionDetailPage() {
 
   // Context Inspector
   const context = useMemo(() => {
+    // turn_context is stripped from `events` (see normalizeTraceEvents), so read
+    // it from the raw trace for the context panel.
     const meta = events.find((e) => e.type === "session_meta")?.payload;
-    const turnCtx = events.find((e) => e.type === "turn_context")?.payload;
+    const turnCtx = rawEvents.find((e) => e.type === "turn_context")?.payload;
     const firstSystem = events.find((e) => e.type === "user" && typeof e.message?.content === "string")?.message?.content;
+    // Codex records the model reasoning effort per turn in
+    // turn_context.payload.effort (newer builds also mirror it under
+    // collaboration_mode.settings.reasoning_effort). It can change across
+    // turns, so collect the distinct values in order rather than showing one.
+    const reasoningEfforts: string[] = [];
+    for (const e of rawEvents) {
+      if (e.type !== "turn_context") continue;
+      const eff = e.payload?.effort ?? e.payload?.collaboration_mode?.settings?.reasoning_effort;
+      if (typeof eff === "string" && eff && !reasoningEfforts.includes(eff)) reasoningEfforts.push(eff);
+    }
     return {
       sessionId: id,
       agent: sessionInfo?.agent,
@@ -457,15 +475,20 @@ export default function SessionDetailPage() {
       modelsUsed,
       provider: meta?.model_provider,
       cwd: meta?.cwd || sessionInfo?.project,
-      sandbox: meta?.sandbox_policy || turnCtx?.sandbox_policy,
+      sandbox: (() => {
+        const sb = meta?.sandbox_policy || turnCtx?.sandbox_policy;
+        // Codex sandbox_policy is an object ({type/mode, network_access, …});
+        // show the mode compactly instead of dumping the whole JSON blob.
+        return sb && typeof sb === "object" ? (sb.mode || sb.type || JSON.stringify(sb)) : sb;
+      })(),
       approvalPolicy: meta?.approval_policy || turnCtx?.approval_policy,
-      reasoningEffort: turnCtx?.model_reasoning_effort,
+      reasoningEffort: reasoningEfforts.length ? reasoningEfforts.join(" → ") : undefined,
       instructions: meta?.instructions || turnCtx?.instructions,
       env: meta?.env,
       systemPrompt: typeof firstSystem === "string" ? firstSystem : undefined,
       projectConfig,
     };
-  }, [events, sessionInfo, modelsUsed, projectConfig, id]);
+  }, [events, rawEvents, sessionInfo, modelsUsed, projectConfig, id]);
 
   // Fetch per-project config (skills + MCPs) once we know the cwd
   useEffect(() => {


### PR DESCRIPTION
## What

Shows the **model reasoning effort** a session ran at, in the session context panel — for every coding agent that actually records one. Determined by a per-agent investigation (a dynamic multi-agent workflow probed all 14 supported agents).

## Which agents have a signal

| Agent | Source | Verified value |
|---|---|---|
| **codex** | `turn_context.payload.effort` | `medium → xhigh` (per-turn progression) |
| **claude** | top-level `effort` on assistant records (CLI 2.1.212+) | `high` |
| **grok** | `reasoning_effort` on assistant turns | `xhigh` |
| **copilot** | `reasoningEffort` on `session.model_change` | `medium` |
| **hermes** | `model_config.reasoning_config.effort` | `medium` |
| **pi** | `thinking_level_change` events | `off` |

The other 8 (gemini, antigravity, qwen, vibe, cursor, opencode, cline, smallcode) record **no discrete effort setting** — only thinking-token *output* counts or a tier fused into the model name — so the row simply doesn't render for them.

## Change

**Frontend** (`frontend/src/app/sessions/[id]/page.tsx`): a generic `extractReasoningEfforts(agent, rawEvents)` helper dispatches per agent and returns ordered-distinct enum strings; the context useMemo joins them with `→` (so a session that changed effort shows the progression) and the existing `Reasoning Effort` Row renders it (hidden when empty). Reads from `rawEvents` because `normalizeTraceEvents` strips the source events (e.g. codex `turn_context`) from the step view. Also repaired the long-blank Sandbox/Approval rows for Codex and renders sandbox compactly.

**Backend** (`backend/main.py`): four small emit-only passthroughs so each agent's effort field reaches the detail events — grok (stop dropping `reasoning_effort`), copilot (emit `session.model_change`), hermes (read `model_config`, emit a `session_meta`), pi (pass `thinking_level_change` through). All guarded; agents without the field are unaffected.

## Verification

Every agent verified end-to-end in the running app against a **real session** (frontend pointed at a branch backend for the four that needed backend changes); values in the table above are the actual rendered strings. `tsc --noEmit` clean; `backend/main.py` compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)