### PR TITLE
feat: tokentelemetry wiki CLI — second-brain toolchain for any coding agent

### DIFF
--- a/UPDATE.json
+++ b/UPDATE.json
@@ -1,6 +1,16 @@
 {
   "releases": [
     {
+      "tag": "2026-07-19",
+      "title": "Maintain your project wiki from any coding agent",
+      "highlights": [
+        {
+          "title": "tokentelemetry wiki CLI",
+          "description": "The second-brain toolchain now ships as CLI subcommands: wiki status (is a page FRESH, STALE, or TAMPERED), wiki lint (validate the bundle), wiki mine (evidence from every local agent's session store), plus census, manifest, and context. Any coding agent with a shell — Cursor, Codex, OpenCode, not just Claude Code — can keep the wiki fresh using its own model. No extra API key, no hidden inference: the CLI checks, your agent writes."
+        }
+      ]
+    },
+    {
       "tag": "2026-07-18",
       "title": "See which experimental features each agent has on",
       "highlights": [

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -95,6 +95,7 @@ function pickConnectHost(host, allowedOrigins) {
 function printHelp() {
   console.log([
     'Usage: tokentelemetry [options]',
+    '       tokentelemetry wiki <subcommand>   (see: tokentelemetry wiki --help)',
     '',
     'Options:',
     '  -p, --port <N>            Frontend (Next.js) port. Default 3000.',
@@ -302,6 +303,117 @@ function ensureFrontend() {
   try { fs.writeFileSync(stampPath, currentSha); } catch {}
 }
 
+// --- `tokentelemetry wiki` — deterministic second-brain toolchain ---------
+// Wraps the pure-Python scripts in wikicli/ so ANY coding agent (not just
+// Claude Code) can maintain a docs/wiki OKF bundle via its bash tool. No
+// model, no network: these commands referee (freshness, lint, evidence);
+// whatever agent invoked them does the actual writing.
+
+function printWikiHelp() {
+  console.log([
+    'Usage: tokentelemetry wiki <subcommand> [options] [-- script args]',
+    '',
+    'Subcommands:',
+    '  status [page-id]      Freshness of wiki pages (FRESH/STALE/TAMPERED).',
+    '                        Runs the status.py installed in the wiki bundle.',
+    '  lint                  Validate the OKF bundle (frontmatter, links, index,',
+    '                        manifest). Exit 0 clean / 1 findings / 2 tool error.',
+    '  mine                  Structural signals from ALL local coding-agent session',
+    '                        stores for this project (re-read files, loop',
+    '                        signatures, tool mix). Flags: --harness, --limit, --json.',
+    '  census                Project shape scan + suggested wiki profile. --json.',
+    '  manifest <init|update|stamp> [flags]',
+    '                        Manage manifest.json (provenance stamping installs',
+    '                        the status.py freshness checker).',
+    '  context (--check|--write)',
+    '                        Install/refresh the wiki pointer block in AGENTS.md',
+    '                        and CLAUDE.md.',
+    '',
+    'Options:',
+    '  --project <dir>       Target project. Default: current directory.',
+    '  --wiki <dir>          Wiki dir relative to project. Default: docs/wiki.',
+    '',
+    'All other flags pass through to the underlying script (e.g. --json).',
+  ].join('\n'));
+}
+
+// Prefer system python (zero-setup: everything is stdlib except lint's PyYAML);
+// fall back to the backend venv, whose requirements.txt pins pyyaml.
+function wikiPython(needsYaml) {
+  for (const cmd of ['python3', 'python']) {
+    if (!which(cmd)) continue;
+    const check = 'import sys' + (needsYaml ? ', yaml' : '') +
+      '; sys.exit(0 if sys.version_info >= (3, 9) else 1)';
+    const probe = spawnSync(cmd, ['-c', check], { encoding: 'utf8' });
+    if (probe.status === 0) return cmd;
+  }
+  ensureBackend();
+  return venvPython;
+}
+
+function runWiki(argv) {
+  let project = process.cwd();
+  let wiki = 'docs/wiki';
+  let sub = null;
+  const rest = [];
+  const take = (i, flag) => {
+    if (i + 1 >= argv.length) die(`expected a value after ${flag}`);
+    return argv[i + 1];
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '-h' || a === '--help') { printWikiHelp(); process.exit(0); }
+    else if (a === '--project')            { project = take(i, a); i++; }
+    else if (a.startsWith('--project='))   { project = a.slice('--project='.length); }
+    else if (a === '--wiki')               { wiki = take(i, a); i++; }
+    else if (a.startsWith('--wiki='))      { wiki = a.slice('--wiki='.length); }
+    else if (!sub && !a.startsWith('-'))   { sub = a; }
+    else rest.push(a);
+  }
+  if (!sub) { printWikiHelp(); process.exit(2); }
+
+  const projectAbs = path.resolve(project);
+  const wikiAbs = path.resolve(projectAbs, wiki);
+  const script = (name) => path.join(rootDir, 'wikicli', name);
+
+  let cmd;
+  let args;
+  if (sub === 'status') {
+    // The freshness checker is installed INTO the bundle by `manifest stamp`,
+    // so collaborators without this CLI can still run it. We just locate it.
+    const statusPy = path.join(wikiAbs, 'status.py');
+    if (!fs.existsSync(statusPy)) {
+      die(`no wiki freshness checker at ${statusPy}\n` +
+          'If this project has no wiki yet, compile one first (e.g. /brain-init in your agent).\n' +
+          'If it has a wiki but no status.py, run: tokentelemetry wiki manifest stamp');
+    }
+    cmd = wikiPython(false);
+    args = [statusPy, ...rest];
+  } else if (sub === 'lint') {
+    cmd = wikiPython(true);
+    args = [script('okf_lint.py'), wikiAbs, ...rest];
+  } else if (sub === 'mine') {
+    cmd = wikiPython(false);
+    args = [script('session_scan.py'), projectAbs, ...rest];
+  } else if (sub === 'census') {
+    cmd = wikiPython(false);
+    args = [script('profile_census.py'), projectAbs, ...rest];
+  } else if (sub === 'manifest') {
+    cmd = wikiPython(false);
+    args = [script('wiki_manifest.py'), wikiAbs, ...rest];
+  } else if (sub === 'context') {
+    cmd = wikiPython(false);
+    args = [script('agent_context.py'), projectAbs, ...rest, '--wiki', wiki];
+  } else {
+    die(`unknown wiki subcommand: ${sub}\nRun \`tokentelemetry wiki --help\` for usage.`);
+  }
+
+  // Exit codes are the contract (0 ok / 1 findings / 2 tool error) — agents
+  // branch on them, so pass them through instead of run()'s die-on-nonzero.
+  const res = spawnSync(cmd, args, { stdio: 'inherit' });
+  process.exit(res.status === null ? 2 : res.status);
+}
+
 async function start() {
   const { frontPort, apiPort, host, allowedOrigins, authToken, insecureNoAuth, dataDir } = parseArgs(process.argv.slice(2));
 
@@ -467,4 +579,8 @@ async function start() {
   frontend.on('exit', (code) => shutdown(code || 0));
 }
 
-start();
+if (process.argv[2] === 'wiki') {
+  runWiki(process.argv.slice(3));
+} else {
+  start();
+}

--- a/wikicli/__init__.py
+++ b/wikicli/__init__.py
@@ -1,0 +1,1 @@
+"""TokenTelemetry wiki toolchain: deterministic scripts behind `tokentelemetry wiki`."""

--- a/wikicli/agent_context.py
+++ b/wikicli/agent_context.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""agent_context.py: install/refresh the wiki pointer block in CLAUDE.md and AGENTS.md.
+
+Usage:
+    python3 scripts/agent_context.py <project-dir> (--check | --write)
+        [--wiki docs/wiki] [--targets a.md,b.md] [--json]
+
+Writes a short, stable block between marker comments so coding agents that
+read CLAUDE.md / AGENTS.md learn the compiled wiki exists and route reads
+through it. Idempotent: an existing block is replaced in place; user content
+outside the markers is never touched.
+
+The block is a pointer, not a copy: no page counts, no SHAs (those churn every
+compile and live in manifest.json). Content only changes when the plugin's
+template changes, so prompt-cache prefixes stay stable across compiles.
+
+Default targets ("auto"): AGENTS.md (created if missing; it is the
+cross-agent convention file), plus CLAUDE.md at the project root or
+.claude/CLAUDE.md, whichever exists (never both, root wins; neither is
+created, pass --targets to force one).
+
+Exit codes: 0 = ok / up to date, 1 = --check found work to do, 2 = error.
+"""
+# decision: BUILD-SPEC exit convention is ok/findings/error. For --write a
+# successful apply exits 0 (the work is done, nothing is pending); only
+# --check uses 1 to signal "blocks missing or stale".
+
+import argparse
+import json
+import os
+import re
+import sys
+
+MARKER_START = "<!-- tokentelemetry-brain:start -->"
+MARKER_END = "<!-- tokentelemetry-brain:end -->"
+
+BLOCK_TEMPLATE = """{start}
+## Project wiki (compiled second brain)
+
+This project has a compiled knowledge wiki at `{wiki}/`. It is a CACHE of
+the codebase: pages route you to answers fast; the CODE stays authoritative.
+
+Protocol before using any page:
+- Run `python3 {wiki}/status.py <page-id>` (e.g. `subsystems/scanner`).
+- FRESH: answer from the page.
+- STALE / TAMPERED: do NOT trust the page body. Read the source files it
+  lists, answer from CODE, then re-run with `--note` to queue a refresh.
+- UNVERIFIABLE: treat the page as hints; verify against source first.
+`python3 {wiki}/status.py` with no args reports the whole wiki.
+
+Rules:
+- `{wiki}/index.md` maps every page; use it to route.
+- Code outranks the wiki, always: never change code to match a wiki page,
+  and never hand-edit wiki pages. A stale wiki never blocks work — answer
+  from source and move on.
+- Refreshing is optional batched maintenance: `/brain ingest` (Claude Code)
+  sweeps `{wiki}/raw/` including the notes status.py queues. In a harness
+  without `/brain`, drop a note file into `{wiki}/raw/` and keep working.
+{end}"""
+
+BLOCK_RE = re.compile(
+    re.escape(MARKER_START) + r".*?" + re.escape(MARKER_END),
+    re.DOTALL,
+)
+
+
+def render_block(wiki_rel):
+    return BLOCK_TEMPLATE.format(start=MARKER_START, end=MARKER_END,
+                                 wiki=wiki_rel.rstrip("/"))
+
+
+def resolve_targets(project_dir, targets_arg):
+    """Return list of (rel_path, create_if_missing)."""
+    if targets_arg:
+        return [(t.strip(), True) for t in targets_arg.split(",") if t.strip()]
+    targets = [("AGENTS.md", True)]
+    if os.path.isfile(os.path.join(project_dir, "CLAUDE.md")):
+        targets.append(("CLAUDE.md", False))
+    elif os.path.isfile(os.path.join(project_dir, ".claude", "CLAUDE.md")):
+        targets.append((os.path.join(".claude", "CLAUDE.md"), False))
+    return targets
+
+
+def inspect(path, block):
+    """Status for one file: ok | stale | no-block | missing | broken-markers."""
+    if not os.path.isfile(path):
+        return "missing", None
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            text = f.read()
+    except OSError as e:
+        return "error", str(e)
+    has_start = MARKER_START in text
+    has_end = MARKER_END in text
+    if has_start != has_end:
+        return "broken-markers", text
+    if not has_start:
+        return "no-block", text
+    current = BLOCK_RE.search(text)
+    if current and current.group(0) == block:
+        return "ok", text
+    return "stale", text
+
+
+def apply_write(path, status, text, block, create):
+    """Returns action taken: created | updated | appended | skipped."""
+    if status == "missing":
+        if not create:
+            return "skipped (file absent, not creating)"
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(block + "\n")
+        return "created"
+    if status == "no-block":
+        joined = text.rstrip("\n") + ("\n\n" if text.strip() else "") + block + "\n"
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(joined)
+        return "appended"
+    if status == "stale":
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(BLOCK_RE.sub(block, text, count=1))
+        return "updated"
+    return "unchanged"
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Install/refresh the wiki pointer block in CLAUDE.md / AGENTS.md."
+    )
+    parser.add_argument("project_dir", help="project root")
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--check", action="store_true",
+                      help="report per-target status, write nothing")
+    mode.add_argument("--write", action="store_true",
+                      help="create/append/update blocks")
+    parser.add_argument("--wiki", default="docs/wiki",
+                        help="wiki path relative to project root (default docs/wiki)")
+    parser.add_argument("--targets", default=None,
+                        help="comma-separated target files relative to project "
+                             "root (default: AGENTS.md + existing CLAUDE.md)")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    project_dir = os.path.abspath(args.project_dir)
+    if not os.path.isdir(project_dir):
+        print(f"error: not a directory: {args.project_dir}", file=sys.stderr)
+        return 2
+
+    block = render_block(args.wiki)
+    results = []
+    pending = 0
+    for rel, create in resolve_targets(project_dir, args.targets):
+        path = os.path.join(project_dir, rel)
+        if os.path.commonpath([project_dir, os.path.abspath(path)]) != project_dir:
+            print(f"error: target escapes project dir: {rel}", file=sys.stderr)
+            return 2
+        status, text = inspect(path, block)
+        if status == "error":
+            print(f"error: {rel}: {text}", file=sys.stderr)
+            return 2
+        if status == "broken-markers":
+            # One marker without its pair: never rewrite blind, a human has to
+            # untangle it. Reported, not fatal for the other targets.
+            results.append({"target": rel, "status": status,
+                            "action": "manual fix needed (unpaired marker)"})
+            pending += 1
+            continue
+        if args.write:
+            action = apply_write(path, status, text, block, create)
+        else:
+            action = None
+            if not (status == "ok" or (status == "missing" and not create)):
+                pending += 1
+        results.append({"target": rel, "status": status, "action": action})
+
+    if args.json:
+        print(json.dumps({"project": project_dir, "wiki": args.wiki,
+                          "results": results}, indent=2))
+    else:
+        for r in results:
+            line = f"{r['target']}: {r['status']}"
+            if r["action"]:
+                line += f" -> {r['action']}"
+            print(line)
+
+    if args.check and pending:
+        return 1
+    if any(r["status"] == "broken-markers" for r in results):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/wikicli/harness_adapters.py
+++ b/wikicli/harness_adapters.py
@@ -1,0 +1,1049 @@
+#!/usr/bin/env python3
+"""harness_adapters.py: per-harness session locators/parsers for session_scan.
+
+Each adapter answers, for one coding agent's session store: which sessions
+belong to <project-dir>, and what STRUCTURAL SIGNALS does each contain. The
+signal schema is identical across harnesses (see Acc.result) so the
+session-miner consumes one shape regardless of source.
+
+PRIVACY BOUNDARY (design D2, BUILD-SPEC rule 3) holds for every adapter:
+only tool names, file paths, error flags, timestamps, and token counts are
+emitted. Message text, thinking text, prompts, and tool outputs are never
+read into the result.
+
+Codex exception (maintainer-approved 2026-07-06): Codex records its tools as
+shell command strings, so path signals require parsing those strings. The
+command text is tokenized IN MEMORY and only the extracted path tokens are
+emitted; the command string itself never appears in any output. The same
+rule covers grok's run_terminal_command arguments. This is the single spot
+where command text is touched; do not extend it to transcript prose.
+
+Store roots are module-level constants so tests can monkeypatch them
+(the same fixture pattern TokenTelemetry's backend tests use).
+
+Verified against real stores on 2026-07-06; the format notes on each adapter
+say what was checked. When a harness changes its format, fix the adapter AND
+its fixture in tests/.
+"""
+
+import hashlib
+import json
+import os
+import re
+import shlex
+import sqlite3
+import urllib.parse
+from pathlib import Path
+
+HOME = Path(os.path.expanduser("~"))
+
+CLAUDE_PROJECTS_ROOT = HOME / ".claude" / "projects"
+CODEX_SESSIONS_ROOT = HOME / ".codex" / "sessions"
+OPENCODE_DB = HOME / ".local" / "share" / "opencode" / "opencode.db"
+QWEN_PROJECTS_ROOT = HOME / ".qwen" / "projects"
+GEMINI_TMP_ROOT = HOME / ".gemini" / "tmp"           # antigravity chats
+CLINE_DB = HOME / ".cline" / "data" / "db" / "sessions.db"
+GROK_SESSIONS_ROOT = HOME / ".grok" / "sessions"
+COPILOT_STATE_ROOT = HOME / ".copilot" / "session-state"
+HERMES_ROOT = HOME / ".hermes"
+VIBE_SESSIONS_ROOT = HOME / ".vibe" / "logs" / "session"
+# smallcode traces are project-local (<project>/.smallcode/traces); no root.
+
+# How many store files an expensive locate() may probe before giving up.
+# Codex keeps one global tree for every project, so attribution means opening
+# files; this bounds the worst case.
+PROBE_CAP = 500
+
+_URL_RE = re.compile(r"^[a-z][a-z0-9+.-]*://", re.I)
+_EXT_TOKEN_RE = re.compile(r"^[\w.@%+-]+\.[A-Za-z0-9]{1,8}$")
+
+
+# ---------------------------------------------------------------------------
+# shared accumulator + path helpers
+# ---------------------------------------------------------------------------
+
+class Acc:
+    """Per-session structural-signal accumulator shared by all adapters.
+
+    Adapters call tool_event() in transcript order (loop detection relies on
+    it), tokens()/error()/ts() as the format exposes them, then result().
+    """
+
+    def __init__(self):
+        self.first_ts = None
+        self.last_ts = None
+        self.tool_counts = {}
+        self.read_paths = {}
+        self.file_paths = {}
+        self.error_count = 0
+        self.tokens = {"input": 0, "output": 0, "cache_read": 0, "cache_creation": 0}
+        self._loop_runs = {}
+        self._cur_sig = None
+        self._cur_len = 0
+
+    def ts(self, value):
+        if not isinstance(value, str) or not value:
+            return
+        if self.first_ts is None or value < self.first_ts:
+            self.first_ts = value
+        if self.last_ts is None or value > self.last_ts:
+            self.last_ts = value
+
+    def tokens_add(self, inp=0, out=0, cache_read=0, cache_creation=0):
+        self.tokens["input"] += int(inp or 0)
+        self.tokens["output"] += int(out or 0)
+        self.tokens["cache_read"] += int(cache_read or 0)
+        self.tokens["cache_creation"] += int(cache_creation or 0)
+
+    def tokens_set(self, inp=0, out=0, cache_read=0, cache_creation=0):
+        self.tokens = {
+            "input": int(inp or 0), "output": int(out or 0),
+            "cache_read": int(cache_read or 0),
+            "cache_creation": int(cache_creation or 0),
+        }
+
+    def error(self):
+        self.error_count += 1
+
+    def _flush_run(self):
+        if self._cur_sig is not None and self._cur_len >= 2:
+            self._loop_runs[self._cur_sig] = (
+                self._loop_runs.get(self._cur_sig, 0) + self._cur_len)
+        self._cur_sig = None
+        self._cur_len = 0
+
+    def tool_event(self, name, paths=(), read=False, track_files=False):
+        """One tool call. paths: extracted path strings (possibly empty).
+        read: counts toward the re-read signal. track_files: counts toward
+        file co-occurrence (read/edit/write-shaped tools)."""
+        name = name or "?"
+        self.tool_counts[name] = self.tool_counts.get(name, 0) + 1
+        for p in paths:
+            if read:
+                self.read_paths[p] = self.read_paths.get(p, 0) + 1
+            if track_files:
+                self.file_paths[p] = self.file_paths.get(p, 0) + 1
+        # Loop signature over the first path only (matches the claude scanner:
+        # one signature per call). Path-less calls break any current run.
+        sig = (name, paths[0]) if paths else None
+        if sig is not None and sig == self._cur_sig:
+            self._cur_len += 1
+        else:
+            self._flush_run()
+            if sig is not None:
+                self._cur_sig = sig
+                self._cur_len = 1
+
+    def result(self, session_id):
+        self._flush_run()
+        return {
+            "session_id": session_id,
+            "first_ts": self.first_ts,
+            "last_ts": self.last_ts,
+            "tool_counts": dict(self.tool_counts),
+            "read_paths": dict(self.read_paths),
+            "file_paths": dict(self.file_paths),
+            "error_count": self.error_count,
+            "tokens": self.tokens,
+            "token_total": sum(self.tokens.values()),
+            "loops": [
+                {"tool": t, "path": p, "count": n}
+                for (t, p), n in sorted(self._loop_runs.items(),
+                                        key=lambda kv: -kv[1])
+            ],
+        }
+
+
+def encode_claude_dir(project_path):
+    """Claude Code's (and Qwen's) project-dir munging: every non-alphanumeric
+    character in the absolute path becomes '-'. Verified against real dirs in
+    both ~/.claude/projects and ~/.qwen/projects."""
+    return re.sub(r"[^A-Za-z0-9]", "-", project_path)
+
+
+def _looks_like_path(tok):
+    if not isinstance(tok, str) or not tok or len(tok) > 512:
+        return False
+    if _URL_RE.match(tok):
+        return False
+    return "/" in tok or bool(_EXT_TOKEN_RE.match(tok))
+
+
+def paths_from_value(value, base_dir=None, cap=8):
+    """Harvest path-looking strings from a structured tool-args value
+    (dict/list/str, recursively). Relative candidates resolve against
+    base_dir when given. Returns at most cap paths, order-preserving."""
+    out = []
+
+    def walk(v):
+        if len(out) >= cap:
+            return
+        if isinstance(v, str):
+            if _looks_like_path(v) and "\n" not in v:
+                p = v
+                if base_dir and not os.path.isabs(p):
+                    p = os.path.normpath(os.path.join(base_dir, p))
+                if p not in out:
+                    out.append(p)
+        elif isinstance(v, dict):
+            for x in v.values():
+                walk(x)
+        elif isinstance(v, (list, tuple)):
+            for x in v:
+                walk(x)
+
+    walk(value)
+    return out
+
+
+def paths_from_shell(cmd, workdir=None, project_dir=None, cap=8):
+    """Extract path tokens from a shell command string (codex/grok).
+
+    The string is tokenized in memory; ONLY the path tokens leave this
+    function (maintainer-approved exception, see module docstring). Kept
+    tokens must resolve under project_dir, or be absolute paths that exist —
+    that filter is what keeps shell noise (regexes, URLs, prose args) out of
+    the signals."""
+    if not isinstance(cmd, str) or not cmd:
+        return []
+    try:
+        toks = shlex.split(cmd)
+    except ValueError:
+        toks = cmd.split()
+    out = []
+    for tok in toks:
+        if len(out) >= cap:
+            break
+        tok = tok.strip("'\";,")
+        if tok.startswith("-") or not _looks_like_path(tok):
+            continue
+        p = tok
+        if not os.path.isabs(p):
+            base = workdir or project_dir
+            if not base:
+                continue
+            p = os.path.normpath(os.path.join(base, p))
+        under_project = bool(project_dir) and (
+            p == project_dir or p.startswith(project_dir.rstrip("/") + "/"))
+        if under_project or (os.path.isabs(p) and os.path.exists(p)):
+            if p not in out:
+                out.append(p)
+    return out
+
+
+_SHELL_READ_CMDS = {"cat", "head", "tail", "less", "more", "sed", "awk",
+                    "rg", "grep", "bat", "wc", "ls"}
+
+
+def _shell_is_read(cmd):
+    """True when a shell command's first word is a file-reading tool, so its
+    extracted paths count toward the re-read signal (same rule every
+    shell-recording harness shares)."""
+    if isinstance(cmd, list):
+        cmd = " ".join(str(c) for c in cmd)
+    if not isinstance(cmd, str) or not cmd.strip():
+        return False
+    return os.path.basename(cmd.strip().split()[0]) in _SHELL_READ_CMDS
+
+
+def _read_verb(name, extra=()):
+    n = (name or "").lower()
+    return ("read" in n or "view" in n or "cat" in n or "glob" in n
+            or "list" in n or n in extra)
+
+
+def _write_verb(name, extra=()):
+    n = (name or "").lower()
+    return ("write" in n or "edit" in n or "patch" in n or "replace" in n
+            or "create" in n or n in extra)
+
+
+def _under(path, project_dir):
+    return path == project_dir or path.startswith(project_dir.rstrip("/") + "/")
+
+
+def _sqlite_ro(path):
+    uri = f"file:{path}?mode=ro&immutable=1"
+    conn = sqlite3.connect(uri, uri=True, timeout=1.0)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _json_file(path):
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as fh:
+            return json.load(fh)
+    except Exception:
+        return None
+
+
+def _mtime_sorted(paths, limit):
+    paths = [p for p in paths if p.is_file()]
+    paths.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    return paths[:limit]
+
+
+# ---------------------------------------------------------------------------
+# claude — ~/.claude/projects/<encoded>/<uuid>.jsonl
+# Format: JSONL events; assistant events carry message.usage +
+# message.content[].tool_use with structured inputs. Full signals.
+# ---------------------------------------------------------------------------
+
+_CLAUDE_FILE_TOOLS = {"Read", "Edit", "Write", "Grep", "Glob"}
+_CLAUDE_PATH_KEYS = ("file_path", "path", "pattern")
+
+
+def claude_locate(project_dir, limit):
+    d = CLAUDE_PROJECTS_ROOT / encode_claude_dir(project_dir)
+    if not d.is_dir():
+        return []
+    return _mtime_sorted(list(d.glob("*.jsonl")), limit)
+
+
+def claude_scan(ref, project_dir):
+    acc = Acc()
+    sid = ref.stem
+    try:
+        with open(ref, "r", encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                try:
+                    d = json.loads(line)
+                except Exception:
+                    continue
+                if not isinstance(d, dict):
+                    continue
+                if not sid and d.get("sessionId"):
+                    sid = d["sessionId"]
+                acc.ts(d.get("timestamp"))
+                mtype = d.get("type")
+                msg = d.get("message") if isinstance(d.get("message"), dict) else {}
+                if mtype == "assistant":
+                    usage = msg.get("usage")
+                    if isinstance(usage, dict):
+                        acc.tokens_add(usage.get("input_tokens"),
+                                       usage.get("output_tokens"),
+                                       usage.get("cache_read_input_tokens"),
+                                       usage.get("cache_creation_input_tokens"))
+                    for item in msg.get("content", []) or []:
+                        if not isinstance(item, dict) or item.get("type") != "tool_use":
+                            continue
+                        name = item.get("name") or "?"
+                        inp = item.get("input") or {}
+                        sig = None
+                        if name in _CLAUDE_FILE_TOOLS and isinstance(inp, dict):
+                            for k in _CLAUDE_PATH_KEYS:
+                                v = inp.get(k)
+                                if isinstance(v, str) and v:
+                                    sig = v
+                                    break
+                        acc.tool_event(
+                            name, paths=[sig] if sig else (),
+                            read=(name == "Read"),
+                            track_files=name in ("Read", "Edit", "Write"))
+                elif mtype == "user":
+                    content = msg.get("content")
+                    if isinstance(content, list):
+                        for item in content:
+                            if (isinstance(item, dict)
+                                    and item.get("type") == "tool_result"
+                                    and item.get("is_error")):
+                                acc.error()
+    except Exception:
+        return None
+    return acc.result(sid)
+
+
+# ---------------------------------------------------------------------------
+# codex — ~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl (one global tree)
+# Format (verified): type=session_meta payload.cwd; response_item/
+# function_call name=exec_command arguments='{"cmd": "...", "workdir": ...}';
+# event_msg/token_count payload.info.total_token_usage is CUMULATIVE (input
+# includes cached; last event wins). Paths come from the cmd string via
+# paths_from_shell (approved exception).
+# ---------------------------------------------------------------------------
+
+_CODEX_PATCH_RE = re.compile(r"\*\*\* (?:Add|Update|Delete) File: (.+)")
+
+
+def _codex_meta_cwd(path):
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as fh:
+            for _ in range(5):
+                line = fh.readline()
+                if not line:
+                    break
+                try:
+                    d = json.loads(line)
+                except Exception:
+                    continue
+                if d.get("type") == "session_meta":
+                    p = d.get("payload") or {}
+                    return p.get("cwd") or (p.get("payload") or {}).get("cwd")
+    except Exception:
+        pass
+    return None
+
+
+def codex_locate(project_dir, limit):
+    if not CODEX_SESSIONS_ROOT.is_dir():
+        return []
+    files = list(CODEX_SESSIONS_ROOT.rglob("rollout-*.jsonl"))
+    files = _mtime_sorted(files, PROBE_CAP)
+    out = []
+    for f in files:
+        cwd = _codex_meta_cwd(f)
+        if cwd and _under(cwd, project_dir):
+            out.append(f)
+            if len(out) >= limit:
+                break
+    return out
+
+
+def codex_scan(ref, project_dir):
+    acc = Acc()
+    sid = None
+    last_totals = None
+    workdir = None
+    try:
+        with open(ref, "r", encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                try:
+                    d = json.loads(line)
+                except Exception:
+                    continue
+                acc.ts(d.get("timestamp"))
+                p = d.get("payload") or {}
+                pt = p.get("type")
+                if d.get("type") == "session_meta":
+                    sid = p.get("id") or sid
+                    workdir = p.get("cwd") or (p.get("payload") or {}).get("cwd")
+                elif pt == "function_call":
+                    name = p.get("name") or "?"
+                    try:
+                        args = json.loads(p.get("arguments") or "{}")
+                    except Exception:
+                        args = {}
+                    paths, read, track = [], False, False
+                    if name in ("exec_command", "shell", "local_shell"):
+                        cmd = args.get("cmd") or args.get("command")
+                        if isinstance(cmd, list):
+                            cmd = " ".join(str(c) for c in cmd)
+                        wd = args.get("workdir") or workdir
+                        paths = paths_from_shell(cmd, wd, project_dir)
+                        read = _shell_is_read(cmd)
+                        track = read
+                    elif name == "apply_patch":
+                        blob = args.get("input") or args.get("patch") or ""
+                        if isinstance(blob, str):
+                            for m in _CODEX_PATCH_RE.finditer(blob):
+                                q = m.group(1).strip()
+                                if not os.path.isabs(q):
+                                    q = os.path.normpath(os.path.join(
+                                        workdir or project_dir, q))
+                                paths.append(q)
+                        track = True
+                    else:
+                        paths = paths_from_value(args, base_dir=workdir)
+                        read = _read_verb(name)
+                        track = read or _write_verb(name)
+                    acc.tool_event(name, paths=paths, read=read, track_files=track)
+                elif pt == "token_count":
+                    info = (p.get("info") or {})
+                    tot = info.get("total_token_usage")
+                    if isinstance(tot, dict):
+                        last_totals = tot
+    except Exception:
+        return None
+    if last_totals:
+        cached = int(last_totals.get("cached_input_tokens") or 0)
+        inp = max(0, int(last_totals.get("input_tokens") or 0) - cached)
+        acc.tokens_set(inp, last_totals.get("output_tokens"), cached, 0)
+    if not sid:
+        parts = ref.stem.split("-")
+        sid = "-".join(parts[-5:]) if len(parts) >= 6 else ref.stem
+    return acc.result(sid)
+
+
+# ---------------------------------------------------------------------------
+# opencode — ~/.local/share/opencode/opencode.db (SQLite)
+# Format (verified): session(id, directory, time_created/updated epoch-ms,
+# tokens_*); part.data JSON: type='tool', tool name, state.input structured
+# (filePath etc.). Full signals; tokens pre-aggregated on the session row.
+# ---------------------------------------------------------------------------
+
+def opencode_locate(project_dir, limit):
+    if not OPENCODE_DB.exists():
+        return []
+    try:
+        conn = _sqlite_ro(OPENCODE_DB)
+        try:
+            rows = conn.execute(
+                "SELECT id, directory, time_created, time_updated,"
+                "       tokens_input, tokens_output, tokens_cache_read,"
+                "       tokens_cache_write"
+                "  FROM session ORDER BY time_updated DESC").fetchall()
+        finally:
+            conn.close()
+    except Exception:
+        return []
+    out = []
+    for r in rows:
+        if r["directory"] and _under(r["directory"], project_dir):
+            out.append(dict(r))
+            if len(out) >= limit:
+                break
+    return out
+
+
+def _epoch_iso(ms):
+    try:
+        import datetime as _dt
+        return _dt.datetime.fromtimestamp(
+            float(ms) / 1000.0, tz=_dt.timezone.utc).isoformat()
+    except Exception:
+        return None
+
+
+def opencode_scan(ref, project_dir):
+    acc = Acc()
+    acc.ts(_epoch_iso(ref.get("time_created")))
+    acc.ts(_epoch_iso(ref.get("time_updated")))
+    acc.tokens_set(ref.get("tokens_input"), ref.get("tokens_output"),
+                   ref.get("tokens_cache_read"), ref.get("tokens_cache_write"))
+    try:
+        conn = _sqlite_ro(OPENCODE_DB)
+        try:
+            rows = conn.execute(
+                "SELECT data FROM part WHERE session_id=? ORDER BY id",
+                (ref["id"],)).fetchall()
+        finally:
+            conn.close()
+    except Exception:
+        rows = []
+    for (data,) in rows:
+        try:
+            d = json.loads(data)
+        except Exception:
+            continue
+        if not isinstance(d, dict) or d.get("type") != "tool":
+            continue
+        name = d.get("tool") or "?"
+        state = d.get("state") if isinstance(d.get("state"), dict) else {}
+        inp = state.get("input") if isinstance(state.get("input"), dict) else {}
+        if name == "bash":
+            paths = paths_from_shell(inp.get("command"),
+                                     project_dir, project_dir)
+            read = _shell_is_read(inp.get("command"))
+        else:
+            paths = paths_from_value(inp, base_dir=project_dir)
+            read = _read_verb(name)
+        if state.get("status") == "error":
+            acc.error()
+        acc.tool_event(name, paths=paths, read=read,
+                       track_files=read or _write_verb(name))
+    return acc.result(ref["id"])
+
+
+# ---------------------------------------------------------------------------
+# qwen — ~/.qwen/projects/<claude-style-encoding>/chats/<sid>.jsonl
+# Format (verified): JSONL, cwd on events; assistant message.parts[]
+# .functionCall{name, args{absolute_path,...}}; usageMetadata per assistant
+# event (promptTokenCount INCLUDES cachedContentTokenCount). Full signals.
+# ---------------------------------------------------------------------------
+
+def qwen_locate(project_dir, limit):
+    d = QWEN_PROJECTS_ROOT / encode_claude_dir(project_dir) / "chats"
+    if not d.is_dir():
+        return []
+    return _mtime_sorted(list(d.glob("*.jsonl")), limit)
+
+
+def qwen_scan(ref, project_dir):
+    acc = Acc()
+    sid = ref.stem
+    try:
+        with open(ref, "r", encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                try:
+                    d = json.loads(line)
+                except Exception:
+                    continue
+                acc.ts(d.get("timestamp"))
+                if d.get("sessionId"):
+                    sid = d["sessionId"]
+                m = d.get("message") if isinstance(d.get("message"), dict) else {}
+                usage = d.get("usageMetadata") or m.get("usageMetadata")
+                if isinstance(usage, dict):
+                    cached = int(usage.get("cachedContentTokenCount") or 0)
+                    prompt = int(usage.get("promptTokenCount") or 0)
+                    out = (int(usage.get("candidatesTokenCount") or 0)
+                           + int(usage.get("thoughtsTokenCount") or 0))
+                    acc.tokens_add(max(0, prompt - cached), out, cached, 0)
+                for part in (m.get("parts") or []):
+                    if not isinstance(part, dict):
+                        continue
+                    fc = part.get("functionCall")
+                    if not isinstance(fc, dict):
+                        continue
+                    name = fc.get("name") or "?"
+                    paths = paths_from_value(fc.get("args") or {},
+                                             base_dir=project_dir)
+                    read = _read_verb(name, extra=("read_file",
+                                                   "read_many_files"))
+                    acc.tool_event(name, paths=paths, read=read,
+                                   track_files=read or _write_verb(name))
+    except Exception:
+        return None
+    return acc.result(sid)
+
+
+# ---------------------------------------------------------------------------
+# antigravity — ~/.gemini/tmp/<sha256(project)>/chats/*.json
+# Format (verified): {sessionId, projectHash, startTime, lastUpdated,
+# messages[{id,timestamp,type,content}]}. No tool calls, no usage in this
+# store; the CLI's conversations/*.db is protobuf (not parsed here).
+# Capability: presence/timestamps only — honest zeros elsewhere.
+# ---------------------------------------------------------------------------
+
+def antigravity_locate(project_dir, limit):
+    h = hashlib.sha256(project_dir.encode()).hexdigest()
+    d = GEMINI_TMP_ROOT / h / "chats"
+    if not d.is_dir():
+        return []
+    return _mtime_sorted(list(d.glob("*.json")), limit)
+
+
+def antigravity_scan(ref, project_dir):
+    d = _json_file(ref)
+    if not isinstance(d, dict):
+        return None
+    acc = Acc()
+    for k in ("startTime", "lastUpdated"):
+        v = d.get(k)
+        acc.ts(v if isinstance(v, str) else (str(v) if v else None))
+    for msg in (d.get("messages") or []):
+        if isinstance(msg, dict):
+            v = msg.get("timestamp")
+            acc.ts(v if isinstance(v, str) else (str(v) if v else None))
+    return acc.result(d.get("sessionId") or ref.stem)
+
+
+# ---------------------------------------------------------------------------
+# cline — ~/.cline/data/db/sessions.db + per-session messages JSON
+# Format (verified): sessions(session_id, cwd, workspace_root, started_at,
+# ended_at, metadata_json{usage|aggregateUsage}, messages_path). Transcript:
+# {messages: [...]} with OpenAI-style assistant tool_calls. Full signals.
+# ---------------------------------------------------------------------------
+
+def cline_locate(project_dir, limit):
+    if not CLINE_DB.exists():
+        return []
+    try:
+        conn = _sqlite_ro(CLINE_DB)
+        try:
+            rows = conn.execute("SELECT * FROM sessions").fetchall()
+        finally:
+            conn.close()
+    except Exception:
+        return []
+    out = []
+    for r in rows:
+        d = dict(r)
+        cwd = d.get("cwd") or d.get("workspace_root") or ""
+        if cwd and _under(cwd, project_dir):
+            out.append(d)
+    out.sort(key=lambda d: str(d.get("started_at") or ""), reverse=True)
+    return out[:limit]
+
+
+def _cline_usage(meta):
+    for key in ("aggregateUsage", "usage"):
+        u = meta.get(key)
+        if isinstance(u, dict) and any(u.values()):
+            return u
+    return {}
+
+
+def cline_scan(ref, project_dir):
+    acc = Acc()
+    acc.ts(str(ref.get("started_at") or "") or None)
+    acc.ts(str(ref.get("ended_at") or "") or None)
+    try:
+        meta = json.loads(ref.get("metadata_json") or "{}")
+    except Exception:
+        meta = {}
+    u = _cline_usage(meta if isinstance(meta, dict) else {})
+    acc.tokens_set(
+        u.get("inputTokens") or u.get("tokensIn"),
+        u.get("outputTokens") or u.get("tokensOut"),
+        u.get("cacheReadTokens") or u.get("cacheReads"),
+        u.get("cacheWriteTokens") or u.get("cacheWrites"))
+    mp = ref.get("messages_path")
+    msgs = []
+    if mp and os.path.exists(mp):
+        t = _json_file(mp)
+        if isinstance(t, dict):
+            msgs = t.get("messages") or []
+        elif isinstance(t, list):
+            msgs = t
+    metrics_sum = {"inputTokens": 0, "outputTokens": 0,
+                   "cacheReadTokens": 0, "cacheWriteTokens": 0}
+    for m in msgs:
+        if not isinstance(m, dict):
+            continue
+        met = m.get("metrics")
+        if isinstance(met, dict):
+            for k in metrics_sum:
+                metrics_sum[k] += int(met.get(k) or 0)
+        # OpenAI-style tool_calls on the message...
+        for tc in (m.get("tool_calls") or []):
+            if not isinstance(tc, dict):
+                continue
+            fn = tc.get("function") if isinstance(tc.get("function"), dict) else tc
+            name = fn.get("name") or tc.get("name") or "?"
+            raw = fn.get("arguments")
+            try:
+                args = json.loads(raw) if isinstance(raw, str) else (raw or {})
+            except Exception:
+                args = {}
+            paths = paths_from_value(args, base_dir=project_dir)
+            read = _read_verb(name)
+            acc.tool_event(name, paths=paths, read=read,
+                           track_files=read or _write_verb(name))
+        # ...and Claude-style typed blocks in content (verified transcript
+        # shape: content is a list of {type: thinking|text|tool_use, ...}).
+        content = m.get("content")
+        if isinstance(content, list):
+            for b in content:
+                if isinstance(b, dict) and b.get("type") == "tool_use":
+                    name = b.get("name") or "?"
+                    paths = paths_from_value(b.get("input") or {},
+                                             base_dir=project_dir)
+                    read = _read_verb(name)
+                    acc.tool_event(name, paths=paths, read=read,
+                                   track_files=read or _write_verb(name))
+    # DB usage rows are all-zero for some providers (observed with ollama);
+    # fall back to summing per-message metrics, mirroring TT's parser.
+    if sum(acc.tokens.values()) == 0 and any(metrics_sum.values()):
+        acc.tokens_set(metrics_sum["inputTokens"], metrics_sum["outputTokens"],
+                       metrics_sum["cacheReadTokens"],
+                       metrics_sum["cacheWriteTokens"])
+    return acc.result(str(ref.get("session_id")))
+
+
+# ---------------------------------------------------------------------------
+# grok — ~/.grok/sessions/<urlencoded-project>/<sid>/chat_history.jsonl
+# Format (verified): entries role in {user, assistant, reasoning,
+# tool_result, ...}; assistant entries carry tool_calls[{name, arguments}]
+# where arguments for run_terminal_command hold a command string (approved
+# shell extraction). No usage fields observed → tokens stay zero.
+# ---------------------------------------------------------------------------
+
+def grok_locate(project_dir, limit):
+    d = GROK_SESSIONS_ROOT / urllib.parse.quote(project_dir, safe="")
+    if not d.is_dir():
+        return []
+    hist = [p / "chat_history.jsonl" for p in d.iterdir() if p.is_dir()]
+    return _mtime_sorted([p for p in hist if p.exists()], limit)
+
+
+def grok_scan(ref, project_dir):
+    acc = Acc()
+    sid = ref.parent.name
+    try:
+        with open(ref, "r", encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                try:
+                    d = json.loads(line)
+                except Exception:
+                    continue
+                acc.ts(d.get("timestamp"))
+                if d.get("role") == "tool_result" and d.get("is_error"):
+                    acc.error()
+                for tc in (d.get("tool_calls") or []):
+                    if not isinstance(tc, dict):
+                        continue
+                    name = tc.get("name") or "?"
+                    raw = tc.get("arguments")
+                    try:
+                        args = json.loads(raw) if isinstance(raw, str) else (raw or {})
+                    except Exception:
+                        args = {}
+                    if name in ("run_terminal_command", "bash", "shell"):
+                        cmd = args.get("command") or args.get("cmd")
+                        paths = paths_from_shell(cmd, project_dir, project_dir)
+                        read = _shell_is_read(cmd)
+                    else:
+                        paths = paths_from_value(args, base_dir=project_dir)
+                        read = _read_verb(name)
+                    acc.tool_event(name, paths=paths, read=read,
+                                   track_files=read or _write_verb(name))
+    except Exception:
+        return None
+    return acc.result(sid)
+
+
+# ---------------------------------------------------------------------------
+# copilot-cli — ~/.copilot/session-state/<sid>/events.jsonl
+# Format (verified): session.start data.context.cwd; tool.execution_start
+# data{toolName, arguments{...}}. No usage events observed → tokens zero.
+# ---------------------------------------------------------------------------
+
+def copilot_locate(project_dir, limit):
+    if not COPILOT_STATE_ROOT.is_dir():
+        return []
+    out = []
+    dirs = sorted(COPILOT_STATE_ROOT.iterdir(),
+                  key=lambda p: p.stat().st_mtime if p.exists() else 0,
+                  reverse=True)
+    for sdir in dirs[:PROBE_CAP]:
+        ev = sdir / "events.jsonl"
+        if not ev.exists():
+            continue
+        cwd = None
+        try:
+            with open(ev, "r", encoding="utf-8", errors="replace") as fh:
+                for _ in range(3):
+                    line = fh.readline()
+                    if not line:
+                        break
+                    try:
+                        d = json.loads(line)
+                    except Exception:
+                        continue
+                    if d.get("type") == "session.start":
+                        cwd = ((d.get("data") or {}).get("context") or {}).get("cwd")
+                        break
+        except Exception:
+            continue
+        if cwd and _under(cwd, project_dir):
+            out.append(ev)
+            if len(out) >= limit:
+                break
+    return out
+
+
+def copilot_scan(ref, project_dir):
+    acc = Acc()
+    sid = ref.parent.name
+    try:
+        with open(ref, "r", encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                try:
+                    d = json.loads(line)
+                except Exception:
+                    continue
+                acc.ts(d.get("timestamp"))
+                if d.get("type") == "tool.execution_start":
+                    data = d.get("data") or {}
+                    name = data.get("toolName") or "?"
+                    args = data.get("arguments") or {}
+                    if name in ("bash", "run_in_terminal", "shell"):
+                        cmd = args.get("command") if isinstance(args, dict) else None
+                        paths = paths_from_shell(cmd, project_dir, project_dir)
+                        read = _shell_is_read(cmd)
+                    else:
+                        paths = paths_from_value(args, base_dir=project_dir)
+                        read = _read_verb(name)
+                    acc.tool_event(name, paths=paths, read=read,
+                                   track_files=read or _write_verb(name))
+                elif d.get("type") == "tool.execution_complete":
+                    if (d.get("data") or {}).get("error"):
+                        acc.error()
+    except Exception:
+        return None
+    return acc.result(sid)
+
+
+# ---------------------------------------------------------------------------
+# hermes — ~/.hermes/state.db (+ profiles/*/state.db), SQLite
+# Format (verified): sessions(id, cwd, started_at, ended_at, input_tokens,
+# output_tokens, cache_read_tokens, cache_write_tokens, ...); messages(
+# session_id, role, tool_calls JSON, tool_name). Tokens pre-aggregated.
+# ---------------------------------------------------------------------------
+
+def _hermes_dbs():
+    dbs = []
+    root = HERMES_ROOT / "state.db"
+    if root.exists():
+        dbs.append(root)
+    prof = HERMES_ROOT / "profiles"
+    if prof.is_dir():
+        for p in prof.iterdir():
+            db = p / "state.db"
+            if db.exists():
+                dbs.append(db)
+    return dbs
+
+
+def hermes_locate(project_dir, limit):
+    out = []
+    for db in _hermes_dbs():
+        try:
+            conn = _sqlite_ro(db)
+            try:
+                rows = conn.execute(
+                    "SELECT id, cwd, started_at, ended_at, input_tokens,"
+                    "       output_tokens, cache_read_tokens, cache_write_tokens"
+                    "  FROM sessions ORDER BY started_at DESC").fetchall()
+            finally:
+                conn.close()
+        except Exception:
+            continue
+        for r in rows:
+            d = dict(r)
+            if d.get("cwd") and _under(d["cwd"], project_dir):
+                d["_db"] = str(db)
+                out.append(d)
+    out.sort(key=lambda d: str(d.get("started_at") or ""), reverse=True)
+    return out[:limit]
+
+
+def hermes_scan(ref, project_dir):
+    acc = Acc()
+    acc.ts(str(ref.get("started_at") or "") or None)
+    acc.ts(str(ref.get("ended_at") or "") or None)
+    acc.tokens_set(ref.get("input_tokens"), ref.get("output_tokens"),
+                   ref.get("cache_read_tokens"), ref.get("cache_write_tokens"))
+    try:
+        conn = _sqlite_ro(ref["_db"])
+        try:
+            rows = conn.execute(
+                "SELECT role, tool_calls, tool_name FROM messages"
+                " WHERE session_id=? ORDER BY id", (ref["id"],)).fetchall()
+        finally:
+            conn.close()
+    except Exception:
+        rows = []
+    for r in rows:
+        raw = r["tool_calls"]
+        if not raw:
+            continue
+        try:
+            tcs = json.loads(raw) if isinstance(raw, str) else raw
+        except Exception:
+            continue
+        for tc in (tcs or []):
+            if not isinstance(tc, dict):
+                continue
+            fn = tc.get("function") if isinstance(tc.get("function"), dict) else tc
+            name = fn.get("name") or tc.get("name") or r["tool_name"] or "?"
+            raw_args = fn.get("arguments")
+            try:
+                args = json.loads(raw_args) if isinstance(raw_args, str) else (raw_args or {})
+            except Exception:
+                args = {}
+            paths = paths_from_value(args, base_dir=project_dir)
+            read = _read_verb(name)
+            acc.tool_event(name, paths=paths, read=read,
+                           track_files=read or _write_verb(name))
+    return acc.result(str(ref["id"]))
+
+
+# ---------------------------------------------------------------------------
+# smallcode — <project>/.smallcode/traces/*.json (project-local)
+# Format (from TokenTelemetry's verified parser): {id, model, startedAt,
+# endedAt, steps[{type:'tool_call', name, args}], tokens{prompt,completion}}.
+# ---------------------------------------------------------------------------
+
+def smallcode_locate(project_dir, limit):
+    d = Path(project_dir) / ".smallcode" / "traces"
+    if not d.is_dir():
+        return []
+    return _mtime_sorted(list(d.glob("*.json")), limit)
+
+
+def smallcode_scan(ref, project_dir):
+    t = _json_file(ref)
+    if not isinstance(t, dict):
+        return None
+    acc = Acc()
+    acc.ts(str(t.get("startedAt") or "") or None)
+    acc.ts(str(t.get("endedAt") or "") or None)
+    tok = t.get("tokens") or {}
+    acc.tokens_set(tok.get("prompt"), tok.get("completion"), 0, 0)
+    for step in (t.get("steps") or []):
+        if not isinstance(step, dict) or step.get("type") != "tool_call":
+            continue
+        name = step.get("name") or "?"
+        paths = paths_from_value(step.get("args") or {}, base_dir=project_dir)
+        read = _read_verb(name)
+        acc.tool_event(name, paths=paths, read=read,
+                       track_files=read or _write_verb(name))
+    return acc.result(t.get("id") or ref.stem)
+
+
+# ---------------------------------------------------------------------------
+# vibe — ~/.vibe/logs/session/*.json
+# Format (verified): {metadata{session_id, start_time, end_time,
+# environment: "<python-repr>", stats: "<python-repr>"}, messages[{role,
+# content}]}. Messages carry no tool calls; stats repr holds token counts.
+# Capability: tokens only. repr parsing uses ast.literal_eval (stdlib).
+# ---------------------------------------------------------------------------
+
+def _vibe_repr(v):
+    if isinstance(v, dict):
+        return v
+    if isinstance(v, str):
+        try:
+            import ast
+            d = ast.literal_eval(v)
+            return d if isinstance(d, dict) else {}
+        except Exception:
+            return {}
+    return {}
+
+
+def vibe_locate(project_dir, limit):
+    if not VIBE_SESSIONS_ROOT.is_dir():
+        return []
+    out = []
+    for f in _mtime_sorted(list(VIBE_SESSIONS_ROOT.glob("*.json")), PROBE_CAP):
+        d = _json_file(f)
+        meta = (d.get("metadata") or {}) if isinstance(d, dict) else {}
+        env = _vibe_repr(meta.get("environment"))
+        wd = env.get("working_directory")
+        if wd and _under(wd, project_dir):
+            out.append(f)
+            if len(out) >= limit:
+                break
+    return out
+
+
+def vibe_scan(ref, project_dir):
+    d = _json_file(ref)
+    if d is None:
+        return None
+    meta = (d.get("metadata") or {}) if isinstance(d, dict) else {}
+    acc = Acc()
+    acc.ts(str(meta.get("start_time") or "") or None)
+    acc.ts(str(meta.get("end_time") or "") or None)
+    stats = _vibe_repr(meta.get("stats"))
+    acc.tokens_set(stats.get("session_prompt_tokens"),
+                   stats.get("session_completion_tokens"), 0, 0)
+    return acc.result(str(meta.get("session_id") or ref.stem))
+
+
+# ---------------------------------------------------------------------------
+# registry
+# ---------------------------------------------------------------------------
+# capability: "full"   = tools + paths + tokens
+#             "partial" = tools + paths, tokens missing in the store
+#             "tokens" = token totals only
+#             "presence" = session existence/timestamps only
+ADAPTERS = {
+    "claude": {"capability": "full", "locate": claude_locate, "scan": claude_scan},
+    "codex": {"capability": "full", "locate": codex_locate, "scan": codex_scan},
+    "opencode": {"capability": "full", "locate": opencode_locate, "scan": opencode_scan},
+    "qwen": {"capability": "full", "locate": qwen_locate, "scan": qwen_scan},
+    "cline": {"capability": "full", "locate": cline_locate, "scan": cline_scan},
+    "hermes": {"capability": "full", "locate": hermes_locate, "scan": hermes_scan},
+    "smallcode": {"capability": "full", "locate": smallcode_locate, "scan": smallcode_scan},
+    "grok": {"capability": "partial", "locate": grok_locate, "scan": grok_scan},
+    "copilot": {"capability": "partial", "locate": copilot_locate, "scan": copilot_scan},
+    "vibe": {"capability": "tokens", "locate": vibe_locate, "scan": vibe_scan},
+    "antigravity": {"capability": "presence", "locate": antigravity_locate, "scan": antigravity_scan},
+}
+# gemini (the discontinued CLI) is deliberately absent: legacy store, no new
+# sessions since 2026-06-18. Add an adapter here + a fixture in tests/ when a
+# new harness lands; docs/HARNESS-ADAPTERS.md has the checklist.

--- a/wikicli/okf_lint.py
+++ b/wikicli/okf_lint.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""Lint an OKF v0.1 wiki bundle: frontmatter, type, links, index/log/manifest coverage.
+
+Usage: python3 okf_lint.py <wiki-dir> [--json]
+
+Exit codes: 0 clean, 1 findings (errors and/or warnings), 2 tool error.
+Findings are split into errors (structural violations) and warnings
+(recommended-but-missing fields, orphan pages). Both count toward exit 1;
+only a script/argument/crash failure is exit 2.
+"""
+# decision: the spec's "0/1/2 (ok / findings / error)" does not say whether
+# warnings alone are "findings". They are: any finding at all exits 1, and
+# exit 2 is reserved strictly for tool failures (bad path, crash, no PyYAML).
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    print("error: PyYAML is required (pip install pyyaml)", file=sys.stderr)
+    sys.exit(2)
+
+# decision: root-level meta files carry no frontmatter/type schema and are
+# excluded from the type/frontmatter/index-coverage checks. This mirrors the
+# project-side file set in design doc section 4:
+# docs/wiki/{BRAIN.md, project-profile.md, manifest.json, index.md, log.md, <pages>}.
+RESERVED_ROOT_FILES = {"index.md", "log.md", "BRAIN.md", "project-profile.md"}
+
+RECOMMENDED_FIELDS = ("title", "description", "timestamp")
+
+# decision: a trailing #fragment (page.md#section) is tolerated and resolved
+# against the page path; the original lint's regex rejected it.
+LINK_RE = re.compile(r"\]\(([^)#\s]+\.md)(?:#[^)\s]*)?\)")
+# decision: log.md entries must sit under a '## YYYY-MM-DD' header and start
+# with a bold action word from the set below (the format the reference wiki's
+# log.md uses); the original lint did not check log.md content at all.
+LOG_HEADER_RE = re.compile(r"^##\s+(\d{4}-\d{2}-\d{2})\s*$")
+LOG_ACTION_RE = re.compile(r"^\*\*(Creation|Update|Finding|Deprecation)\*\*")
+
+# decision: manifest.json validation only runs if the file exists (hand-built
+# bundles predate it), but when present it must carry every key of the fixed
+# schema in BUILD-SPEC rule 8. Values are checked where derivable: page_count
+# and page_types against the scanned bundle, status against its enum.
+MANIFEST_REQUIRED_KEYS = (
+    "okf", "profile", "created", "updated", "status",
+    "batches_done", "batches_total", "page_count", "page_types",
+    "compiled_from_sha", "plugin_version",
+)
+MANIFEST_STATUSES = {"compiling", "complete"}
+
+
+def is_dot_path(rel: str) -> bool:
+    # decision: dot-directories (.obsidian/, .compile/) are tooling/working
+    # state per design section 4, not OKF pages; excluded from all scanning.
+    return any(part.startswith(".") for part in Path(rel).parts)
+
+
+def load_frontmatter(text: str):
+    """Return (frontmatter_dict_or_None, error_str_or_None)."""
+    if not text.startswith("---\n"):
+        return None, "missing frontmatter"
+    parts = text.split("---\n", 2)
+    if len(parts) < 3:
+        return None, "malformed frontmatter delimiters"
+    try:
+        fm = yaml.safe_load(parts[1])
+    except Exception as e:
+        return None, f"frontmatter parse error: {e}"
+    if not isinstance(fm, dict):
+        return None, "frontmatter did not parse to a mapping"
+    return fm, None
+
+
+def resolve_link(page_path: Path, root: Path, target: str) -> Path:
+    base = root if target.startswith("/") else page_path.parent
+    return (base / target.lstrip("/")).resolve()
+
+
+def lint(root: Path):
+    errors = []
+    warnings = []
+
+    if not root.is_dir():
+        raise FileNotFoundError(f"not a directory: {root}")
+    # Resolve so is_relative_to()/relative_to() work when the caller passes a
+    # relative wiki-dir (link targets are resolved to absolute paths below).
+    root = root.resolve()
+
+    all_md = sorted(p for p in root.rglob("*.md"))
+    # decision: raw/ is the committed inbox of immutable non-repo sources
+    # (llm-wiki's raw layer). Its files are sources, not pages: no frontmatter
+    # schema, no index listing, no link lint. Fully excluded from page
+    # scanning; a separate pass below warns on unprocessed inbox items.
+    all_md = [
+        p for p in all_md
+        if not is_dot_path(p.relative_to(root).as_posix())
+        and not p.relative_to(root).as_posix().startswith("raw/")
+    ]
+
+    pages = []       # (rel, path) for content pages (non-reserved)
+    reserved = {}     # rel -> path, for index.md/log.md/etc found at root
+    for p in all_md:
+        rel = p.relative_to(root).as_posix()
+        if rel in RESERVED_ROOT_FILES:
+            reserved[rel] = p
+        else:
+            pages.append((rel, p))
+
+    page_rels = {rel for rel, _ in pages}
+    fm_by_page = {}
+
+    # --- frontmatter / type / recommended fields ---
+    for rel, p in pages:
+        text = p.read_text()
+        fm, err = load_frontmatter(text)
+        if err:
+            errors.append(f"{rel}: {err}")
+            continue
+        fm_by_page[rel] = fm
+        if not str(fm.get("type") or "").strip():
+            errors.append(f"{rel}: empty/missing type")
+        for k in RECOMMENDED_FIELDS:
+            if not fm.get(k):
+                warnings.append(f"{rel}: missing recommended field '{k}'")
+
+    # --- link resolution + inbound-link tracking (all md files, including reserved) ---
+    inbound = {rel: 0 for rel in page_rels}
+    for p in all_md:
+        rel = p.relative_to(root).as_posix()
+        text = p.read_text()
+        for target in LINK_RE.findall(text):
+            if target.startswith("http://") or target.startswith("https://"):
+                continue
+            resolved = resolve_link(p, root, target)
+            if not resolved.exists():
+                errors.append(f"{rel}: broken link -> {target}")
+                continue
+            if resolved.is_relative_to(root):
+                target_rel = resolved.relative_to(root).as_posix()
+                if target_rel in inbound and target_rel != rel:
+                    inbound[target_rel] += 1
+
+    # --- orphan pages (warning) ---
+    for rel in sorted(page_rels):
+        if inbound.get(rel, 0) == 0:
+            warnings.append(f"{rel}: orphan page (no inbound links)")
+
+    # --- index.md coverage (exact: every page listed exactly once) ---
+    # decision: duplicate listings are errors too, not just missing/extra;
+    # "listed exactly once" is read literally.
+    if "index.md" not in reserved:
+        errors.append("index.md: missing")
+    else:
+        index_text = reserved["index.md"].read_text()
+        listed = [t for t in LINK_RE.findall(index_text) if not t.startswith("http")]
+        counts = {}
+        for t in listed:
+            resolved = resolve_link(reserved["index.md"], root, t)
+            if not resolved.is_relative_to(root):
+                # Outside the bundle: not a page listing. The broken-link pass
+                # above already errors if the target does not exist.
+                continue
+            key = resolved.relative_to(root).as_posix()
+            counts[key] = counts.get(key, 0) + 1
+
+        for rel in sorted(page_rels):
+            n = counts.get(rel, 0)
+            if n == 0:
+                errors.append(f"index.md: page not listed -> {rel}")
+            elif n > 1:
+                errors.append(f"index.md: page listed {n} times (expected exactly 1) -> {rel}")
+
+        for key, n in counts.items():
+            if key not in page_rels and key not in RESERVED_ROOT_FILES:
+                errors.append(f"index.md: lists nonexistent page -> {key}")
+
+    # --- log.md entries: '## YYYY-MM-DD' headers, bold action words ---
+    if "log.md" not in reserved:
+        errors.append("log.md: missing")
+    else:
+        log_lines = reserved["log.md"].read_text().splitlines()
+        current_date = None
+        entries_under_date = 0
+        for i, line in enumerate(log_lines, start=1):
+            header_match = LOG_HEADER_RE.match(line)
+            if header_match:
+                if current_date is not None and entries_under_date == 0:
+                    errors.append(f"log.md: date section '{current_date}' has no entries")
+                current_date = header_match.group(1)
+                entries_under_date = 0
+                continue
+            if line.startswith("**"):
+                if current_date is None:
+                    errors.append(f"log.md:{i}: bold entry outside any '## YYYY-MM-DD' section")
+                    continue
+                if LOG_ACTION_RE.match(line):
+                    entries_under_date += 1
+                else:
+                    errors.append(
+                        f"log.md:{i}: entry does not start with a recognized bold action "
+                        f"word (Creation/Update/Finding/Deprecation): {line[:60]!r}"
+                    )
+        if current_date is not None and entries_under_date == 0:
+            errors.append(f"log.md: date section '{current_date}' has no entries")
+        if current_date is None and log_lines:
+            # log.md exists with content but no dated section at all
+            has_any_heading = any(l.strip().startswith("#") for l in log_lines)
+            if has_any_heading:
+                warnings.append("log.md: no '## YYYY-MM-DD' section found")
+
+    # --- raw/ inbox: warn on unprocessed items ---
+    # raw/<file> is pending; raw/processed/<file> has been distilled into
+    # pages by /brain ingest. Any filetype counts (sources are not limited to
+    # markdown); dotfiles (.gitkeep) are ignored.
+    raw_dir = root / "raw"
+    if raw_dir.is_dir():
+        for p in sorted(raw_dir.rglob("*")):
+            if not p.is_file() or p.name.startswith("."):
+                continue
+            rel = p.relative_to(root).as_posix()
+            inner = p.relative_to(raw_dir).as_posix()
+            if not inner.startswith("processed/"):
+                warnings.append(
+                    f"{rel}: unprocessed inbox item (run /brain ingest to distill it)"
+                )
+
+    # --- manifest.json (optional) ---
+    manifest_path = root / "manifest.json"
+    if manifest_path.exists():
+        try:
+            manifest = json.loads(manifest_path.read_text())
+        except Exception as e:
+            errors.append(f"manifest.json: parse error: {e}")
+            manifest = None
+        if manifest is not None and not isinstance(manifest, dict):
+            errors.append("manifest.json: top level is not an object")
+            manifest = None
+        if manifest is not None:
+            for key in MANIFEST_REQUIRED_KEYS:
+                if key not in manifest:
+                    errors.append(f"manifest.json: missing required key '{key}'")
+            status = manifest.get("status")
+            if "status" in manifest and status not in MANIFEST_STATUSES:
+                errors.append(
+                    f"manifest.json: status={status!r}, expected one of "
+                    f"{sorted(MANIFEST_STATUSES)}"
+                )
+            okf_version = manifest.get("okf")
+            if "okf" in manifest and okf_version != "0.1":
+                warnings.append(
+                    f"manifest.json: okf={okf_version!r}, this linter targets '0.1'"
+                )
+
+            actual_count = len(page_rels)
+            claimed_count = manifest.get("page_count")
+            if "page_count" in manifest and claimed_count != actual_count:
+                errors.append(
+                    f"manifest.json: page_count={claimed_count!r}, actual={actual_count}"
+                )
+
+            actual_types = {}
+            for rel, fm in fm_by_page.items():
+                t = str(fm.get("type") or "").strip()
+                if t:
+                    actual_types[t] = actual_types.get(t, 0) + 1
+            claimed_types = manifest.get("page_types") or {}
+            if "page_types" in manifest and claimed_types != actual_types:
+                errors.append(
+                    f"manifest.json: page_types mismatch. "
+                    f"manifest={claimed_types!r} actual={actual_types!r}"
+                )
+
+    return {
+        "root": str(root),
+        "page_count": len(page_rels),
+        "file_count": len(all_md),
+        "errors": errors,
+        "warnings": warnings,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Lint an OKF v0.1 wiki bundle.")
+    parser.add_argument("wiki_dir", help="path to the wiki bundle (e.g. docs/wiki)")
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    args = parser.parse_args()
+
+    root = Path(args.wiki_dir)
+    try:
+        result = lint(root)
+    except FileNotFoundError as e:
+        if args.json:
+            print(json.dumps({"error": str(e)}))
+        else:
+            print(f"error: {e}", file=sys.stderr)
+        sys.exit(2)
+    except Exception as e:
+        if args.json:
+            print(json.dumps({"error": f"unexpected failure: {e}"}))
+        else:
+            print(f"error: unexpected failure: {e}", file=sys.stderr)
+        sys.exit(2)
+
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(f"{result['page_count']} concept pages, {result['file_count']} files total")
+        if result["errors"]:
+            print(f"\n{len(result['errors'])} error(s):")
+            for e in result["errors"]:
+                print(f"  ERROR: {e}")
+        if result["warnings"]:
+            print(f"\n{len(result['warnings'])} warning(s):")
+            for w in result["warnings"]:
+                print(f"  WARN: {w}")
+        if not result["errors"] and not result["warnings"]:
+            print("OK: bundle conforms")
+
+    sys.exit(1 if (result["errors"] or result["warnings"]) else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/wikicli/profile_census.py
+++ b/wikicli/profile_census.py
@@ -1,0 +1,626 @@
+#!/usr/bin/env python3
+"""profile_census.py: walk a project dir and propose a /brain domain profile.
+
+Usage:
+    python3 scripts/profile_census.py <project-dir> [--json] [--max-files N]
+
+Stdlib only. No network. No writes. Read-only walk of the given path.
+
+Exit codes: 0 = ok (profile suggested), 1 = ok but low-confidence / no strong
+signal, 2 = error (bad path, walk failure).
+
+# decision: BUILD-SPEC exit-code convention is ok/findings/error. There is no
+# "findings" concept for a census (it always produces *a* suggestion), so 0/2
+# are used normally and 1 is reserved for "ran fine but confidence is low";
+# callers that care can branch on it, everyone else treats 0 and 1 as success.
+"""
+
+import argparse
+import json
+import os
+import sys
+from collections import Counter
+
+SKIP_DIRS = {
+    ".git", "node_modules", ".venv", "venv", ".next", "dist", "build",
+    "__pycache__", ".obsidian",
+}
+
+DEFAULT_MAX_FILES = 50_000
+
+FRONTEND_FRAMEWORK_DEPS = {
+    "next": "Next.js",
+    "react": "React",
+    "react-dom": "React",
+    "vue": "Vue",
+    "@angular/core": "Angular",
+    "svelte": "Svelte",
+}
+
+BACKEND_PY_FRAMEWORK_MARKERS = {
+    "fastapi": "FastAPI",
+    "flask": "Flask",
+    "django": "Django",
+}
+
+
+def walk_project(root, max_files):
+    """Single bounded walk. Returns dict of raw counters + collected paths."""
+    ext_count = Counter()
+    ext_bytes = Counter()
+    top_dir_count = Counter()
+    top_dir_bytes = Counter()
+    package_json_paths = []
+    pyproject_paths = []
+    requirements_paths = []
+    dockerfile_paths = []
+    graphify_out_dirs = []
+    obsidian_dirs = []
+    adr_dirs = []
+    design_doc_paths = []
+    sql_count = 0
+    ipynb_count = 0
+    total_files = 0
+    truncated = False
+
+    root = os.path.abspath(root)
+
+    for dirpath, dirnames, filenames in os.walk(root):
+        # Prior-knowledge markers: record BEFORE pruning (graphify-out and
+        # .obsidian are skipped for the histogram walk; their presence is
+        # still a signal brain-init leverages).
+        if "graphify-out" in dirnames:
+            graphify_out_dirs.append(os.path.join(dirpath, "graphify-out"))
+        if ".obsidian" in dirnames:
+            obsidian_dirs.append(os.path.join(dirpath, ".obsidian"))
+        for adr_name in ("adr", "adrs"):
+            if adr_name in dirnames:
+                adr_dirs.append(os.path.join(dirpath, adr_name))
+
+        # prune skip dirs in-place (works with topdown os.walk). A dir
+        # containing pyvenv.cfg is a virtualenv whatever its name
+        # (.venv-qwen, env310, ...); name matching alone misses those and a
+        # single venv can dominate the whole histogram.
+        dirnames[:] = sorted(
+            d for d in dirnames
+            if d not in SKIP_DIRS
+            and d != "graphify-out"
+            and not os.path.exists(os.path.join(dirpath, d, "pyvenv.cfg"))
+        )
+
+        rel = os.path.relpath(dirpath, root)
+        top_dir = "." if rel == "." else rel.split(os.sep)[0]
+
+        for fname in sorted(filenames):
+            if total_files >= max_files:
+                truncated = True
+                break
+            fpath = os.path.join(dirpath, fname)
+            try:
+                size = os.path.getsize(fpath)
+            except OSError:
+                size = 0
+
+            total_files += 1
+            top_dir_count[top_dir] += 1
+            top_dir_bytes[top_dir] += size
+
+            _, ext = os.path.splitext(fname)
+            ext = ext.lower() if ext else "(no ext)"
+            ext_count[ext] += 1
+            ext_bytes[ext] += size
+
+            lower = fname.lower()
+            if lower == "package.json":
+                package_json_paths.append(fpath)
+            elif lower == "pyproject.toml":
+                pyproject_paths.append(fpath)
+            elif lower.startswith("requirements") and lower.endswith(".txt"):
+                requirements_paths.append(fpath)
+            elif lower == "dockerfile" or lower.startswith("dockerfile."):
+                dockerfile_paths.append(fpath)
+            elif lower in ("design.md", "architecture.md"):
+                design_doc_paths.append(fpath)
+            elif ext == ".sql":
+                sql_count += 1
+            elif ext == ".ipynb":
+                ipynb_count += 1
+
+        if truncated:
+            break
+
+    return {
+        "root": root,
+        "total_files": total_files,
+        "truncated": truncated,
+        "ext_count": ext_count,
+        "ext_bytes": ext_bytes,
+        "top_dir_count": top_dir_count,
+        "top_dir_bytes": top_dir_bytes,
+        "package_json_paths": package_json_paths,
+        "pyproject_paths": pyproject_paths,
+        "requirements_paths": requirements_paths,
+        "dockerfile_paths": dockerfile_paths,
+        "graphify_out_dirs": graphify_out_dirs,
+        "obsidian_dirs": obsidian_dirs,
+        "adr_dirs": adr_dirs,
+        "design_doc_paths": design_doc_paths,
+        "sql_count": sql_count,
+        "ipynb_count": ipynb_count,
+    }
+
+
+def parse_package_json_files(paths):
+    """Parse each package.json found (excluding node_modules by construction
+    of the walk). Returns aggregate dep set + per-file summaries."""
+    all_deps = set()
+    frontend_frameworks = set()
+    files = []
+    for p in paths:
+        try:
+            with open(p, "r", encoding="utf-8", errors="replace") as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            files.append({"path": p, "error": "unparseable"})
+            continue
+        deps = {}
+        deps.update(data.get("dependencies", {}) or {})
+        deps.update(data.get("devDependencies", {}) or {})
+        for dep_name in deps:
+            all_deps.add(dep_name)
+            if dep_name in FRONTEND_FRAMEWORK_DEPS:
+                frontend_frameworks.add(FRONTEND_FRAMEWORK_DEPS[dep_name])
+        files.append({
+            "path": p,
+            "name": data.get("name"),
+            "dep_count": len(deps),
+        })
+    return {
+        "files": files,
+        "all_deps": sorted(all_deps),
+        "frontend_frameworks": sorted(frontend_frameworks),
+    }
+
+
+def scan_python_backend_markers(pyproject_paths, requirements_paths):
+    """Grep pyproject.toml / requirements*.txt text for known backend
+    framework names. Cheap text search, not a real TOML/requirements parser
+    (stdlib-only constraint; good enough for a marker, not a dependency
+    resolver)."""
+    found = set()
+    for p in list(pyproject_paths) + list(requirements_paths):
+        try:
+            with open(p, "r", encoding="utf-8", errors="replace") as f:
+                text = f.read().lower()
+        except OSError:
+            continue
+        for marker, label in BACKEND_PY_FRAMEWORK_MARKERS.items():
+            if marker in text:
+                found.add(label)
+    return sorted(found)
+
+
+def detect_git(root):
+    # a worktree's ".git" is a *file* (gitdir: <path>), not a directory,
+    # so check existence, not is-a-directory.
+    return os.path.exists(os.path.join(root, ".git"))
+
+
+def _file_has_frontmatter_type(path):
+    """True if the file's leading YAML frontmatter block contains a
+    `type:` key. Cheap line scan, not a YAML parser."""
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            lines = f.readlines()
+    except OSError:
+        return False
+    if not lines or lines[0].strip() != "---":
+        return False
+    for line in lines[1:200]:
+        if line.strip() == "---":
+            return False
+        if line.lstrip().lower().startswith("type:"):
+            return True
+    return False
+
+
+def any_wiki_page_has_frontmatter_type(wiki_dir, exclude=("index.md", "log.md")):
+    """OKF page frontmatter (`type: Subsystem`, etc.) lives on content pages,
+    not index.md/log.md. Sample up to 20 markdown files under the wiki dir
+    (one level of subdirectories deep is enough; OKF bundles are shallow) and
+    return True on the first frontmatter `type:` hit."""
+    checked = 0
+    for dirpath, dirnames, filenames in os.walk(wiki_dir):
+        dirnames[:] = [d for d in sorted(dirnames) if d not in SKIP_DIRS]
+        for fname in sorted(filenames):
+            if not fname.endswith(".md") or fname in exclude:
+                continue
+            if checked >= 20:
+                return False
+            checked += 1
+            if _file_has_frontmatter_type(os.path.join(dirpath, fname)):
+                return True
+    return False
+
+
+def detect_existing_wiki(root):
+    """Design doc section 8 detection ladder, applied to a single project
+    root: docs/wiki/manifest.json (first-class) > OKF-ish (index.md + log.md
+    + frontmatter type:) > Obsidian markers > generic markdown-wiki shape.
+    Returns dict with `kind` in {plugin_wiki, okf_ish, obsidian_vault,
+    generic_markdown_wiki, none} and supporting evidence."""
+    docs_wiki = os.path.join(root, "docs", "wiki")
+    manifest_path = os.path.join(docs_wiki, "manifest.json")
+    index_path = os.path.join(docs_wiki, "index.md")
+    log_path = os.path.join(docs_wiki, "log.md")
+    obsidian_in_wiki = os.path.join(docs_wiki, ".obsidian")
+    obsidian_at_root = os.path.join(root, ".obsidian")
+
+    if os.path.isfile(manifest_path):
+        return {
+            "kind": "plugin_wiki",
+            "path": docs_wiki,
+            "evidence": ["docs/wiki/manifest.json present"],
+        }
+
+    if os.path.isdir(docs_wiki):
+        has_index = os.path.isfile(index_path)
+        has_log = os.path.isfile(log_path)
+        if has_index and has_log:
+            frontmatter_hit = any_wiki_page_has_frontmatter_type(docs_wiki)
+            if frontmatter_hit:
+                return {
+                    "kind": "okf_ish",
+                    "path": docs_wiki,
+                    "evidence": [
+                        "docs/wiki/index.md + log.md present",
+                        "wiki page(s) carry frontmatter `type:` field",
+                    ],
+                }
+            if os.path.isdir(obsidian_in_wiki):
+                return {
+                    "kind": "obsidian_vault",
+                    "path": docs_wiki,
+                    "evidence": [
+                        "docs/wiki/index.md + log.md present",
+                        "docs/wiki/.obsidian/ present",
+                    ],
+                }
+            # decision: design section 8 lists OKF-ish signals conjunctively
+            # (index.md + log.md + frontmatter type:). index+log alone, with
+            # no typed page, falls through to generic markdown wiki rather
+            # than claiming okf_ish on a partial match.
+            return {
+                "kind": "generic_markdown_wiki",
+                "path": docs_wiki,
+                "evidence": ["docs/wiki/index.md + log.md present, but no page carries frontmatter type:"],
+            }
+        if any(fname.endswith(".md") for fname in os.listdir(docs_wiki) if
+               os.path.isfile(os.path.join(docs_wiki, fname))):
+            return {
+                "kind": "generic_markdown_wiki",
+                "path": docs_wiki,
+                "evidence": ["docs/wiki/ contains markdown files, no manifest/index+log"],
+            }
+
+    if os.path.isdir(obsidian_at_root):
+        return {
+            "kind": "obsidian_vault",
+            "path": root,
+            "evidence": [".obsidian/ present at project root"],
+        }
+
+    return {"kind": "none", "path": None, "evidence": []}
+
+
+def collect_prior_knowledge(census, wiki):
+    """Aggregate pre-existing knowledge sources /brain-init can leverage
+    instead of paying full discovery cost: graphify graphs, Obsidian vaults,
+    ADR dirs, design docs, and any wiki detect_existing_wiki found. One list,
+    strongest evidence first. Paths capped at 10 per kind."""
+    entries = []
+    root = census["root"]
+
+    for d in census["graphify_out_dirs"][:10]:
+        graph = os.path.join(d, "graph.json")
+        if os.path.isfile(graph):
+            entries.append({
+                "kind": "graphify_graph",
+                "path": graph,
+                "evidence": ["graphify-out/graph.json present (clusters can seed the compile queue)"],
+            })
+        else:
+            entries.append({
+                "kind": "graphify_out",
+                "path": d,
+                "evidence": ["graphify-out/ present but no graph.json (partial run?)"],
+            })
+
+    if wiki["kind"] != "none":
+        entries.append({
+            "kind": f"wiki:{wiki['kind']}",
+            "path": wiki["path"],
+            "evidence": wiki["evidence"],
+        })
+
+    # .obsidian inside docs/wiki is already covered by detect_existing_wiki;
+    # report other vault locations separately.
+    wiki_path = wiki["path"] or ""
+    for d in census["obsidian_dirs"][:10]:
+        parent = os.path.dirname(d)
+        if wiki["kind"] == "obsidian_vault" and parent == wiki_path:
+            continue
+        entries.append({
+            "kind": "obsidian_vault",
+            "path": parent,
+            "evidence": [os.path.relpath(d, root) + "/ present"],
+        })
+
+    for d in census["adr_dirs"][:10]:
+        entries.append({
+            "kind": "adr_dir",
+            "path": d,
+            "evidence": [os.path.relpath(d, root) + "/ present"],
+        })
+
+    if census["design_doc_paths"]:
+        entries.append({
+            "kind": "design_docs",
+            "path": None,
+            "evidence": [os.path.relpath(p, root)
+                         for p in census["design_doc_paths"][:10]],
+        })
+
+    return entries
+
+
+def suggest_profile(census, pkg_info, backend_markers, sql_count, ipynb_count):
+    """Design doc section 5 detect signals:
+    - package.json + backend/*.py -> fullstack-app
+    - high .sql/.ipynb density -> research-data
+    - .md/.pdf dominant, no build files -> generic
+    """
+    reasons_fullstack = []
+    reasons_research = []
+    reasons_generic = []
+
+    has_package_json = bool(pkg_info["files"])
+    has_frontend_framework = bool(pkg_info["frontend_frameworks"])
+    has_backend_py = bool(backend_markers)
+    has_pyproject_or_reqs = bool(census["pyproject_paths"]) or bool(census["requirements_paths"])
+    has_dockerfile = bool(census["dockerfile_paths"])
+    has_any_py = census["ext_count"].get(".py", 0) > 0
+
+    if has_package_json:
+        reasons_fullstack.append(
+            f"package.json found ({len(pkg_info['files'])} file(s))"
+        )
+    if has_frontend_framework:
+        reasons_fullstack.append(
+            "frontend framework dep(s): " + ", ".join(pkg_info["frontend_frameworks"])
+        )
+    if has_backend_py:
+        reasons_fullstack.append(
+            "backend Python framework marker(s): " + ", ".join(backend_markers)
+        )
+    elif has_pyproject_or_reqs and has_any_py:
+        reasons_fullstack.append("pyproject.toml/requirements.txt + .py files present")
+    if has_dockerfile:
+        reasons_fullstack.append(f"Dockerfile present ({len(census['dockerfile_paths'])})")
+
+    total_files = max(census["total_files"], 1)
+    sql_density = sql_count / total_files
+    ipynb_density = ipynb_count / total_files
+
+    if sql_count >= 5:
+        reasons_research.append(f".sql files: {sql_count}")
+    if ipynb_count >= 3:
+        reasons_research.append(f".ipynb notebooks: {ipynb_count}")
+    if sql_density > 0.03:
+        reasons_research.append(f".sql density {sql_density:.1%} of all files")
+    if ipynb_density > 0.02:
+        reasons_research.append(f".ipynb density {ipynb_density:.1%} of all files")
+
+    md_pdf_count = census["ext_count"].get(".md", 0) + census["ext_count"].get(".pdf", 0)
+    md_pdf_ratio = md_pdf_count / total_files
+    no_build_files = not has_package_json and not has_pyproject_or_reqs and not has_dockerfile
+    if md_pdf_ratio > 0.4:
+        reasons_generic.append(f".md/.pdf are {md_pdf_ratio:.1%} of all files")
+    if no_build_files:
+        reasons_generic.append("no package.json / pyproject.toml / requirements.txt / Dockerfile found")
+
+    # scoring: each qualifying reason contributes; fullstack and research
+    # signals are stronger indicators (explicit build tooling) than the
+    # generic fallback, which is deliberately the weakest default.
+    fullstack_score = len(reasons_fullstack) * 2
+    research_score = len(reasons_research) * 2
+    generic_score = len(reasons_generic)
+
+    scores = {
+        "fullstack-app": fullstack_score,
+        "research-data": research_score,
+        "generic": generic_score,
+    }
+    reasons_by_profile = {
+        "fullstack-app": reasons_fullstack,
+        "research-data": reasons_research,
+        "generic": reasons_generic,
+    }
+
+    ranked = sorted(scores.items(), key=lambda kv: kv[1], reverse=True)
+    top_profile, top_score = ranked[0]
+    second_score = ranked[1][1]
+
+    reasons = reasons_by_profile[top_profile][:4]
+    if len(reasons) < 2:
+        # pad with the generic no-signal reason so we never emit a bare
+        # 1-reason suggestion (spec asks for 2-4 stated reasons).
+        if not reasons:
+            reasons.append("no strong domain signal detected; defaulting to generic")
+            top_profile = "generic"
+        reasons.append("insufficient corroborating signals; treat as a starting guess")
+
+    if top_score == 0:
+        confidence = "low"
+        top_profile = "generic"
+        reasons = reasons_by_profile["generic"][:4] or [
+            "no strong domain signal detected; defaulting to generic",
+            "run /brain-init and confirm/override manually",
+        ]
+    elif top_score >= 4 and top_score >= 2 * max(second_score, 1):
+        confidence = "high"
+    elif top_score >= 2:
+        confidence = "medium"
+    else:
+        confidence = "low"
+
+    return {
+        "profile": top_profile,
+        "confidence": confidence,
+        "reasons": reasons,
+        "scores": scores,
+    }
+
+
+def build_report(root, max_files):
+    census = walk_project(root, max_files)
+    pkg_info = parse_package_json_files(census["package_json_paths"])
+    backend_markers = scan_python_backend_markers(
+        census["pyproject_paths"], census["requirements_paths"]
+    )
+    git_present = detect_git(census["root"])
+    wiki = detect_existing_wiki(census["root"])
+    prior_knowledge = collect_prior_knowledge(census, wiki)
+    suggestion = suggest_profile(
+        census, pkg_info, backend_markers, census["sql_count"], census["ipynb_count"]
+    )
+
+    ext_histogram = [
+        {"ext": ext, "count": count, "bytes": census["ext_bytes"][ext]}
+        for ext, count in census["ext_count"].most_common()
+    ]
+    top_dir_summary = [
+        {"dir": d, "count": count, "bytes": census["top_dir_bytes"][d]}
+        for d, count in census["top_dir_count"].most_common()
+    ]
+
+    return {
+        "root": census["root"],
+        "total_files_scanned": census["total_files"],
+        "walk_truncated": census["truncated"],
+        "ext_histogram": ext_histogram,
+        "top_dir_summary": top_dir_summary,
+        "framework_markers": {
+            "package_json": pkg_info["files"],
+            "frontend_frameworks": pkg_info["frontend_frameworks"],
+            "backend_python_frameworks": backend_markers,
+            "pyproject_toml": census["pyproject_paths"],
+            "requirements_txt": census["requirements_paths"],
+            "dockerfiles": census["dockerfile_paths"],
+            "sql_file_count": census["sql_count"],
+            "ipynb_file_count": census["ipynb_count"],
+        },
+        "git_present": git_present,
+        "existing_wiki": wiki,
+        "prior_knowledge": prior_knowledge,
+        "suggested_profile": suggestion,
+    }
+
+
+def format_bytes(n):
+    for unit in ("B", "KB", "MB", "GB"):
+        if n < 1024:
+            return f"{n:.0f}{unit}" if unit == "B" else f"{n:.1f}{unit}"
+        n /= 1024
+    return f"{n:.1f}TB"
+
+
+def print_human(report):
+    print(f"project census: {report['root']}")
+    print(f"files scanned: {report['total_files_scanned']}" +
+          (" (TRUNCATED at cap)" if report["walk_truncated"] else ""))
+    print(f"git present: {'yes' if report['git_present'] else 'no'}")
+    print()
+
+    print("extension histogram (top 15 by count):")
+    for row in report["ext_histogram"][:15]:
+        print(f"  {row['ext']:<14} count={row['count']:<6} bytes={format_bytes(row['bytes'])}")
+    print()
+
+    print("top-level dir summary:")
+    for row in report["top_dir_summary"]:
+        print(f"  {row['dir']:<20} count={row['count']:<6} bytes={format_bytes(row['bytes'])}")
+    print()
+
+    fm = report["framework_markers"]
+    print("framework markers:")
+    print(f"  package.json files: {len(fm['package_json'])}")
+    for p in fm["package_json"]:
+        if "error" in p:
+            print(f"    {p['path']} (unparseable)")
+        else:
+            print(f"    {p['path']} (name={p.get('name')}, deps={p.get('dep_count')})")
+    print(f"  frontend frameworks: {', '.join(fm['frontend_frameworks']) or 'none'}")
+    print(f"  backend python frameworks: {', '.join(fm['backend_python_frameworks']) or 'none'}")
+    print(f"  pyproject.toml: {len(fm['pyproject_toml'])}")
+    print(f"  requirements.txt: {len(fm['requirements_txt'])}")
+    print(f"  Dockerfiles: {len(fm['dockerfiles'])}")
+    print(f"  .sql files: {fm['sql_file_count']}")
+    print(f"  .ipynb files: {fm['ipynb_file_count']}")
+    print()
+
+    wiki = report["existing_wiki"]
+    print(f"existing wiki: {wiki['kind']}" + (f" ({wiki['path']})" if wiki["path"] else ""))
+    for ev in wiki["evidence"]:
+        print(f"  - {ev}")
+    print()
+
+    pk = report["prior_knowledge"]
+    print(f"prior knowledge sources: {len(pk)}")
+    for entry in pk:
+        loc = f" ({entry['path']})" if entry["path"] else ""
+        print(f"  {entry['kind']}{loc}")
+        for ev in entry["evidence"]:
+            print(f"    - {ev}")
+    print()
+
+    sugg = report["suggested_profile"]
+    print(f"suggested profile: {sugg['profile']}  (confidence: {sugg['confidence']})")
+    print("reasons:")
+    for r in sugg["reasons"]:
+        print(f"  - {r}")
+    print(f"scores: {sugg['scores']}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Census a project dir and suggest a /brain domain profile."
+    )
+    parser.add_argument("project_dir", help="path to project root to scan")
+    parser.add_argument("--json", action="store_true", help="emit JSON instead of human text")
+    parser.add_argument(
+        "--max-files", type=int, default=DEFAULT_MAX_FILES,
+        help=f"hard cap on files walked (default {DEFAULT_MAX_FILES})",
+    )
+    args = parser.parse_args()
+
+    if not os.path.isdir(args.project_dir):
+        print(f"error: not a directory: {args.project_dir}", file=sys.stderr)
+        return 2
+
+    try:
+        report = build_report(args.project_dir, args.max_files)
+    except OSError as e:
+        print(f"error: walk failed: {e}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print_human(report)
+
+    return 0 if report["suggested_profile"]["confidence"] != "low" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/wikicli/session_scan.py
+++ b/wikicli/session_scan.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""session_scan.py: locate a project's coding-agent session logs across every
+supported harness and emit STRUCTURAL SIGNALS ONLY for the session-miner
+subagent (design D2).
+
+Harnesses are pluggable: scripts/harness_adapters.py holds one locate+parse
+adapter per agent (claude, codex, opencode, qwen, cline, hermes, smallcode,
+grok, copilot, vibe, antigravity), each tagged with a capability level
+("full" / "partial" / "tokens" / "presence") describing which signal classes
+that store can honestly provide. The signal schema is identical across
+harnesses; each session carries a "harness" field and the aggregate includes
+a per-harness breakdown.
+
+PRIVACY BOUNDARY (design D2, BUILD-SPEC rule 3). Only structural metadata is
+extracted:
+  - session id, harness, first/last timestamps
+  - per-tool-name call counts
+  - file paths taken from tool INPUTS (these name the user's own files)
+  - is_error FLAG counts where the store exposes one (the boolean only)
+  - repeated identical consecutive tool calls (loop signatures)
+  - token totals as the store records them
+
+It NEVER emits message text, thinking text, user prompts, tool_result
+content, or any data value. One approved exception (maintainer, 2026-07-06):
+harnesses that record tools as shell strings (codex, grok's terminal tool)
+have those strings tokenized IN MEMORY to extract file-path tokens; only the
+paths are emitted, never the command text. Do not extend content extraction
+beyond that.
+
+Usage:
+  python3 scripts/session_scan.py <project-dir> [--harness all]
+                                  [--limit 30] [--json]
+
+--harness accepts "all" (default), one name, or a comma list.
+--limit is per harness (newest N sessions by recency).
+
+Exit codes: 0 = scanned ok (signals emitted, possibly empty), 2 = error
+(bad args / unknown harness).
+# decision: no exit-1 "findings" state, a scan has no pass/fail; empty result
+# is still a successful scan. Follows BUILD-SPEC rule 2's 0/2 for this script.
+"""
+
+import argparse
+import json
+import os
+import sys
+from collections import Counter, defaultdict
+
+try:
+    # package invocation: python3 -m wikicli.session_scan (how bin/cli.js runs it)
+    from .harness_adapters import ADAPTERS, encode_claude_dir
+except ImportError:
+    # direct invocation: python3 wikicli/session_scan.py
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    from harness_adapters import ADAPTERS, encode_claude_dir  # noqa: E402
+
+
+def aggregate(sessions):
+    """Roll per-session signals up across the scanned set (all harnesses)."""
+    reread_count = Counter()
+    reread_sessions = defaultdict(set)
+    loop_count = Counter()
+    loop_sessions = defaultdict(set)
+    tool_totals = Counter()
+    tokens = {"input": 0, "output": 0, "cache_read": 0, "cache_creation": 0}
+    errors = 0
+    by_harness = {}
+
+    for s in sessions:
+        sid = s["session_id"]
+        h = s["harness"]
+        hb = by_harness.setdefault(h, {"session_count": 0, "token_total": 0,
+                                       "tool_calls": 0})
+        hb["session_count"] += 1
+        hb["token_total"] += s["token_total"]
+        hb["tool_calls"] += sum(s["tool_counts"].values())
+        for path, n in s["read_paths"].items():
+            reread_count[path] += n
+            reread_sessions[path].add((h, sid))
+        for lp in s["loops"]:
+            key = (lp["tool"], lp["path"])
+            loop_count[key] += lp["count"]
+            loop_sessions[key].add((h, sid))
+        for name, n in s["tool_counts"].items():
+            tool_totals[name] += n
+        for k in tokens:
+            tokens[k] += s["tokens"][k]
+        errors += s["error_count"]
+
+    top_reread = [
+        {"path": p, "read_count": n, "session_count": len(reread_sessions[p])}
+        for p, n in reread_count.most_common()
+        if n >= 2  # "re-read" = read more than once
+    ]
+    loops = [
+        {"tool": t, "path": p, "count": n,
+         "session_count": len(loop_sessions[(t, p)])}
+        for (t, p), n in loop_count.most_common()
+    ]
+    return {
+        "session_count": len(sessions),
+        "by_harness": by_harness,
+        "top_reread_files": top_reread,
+        "loop_signatures": loops,
+        "tool_call_mix": dict(tool_totals.most_common()),
+        "tokens": tokens,
+        "token_total": sum(tokens.values()),
+        "error_result_count": errors,
+    }
+
+
+def build_result(project_dir, harnesses, sessions, limit):
+    per_session = [
+        {
+            "session_id": s["session_id"],
+            "harness": s["harness"],
+            "capability": s["capability"],
+            "first_ts": s["first_ts"],
+            "last_ts": s["last_ts"],
+            "tool_counts": s["tool_counts"],
+            "file_paths": s["file_paths"],
+            "error_result_count": s["error_count"],
+            "token_total": s["token_total"],
+            "loop_signatures": s["loops"],
+        }
+        for s in sessions
+    ]
+    return {
+        "harness": ",".join(harnesses),
+        "project_dir": project_dir,
+        "encoded_dir": encode_claude_dir(project_dir),
+        "limit": limit,
+        "capabilities": {h: ADAPTERS[h]["capability"] for h in harnesses},
+        "aggregate": aggregate(sessions) if sessions else {
+            "session_count": 0, "by_harness": {}, "top_reread_files": [],
+            "loop_signatures": [], "tool_call_mix": {},
+            "tokens": {"input": 0, "output": 0, "cache_read": 0,
+                       "cache_creation": 0},
+            "token_total": 0, "error_result_count": 0,
+        },
+        "sessions": per_session,
+    }
+
+
+def render_human(result):
+    out = []
+    agg = result["aggregate"]
+    out.append("session_scan (structural signals only)")
+    out.append(f"project:   {result['project_dir']}")
+    out.append(f"harnesses: {result['harness']}")
+    out.append(f"scanned:   {agg['session_count']} session(s), "
+               f"limit {result['limit']}/harness")
+    if agg["session_count"] == 0:
+        out.append("")
+        out.append("No sessions found for this project in any scanned harness.")
+        return "\n".join(out)
+
+    if agg["by_harness"]:
+        out.append("")
+        out.append("by harness (sessions | tool calls | tokens | capability)")
+        for h, hb in sorted(agg["by_harness"].items(),
+                            key=lambda kv: -kv[1]["session_count"]):
+            cap = result["capabilities"].get(h, "?")
+            out.append(f"  {hb['session_count']:>4} | {hb['tool_calls']:>5} | "
+                       f"{hb['token_total']:>12,} | {cap:<8} {h}")
+
+    t = agg["tokens"]
+    out.append("")
+    out.append("totals")
+    out.append(f"  tokens: {agg['token_total']:,} "
+               f"(in {t['input']:,} / out {t['output']:,} / "
+               f"cache_read {t['cache_read']:,} / cache_write {t['cache_creation']:,})")
+    out.append(f"  tool_result errors (flag only): {agg['error_result_count']}")
+
+    mix = agg["tool_call_mix"]
+    if mix:
+        out.append("")
+        out.append("tool call mix")
+        for name, n in list(mix.items())[:12]:
+            out.append(f"  {n:>5}  {name}")
+
+    if agg["top_reread_files"]:
+        out.append("")
+        out.append("top re-read files (path | reads | sessions)")
+        for r in agg["top_reread_files"][:15]:
+            out.append(f"  {r['read_count']:>4} | {r['session_count']:>2} | {r['path']}")
+
+    if agg["loop_signatures"]:
+        out.append("")
+        out.append("loop signatures (repeated consecutive identical calls)")
+        for lp in agg["loop_signatures"][:15]:
+            out.append(f"  {lp['count']:>4} x  {lp['tool']}  {lp['path']}")
+
+    return "\n".join(out)
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        description="Locate a project's coding-agent session logs across all "
+                    "supported harnesses and emit structural signals only "
+                    "(no transcript content).")
+    ap.add_argument("project_dir", help="Absolute or relative path to the project.")
+    ap.add_argument("--harness", default="all",
+                    help="'all' (default), one harness name, or a comma list. "
+                         f"Known: {', '.join(sorted(ADAPTERS))}.")
+    ap.add_argument("--limit", type=int, default=30,
+                    help="Parse the newest N sessions per harness (default 30).")
+    ap.add_argument("--json", action="store_true", dest="as_json",
+                    help="Emit the full structured result as JSON.")
+    args = ap.parse_args(argv)
+
+    if args.limit <= 0:
+        print("error: --limit must be positive", file=sys.stderr)
+        return 2
+
+    if args.harness.strip().lower() == "all":
+        harnesses = sorted(ADAPTERS)
+    else:
+        harnesses = [h.strip() for h in args.harness.split(",") if h.strip()]
+        unknown = [h for h in harnesses if h not in ADAPTERS]
+        if unknown:
+            print(f"error: unknown harness(es): {', '.join(unknown)}. "
+                  f"Known: {', '.join(sorted(ADAPTERS))}", file=sys.stderr)
+            return 2
+
+    project_dir = os.path.abspath(os.path.expanduser(args.project_dir))
+
+    sessions = []
+    for h in harnesses:
+        adapter = ADAPTERS[h]
+        try:
+            refs = adapter["locate"](project_dir, args.limit)
+        except Exception:
+            continue  # a broken store never fails the whole scan
+        for ref in refs:
+            try:
+                s = adapter["scan"](ref, project_dir)
+            except Exception:
+                s = None
+            if s is not None:
+                s["harness"] = h
+                s["capability"] = adapter["capability"]
+                sessions.append(s)
+
+    result = build_result(project_dir, harnesses, sessions, args.limit)
+
+    if args.as_json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(render_human(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/wikicli/templates/status.py
+++ b/wikicli/templates/status.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+# STATUS_PY_VERSION: 2
+"""status.py — freshness checker for this compiled wiki. Self-contained,
+Python 3.9+ stdlib only, no plugin required: anyone who clones the repo can
+run it, in any coding harness that can run a shell command.
+
+The wiki is a CACHE of the codebase. This script is the cache-validity
+check. It compares content hashes recorded in manifest.json (written by the
+tokentelemetry plugin's stamp step at compile/ingest time) against the
+repository's files RIGHT NOW. Content hashes, not git shas: results are
+identical across worktrees, squash-merges, rebases, and tarballs.
+
+Usage:
+  python3 docs/wiki/status.py                 whole-wiki report
+  python3 docs/wiki/status.py <page-id>       one page (e.g. subsystems/scanner)
+  python3 docs/wiki/status.py <page-id> --note  also queue a refresh note in raw/
+  python3 docs/wiki/status.py --json          machine-readable full report
+
+Verdicts per page:
+  FRESH        at least one recorded source verified byte-identical to
+               compile time, none changed, and the page itself is
+               untouched. Safe to answer from.
+  STALE        a source changed (or moved/vanished). Do NOT trust the page
+               body. Read the listed source files and answer from CODE; the
+               page still tells you which files matter.
+  TAMPERED     the page file was edited outside /brain workflows. Trust the
+               listed sources, not the page.
+  UNVERIFIABLE nothing checkable: no provenance recorded, no repo files
+               cited, or every cited source is unhashable (too large,
+               missing at stamp time). Treat as hints; verify before
+               relying. An unhashable source is NEVER reported fresh.
+
+Honest limits (read once):
+- FRESH means "no drift since compile", not "cannot be forged": an editor
+  with repo write access who updates both a page and manifest.json will not
+  be detected. TAMPERED catches accidents and naive edits only.
+- Many pages STALE at once usually means one shared source file changed,
+  not that the wiki rotted; the report groups by changed file.
+- A fact that moved to a file NO page cites is invisible per page; the
+  repo-fingerprint advisory at the bottom of the report is the only signal.
+
+The protocol for agents (also in the CLAUDE.md/AGENTS.md pointer block):
+fresh -> use the page; stale/tampered -> read sources, answer from code,
+re-run with --note; unverifiable -> verify first. Code is ALWAYS
+authoritative over the wiki. Never edit wiki pages by hand; never "fix"
+code to match a wiki page. Refreshing the wiki (/brain ingest, in Claude
+Code) is optional batched maintenance, never required to keep working.
+
+Exit codes: 0 fresh/ok, 1 stale or tampered pages found, 2 error,
+3 nothing checkable (whole-wiki report where no page could be verified —
+automation must not read this as a green light).
+"""
+
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+WIKI = Path(__file__).resolve().parent
+NOTES = WIKI / "raw" / "stale-notes.md"
+NOTES_HEADER = ("# Pending wiki refresh notes\n\nAppended by status.py --note; "
+                "swept and cleared by the next /brain ingest. One line per "
+                "stale page.\n\n")
+DIR_HASH_FILE_CAP = 200
+SENTINELS = {"missing", "unhashable"}
+SAFE_ID_RE = re.compile(r"[^\w/.-]")
+
+
+def sha12(data):
+    return hashlib.sha256(data).hexdigest()[:12]
+
+
+def self_cmd():
+    """How to invoke this script from the caller's cwd (footer suggestions
+    must be copy-pasteable, not just the bare filename)."""
+    try:
+        return os.path.relpath(Path(__file__).resolve())
+    except ValueError:
+        return str(Path(__file__).resolve())
+
+
+def repo_root():
+    try:
+        top = subprocess.run(["git", "rev-parse", "--show-toplevel"],
+                             cwd=WIKI, capture_output=True, text=True, check=True
+                             ).stdout.strip()
+        if top:
+            return Path(top)
+    except Exception:
+        pass
+    return WIKI.parent.parent
+
+
+def hash_resource(root, rel):
+    p = (root / rel.lstrip("/")).resolve()
+    try:
+        p.relative_to(root.resolve())
+    except ValueError:
+        return "unhashable"
+    if p.is_file():
+        try:
+            return sha12(p.read_bytes())
+        except OSError:
+            return "unhashable"
+    if p.is_dir():
+        files = sorted(f for f in p.rglob("*") if f.is_file()
+                       and not any(part.startswith(".") for part in f.relative_to(p).parts))
+        if len(files) > DIR_HASH_FILE_CAP:
+            return "unhashable"
+        h = hashlib.sha256()
+        for f in files:
+            try:
+                h.update(str(f.relative_to(p)).encode())
+                h.update(sha12(f.read_bytes()).encode())
+            except OSError:
+                return "unhashable"
+        return h.hexdigest()[:12]
+    return "missing"
+
+
+def check_page(root, prov, page_id):
+    """Return (verdict, changed_resources, sources, why). Precedence:
+    TAMPERED > STALE > UNVERIFIABLE > FRESH. A sentinel recorded hash
+    ("missing"/"unhashable") never counts as verification: comparing
+    unhashable to unhashable proves nothing, so a page with only sentinel
+    resources is UNVERIFIABLE, not FRESH."""
+    entry = prov.get(page_id)
+    page_file = WIKI / (page_id + ".md")
+    if entry is None:
+        return "UNVERIFIABLE", [], [], "no provenance recorded for this page"
+    resources = entry.get("resources") or {}
+    sources = sorted(resources)
+    if not page_file.exists():
+        return "STALE", [], sources, "page file missing (deleted or moved)"
+    if sha12(page_file.read_bytes()) != entry.get("page_sha"):
+        return ("TAMPERED", [], sources,
+                "page body changed outside /brain workflows")
+    if not resources:
+        return ("UNVERIFIABLE", [], [],
+                "page cites no repo files; nothing to check")
+    changed, verified, unhashable = [], 0, 0
+    for rel, recorded in resources.items():
+        now = hash_resource(root, rel)
+        if now != recorded:
+            changed.append(f"{rel} ({recorded} -> {now})")
+        elif recorded in SENTINELS:
+            unhashable += 1
+        else:
+            verified += 1
+    if changed:
+        return "STALE", changed, sources, "source changed since this page was compiled"
+    if verified == 0:
+        return ("UNVERIFIABLE", [], sources,
+                f"all {unhashable} cited source(s) unhashable or missing; "
+                f"freshness cannot be proven")
+    why = "all verifiable sources byte-identical to compile time"
+    if unhashable:
+        why += f" ({unhashable} source(s) unhashable, not counted)"
+    return "FRESH", [], sources, why
+
+
+def load():
+    mpath = WIKI / "manifest.json"
+    if not mpath.exists():
+        print("error: no manifest.json next to status.py; this wiki has no "
+              "provenance. Run the plugin's stamp step (wiki_manifest.py "
+              "<wiki-dir> stamp) from Claude Code first.", file=sys.stderr)
+        sys.exit(2)
+    try:
+        manifest = json.loads(mpath.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"error: cannot parse manifest.json: {e}", file=sys.stderr)
+        sys.exit(2)
+    prov = manifest.get("provenance")
+    if not isinstance(prov, dict) or not prov:
+        print("error: manifest.json has no provenance block; run the stamp "
+              "step (wiki_manifest.py <wiki-dir> stamp) first.", file=sys.stderr)
+        sys.exit(2)
+    return manifest, prov
+
+
+def pending_notes():
+    if not NOTES.exists():
+        return 0
+    try:
+        return sum(1 for l in NOTES.read_text(encoding="utf-8").splitlines()
+                   if l.startswith("- STALE:"))
+    except OSError:
+        return 0
+
+
+def append_note(page_id, changed):
+    # page ids come from filenames, which an attacker (or accident) can fill
+    # with instruction-looking text; sanitize so raw/stale-notes.md only ever
+    # carries [word/.-] ids and known-charset paths, never free text
+    safe_id = SAFE_ID_RE.sub("_", page_id)
+    files = ", ".join(SAFE_ID_RE.sub("_", c.split(" ")[0]) for c in changed)
+    line = f"- STALE: `{safe_id}` — changed: {files or 'page/sources'}"
+    NOTES.parent.mkdir(parents=True, exist_ok=True)
+    existing = NOTES.read_text(encoding="utf-8") if NOTES.exists() else ""
+    if f"- STALE: `{safe_id}`" in existing:
+        return False  # already queued; one note per page until the next ingest
+    with open(NOTES, "a", encoding="utf-8") as f:
+        if not existing:
+            f.write(NOTES_HEADER)
+        f.write(line + "\n")
+    return True
+
+
+def protocol_line(verdict):
+    return {
+        "FRESH": "OK to answer from this page.",
+        "STALE": "Do NOT trust the page body. Read the changed source files "
+                 "listed above and answer from CODE. The rest of the page's "
+                 "file map is still useful for finding things.",
+        "TAMPERED": "Page was hand-edited; do not trust its body. Answer from "
+                    "the recorded source files listed above. Mention the "
+                    "tamper to the user.",
+        "UNVERIFIABLE": "Treat the page as hints only; verify claims against "
+                        "the files it mentions before relying on them.",
+    }[verdict]
+
+
+def main(argv):
+    as_json = "--json" in argv
+    note = "--note" in argv
+    args = [a for a in argv if not a.startswith("--")]
+    manifest, prov = load()
+    root = repo_root()
+
+    if args:  # single page
+        page_id = args[0]
+        if page_id.endswith(".md"):
+            page_id = page_id[:-3]
+        page_id = page_id.strip("/")
+        # never let a page id escape the wiki dir
+        try:
+            (WIKI / (page_id + ".md")).resolve().relative_to(WIKI)
+        except ValueError:
+            print(f"error: not a wiki page id: {page_id}", file=sys.stderr)
+            return 2
+        if page_id not in prov and not (WIKI / (page_id + ".md")).exists():
+            print(f"error: no such page: {page_id}", file=sys.stderr)
+            return 2
+        verdict, changed, sources, why = check_page(root, prov, page_id)
+        if as_json:
+            print(json.dumps({"page": page_id, "verdict": verdict,
+                              "changed": changed, "sources": sources,
+                              "why": why}))
+        else:
+            print(f"{verdict}: {page_id} — {why}")
+            for c in changed:
+                print(f"  changed: {c}")
+            if verdict in ("TAMPERED", "UNVERIFIABLE") and sources:
+                print(f"  recorded sources: {', '.join(sources)}")
+            print(f"  -> {protocol_line(verdict)}")
+        if note and verdict in ("STALE", "TAMPERED"):
+            added = append_note(page_id, changed)
+            if not as_json:
+                print("  note queued in raw/stale-notes.md" if added
+                      else "  note already queued")
+        return 1 if verdict in ("STALE", "TAMPERED") else 0
+
+    # whole wiki
+    rows = []
+    for page_id in sorted(prov):
+        verdict, changed, sources, why = check_page(root, prov, page_id)
+        rows.append({"page": page_id, "verdict": verdict,
+                     "changed": changed, "why": why})
+    # pages on disk that were never stamped are unverifiable too
+    for p in sorted(WIKI.rglob("*.md")):
+        rel = p.relative_to(WIKI)
+        if rel.name in ("index.md", "log.md", "BRAIN.md", "project-profile.md") and len(rel.parts) == 1:
+            continue
+        if any(part.startswith(".") for part in rel.parts) or rel.parts[0] == "raw":
+            continue
+        pid = str(rel)[:-3]
+        if pid not in prov:
+            rows.append({"page": pid, "verdict": "UNVERIFIABLE",
+                         "changed": [], "why": "created after last stamp"})
+
+    counts = {}
+    for r in rows:
+        counts[r["verdict"]] = counts.get(r["verdict"], 0) + 1
+    bad = [r for r in rows if r["verdict"] in ("STALE", "TAMPERED")]
+    checkable = counts.get("FRESH", 0) + len(bad)
+    queued = pending_notes()
+
+    # repo-fingerprint advisory: files added/removed since stamp may carry
+    # facts no page cites (the per-page check cannot see those)
+    tree_note = None
+    recorded_tree = manifest.get("source_tree")
+    if isinstance(recorded_tree, dict) and recorded_tree.get("sha"):
+        # recompute the same way stamp did (git list, pruned-walk fallback)
+        try:
+            out = subprocess.run(["git", "ls-files"], cwd=root, capture_output=True,
+                                 text=True, check=True).stdout
+            files = sorted(l for l in out.splitlines() if l)
+        except (subprocess.CalledProcessError, OSError):
+            skip = {"node_modules", "__pycache__", ".git", "output", "dist", "build"}
+            files = sorted(
+                str(f.relative_to(root)) for f in root.rglob("*")
+                if f.is_file() and not any(
+                    part in skip or part.startswith(".")
+                    for part in f.relative_to(root).parts))
+        now_sha = hashlib.sha256("\n".join(files).encode()).hexdigest()[:12]
+        if now_sha != recorded_tree["sha"]:
+            tree_note = (f"repo file set changed since stamp "
+                         f"({recorded_tree.get('count')} -> {len(files)} files): "
+                         f"new files may hold facts no page cites yet.")
+
+    if as_json:
+        print(json.dumps({"stamped": manifest.get("provenance_stamped"),
+                          "counts": counts, "checkable": checkable,
+                          "pending_notes": queued, "tree_changed": bool(tree_note),
+                          "pages": rows}))
+        return 1 if bad else (3 if checkable == 0 else 0)
+
+    print(f"wiki status (stamped {manifest.get('provenance_stamped')}): "
+          + ", ".join(f"{v} {k}" for k, v in sorted(counts.items())))
+    for r in bad:
+        print(f"  {r['verdict']}: {r['page']}"
+              + (f" — {r['changed'][0]}" + (f" (+{len(r['changed'])-1} more)" if len(r['changed']) > 1 else "")
+                 if r["changed"] else ""))
+    unv = counts.get("UNVERIFIABLE", 0)
+    if unv:
+        print(f"  blind spot: {unv} page(s) have no checkable provenance and "
+              f"CANNOT be verified — treat them as hints, not facts.")
+    if queued:
+        print(f"  pending: raw/stale-notes.md has {queued} queued note(s); "
+              f"the next /brain ingest sweeps them.")
+    if tree_note:
+        print(f"  advisory: {tree_note}")
+    if bad:
+        print(f"  -> stale/tampered pages: answer from their source files, not "
+              f"the page body. Queue refreshes with: python3 {self_cmd()} "
+              f"<page> --note. Catch up anytime with /brain ingest "
+              f"(Claude Code; optional).")
+    if checkable == 0:
+        print("  -> NOTHING here could be verified; this report is not a "
+              "green light. Run the stamp step to establish provenance.")
+        return 3
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/wikicli/test_harness_adapters.py
+++ b/wikicli/test_harness_adapters.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""Conformance tests for scripts/harness_adapters.py.
+
+Each test builds a tiny synthetic store in a tmp dir (mirroring the real
+layout verified on 2026-07-06), monkeypatches the adapter's module-level
+root constant, and checks locate() attribution + scan() signals. When a
+harness changes its on-disk format, the matching test is where the drift
+shows up.
+
+Run: python3 -m unittest discover -s tests -v   (stdlib only)
+"""
+
+import json
+import os
+import shutil
+import sqlite3
+import sys
+import tempfile
+import unittest
+import urllib.parse
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import harness_adapters as ha  # noqa: E402
+import session_scan  # noqa: E402
+
+PROJECT = "/tmp/tt-fixture-project"
+
+
+class Base(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="ha-test-"))
+        self.addCleanup(shutil.rmtree, self.tmp, True)
+
+    def patch(self, name, value):
+        old = getattr(ha, name)
+        setattr(ha, name, value)
+        self.addCleanup(setattr, ha, name, old)
+
+
+class TestHelpers(Base):
+    def test_paths_from_shell_keeps_project_paths_only(self):
+        cmd = "sed -n '1,50p' src/main.py && cat /etc/hosts | grep -v '^#'"
+        paths = ha.paths_from_shell(cmd, PROJECT, PROJECT)
+        self.assertIn(f"{PROJECT}/src/main.py", paths)
+        # /etc/hosts exists but the command text itself must never leak
+        for p in paths:
+            self.assertNotIn("grep", p)
+
+    def test_paths_from_value_recurses_and_resolves(self):
+        args = {"absolute_path": f"{PROJECT}/a.py",
+                "nested": {"file": "b/c.ts"}, "count": 3,
+                "url": "https://example.com/x.py"}
+        paths = ha.paths_from_value(args, base_dir=PROJECT)
+        self.assertIn(f"{PROJECT}/a.py", paths)
+        self.assertIn(f"{PROJECT}/b/c.ts", paths)
+        self.assertFalse(any(p.startswith("https://") for p in paths))
+
+    def test_acc_loop_and_reread(self):
+        acc = ha.Acc()
+        for _ in range(3):
+            acc.tool_event("Read", [f"{PROJECT}/x.py"], read=True,
+                           track_files=True)
+        acc.tool_event("Bash")  # path-less call breaks the run
+        r = acc.result("s1")
+        self.assertEqual(r["read_paths"][f"{PROJECT}/x.py"], 3)
+        self.assertEqual(r["loops"][0]["count"], 3)
+
+
+class TestClaude(Base):
+    def test_locate_and_scan(self):
+        root = self.tmp / "projects"
+        d = root / ha.encode_claude_dir(PROJECT)
+        d.mkdir(parents=True)
+        events = [
+            {"type": "assistant", "timestamp": "2026-07-01T00:00:00Z",
+             "message": {"usage": {"input_tokens": 10, "output_tokens": 5,
+                                   "cache_read_input_tokens": 100,
+                                   "cache_creation_input_tokens": 7},
+                         "content": [
+                             {"type": "tool_use", "name": "Read",
+                              "input": {"file_path": f"{PROJECT}/a.py"}},
+                             {"type": "tool_use", "name": "Read",
+                              "input": {"file_path": f"{PROJECT}/a.py"}}]}},
+            {"type": "user", "message": {"content": [
+                {"type": "tool_result", "is_error": True}]}},
+        ]
+        with open(d / "abc.jsonl", "w") as f:
+            for e in events:
+                f.write(json.dumps(e) + "\n")
+        self.patch("CLAUDE_PROJECTS_ROOT", root)
+        refs = ha.claude_locate(PROJECT, 10)
+        self.assertEqual(len(refs), 1)
+        s = ha.claude_scan(refs[0], PROJECT)
+        self.assertEqual(s["session_id"], "abc")
+        self.assertEqual(s["tokens"], {"input": 10, "output": 5,
+                                       "cache_read": 100, "cache_creation": 7})
+        self.assertEqual(s["read_paths"][f"{PROJECT}/a.py"], 2)
+        self.assertEqual(s["error_count"], 1)
+        self.assertEqual(s["loops"][0]["count"], 2)
+
+
+class TestCodex(Base):
+    def _write_rollout(self, path, cwd):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        lines = [
+            {"type": "session_meta", "timestamp": "2026-07-01T00:00:00Z",
+             "payload": {"id": "sess-1", "cwd": cwd}},
+            {"type": "response_item", "payload": {
+                "type": "function_call", "name": "exec_command",
+                "arguments": json.dumps(
+                    {"cmd": "cat src/app.py", "workdir": cwd})}},
+            {"type": "response_item", "payload": {
+                "type": "function_call", "name": "apply_patch",
+                "arguments": json.dumps(
+                    {"input": "*** Update File: src/app.py\n@@ -1 +1 @@"})}},
+            {"type": "event_msg", "payload": {
+                "type": "token_count", "info": {"total_token_usage": {
+                    "input_tokens": 120, "cached_input_tokens": 100,
+                    "output_tokens": 30}}}},
+        ]
+        with open(path, "w") as f:
+            for e in lines:
+                f.write(json.dumps(e) + "\n")
+
+    def test_attribution_and_shell_paths(self):
+        root = self.tmp / "sessions"
+        self._write_rollout(root / "2026/07/01/rollout-2026-07-01T00-00-00-aa-bb-cc-dd-ee.jsonl", PROJECT)
+        self._write_rollout(root / "2026/07/01/rollout-2026-07-01T00-00-01-ff-gg-hh-ii-jj.jsonl", "/somewhere/else")
+        self.patch("CODEX_SESSIONS_ROOT", root)
+        refs = ha.codex_locate(PROJECT, 10)
+        self.assertEqual(len(refs), 1)  # the other cwd is excluded
+        s = ha.codex_scan(refs[0], PROJECT)
+        self.assertEqual(s["session_id"], "sess-1")
+        # cat = read-ish; path extracted from cmd string, resolved to project
+        self.assertEqual(s["read_paths"][f"{PROJECT}/src/app.py"], 1)
+        # apply_patch marker path tracked as file touch
+        self.assertEqual(s["file_paths"][f"{PROJECT}/src/app.py"], 2)
+        # cumulative token event: input excludes cached
+        self.assertEqual(s["tokens"], {"input": 20, "output": 30,
+                                       "cache_read": 100, "cache_creation": 0})
+        # the command text itself must never appear anywhere in the result
+        self.assertNotIn("cat", json.dumps(s["read_paths"]) + json.dumps(s["loops"]))
+
+
+class TestOpencode(Base):
+    def test_locate_and_scan(self):
+        db = self.tmp / "opencode.db"
+        conn = sqlite3.connect(db)
+        conn.execute("CREATE TABLE session (id TEXT, directory TEXT,"
+                     " time_created INT, time_updated INT, tokens_input INT,"
+                     " tokens_output INT, tokens_cache_read INT,"
+                     " tokens_cache_write INT)")
+        conn.execute("CREATE TABLE part (id INTEGER PRIMARY KEY,"
+                     " session_id TEXT, data TEXT)")
+        conn.execute("INSERT INTO session VALUES ('s1', ?, 1751000000000,"
+                     " 1751000060000, 50, 20, 400, 0)", (PROJECT,))
+        conn.execute("INSERT INTO session VALUES ('s2', '/other', 1, 2, 9, 9, 0, 0)")
+        conn.execute("INSERT INTO part (session_id, data) VALUES ('s1', ?)",
+                     (json.dumps({"type": "tool", "tool": "read",
+                                  "state": {"status": "completed",
+                                            "input": {"filePath": f"{PROJECT}/x.ts"}}}),))
+        conn.execute("INSERT INTO part (session_id, data) VALUES ('s1', ?)",
+                     (json.dumps({"type": "tool", "tool": "bash",
+                                  "state": {"status": "error",
+                                            "input": {"command": "ls src/"}}}),))
+        conn.commit()
+        conn.close()
+        self.patch("OPENCODE_DB", db)
+        refs = ha.opencode_locate(PROJECT, 10)
+        self.assertEqual([r["id"] for r in refs], ["s1"])
+        s = ha.opencode_scan(refs[0], PROJECT)
+        self.assertEqual(s["tokens"]["input"], 50)
+        self.assertEqual(s["read_paths"][f"{PROJECT}/x.ts"], 1)
+        self.assertEqual(s["error_count"], 1)
+        self.assertEqual(s["tool_counts"], {"read": 1, "bash": 1})
+
+
+class TestQwen(Base):
+    def test_scan(self):
+        d = self.tmp / ha.encode_claude_dir(PROJECT) / "chats"
+        d.mkdir(parents=True)
+        events = [
+            {"type": "assistant", "sessionId": "q1",
+             "timestamp": "2026-07-01T00:00:00Z",
+             "message": {"parts": [
+                 {"functionCall": {"name": "read_file",
+                                   "args": {"absolute_path": f"{PROJECT}/m.py"}}}]},
+             "usageMetadata": {"promptTokenCount": 100,
+                               "candidatesTokenCount": 10,
+                               "thoughtsTokenCount": 2,
+                               "cachedContentTokenCount": 60}},
+        ]
+        with open(d / "q1.jsonl", "w") as f:
+            for e in events:
+                f.write(json.dumps(e) + "\n")
+        self.patch("QWEN_PROJECTS_ROOT", self.tmp)
+        refs = ha.qwen_locate(PROJECT, 10)
+        s = ha.qwen_scan(refs[0], PROJECT)
+        self.assertEqual(s["tokens"], {"input": 40, "output": 12,
+                                       "cache_read": 60, "cache_creation": 0})
+        self.assertEqual(s["read_paths"][f"{PROJECT}/m.py"], 1)
+
+
+class TestCline(Base):
+    def test_scan_blocks_and_metrics_fallback(self):
+        db = self.tmp / "sessions.db"
+        msgs = self.tmp / "m.json"
+        json.dump({"messages": [
+            {"role": "assistant",
+             "metrics": {"inputTokens": 11, "outputTokens": 4,
+                         "cacheReadTokens": 0, "cacheWriteTokens": 0},
+             "content": [{"type": "tool_use", "name": "read_file",
+                          "input": {"path": "math.py"}}]},
+        ]}, open(msgs, "w"))
+        conn = sqlite3.connect(db)
+        conn.execute("CREATE TABLE sessions (session_id TEXT, cwd TEXT,"
+                     " workspace_root TEXT, started_at TEXT, ended_at TEXT,"
+                     " metadata_json TEXT, messages_path TEXT)")
+        conn.execute("INSERT INTO sessions VALUES ('c1', ?, ?, '2026-07-01',"
+                     " '2026-07-01', ?, ?)",
+                     (PROJECT, PROJECT,
+                      json.dumps({"usage": {"inputTokens": 0, "outputTokens": 0}}),
+                      str(msgs)))
+        conn.commit()
+        conn.close()
+        self.patch("CLINE_DB", db)
+        refs = ha.cline_locate(PROJECT, 10)
+        s = ha.cline_scan(refs[0], PROJECT)
+        self.assertEqual(s["tokens"]["input"], 11)  # metrics fallback
+        self.assertEqual(s["read_paths"][f"{PROJECT}/math.py"], 1)
+
+
+class TestGrok(Base):
+    def test_urlencoded_dir_and_shell_extraction(self):
+        d = self.tmp / urllib.parse.quote(PROJECT, safe="") / "sess-1"
+        d.mkdir(parents=True)
+        with open(d / "chat_history.jsonl", "w") as f:
+            f.write(json.dumps({"role": "assistant", "tool_calls": [
+                {"name": "run_terminal_command",
+                 "arguments": json.dumps({"command": f"cat {PROJECT}/prov/data.yml"})}]}) + "\n")
+            f.write(json.dumps({"role": "tool_result", "is_error": True}) + "\n")
+        self.patch("GROK_SESSIONS_ROOT", self.tmp)
+        refs = ha.grok_locate(PROJECT, 10)
+        self.assertEqual(len(refs), 1)
+        s = ha.grok_scan(refs[0], PROJECT)
+        self.assertEqual(s["session_id"], "sess-1")
+        # cat is read-shaped: the extracted path feeds the re-read signal
+        self.assertEqual(s["read_paths"][f"{PROJECT}/prov/data.yml"], 1)
+        self.assertEqual(s["error_count"], 1)
+        self.assertEqual(s["tool_counts"]["run_terminal_command"], 1)
+
+
+class TestCopilot(Base):
+    def test_locate_by_cwd_and_tools(self):
+        d = self.tmp / "sess-9"
+        d.mkdir(parents=True)
+        with open(d / "events.jsonl", "w") as f:
+            f.write(json.dumps({"type": "session.start",
+                                "data": {"context": {"cwd": PROJECT}}}) + "\n")
+            f.write(json.dumps({"type": "tool.execution_start",
+                                "data": {"toolName": "view",
+                                         "arguments": {"path": f"{PROJECT}/z.go"}}}) + "\n")
+        self.patch("COPILOT_STATE_ROOT", self.tmp)
+        refs = ha.copilot_locate(PROJECT, 10)
+        self.assertEqual(len(refs), 1)
+        s = ha.copilot_scan(refs[0], PROJECT)
+        self.assertEqual(s["read_paths"][f"{PROJECT}/z.go"], 1)
+
+
+class TestHermes(Base):
+    def test_null_cwd_excluded(self):
+        db = self.tmp / "state.db"
+        conn = sqlite3.connect(db)
+        conn.execute("CREATE TABLE sessions (id TEXT, cwd TEXT, started_at TEXT,"
+                     " ended_at TEXT, input_tokens INT, output_tokens INT,"
+                     " cache_read_tokens INT, cache_write_tokens INT)")
+        conn.execute("CREATE TABLE messages (id INTEGER PRIMARY KEY,"
+                     " session_id TEXT, role TEXT, tool_calls TEXT, tool_name TEXT)")
+        conn.execute("INSERT INTO sessions VALUES ('h1', ?, 't', 't', 7, 3, 0, 0)",
+                     (PROJECT,))
+        conn.execute("INSERT INTO sessions VALUES ('h2', NULL, 't', 't', 9, 9, 0, 0)")
+        conn.execute("INSERT INTO messages (session_id, role, tool_calls, tool_name)"
+                     " VALUES ('h1', 'assistant', ?, NULL)",
+                     (json.dumps([{"function": {"name": "read_file",
+                                                "arguments": json.dumps({"path": f"{PROJECT}/h.rs"})}}]),))
+        conn.commit()
+        conn.close()
+        self.patch("HERMES_ROOT", self.tmp)
+        refs = ha.hermes_locate(PROJECT, 10)
+        self.assertEqual([r["id"] for r in refs], ["h1"])  # null cwd excluded
+        s = ha.hermes_scan(refs[0], PROJECT)
+        self.assertEqual(s["tokens"]["input"], 7)
+        self.assertEqual(s["read_paths"][f"{PROJECT}/h.rs"], 1)
+
+
+class TestSmallcodeVibeAntigravity(Base):
+    def test_smallcode_project_local(self):
+        proj = self.tmp / "proj"
+        traces = proj / ".smallcode" / "traces"
+        traces.mkdir(parents=True)
+        json.dump({"id": "t1", "startedAt": "2026-07-01T00:00:00Z",
+                   "tokens": {"prompt": 5, "completion": 2},
+                   "steps": [{"type": "tool_call", "name": "read_file",
+                              "args": {"path": "a.c"}}]},
+                  open(traces / "t1.json", "w"))
+        refs = ha.smallcode_locate(str(proj), 10)
+        s = ha.smallcode_scan(refs[0], str(proj))
+        self.assertEqual(s["tokens"]["input"], 5)
+        self.assertEqual(s["read_paths"][f"{proj}/a.c"], 1)
+
+    def test_vibe_repr_metadata(self):
+        d = self.tmp / "session"
+        d.mkdir(parents=True)
+        json.dump({"metadata": {
+            "session_id": "v1", "start_time": "2026-07-01T00:00:00",
+            "environment": repr({"working_directory": PROJECT}),
+            "stats": repr({"session_prompt_tokens": 42,
+                           "session_completion_tokens": 6})},
+            "messages": []}, open(d / "s.json", "w"))
+        self.patch("VIBE_SESSIONS_ROOT", d)
+        refs = ha.vibe_locate(PROJECT, 10)
+        self.assertEqual(len(refs), 1)
+        s = ha.vibe_scan(refs[0], PROJECT)
+        self.assertEqual(s["tokens"], {"input": 42, "output": 6,
+                                       "cache_read": 0, "cache_creation": 0})
+
+    def test_antigravity_hash_dir(self):
+        import hashlib
+        h = hashlib.sha256(PROJECT.encode()).hexdigest()
+        d = self.tmp / h / "chats"
+        d.mkdir(parents=True)
+        json.dump({"sessionId": "ag1", "startTime": "2026-07-01T00:00:00Z",
+                   "lastUpdated": "2026-07-01T01:00:00Z", "messages": []},
+                  open(d / "c.json", "w"))
+        self.patch("GEMINI_TMP_ROOT", self.tmp)
+        refs = ha.antigravity_locate(PROJECT, 10)
+        s = ha.antigravity_scan(refs[0], PROJECT)
+        self.assertEqual(s["session_id"], "ag1")
+        self.assertEqual(s["token_total"], 0)  # honest zeros
+
+
+class TestSessionScanCLI(Base):
+    def test_unknown_harness_exits_2(self):
+        rc = session_scan.main([PROJECT, "--harness", "nope"])
+        self.assertEqual(rc, 2)
+
+    def test_harness_list_and_schema(self):
+        # empty stores: still a successful scan with the full schema
+        self.patch("CLAUDE_PROJECTS_ROOT", self.tmp / "none")
+        import io
+        from contextlib import redirect_stdout
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = session_scan.main([PROJECT, "--harness", "claude", "--json"])
+        self.assertEqual(rc, 0)
+        out = json.loads(buf.getvalue())
+        self.assertEqual(out["harness"], "claude")
+        self.assertIn("by_harness", out["aggregate"])
+        self.assertEqual(out["capabilities"], {"claude": "full"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/wikicli/test_wiki_status.py
+++ b/wikicli/test_wiki_status.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+"""Tests for the wiki freshness pipeline:
+
+  scripts/wiki_manifest.py stamp   — content-hash provenance written into
+                                     manifest.json + status.py installation
+  skills/brain-init/templates/wiki-skeleton/status.py
+                                   — self-contained FRESH/STALE/TAMPERED/
+                                     UNVERIFIABLE checker
+
+Each test builds a synthetic repo in a tmp dir (src files + docs/wiki),
+runs `init` then `stamp` in-process via wiki_manifest.main(), and invokes
+the installed status.py via subprocess (it resolves everything from
+__file__, so it must run from inside the fixture wiki).
+
+Run: python3 -m unittest discover -s tests -v   (stdlib only)
+"""
+
+import hashlib
+import io
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+WIKICLI_ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(WIKICLI_ROOT))
+import wiki_manifest as wm  # noqa: E402
+
+STATUS_TEMPLATE = WIKICLI_ROOT / "templates" / "status.py"
+
+APP_PAGE = """---
+type: concept
+resource: src/app.py
+---
+
+# App entrypoint
+
+Startup order lives in `src/app.py` (cited in frontmatter AND body,
+to pin dedup).
+"""
+
+PLAYBOOK_PAGE = """---
+type: playbook
+---
+
+# DB refresh playbook
+
+Run `scripts/db.js` after every migration. No frontmatter resource:
+the body citation is the only provenance link.
+"""
+
+ORPHAN_PAGE = """---
+type: note
+---
+
+# Orphan note
+
+Pure prose. Nothing here names a repo file.
+"""
+
+DATADIR_PAGE = """---
+type: concept
+resource: data
+---
+
+# Data directory
+
+Whole-directory resource; provenance is a tree hash.
+"""
+
+
+def sha12(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()[:12]
+
+
+class WikiBase(unittest.TestCase):
+    """Fixture: tmp repo with two source files, a data dir, and a stamped
+    docs/wiki containing four pages (frontmatter-resource, body-cited,
+    no-resource, dir-resource)."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="wiki-status-test-"))
+        self.addCleanup(shutil.rmtree, self.tmp, True)
+        self.root = self.tmp / "repo"
+        self.wiki = self.root / "docs" / "wiki"
+        self.wiki.mkdir(parents=True)
+        self.src_app = self.root / "src" / "app.py"
+        self.db_js = self.root / "scripts" / "db.js"
+        self.data_file = self.root / "data" / "one.txt"
+        for p, text in ((self.src_app, "print('v1')\n"),
+                        (self.db_js, "console.log('v1');\n"),
+                        (self.data_file, "one v1\n")):
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(text, encoding="utf-8")
+        # git init makes repo-root resolution deterministic even if the tmp
+        # dir sits under some outer repo; if git is absent, the scripts'
+        # wiki.parent.parent fallback lands on the same root anyway.
+        subprocess.run(["git", "init", "-q", str(self.root)],
+                       capture_output=True)
+
+        rc, _ = self.manifest_cli("init", "--profile", "generic",
+                                  "--status", "complete")
+        self.assertEqual(rc, 0)
+        self.write_page("concepts/app.md", APP_PAGE)
+        self.write_page("playbooks/db-refresh.md", PLAYBOOK_PAGE)
+        self.write_page("notes/orphan.md", ORPHAN_PAGE)
+        self.write_page("datasets/data-dir.md", DATADIR_PAGE)
+        rc, _ = self.manifest_cli("stamp")
+        self.assertEqual(rc, 0)
+
+    # -- helpers -------------------------------------------------------
+
+    def manifest_cli(self, *args):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = wm.main([str(self.wiki), *args])
+        return rc, buf.getvalue()
+
+    def write_page(self, rel, text):
+        p = self.wiki / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(text, encoding="utf-8")
+        return p
+
+    def read_manifest(self):
+        return json.loads((self.wiki / "manifest.json").read_text(
+            encoding="utf-8"))
+
+    def status(self, *args, wiki=None):
+        """Run the installed status.py via subprocess: it resolves the wiki
+        and repo root from __file__, so in-process import would not work."""
+        wiki = wiki or self.wiki
+        return subprocess.run(
+            [sys.executable, str(wiki / "status.py"), *args],
+            capture_output=True, text=True)
+
+
+class TestStamp(WikiBase):
+    def test_records_frontmatter_and_body_resources(self):
+        prov = self.read_manifest()["provenance"]
+        self.assertEqual(
+            set(prov),
+            {"concepts/app", "playbooks/db-refresh", "notes/orphan",
+             "datasets/data-dir"})
+        # frontmatter resource, hashed to the file's actual content sha
+        app_res = prov["concepts/app"]["resources"]
+        self.assertEqual(app_res.get("src/app.py"),
+                         sha12(self.src_app.read_bytes()))
+        # cited in frontmatter AND body: recorded exactly once (dedup)
+        self.assertEqual(len(app_res), 1)
+        # body-only code-span citation is picked up for the playbook
+        self.assertEqual(
+            prov["playbooks/db-refresh"]["resources"].get("scripts/db.js"),
+            sha12(self.db_js.read_bytes()))
+
+    def test_page_sha_present_and_orphan_has_empty_resources(self):
+        prov = self.read_manifest()["provenance"]
+        self.assertEqual(prov["notes/orphan"]["resources"], {})
+        for page_id, entry in prov.items():
+            self.assertEqual(
+                entry["page_sha"],
+                sha12((self.wiki / (page_id + ".md")).read_bytes()),
+                f"page_sha mismatch for {page_id}")
+
+    def test_installs_status_py_matching_template(self):
+        installed = self.wiki / "status.py"
+        self.assertTrue(installed.exists())
+        self.assertEqual(installed.read_bytes(), STATUS_TEMPLATE.read_bytes())
+
+    def test_dir_resource_gets_tree_hash_that_tracks_contents(self):
+        recorded = self.read_manifest()["provenance"][
+            "datasets/data-dir"]["resources"]["data"]
+        self.assertRegex(recorded, r"^[0-9a-f]{12}$")
+        # editing a file inside the dir changes the tree hash
+        self.data_file.write_text("one v2\n", encoding="utf-8")
+        self.manifest_cli("stamp")
+        after_edit = self.read_manifest()["provenance"][
+            "datasets/data-dir"]["resources"]["data"]
+        self.assertNotEqual(recorded, after_edit)
+        # adding a file changes it again (tree hash covers the file list)
+        (self.root / "data" / "two.txt").write_text("new\n", encoding="utf-8")
+        self.manifest_cli("stamp")
+        after_add = self.read_manifest()["provenance"][
+            "datasets/data-dir"]["resources"]["data"]
+        self.assertNotEqual(after_edit, after_add)
+
+    def test_dir_resource_over_file_cap_is_unhashable(self):
+        big = self.root / "big"
+        big.mkdir()
+        for i in range(201):  # cap is 200 files
+            (big / f"f{i}.txt").write_text(str(i), encoding="utf-8")
+        self.write_page("datasets/big-dir.md",
+                        "---\ntype: concept\nresource: big\n---\n\n# Big\n")
+        self.manifest_cli("stamp")
+        self.assertEqual(
+            self.read_manifest()["provenance"]["datasets/big-dir"]
+            ["resources"]["big"],
+            "unhashable")
+
+    def test_frontmatter_resource_escaping_repo_is_unhashable(self):
+        secret = self.tmp / "secret.txt"
+        secret.write_text("outside the repo\n", encoding="utf-8")
+        self.write_page(
+            "security/outside.md",
+            "---\ntype: note\nresource: ../secret.txt\n---\n\n# Outside\n")
+        self.manifest_cli("stamp")
+        recorded = self.read_manifest()["provenance"]["security/outside"][
+            "resources"]
+        self.assertEqual(recorded.get("../secret.txt"), "unhashable")
+        # the sentinel must never be the real content hash: no read outside
+        self.assertNotEqual(recorded.get("../secret.txt"),
+                            sha12(secret.read_bytes()))
+
+    def test_body_cited_escape_is_unhashable_too(self):
+        secret = self.tmp / "secret.txt"
+        secret.write_text("outside the repo\n", encoding="utf-8")
+        self.write_page(
+            "security/body-escape.md",
+            "---\ntype: note\n---\n\nSee `../secret.txt` for details.\n")
+        self.manifest_cli("stamp")
+        res = self.read_manifest()["provenance"]["security/body-escape"][
+            "resources"]
+        # page_resources' exists() filter does not confine body citations to
+        # the repo (Path.exists resolves the ..), so the escaping path IS
+        # recorded — but only ever as the unhashable sentinel, never hashed
+        # content.
+        self.assertNotIn("../secret.txt", res)  # escapes repo: never recorded
+        self.assertNotIn(sha12(secret.read_bytes()), res.values())
+
+
+class TestStatusFresh(WikiBase):
+    def test_all_fresh_exit0_with_blind_spot_line(self):
+        r = self.status()
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn("FRESH", r.stdout)
+        self.assertNotIn("STALE:", r.stdout)
+        self.assertNotIn("TAMPERED:", r.stdout)
+        # the orphan page is a blind spot; exit stays 0 (nothing stale)
+        self.assertIn("blind spot", r.stdout)
+
+    def test_single_page_fresh(self):
+        r = self.status("concepts/app")
+        self.assertEqual(r.returncode, 0)
+        self.assertTrue(r.stdout.startswith("FRESH: concepts/app"))
+
+    def test_orphan_page_is_unverifiable_exit0(self):
+        r = self.status("notes/orphan")
+        self.assertEqual(r.returncode, 0)
+        self.assertTrue(r.stdout.startswith("UNVERIFIABLE: notes/orphan"))
+
+
+class TestStatusStale(WikiBase):
+    def test_source_change_marks_only_affected_pages_stale(self):
+        self.src_app.write_text("print('v2')\n", encoding="utf-8")
+        r = self.status()
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("STALE: concepts/app", r.stdout)
+        # unaffected pages stay FRESH (checked precisely via --json)
+        rj = self.status("--json")
+        verdicts = {row["page"]: row["verdict"]
+                    for row in json.loads(rj.stdout)["pages"]}
+        self.assertEqual(verdicts["concepts/app"], "STALE")
+        self.assertEqual(verdicts["playbooks/db-refresh"], "FRESH")
+        self.assertEqual(verdicts["datasets/data-dir"], "FRESH")
+
+    def test_single_page_mode_prints_the_changed_file(self):
+        self.db_js.write_text("console.log('v2');\n", encoding="utf-8")
+        r = self.status("playbooks/db-refresh")
+        self.assertEqual(r.returncode, 1)
+        self.assertTrue(r.stdout.startswith("STALE: playbooks/db-refresh"))
+        self.assertIn("changed: scripts/db.js", r.stdout)
+
+    def test_dir_resource_page_goes_stale_when_inner_file_changes(self):
+        self.data_file.write_text("one v2\n", encoding="utf-8")
+        r = self.status("datasets/data-dir")
+        self.assertEqual(r.returncode, 1)
+        self.assertTrue(r.stdout.startswith("STALE: datasets/data-dir"))
+        self.assertIn("changed: data", r.stdout)
+
+    def test_restamp_after_source_refresh_returns_to_fresh(self):
+        self.src_app.write_text("print('v2')\n", encoding="utf-8")
+        self.assertEqual(self.status().returncode, 1)  # stale first
+        rc, _ = self.manifest_cli("stamp")               # the ingest re-stamp
+        self.assertEqual(rc, 0)
+        r = self.status()
+        self.assertEqual(r.returncode, 0)
+        self.assertTrue(
+            self.status("concepts/app").stdout.startswith(
+                "FRESH: concepts/app"))
+
+
+class TestTampered(WikiBase):
+    def test_hand_edit_wins_over_stale(self):
+        # change BOTH the page and its source: TAMPERED must take precedence
+        page = self.wiki / "concepts" / "app.md"
+        page.write_text(page.read_text(encoding="utf-8")
+                        + "\nhand-edited line\n", encoding="utf-8")
+        self.src_app.write_text("print('v2')\n", encoding="utf-8")
+        r = self.status("concepts/app")
+        self.assertEqual(r.returncode, 1)
+        self.assertTrue(r.stdout.startswith("TAMPERED: concepts/app"))
+        # whole-wiki report flags it too
+        rw = self.status()
+        self.assertEqual(rw.returncode, 1)
+        self.assertIn("TAMPERED: concepts/app", rw.stdout)
+
+
+class TestNewPage(WikiBase):
+    def test_page_added_after_stamp_is_unverifiable(self):
+        self.write_page("notes/later.md",
+                        "---\ntype: note\n---\n\n# Added after stamp\n")
+        r = self.status("--json")
+        self.assertEqual(r.returncode, 0)
+        report = json.loads(r.stdout)
+        rows = {row["page"]: row for row in report["pages"]}
+        self.assertEqual(rows["notes/later"]["verdict"], "UNVERIFIABLE")
+        self.assertGreaterEqual(report["counts"]["UNVERIFIABLE"], 2)
+
+
+class TestNote(WikiBase):
+    NOTES = property(lambda self: self.wiki / "raw" / "stale-notes.md")
+
+    def test_note_not_written_for_fresh_page(self):
+        r = self.status("playbooks/db-refresh", "--note")
+        self.assertEqual(r.returncode, 0)
+        self.assertFalse(self.NOTES.exists())
+
+    def test_note_written_once_and_deduped(self):
+        self.db_js.write_text("console.log('v2');\n", encoding="utf-8")
+        r1 = self.status("playbooks/db-refresh", "--note")
+        self.assertEqual(r1.returncode, 1)
+        self.assertIn("note queued", r1.stdout)
+        text = self.NOTES.read_text(encoding="utf-8")
+        self.assertIn("- STALE: `playbooks/db-refresh`", text)
+        r2 = self.status("playbooks/db-refresh", "--note")
+        self.assertIn("already queued", r2.stdout)
+        text = self.NOTES.read_text(encoding="utf-8")
+        self.assertEqual(text.count("STALE: `playbooks/db-refresh`"), 1)
+
+    def test_note_written_for_tampered_page(self):
+        page = self.wiki / "concepts" / "app.md"
+        page.write_text(page.read_text(encoding="utf-8") + "\nedit\n",
+                        encoding="utf-8")
+        r = self.status("concepts/app", "--note")
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("concepts/app", self.NOTES.read_text(encoding="utf-8"))
+
+
+class TestJson(WikiBase):
+    def test_json_single_page_fresh_and_stale(self):
+        out = json.loads(self.status("concepts/app", "--json").stdout)
+        self.assertEqual(out["page"], "concepts/app")
+        self.assertEqual(out["verdict"], "FRESH")
+        self.assertEqual(out["changed"], [])
+        self.assertIn("why", out)
+        self.src_app.write_text("print('v2')\n", encoding="utf-8")
+        r = self.status("concepts/app", "--json")
+        self.assertEqual(r.returncode, 1)
+        out = json.loads(r.stdout)
+        self.assertEqual(out["verdict"], "STALE")
+        self.assertTrue(out["changed"][0].startswith("src/app.py"))
+
+    def test_json_whole_wiki_shape_and_counts(self):
+        r = self.status("--json")
+        self.assertEqual(r.returncode, 0)
+        report = json.loads(r.stdout)
+        self.assertIn("stamped", report)
+        self.assertEqual(report["counts"].get("FRESH"), 3)
+        self.assertEqual(report["counts"].get("UNVERIFIABLE"), 1)
+        verdicts = {row["page"]: row["verdict"] for row in report["pages"]}
+        self.assertEqual(verdicts["notes/orphan"], "UNVERIFIABLE")
+        self.assertEqual(verdicts["concepts/app"], "FRESH")
+
+
+class TestErrorsAndTraversal(WikiBase):
+    def test_missing_manifest_exits_2_with_hint(self):
+        bare = self.tmp / "bare" / "docs" / "wiki"
+        bare.mkdir(parents=True)
+        shutil.copy(STATUS_TEMPLATE, bare / "status.py")
+        r = self.status(wiki=bare)
+        self.assertEqual(r.returncode, 2)
+        self.assertIn("manifest.json", r.stderr)
+        self.assertIn("stamp", r.stderr)  # tells the user what to run
+
+    def test_manifest_without_provenance_exits_2_with_hint(self):
+        # init writes a manifest but only stamp adds the provenance block
+        other_root = self.tmp / "unstamped"
+        other = other_root / "docs" / "wiki"
+        other.mkdir(parents=True)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = wm.main([str(other), "init", "--profile", "generic"])
+        self.assertEqual(rc, 0)
+        shutil.copy(STATUS_TEMPLATE, other / "status.py")
+        r = self.status(wiki=other)
+        self.assertEqual(r.returncode, 2)
+        self.assertIn("provenance", r.stderr)
+        self.assertIn("stamp", r.stderr)
+
+    def test_traversal_page_id_never_yields_trusted_verdict(self):
+        # an .md file OUTSIDE the wiki that a ..-id could point at
+        (self.root / "evil.md").write_text("# outside the wiki\n",
+                                           encoding="utf-8")
+        r = self.status("../../evil")
+        # provenance keys never contain '..', so the traversal id can only
+        # degrade to UNVERIFIABLE (file exists) or an error — never
+        # FRESH/STALE/TAMPERED, and check_page never reads the target.
+        self.assertIn(r.returncode, (0, 2))
+        for trusted in ("FRESH", "STALE", "TAMPERED"):
+            self.assertNotIn(trusted, r.stdout)
+        r2 = self.status("../../does-not-exist")
+        self.assertEqual(r2.returncode, 2)
+        self.assertIn("not a wiki page id", r2.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/wikicli/wiki_manifest.py
+++ b/wikicli/wiki_manifest.py
@@ -1,0 +1,456 @@
+#!/usr/bin/env python3
+"""Write/update docs/wiki/manifest.json for an OKF v0.1 wiki bundle.
+
+Usage:
+    python3 wiki_manifest.py <wiki-dir> init   --profile P [--status S] [--plugin-version V]
+                                                [--sha SHA|auto] [--date D] [--json]
+    python3 wiki_manifest.py <wiki-dir> update [--status S] [--batches-done N] [--batches-total N]
+                                                [--sha SHA|auto] [--date D] [--json]
+    python3 wiki_manifest.py <wiki-dir> stamp  [--date D] [--json]
+
+`stamp` writes content-hash provenance for every page into the manifest
+(the freshness ground truth docs/wiki/status.py checks) and installs or
+refreshes status.py in the wiki dir. Hashes are of file CONTENT, so they
+survive squash-merges, rebases, worktrees, and tarballs where commit shas
+do not. Per page it records:
+  - resources: frontmatter `resource:` plus repo paths cited in the body
+    as code spans (playbooks cite the scripts they orchestrate without
+    declaring resource:; body-cited paths close that blind spot),
+    each mapped to a sha256-12 of the file bytes (dirs: capped tree hash).
+  - page_sha: sha256-12 of the page file itself, so hand edits are
+    detectable as tampering.
+Run stamp after every compile/ingest that touches pages.
+
+Stdlib only. Exit codes: 0 ok, 1 findings (not used by this script), 2 error.
+"""
+import argparse
+import datetime
+import hashlib
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+SCHEMA_VERSION = "0.1"
+DEFAULT_PLUGIN_VERSION = "0.1.0"
+DEFAULT_STATUS_INIT = "compiling"
+# "project" is the sentinel for a census-derived schema (brain-init derives
+# the page-type table from the project census instead of a shipped profile;
+# the derivation record lives in project-profile.md, the contract in BRAIN.md).
+VALID_PROFILES = {"fullstack-app", "research-data", "generic", "project"}
+VALID_STATUSES = {"compiling", "complete"}
+
+# Files at the wiki root that are bundle scaffolding, not concept pages.
+# Mirrors okf_lint.py's index.md/log.md exclusion, plus the plugin-added
+# BRAIN.md / project-profile.md (design doc section 4: project-side state).
+NON_PAGE_NAMES = {"index.md", "log.md", "BRAIN.md", "project-profile.md"}
+
+FRONTMATTER_DELIM = "---"
+TYPE_LINE_RE = re.compile(r'^type:\s*["\']?([^"\'\n]+?)["\']?\s*$', re.MULTILINE)
+
+
+def today(date_arg):
+    if date_arg:
+        try:
+            datetime.date.fromisoformat(date_arg)
+        except ValueError:
+            die(f"--date must be YYYY-MM-DD, got {date_arg!r}")
+        return date_arg
+    return datetime.date.today().isoformat()
+
+
+def die(msg, code=2):
+    print(f"error: {msg}", file=sys.stderr)
+    sys.exit(code)
+
+
+def manifest_path(wiki_dir):
+    return wiki_dir / "manifest.json"
+
+
+def extract_type(text):
+    """Minimal frontmatter parse: find the 'type:' line inside the leading
+    ---/--- block. No PyYAML dependency (BUILD-SPEC rule 2 reserves PyYAML
+    for okf_lint.py only)."""
+    if not text.startswith(FRONTMATTER_DELIM + "\n"):
+        return None
+    body = text[len(FRONTMATTER_DELIM) + 1:]
+    end = body.find("\n" + FRONTMATTER_DELIM)
+    if end == -1:
+        return None
+    block = body[:end]
+    m = TYPE_LINE_RE.search(block)
+    if not m:
+        return None
+    return m.group(1).strip()
+
+
+def scan_pages(wiki_dir):
+    """Return (page_count, page_types dict) by walking *.md files, excluding
+    scaffolding files and anything under a dot-directory (covers the .compile/
+    working-state tree and editor dirs like .obsidian/). Must stay in lockstep
+    with okf_lint.py's page set: lint cross-checks page_count/page_types
+    against its own scan and errors on any mismatch."""
+    page_types = {}
+    count = 0
+    for p in sorted(wiki_dir.rglob("*.md")):
+        rel = p.relative_to(wiki_dir)
+        if rel.name in NON_PAGE_NAMES and len(rel.parts) == 1:
+            continue
+        if any(part.startswith(".") for part in rel.parts):
+            continue
+        try:
+            text = p.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        page_type = extract_type(text)
+        count += 1
+        if page_type:
+            page_types[page_type] = page_types.get(page_type, 0) + 1
+    return count, page_types
+
+
+def resolve_sha(wiki_dir, sha_arg):
+    """--sha auto: git rev-parse HEAD of the repo containing wiki_dir.
+    Any other value (including a literal sha, or omitted) passes through."""
+    if sha_arg != "auto":
+        return sha_arg
+    try:
+        toplevel = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=wiki_dir, capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=toplevel, capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        return sha
+    except (subprocess.CalledProcessError, OSError) as e:
+        die(f"--sha auto requested but git rev-parse failed: {e}")
+
+
+def cmd_init(args, wiki_dir):
+    if args.profile not in VALID_PROFILES:
+        die(f"--profile must be one of {sorted(VALID_PROFILES)}, got {args.profile!r}")
+    status = args.status or DEFAULT_STATUS_INIT
+    if status not in VALID_STATUSES:
+        die(f"--status must be one of {sorted(VALID_STATUSES)}, got {status!r}")
+    mpath = manifest_path(wiki_dir)
+    # decision: init refuses to clobber an existing manifest.json (no --force
+    # escape hatch requested by spec); re-running init on an already-compiled
+    # wiki is almost certainly a mistake. Use `update` to change an existing
+    # manifest.
+    if mpath.exists():
+        die(f"{mpath} already exists; use 'update' to modify it")
+    date = today(args.date)
+    page_count, page_types = scan_pages(wiki_dir)
+    manifest = {
+        "okf": SCHEMA_VERSION,
+        "profile": args.profile,
+        "created": date,
+        "updated": date,
+        "status": status,
+        "batches_done": 0,
+        "batches_total": 0,
+        "page_count": page_count,
+        "page_types": page_types,
+        "compiled_from_sha": resolve_sha(wiki_dir, args.sha) if args.sha else None,
+        "plugin_version": args.plugin_version,
+    }
+    write_manifest(mpath, manifest)
+    return manifest
+
+
+def cmd_update(args, wiki_dir):
+    mpath = manifest_path(wiki_dir)
+    if not mpath.exists():
+        die(f"{mpath} not found; run 'init' first")
+    try:
+        manifest = json.loads(mpath.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        die(f"could not read/parse {mpath}: {e}")
+
+    page_count, page_types = scan_pages(wiki_dir)
+    manifest["page_count"] = page_count
+    manifest["page_types"] = page_types
+    manifest["updated"] = today(args.date)
+
+    if args.profile is not None:
+        # re-scaffolds may move a wiki from a shipped profile to the
+        # census-derived "project" schema (or to a profile) without
+        # losing created/batch history the way delete+init would.
+        manifest["profile"] = args.profile
+    if args.status is not None:
+        if args.status not in VALID_STATUSES:
+            die(f"--status must be one of {sorted(VALID_STATUSES)}, got {args.status!r}")
+        manifest["status"] = args.status
+    if args.batches_done is not None:
+        manifest["batches_done"] = args.batches_done
+    if args.batches_total is not None:
+        manifest["batches_total"] = args.batches_total
+    if args.sha is not None:
+        manifest["compiled_from_sha"] = resolve_sha(wiki_dir, args.sha)
+
+    write_manifest(mpath, manifest)
+    return manifest
+
+
+def write_manifest(mpath, manifest):
+    mpath.write_text(json.dumps(manifest, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+
+
+# --- stamp: content-hash provenance ---------------------------------------
+
+RESOURCE_LINE_RE = re.compile(r'^resource:\s*["\']?([^"\'\n]+?)["\']?\s*$', re.MULTILINE)
+SENTINELS = {"missing", "unhashable"}
+# Repo paths cited in a page body as `code spans`: must contain a slash or a
+# file extension, no spaces/newlines, not a URL. Existence in the repo is the
+# final filter, so prose that merely looks path-ish drops out.
+BODY_PATH_RE = re.compile(r"`([A-Za-z0-9_./-]+(?:/[A-Za-z0-9_.-]+|\.[A-Za-z0-9]{1,8}))`")
+DIR_HASH_FILE_CAP = 200     # dirs with more files than this are "unhashable"
+BODY_RESOURCE_CAP = 12      # max body-cited paths recorded per page
+
+
+def sha12(data):
+    return hashlib.sha256(data).hexdigest()[:12]
+
+
+def repo_root_for(wiki_dir):
+    try:
+        top = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=wiki_dir, capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        if top:
+            return Path(top)
+    except (subprocess.CalledProcessError, OSError):
+        pass
+    # docs/wiki -> repo root two levels up; best effort outside git
+    return wiki_dir.parent.parent
+
+
+def hash_resource(root, rel):
+    """Hash one resource path. Files: sha256-12 of bytes. Dirs: sha256-12 of
+    the sorted (relpath, file-sha) list, capped — a moved/added/removed file
+    changes the hash. Returns 'missing' or 'unhashable' sentinels."""
+    p = (root / rel.lstrip("/")).resolve()
+    try:
+        p.relative_to(root.resolve())
+    except ValueError:
+        return "unhashable"  # escapes the repo; never follow
+    if p.is_file():
+        try:
+            return sha12(p.read_bytes())
+        except OSError:
+            return "unhashable"
+    if p.is_dir():
+        files = sorted(f for f in p.rglob("*") if f.is_file()
+                       and not any(part.startswith(".") for part in f.relative_to(p).parts))
+        if len(files) > DIR_HASH_FILE_CAP:
+            return "unhashable"
+        h = hashlib.sha256()
+        for f in files:
+            try:
+                h.update(str(f.relative_to(p)).encode())
+                h.update(sha12(f.read_bytes()).encode())
+            except OSError:
+                return "unhashable"
+        return h.hexdigest()[:12]
+    return "missing"
+
+
+def page_resources(root, text, wiki_rel):
+    """Resource paths for one page: frontmatter resource: (if repo-local)
+    plus body-cited repo paths that actually exist. Paths inside the wiki
+    itself are excluded — the wiki referencing the wiki is self-provenance
+    (stamp's own manifest write would flip such pages stale forever).
+    Returns ordered unique relpath list."""
+    def wiki_internal(rel):
+        return rel == wiki_rel or rel.startswith(wiki_rel + "/")
+
+    def in_repo(rel):
+        # resolve() so a body-cited ../x can never smuggle an outside path
+        # into the provenance record (it would only ever hash to a sentinel,
+        # but recording it at all invites vacuous-freshness bugs)
+        try:
+            p = (root / rel).resolve()
+            p.relative_to(root.resolve())
+            return p.exists()
+        except (ValueError, OSError):
+            return False
+
+    out = []
+    # frontmatter block only: a body line starting "resource: x" is prose,
+    # not metadata
+    fm = ""
+    if text.startswith(FRONTMATTER_DELIM + "\n"):
+        end = text.find("\n" + FRONTMATTER_DELIM, len(FRONTMATTER_DELIM))
+        if end != -1:
+            fm = text[:end]
+    m = RESOURCE_LINE_RE.search(fm)
+    if m:
+        r = m.group(1).strip().lstrip("/")
+        if r and "://" not in r and not wiki_internal(r):
+            out.append(r)
+    body_hits = 0
+    for cand in BODY_PATH_RE.findall(text):
+        if body_hits >= BODY_RESOURCE_CAP:
+            break
+        cand = cand.strip().lstrip("/")
+        if not cand or "://" in cand or cand in out or wiki_internal(cand):
+            continue
+        if in_repo(cand):
+            out.append(cand)
+            body_hits += 1
+    return out
+
+
+def cmd_stamp(args, wiki_dir):
+    mpath = manifest_path(wiki_dir)
+    if not mpath.exists():
+        die(f"{mpath} not found; run 'init' first")
+    try:
+        manifest = json.loads(mpath.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        die(f"could not read/parse {mpath}: {e}")
+
+    root = repo_root_for(wiki_dir)
+    old_prov = manifest.get("provenance") or {}
+    try:
+        wiki_rel = str(wiki_dir.resolve().relative_to(root.resolve()))
+    except ValueError:
+        wiki_rel = wiki_dir.name
+
+    provenance = {}
+    drifted = []
+    for p in sorted(wiki_dir.rglob("*.md")):
+        rel = p.relative_to(wiki_dir)
+        if rel.name in NON_PAGE_NAMES and len(rel.parts) == 1:
+            continue
+        if any(part.startswith(".") for part in rel.parts):
+            continue
+        # raw/ is the immutable inbox, not compiled pages; never stamp it
+        if rel.parts[0] == "raw":
+            continue
+        try:
+            text = p.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        page_id = str(rel)[:-3]
+        resources = {r: hash_resource(root, r) for r in page_resources(root, text, wiki_rel)}
+        # a page whose sources moved since the LAST stamp is being
+        # re-baselined right now; if its body wasn't refreshed first, this
+        # stamp would launder staleness into a forged FRESH
+        old = old_prov.get(page_id)
+        if old and any(old["resources"].get(r) not in (None, h)
+                       for r, h in resources.items()):
+            drifted.append(page_id)
+        provenance[page_id] = {
+            "resources": resources,
+            "page_sha": sha12(p.read_bytes()),
+        }
+
+    manifest["provenance"] = provenance
+    manifest["provenance_stamped"] = today(args.date)
+    # repo-wide file-set fingerprint: lets status.py warn when new source
+    # files appear that NO page cites (the fact-moved-to-a-new-file blind
+    # spot cannot be caught per page, but it can be flagged per repo)
+    manifest["source_tree"] = source_tree_fingerprint(root)
+    manifest["updated"] = today(args.date)
+    write_manifest(mpath, manifest)
+
+    # install/refresh status.py next to the manifest so the checker travels
+    # with the repo (collaborators without the CLI can still run it)
+    tmpl = Path(__file__).resolve().parent / "templates" / "status.py"
+    if tmpl.exists():
+        dst = wiki_dir / "status.py"
+        if not dst.exists() or dst.read_bytes() != tmpl.read_bytes():
+            dst.write_bytes(tmpl.read_bytes())
+    else:
+        # never silently skip: a missing template means a broken install
+        print(f"warning: status.py template missing at {tmpl}; "
+              "freshness checker not installed", file=sys.stderr)
+
+    checkable = sum(1 for v in provenance.values()
+                    if any(h not in SENTINELS for h in v["resources"].values()))
+    print(f"stamped {len(provenance)} pages ({checkable} checkable, "
+          f"{len(provenance) - checkable} unverifiable) in {mpath}")
+    if drifted:
+        print(f"warning: {len(drifted)} page(s) had drifted sources and are "
+              f"now re-baselined: {', '.join(drifted[:6])}"
+              + (" ..." if len(drifted) > 6 else ""))
+        print("  if their content was NOT refreshed from source first "
+              "(/brain ingest), this stamp just hid real staleness.")
+    return manifest
+
+
+def source_tree_fingerprint(root):
+    """{count, sha12} over the repo's tracked file list (git), falling back
+    to a pruned walk. List only, no contents: cheap, and enough to notice
+    'files appeared that no page cites'."""
+    files = None
+    try:
+        out = subprocess.run(["git", "ls-files"], cwd=root, capture_output=True,
+                             text=True, check=True).stdout
+        files = sorted(l for l in out.splitlines() if l)
+    except (subprocess.CalledProcessError, OSError):
+        pass
+    if files is None:
+        skip = {"node_modules", "__pycache__", ".git", "output", "dist", "build"}
+        files = sorted(
+            str(f.relative_to(root)) for f in root.rglob("*")
+            if f.is_file() and not any(
+                part in skip or part.startswith(".")
+                for part in f.relative_to(root).parts))
+    h = hashlib.sha256("\n".join(files).encode()).hexdigest()[:12]
+    return {"count": len(files), "sha": h}
+
+
+def build_parser():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("wiki_dir", help="path to docs/wiki (or equivalent) directory")
+    p.add_argument("command", choices=["init", "update", "stamp"])
+    p.add_argument("--profile", choices=sorted(VALID_PROFILES), help="required for init")
+    p.add_argument("--status", choices=sorted(VALID_STATUSES), default=None)
+    p.add_argument("--plugin-version", default=DEFAULT_PLUGIN_VERSION)
+    p.add_argument("--batches-done", type=int, default=None)
+    p.add_argument("--batches-total", type=int, default=None)
+    p.add_argument("--sha", default=None, help="git sha, or 'auto' to resolve HEAD of the containing repo")
+    p.add_argument("--date", default=None, help="override created/updated date (YYYY-MM-DD); default: today")
+    p.add_argument("--json", action="store_true", help="print resulting manifest as JSON to stdout")
+    return p
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+    wiki_dir = Path(args.wiki_dir)
+    if not wiki_dir.exists():
+        die(f"wiki dir does not exist: {wiki_dir}")
+    if not wiki_dir.is_dir():
+        die(f"not a directory: {wiki_dir}")
+
+    if args.command == "init":
+        if not args.profile:
+            die("init requires --profile")
+        manifest = cmd_init(args, wiki_dir)
+    elif args.command == "stamp":
+        manifest = cmd_stamp(args, wiki_dir)
+    else:
+        manifest = cmd_update(args, wiki_dir)
+
+    if args.json:
+        print(json.dumps(manifest, indent=2))
+    else:
+        # .get(): an `update` may be run against a hand-written manifest
+        # (design S3 adopt path) that lacks some schema keys.
+        print(f"wrote {manifest_path(wiki_dir)}")
+        print(f"  profile={manifest.get('profile')} status={manifest.get('status')} "
+              f"page_count={manifest.get('page_count')} "
+              f"batches={manifest.get('batches_done')}/{manifest.get('batches_total')} "
+              f"sha={manifest.get('compiled_from_sha')}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Moves the five deterministic brain scripts out of the Claude Code plugin into `wikicli/` and exposes them as `tokentelemetry wiki <subcommand>` on the existing npm bin:

| Subcommand | Wraps | Model needed |
|---|---|---|
| `wiki status [page-id]` | the bundle's installed `status.py` | none |
| `wiki lint` | `okf_lint.py` | none |
| `wiki mine` | `session_scan.py` + 11-harness adapters | none |
| `wiki census` | `profile_census.py` | none |
| `wiki manifest <init\|update\|stamp>` | `wiki_manifest.py` | none |
| `wiki context (--check\|--write)` | `agent_context.py` | none |

## Why

The wiki's *consumption* side was already universal (committed OKF markdown), but *maintenance* was locked to Claude Code via plugin skills. With this, any coding agent with a bash tool — Cursor, Codex, OpenCode — keeps the wiki fresh using its own model. The CLI referees (freshness, lint, evidence); the invoking agent writes. No embedded model, no extra API key, no network. Context: OpenWiki 0.2 adopted the same OKF spec but brings its own billed model; `wiki mine` (cross-harness session evidence) is the part they structurally can't copy.

Plugin v0.6 will delete its `scripts/` copy and shell to this CLI (tracked separately). ADR follows in a docs PR.

## Fixes folded in (vs the plugin copies)

- `session_scan.py`: package-relative import with direct-invocation fallback, replacing the `sys.path.insert` sibling hack
- `wiki_manifest.py`: `status.py` template resolves to `wikicli/templates/`; a missing template now **warns on stderr** instead of silently skipping the install
- python resolution: system `python3` preferred (stdlib-only except lint's PyYAML), backend venv fallback; script exit codes (0 ok / 1 findings / 2 tool error) pass through untouched

## Verification

- 40/40 tests pass in the new location (`python3 -m pytest wikicli/ -q`)
- `wiki mine` against this repo live: 23 sessions across 6 harnesses (claude, grok, opencode, smallcode, codex, copilot), 38.7M tokens attributed
- Full fixture lifecycle: `manifest init` → author page → `lint` (caught 3 real errors, then clean exit 0) → `stamp` (installs status.py from the new template path) → `status` transitions FRESH → STALE (source hash change) → TAMPERED (hand-edit), exit codes 0/1/1
- `context --write` installs the AGENTS.md pointer block; `--check` exits 1 on pending work
- `node --check` + `compileall` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)