### PR TITLE
perf(trace): speed up trace loading (mtime cache + O(n²)→O(n) pairing)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -5491,41 +5491,61 @@ async def invalidate_cache():
     return {"ok": True}
 
 
+# --- Session-detail parse cache -------------------------------------------------
+# get_session_detail re-reads and re-parses a session's full transcript on every
+# open; large transcripts (tens of MB) made re-opens slow. Memoize the parsed
+# event list on (mtime_ns, size) so an unchanged file is parsed only once. The key
+# changes the instant the file is appended to, so a live session never goes stale.
+_SESSION_DETAIL_CACHE: Dict[str, Tuple[Tuple[int, int], List[Dict[str, Any]]]] = {}
+_SESSION_DETAIL_CACHE_MAX = 16
+
+
+def _parse_session_jsonl_cached(path: Path) -> List[Dict[str, Any]]:
+    """Parse a JSONL transcript into normalized event dicts, memoized on file
+    identity + (mtime_ns, size). Returns the cached list on a hit (callers must
+    treat it as read-only — the detail endpoint only serializes it)."""
+    try:
+        st = path.stat()
+        stamp = (st.st_mtime_ns, st.st_size)
+    except OSError:
+        stamp = None
+    key = str(path)
+    if stamp is not None:
+        hit = _SESSION_DETAIL_CACHE.get(key)
+        if hit is not None and hit[0] == stamp:
+            return hit[1]
+    events: List[Dict[str, Any]] = []
+    with open(path, "r", encoding="utf-8", errors="replace") as f:
+        for line in f:
+            try:
+                data = json.loads(line)
+            except Exception:
+                continue
+            # Add a normalized_timestamp for the waterfall view.
+            if data.get("timestamp"):
+                try:
+                    ts = _aware(datetime.fromisoformat(data["timestamp"].replace('Z', '+00:00')))
+                    data["normalized_timestamp"] = ts.timestamp() * 1000
+                except Exception:
+                    pass
+            events.append(data)
+    if stamp is not None:
+        if key not in _SESSION_DETAIL_CACHE and len(_SESSION_DETAIL_CACHE) >= _SESSION_DETAIL_CACHE_MAX:
+            _SESSION_DETAIL_CACHE.pop(next(iter(_SESSION_DETAIL_CACHE)))
+        _SESSION_DETAIL_CACHE[key] = (stamp, events)
+    return events
+
+
 @app.get("/sessions/{session_id}")
 async def get_session_detail(session_id: str, agent: str):
     if agent == "claude":
         files = list(CLAUDE_DIR.glob(f"projects/**/{session_id}.jsonl")) or list(CLAUDE_DIR.glob(f"sessions/{session_id}.json"))
         if not files: return {"error": "Not found"}
-        events = []
-        with open(files[0], "r", encoding="utf-8", errors="replace") as f:
-            for line in f:
-                try:
-                    data = json.loads(line)
-                    # Add a normalized_timestamp for waterfall
-                    if data.get("timestamp"):
-                        try:
-                            ts = _aware(datetime.fromisoformat(data["timestamp"].replace('Z', '+00:00')))
-                            data["normalized_timestamp"] = ts.timestamp() * 1000
-                        except Exception: pass
-                    events.append(data)
-                except Exception: continue
-        return events
+        return _parse_session_jsonl_cached(files[0])
     elif agent == "codex":
         files = list(CODEX_DIR.glob(f"sessions/**/rollout-*{session_id}*.jsonl"))
         if not files: return {"error": "Not found"}
-        events = []
-        with open(files[0], "r", encoding="utf-8", errors="replace") as f:
-            for line in f:
-                try:
-                    data = json.loads(line)
-                    if data.get("timestamp"):
-                        try:
-                            ts = _aware(datetime.fromisoformat(data["timestamp"].replace('Z', '+00:00')))
-                            data["normalized_timestamp"] = ts.timestamp() * 1000
-                        except Exception: pass
-                    events.append(data)
-                except Exception: continue
-        return events
+        return _parse_session_jsonl_cached(files[0])
     elif agent == "grok":
         # Grok Build dialogue. chat_history.jsonl is the canonical conversation in
         # FILE ORDER and carries NO per-message timestamps, so we normalize each

--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -477,6 +477,23 @@ export default function SessionDetailPage() {
       .catch(() => {});
   }, [events, sessionInfo]);
 
