### PR TITLE
fix(container): forward TT_AUTH_TOKEN into the backend container

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ The frontend runs on host port **13000** and the backend on **18000**, bound to 
 
 **Windows:** the container path requires WSL or Git Bash — `${HOME}` is not set in plain `cmd.exe` or PowerShell, which causes the `~/.claude` mount to fail silently.
 
-Pre-built images are published to GitHub Container Registry on every push to main. To run without building locally, use the production overlay:
+Pre-built images are published to GitHub Container Registry when a push to main touches `backend/`, `frontend/`, or `compose.yml`. To run without building locally, use the production overlay:
 
 ```bash
 make up-prod                                   # pull from GHCR and start detached

--- a/UPDATE.json
+++ b/UPDATE.json
@@ -1,6 +1,21 @@
 {
   "releases": [
     {
+      "tag": "2026-07-26",
+      "title": "Run TokenTelemetry in Docker or Podman",
+      "highlights": [
+        {
+          "title": "Container support via Docker or Podman",
+          "description": "TokenTelemetry now ships Dockerfiles and a Compose file, so you can run it as a container instead of installing Python and Node on the host. A Makefile handles the rest: `make up` builds and starts, `make down` stops, `make logs` tails output, auto-detecting whether you have Docker or Podman. The dashboard serves on port 13000 and the API on 18000, both loopback-only, and your agent logs are mounted read-only. Thanks to slmingol for building and contributing this (PR #172).",
+          "href": "https://tokentelemetry.com/docs/docker"
+        },
+        {
+          "title": "Pre-built images, no local build",
+          "description": "Multi-arch images (Intel and Apple Silicon) are published to GitHub Container Registry, so `make up-prod` pulls and runs without compiling anything. Pin a specific build with `TT_IMAGE_TAG=sha-abc1234` when you want a known-good version."
+        }
+      ]
+    },
+    {
       "tag": "2026-07-23",
       "title": "Active loops now show their next run",
       "highlights": [

--- a/compose.yml
+++ b/compose.yml
@@ -11,8 +11,14 @@
 #   PORT         frontend default 13000  →  http://localhost:13000
 #
 # Both ports bind to 127.0.0.1 (loopback) by default.  For LAN/tailnet access
-# set TT_AUTH_TOKEN and publish on 0.0.0.0 in a local override file:
+# run with TT_AUTH_TOKEN set and publish on 0.0.0.0 in a local override file:
+#   TT_AUTH_TOKEN=<secret> make up
 #   ports: ["0.0.0.0:${TT_API_PORT:-18000}:8000"]
+# TT_AUTH_TOKEN is forwarded from your shell below; unset (the default) leaves
+# the auth gate a no-op, which is why the loopback-only default is safe.
+# Note: inside a container the backend sees the bridge gateway as the client
+# address, never 127.0.0.1, so the middleware's loopback exemption never
+# applies here. Once a token is set, the local browser is prompted too.
 #
 # Container-internal ports are always 8000 (backend) and 3000 (frontend).
 # NEXT_PUBLIC_API_PORT is baked into the Next.js client bundle at build time —
@@ -35,6 +41,7 @@ services:
       - TOKENTELEMETRY_DATA_DIR=/tt-data
       - TOKENTELEMETRY_HOME=/tt-data
       - TZ=${TZ:-}
+      - TT_AUTH_TOKEN=${TT_AUTH_TOKEN:-}
     volumes:
       - tt_data:/tt-data
       # Agent log directories (read-only) — add/remove to match what's on this host.

--- a/website/content/docs/docker.mdx
+++ b/website/content/docs/docker.mdx
@@ -128,7 +128,7 @@ Your agent logs are never stored in the volume; they are read live from the host
 
 ## Pre-built images
 
-CI publishes multi-arch images (amd64 + arm64) to GitHub Container Registry on every push to `main`. To run without building anything locally, use the production overlay via `make up-prod`:
+CI publishes multi-arch images (amd64 + arm64) to GitHub Container Registry when a push to `main` touches `backend/`, `frontend/`, or `compose.yml`. Pushes that change only docs or the website don't rebuild them, so `latest` tracks the last code change rather than the newest commit. To run without building anything locally, use the production overlay via `make up-prod`:
 
 ```bash
 make up-prod                          # pull the latest images and start detached
@@ -177,9 +177,13 @@ To reach the dashboard from another device, you need two things:
    TT_AUTH_TOKEN=your-secret-token make up
    ```
 
+   `compose.yml` forwards `TT_AUTH_TOKEN` from your shell into the backend container. Leaving it unset (the default) keeps the auth gate switched off, which is what makes the loopback-only default safe.
+
 <Callout type="warn">
 The token is the security boundary, not the port binding or CORS. Never expose the ports on `0.0.0.0` without `TT_AUTH_TOKEN` set. See [Remote Access](/docs/configuration/remote-access) for how the token works and how remote clients supply it.
 </Callout>
+
+Unlike the native launcher, the container path has no loopback exemption. The backend sees requests arriving from the container network's gateway address rather than `127.0.0.1`, so once you set a token, the dashboard asks you for it on the host machine too, not just from remote devices.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Follow-up to #172. Three fixes, one of them security-relevant.

## 1. `TT_AUTH_TOKEN` never reached the container

`compose.yml` documented setting `TT_AUTH_TOKEN` for LAN/tailnet access, but the variable was only mentioned in the header comment. It was never declared under the backend's `environment:`, and Compose forwards only declared variables.

So `TT_AUTH_TOKEN=secret make up` did nothing. `backend/main.py:230` read an empty string, `RemoteAuthMiddleware` returned early as a no-op, and anyone who followed the documented path to expose the dashboard on `0.0.0.0` ended up with an unauthenticated API serving full session history and spend, while the docs told them the token was the security boundary.

Proof before the fix, with the variable set in the shell:

```
$ TT_AUTH_TOKEN=supersecret TZ=Asia/Kolkata docker compose config
    environment:
      TOKENTELEMETRY_DATA_DIR: /tt-data
      TOKENTELEMETRY_HOME: /tt-data
      TT_API_PORT: "8000"
      TT_HOST: 0.0.0.0
      TZ: Asia/Kolkata          # declared, so forwarded
                                # TT_AUTH_TOKEN absent
```

After, in both the dev config and the prod overlay:

```
$ TT_AUTH_TOKEN=supersecret docker compose config | grep TT_AUTH_TOKEN
      TT_AUTH_TOKEN: supersecret
$ TT_AUTH_TOKEN=supersecret docker compose -f compose.yml -f docker-compose.prod.yml config | grep TT_AUTH_TOKEN
      TT_AUTH_TOKEN: supersecret
```

Unset, it resolves to `""`, so `.strip()` is falsy and the gate stays off. The loopback-only default is byte-for-byte unchanged.

Also documented, in `compose.yml` and the docs page: the container path has no loopback exemption. Host traffic arrives from the bridge gateway, never `127.0.0.1`, so `_is_loopback()` never matches and setting a token prompts the local browser too. That differs from the native launcher and is worth knowing before someone sets a token and is surprised.

## 2. Restores the lost release entry

The container release entry was added in the feature branch but dropped when it was merged with main, so the feature shipped with no `UPDATE.json` note. Restored under today's date, with contributor credit to slmingol per the repo convention.

## 3. Corrects the GHCR publishing claim

README and the docs page both said images publish "on every push to main". `container-publish.yml` is path-filtered to `backend/**`, `frontend/**`, and `compose.yml`, so docs-only pushes don't refresh `latest`.

## Verification

- `docker compose config` and the prod overlay, set and unset, shown above
- `UPDATE.json` parses; title 38 chars (limit 50); 2 highlights (limit 5)
- `website/`: `fumadocs-mdx && next build` exits 0, `/docs/docker` route generated

Draft because the container images have never actually been built. `container-publish.yml` has queued runs sitting at `action_required` from the fork PR and has not run once, so the image build itself is still unexercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)