+  // Map each tool_use_id -> the user event carrying its tool_result. Built once
+  // per events change so the tool summary and waterfall can pair a call to its
+  // result in O(1) instead of rescanning the whole event array per tool_use
+  // (that rescan was O(n²) and dominated load time on long traces).
+  const toolResultByUseId = useMemo(() => {
+    const map = new Map<string, Event>();
+    for (const e of events) {
+      if (e.type === "user" && Array.isArray(e.message?.content)) {
+        for (const c of e.message.content as any[]) {
+          const rid = c?.tool_use_id;
+          if (rid && !map.has(rid)) map.set(rid, e);
+        }
+      }
+    }
+    return map;
+  }, [events]);
+
   // Tool summary
   const toolSummary = useMemo(() => {
     const rows: { name: string; start: number; duration: number }[] = [];
@@ -485,7 +502,7 @@ export default function SessionDetailPage() {
       if (evt.message?.role === "assistant" && Array.isArray(evt.message?.content)) {
         const tu = evt.message.content.find((c: any) => c.type === "tool_use");
         if (tu && ts) {
-          const result = events.slice(idx + 1).find((e) => e.type === "user" && Array.isArray(e.message?.content) && e.message.content.some((c: any) => c.tool_use_id === tu.id));
+          const result = toolResultByUseId.get(tu.id);
           const end = (result && normalizeTs(result)) || ts + 200;
           rows.push({ name: tu.name, start: ts, duration: end - ts });
         }
@@ -506,7 +523,7 @@ export default function SessionDetailPage() {
     return Object.entries(m)
       .map(([name, v]) => ({ name, count: v.count, avg: v.total / v.count }))
       .sort((a, b) => b.count - a.count);
-  }, [events]);
+  }, [events, toolResultByUseId]);
 
   const jumpTo = (idx: number) => {
     setActiveStep(idx);
@@ -529,7 +546,7 @@ export default function SessionDetailPage() {
            if (tu) {
               toolName = tu.name;
               // Look ahead for tool_result from user
-              const result = events.slice(idx).find(e => e.type === "user" && Array.isArray(e.message?.content) && e.message.content.some((c: any) => c.tool_use_id === tu.id));
+              const result = toolResultByUseId.get(tu.id);
               const endTime = result?.normalized_timestamp || (result?.timestamp ? new Date(result.timestamp).getTime() : startTime + 2000);
               tools.push({ name: toolName, start: startTime, end: endTime, id: tu.id });
            }
@@ -546,7 +563,7 @@ export default function SessionDetailPage() {
         }
      });
      return tools;
-  }, [events]);
+  }, [events, toolResultByUseId]);
 
   return (
     <div className="min-h-screen bg-[var(--tt-canvas)] text-[var(--tt-fg)] font-sans flex flex-col">


### PR DESCRIPTION
## Why
Opening a trace got noticeably slower as sessions grew (largest local transcripts are now 40–100MB). Two compounding costs on the trace-open path, neither present when traces were small:

1. **Backend re-parsed the whole transcript on every open.** `get_session_detail` re-globbed and read + `json.loads`'d the entire JSONL, with no cache, on every request.
2. **Frontend paired tool calls to results in O(n²).** The tool summary and waterfall did `events.slice(idx).find(...)` per tool_use, rescanning the whole event array each time.

## What
- **`backend/main.py`** — factor the claude/codex transcript parse into `_parse_session_jsonl_cached(path)`, memoized on `(path, mtime_ns, size)`. Unchanged file → parsed once; an append changes the key, so **live sessions stay fresh**. Bounded to 16 entries.
- **`frontend/.../sessions/[id]/page.tsx`** — build a `tool_use_id → result-event` `Map` once per `events` change; the summary and waterfall now look up in O(1). Behavior is identical (tool_use_ids are unique and the result always follows the call). Net removes one explicit `any`.

## Validation
- Backend: `py_compile` clean; standalone test covers cache hit, bad-line skip, timestamp normalization, **append-invalidation**, and eviction.
- Frontend: `tsc --noEmit` clean (exit 0); no new lint findings (the 36 `no-explicit-any` errors are the file's pre-existing baseline); dependency arrays updated so `react-hooks/exhaustive-deps` stays quiet.

## Not in this PR (follow-ups)
- Event-list **virtualization** and detail-endpoint **pagination** for the pathological 100MB+ sessions.
- Replacing the per-open recursive `glob("projects/**/{id}.jsonl")` with the path the scanner already knows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)