### PR TITLE
feat(goals): surface Codex Goal Mode on the session trace

### DIFF
--- a/UPDATE.json
+++ b/UPDATE.json
@@ -1,6 +1,21 @@
 {
   "releases": [
     {
+      "tag": "2026-07-26",
+      "title": "See what Codex Goal Mode actually cost",
+      "highlights": [
+        {
+          "title": "Goal Mode on the session trace",
+          "description": "Sessions where you ran Codex's /goal now show a Goal Mode card: the objective, Codex's own status (active, paused, complete or blocked), tokens used, time spent in the goal, and any token budget. A long unattended goal is no longer indistinguishable from an ordinary session.",
+          "href": "/sessions"
+        },
+        {
+          "title": "Goal cost shown as a share, not a second bill",
+          "description": "The card reports a goal's tokens as a percentage of its session total, because Codex counts them inside that total. The numbers come from Codex itself rather than being estimated, and status is re-read on every load so a finished goal never keeps showing as running."
+        }
+      ]
+    },
+    {
       "tag": "2026-07-23",
       "title": "Active loops now show their next run",
       "highlights": [

--- a/backend/codex_goals.py
+++ b/backend/codex_goals.py
@@ -1,0 +1,189 @@
+"""Codex Goal Mode (`/goal`) telemetry.
+
+Codex is the only supported agent that keeps first-class goal state on disk, and
+the only one that counts a goal's tokens and wall-clock *itself*. Everything here
+is therefore **reported**, never inferred: we copy Codex's own numbers and its
+own status string, and we never synthesise a status it didn't write.
+
+Design notes in `docs/design/goal-telemetry.md`. Two of them matter for reading
+this file:
+
+1. **Two copies of the DB exist at different migration levels**, and on this
+   machine the *populated* one is on the OLDER schema (v1, no
+   `thread_goal_continuation_deferrals`). So pick the DB by row count rather than
+   by path, and probe `sqlite_master` before touching the v2-only table.
+2. **Goal status is live mutable state** (`active -> paused -> complete`). The
+   caller must attach it outside the session cache, the way loop lifecycle is
+   recomputed per request, or a stale `active` sticks forever.
+
+Reads never raise: a missing, locked, or unexpected DB yields no goals.
+"""
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# Relative to ~/.codex. Order is only a tie-break; row count decides.
+_DB_CANDIDATES = ("sqlite/goals_1.sqlite", "goals_1.sqlite")
+
+_GOALS_TABLE = "thread_goals"
+_DEFERRALS_TABLE = "thread_goal_continuation_deferrals"
+
+# Codex's own vocabulary, normalised. Anything we don't recognise becomes
+# "unknown" rather than being guessed at, but the raw string is kept in
+# evidence.status_raw so the UI can still show what Codex actually said.
+_STATUS_MAP = {
+    "active": "active",
+    "running": "active",
+    "in_progress": "active",
+    "paused": "paused",
+    "complete": "complete",
+    "completed": "complete",
+    "done": "complete",
+    "blocked": "blocked",
+}
+
+OBJECTIVE_MAX = 200
+
+
+def _connect(path: Path) -> Optional[sqlite3.Connection]:
+    """Read-only connection, or None if the file is missing/unreadable."""
+    try:
+        if not path.is_file():
+            return None
+        con = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+        con.execute("PRAGMA busy_timeout=500")
+        return con
+    except (sqlite3.Error, OSError):
+        return None
+
+
+def _tables(con: sqlite3.Connection) -> set:
+    try:
+        return {r[0] for r in con.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'")}
+    except sqlite3.Error:
+        return set()
+
+
+def _pick_db(codex_dir: Path) -> Optional[Path]:
+    """Choose the goals DB that actually has rows.
+
+    Codex leaves an empty newer-schema DB alongside a populated older-schema one,
+    so "newest path wins" and "first path wins" both pick the wrong file. Fall
+    back to any readable DB (so a fresh install with zero goals still resolves)
+    and finally None.
+    """
+    fallback: Optional[Path] = None
+    for rel in _DB_CANDIDATES:
+        path = codex_dir / rel
+        con = _connect(path)
+        if con is None:
+            continue
+        try:
+            if _GOALS_TABLE not in _tables(con):
+                continue
+            if fallback is None:
+                fallback = path
+            try:
+                if con.execute(f"SELECT 1 FROM {_GOALS_TABLE} LIMIT 1").fetchone():
+                    return path
+            except sqlite3.Error:
+                continue
+        finally:
+            con.close()
+    return fallback
+
+
+def _iso(ms: Any) -> Optional[str]:
+    """Epoch milliseconds -> aware UTC ISO string."""
+    try:
+        return datetime.fromtimestamp(int(ms) / 1000, tz=timezone.utc).isoformat()
+    except (TypeError, ValueError, OSError, OverflowError):
+        return None
+
+
+def _int_or_none(v: Any) -> Optional[int]:
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def _deferral_counts(con: sqlite3.Connection) -> Optional[Dict[str, int]]:
+    """thread_id -> deferral count, or None when the table predates migration v2.
+
+    None and 0 mean different things here: 0 is "Codex recorded no deferrals",
+    None is "this Codex version cannot record them", and the UI must not show
+    a confident zero for the latter.
+    """
+    if _DEFERRALS_TABLE not in _tables(con):
+        return None
+    try:
+        return {str(tid): int(n) for tid, n in con.execute(
+            f"SELECT thread_id, COUNT(*) FROM {_DEFERRALS_TABLE} GROUP BY thread_id")}
+    except sqlite3.Error:
+        return None
+
+
+def read_goals(codex_dir: Path) -> Dict[str, List[Dict[str, Any]]]:
+    """Map Codex `thread_id` -> list of goals, oldest first.
+
+    The thread id is exactly the session id `_scan_sessions_sync` builds for
+    Codex (it rebuilds the same UUID from the rollout filename), so callers can
+    join on it directly with no translation.
+    """
+    out: Dict[str, List[Dict[str, Any]]] = {}
+    db = _pick_db(codex_dir)
+    if db is None:
+        return out
+    con = _connect(db)
+    if con is None:
+        return out
+    try:
+        deferrals = _deferral_counts(con)
+        try:
+            rows = con.execute(
+                f"SELECT thread_id, goal_id, objective, status, token_budget, "
+                f"tokens_used, time_used_seconds, created_at_ms, updated_at_ms "
+                f"FROM {_GOALS_TABLE}"
+            ).fetchall()
+        except sqlite3.Error:
+            return out
+
+        for (thread_id, goal_id, objective, status, budget,
+             tokens_used, time_used, created_ms, updated_ms) in rows:
+            if not thread_id:
+                continue
+            raw = (str(status).strip().lower() if status is not None else "")
+            obj = str(objective or "").strip()
+            goal = {
+                "source": "codex",
+                "goal_id": str(goal_id) if goal_id else None,
+                "objective": obj[:OBJECTIVE_MAX],
+                "objective_truncated": len(obj) > OBJECTIVE_MAX,
+                "created_at": _iso(created_ms),
+                "updated_at": _iso(updated_ms),
+                # Codex wrote this down; we are not guessing.
+                "state": _STATUS_MAP.get(raw, "unknown"),
+                "state_source": "reported",
+                "tokens": _int_or_none(tokens_used),
+                "duration_seconds": _int_or_none(time_used),
+                "token_budget": _int_or_none(budget),
+                # Native counts: a SHARE OF the session total, never an addition.
+                "cost_basis": "native",
+                "evidence": {
+                    "status_raw": str(status) if status is not None else None,
+                    "deferrals": (deferrals.get(str(thread_id), 0)
+                                  if deferrals is not None else None),
+                },
+            }
+            out.setdefault(str(thread_id), []).append(goal)
+    finally:
+        con.close()
+
+    for goals in out.values():
+        goals.sort(key=lambda g: (g.get("created_at") or "", g.get("goal_id") or ""))
+    return out

--- a/backend/main.py
+++ b/backend/main.py
@@ -23,6 +23,7 @@ from harness_config import (
 import notifications as notif
 from tt_paths import data_dir
 import scan_cache
+import codex_goals
 
 def _aware(dt):
     """Ensure datetime is timezone-aware UTC. Naive inputs are assumed to be UTC."""
@@ -4600,6 +4601,21 @@ def _scan_sessions_sync():
             if kids:
                 s["delegation"] = {"supported": True, "tokens_recorded": False,
                                    "linked_children": len(kids)}
+        # Goal Mode (`/goal`). Attached HERE, after the per-session cache
+        # branch, precisely because a goal's status is live mutable state
+        # (active -> paused -> complete): caching it would freeze the first
+        # status we ever saw, the same trap `_annotate_loop_lifecycle` exists
+        # to avoid. `thread_id` is the session id verbatim, so this is a
+        # straight join. One cheap SQLite read for the whole scan.
+        try:
+            goals_by_thread = codex_goals.read_goals(CODEX_DIR)
+        except Exception:
+            goals_by_thread = {}
+        if goals_by_thread:
+            for s in codex_sessions.values():
+                g = goals_by_thread.get(s["id"])
+                if g:
+                    s["goals"] = g
         sessions.extend(codex_sessions.values())
 
     # 3 & 7. Gemini & Antigravity

--- a/backend/test_goals.py
+++ b/backend/test_goals.py
@@ -1,0 +1,210 @@
+"""Tests for Codex Goal Mode (`/goal`) telemetry.
+
+Mirrors test_loops.py: build throwaway SQLite DBs on disk, then assert on what
+`codex_goals.read_goals` returns. The cases that matter are the ones that keep
+the feature HONEST (never invent a status, never show a confident zero for a
+field the agent cannot record) and the ones that survive Codex's real-world
+oddity of shipping two goal DBs at different migration levels.
+"""
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+import codex_goals
+
+
+# --- helpers ---------------------------------------------------------------
+
+V1_SCHEMA = """
+CREATE TABLE thread_goals (
+    thread_id TEXT, goal_id TEXT, objective TEXT, status TEXT,
+    token_budget INTEGER, tokens_used INTEGER, time_used_seconds INTEGER,
+    created_at_ms INTEGER, updated_at_ms INTEGER
+);
+"""
+
+V2_EXTRA = "CREATE TABLE thread_goal_continuation_deferrals (thread_id TEXT);"
+
+
+def make_db(path: Path, rows=(), *, v2=False, deferrals=()):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    con = sqlite3.connect(path)
+    con.executescript(V1_SCHEMA)
+    if v2:
+        con.executescript(V2_EXTRA)
+        con.executemany("INSERT INTO thread_goal_continuation_deferrals VALUES (?)",
+                        [(t,) for t in deferrals])
+    con.executemany("INSERT INTO thread_goals VALUES (?,?,?,?,?,?,?,?,?)", rows)
+    con.commit()
+    con.close()
+
+
+def row(thread="t1", goal="g1", objective="ship it", status="active",
+        budget=None, used=1000, secs=60, created=1_781_336_283_882,
+        updated=1_781_342_475_254):
+    return (thread, goal, objective, status, budget, used, secs, created, updated)
+
+
+@pytest.fixture
+def codex_dir(tmp_path):
+    return tmp_path / ".codex"
+
+
+# --- basic mapping ---------------------------------------------------------
+
+def test_reads_a_goal_and_reports_native_counts(codex_dir):
+    make_db(codex_dir / "goals_1.sqlite", [row(used=270359, secs=2615)])
+    goals = codex_goals.read_goals(codex_dir)
+    assert list(goals) == ["t1"]
+    g = goals["t1"][0]
+    assert g["source"] == "codex"
+    assert g["tokens"] == 270359
+    assert g["duration_seconds"] == 2615
+    assert g["cost_basis"] == "native"
+    # Codex wrote the status down, so we must not label it a guess.
+    assert g["state_source"] == "reported"
+
+
+def test_timestamps_become_aware_utc_iso(codex_dir):
+    make_db(codex_dir / "goals_1.sqlite", [row()])
+    g = codex_goals.read_goals(codex_dir)["t1"][0]
+    assert g["created_at"].startswith("2026-06-13T07:38:03")
+    assert g["created_at"].endswith("+00:00")
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("active", "active"), ("running", "active"), ("in_progress", "active"),
+    ("paused", "paused"), ("complete", "complete"), ("completed", "complete"),
+    ("blocked", "blocked"), ("ACTIVE", "active"), ("  paused ", "paused"),
+])
+def test_status_vocabulary_is_normalised(codex_dir, raw, expected):
+    make_db(codex_dir / "goals_1.sqlite", [row(status=raw)])
+    assert codex_goals.read_goals(codex_dir)["t1"][0]["state"] == expected
+
+
+def test_unknown_status_is_not_guessed_but_raw_is_kept(codex_dir):
+    """A status we don't recognise must degrade to "unknown", never to a
+    plausible-looking "active"."""
+    make_db(codex_dir / "goals_1.sqlite", [row(status="hibernating")])
+    g = codex_goals.read_goals(codex_dir)["t1"][0]
+    assert g["state"] == "unknown"
+    assert g["evidence"]["status_raw"] == "hibernating"
+
+
+def test_objective_is_truncated_and_flagged(codex_dir):
+    make_db(codex_dir / "goals_1.sqlite", [row(objective="x" * 500)])
+    g = codex_goals.read_goals(codex_dir)["t1"][0]
+    assert len(g["objective"]) == codex_goals.OBJECTIVE_MAX
+    assert g["objective_truncated"] is True
+
+
+def test_short_objective_not_flagged_truncated(codex_dir):
+    make_db(codex_dir / "goals_1.sqlite", [row(objective="short")])
+    assert codex_goals.read_goals(codex_dir)["t1"][0]["objective_truncated"] is False
+
+
+# --- the two-DB / migration-level trap -------------------------------------
+
+def test_populated_db_wins_over_empty_one_regardless_of_path(codex_dir):
+    """Codex leaves an empty newer-schema DB beside a populated older one, so
+    neither "first path" nor "newest schema" picks correctly."""
+    make_db(codex_dir / "sqlite" / "goals_1.sqlite", [row(goal="real")])
+    make_db(codex_dir / "goals_1.sqlite", [], v2=True)
+    goals = codex_goals.read_goals(codex_dir)
+    assert goals["t1"][0]["goal_id"] == "real"
+
+
+def test_populated_db_wins_in_the_other_arrangement(codex_dir):
+    make_db(codex_dir / "sqlite" / "goals_1.sqlite", [])
+    make_db(codex_dir / "goals_1.sqlite", [row(goal="real")], v2=True)
+    assert codex_goals.read_goals(codex_dir)["t1"][0]["goal_id"] == "real"
+
+
+def test_v1_db_yields_null_deferrals_not_zero(codex_dir):
+    """None means "this Codex build cannot record deferrals"; 0 would be a
+    confident claim the agent never made."""
+    make_db(codex_dir / "goals_1.sqlite", [row()])
+    assert codex_goals.read_goals(codex_dir)["t1"][0]["evidence"]["deferrals"] is None
+
+
+def test_v2_db_counts_deferrals(codex_dir):
+    make_db(codex_dir / "goals_1.sqlite", [row()], v2=True,
+            deferrals=["t1", "t1", "other"])
+    assert codex_goals.read_goals(codex_dir)["t1"][0]["evidence"]["deferrals"] == 2
+
+
+def test_v2_db_reports_zero_deferrals_when_table_is_empty(codex_dir):
+    make_db(codex_dir / "goals_1.sqlite", [row()], v2=True)
+    assert codex_goals.read_goals(codex_dir)["t1"][0]["evidence"]["deferrals"] == 0
+
+
+# --- robustness: reads never raise -----------------------------------------
+
+def test_missing_dir_yields_no_goals(tmp_path):
+    assert codex_goals.read_goals(tmp_path / "nope") == {}
+
+
+def test_db_without_goals_table_yields_no_goals(codex_dir):
+    codex_dir.mkdir(parents=True)
+    con = sqlite3.connect(codex_dir / "goals_1.sqlite")
+    con.executescript("CREATE TABLE unrelated (x INTEGER);")
+    con.close()
+    assert codex_goals.read_goals(codex_dir) == {}
+
+
+def test_garbage_file_yields_no_goals(codex_dir):
+    codex_dir.mkdir(parents=True)
+    (codex_dir / "goals_1.sqlite").write_bytes(b"not a database at all")
+    assert codex_goals.read_goals(codex_dir) == {}
+
+
+def test_null_and_bad_values_do_not_raise(codex_dir):
+    make_db(codex_dir / "goals_1.sqlite", [
+        ("t1", None, None, None, None, None, None, None, None),
+        ("t2", "g", "o", "active", "notanint", "notanint", "x", "y", "z"),
+    ])
+    goals = codex_goals.read_goals(codex_dir)
+    assert goals["t1"][0]["tokens"] is None
+    assert goals["t1"][0]["state"] == "unknown"
+    assert goals["t1"][0]["created_at"] is None
+    assert goals["t2"][0]["tokens"] is None
+
+
+def test_rows_without_thread_id_are_dropped(codex_dir):
+    make_db(codex_dir / "goals_1.sqlite", [row(thread=None), row(thread="t2")])
+    assert list(codex_goals.read_goals(codex_dir)) == ["t2"]
+
+
+# --- multiple goals --------------------------------------------------------
+
+def test_multiple_goals_on_one_thread_are_ordered_oldest_first(codex_dir):
+    make_db(codex_dir / "goals_1.sqlite", [
+        row(goal="second", created=2_000_000_000_000),
+        row(goal="first", created=1_000_000_000_000),
+    ])
+    ids = [g["goal_id"] for g in codex_goals.read_goals(codex_dir)["t1"]]
+    assert ids == ["first", "second"]
+
+
+def test_goals_split_across_threads(codex_dir):
+    make_db(codex_dir / "goals_1.sqlite", [row(thread="a"), row(thread="b")])
+    goals = codex_goals.read_goals(codex_dir)
+    assert set(goals) == {"a", "b"}
+    assert len(goals["a"]) == 1
+
+
+# --- the honesty invariant -------------------------------------------------
+
+def test_every_goal_declares_a_known_state_and_reported_source(codex_dir):
+    allowed = {"active", "paused", "complete", "blocked", "unknown"}
+    make_db(codex_dir / "goals_1.sqlite", [
+        row(thread=f"t{i}", status=s)
+        for i, s in enumerate(["active", "paused", "complete", "blocked",
+                               "weird", None, ""])
+    ])
+    for goals in codex_goals.read_goals(codex_dir).values():
+        for g in goals:
+            assert g["state"] in allowed
+            assert g["state_source"] == "reported"
+            assert g["cost_basis"] == "native"

--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -5,7 +5,7 @@ import { createPortal } from "react-dom";
 import { useParams, useSearchParams, useRouter } from "next/navigation";
 import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { ArrowLeft, Brain, Code, MessageSquare, Terminal, User, Users, FileText, Activity, Zap, Info, Sparkles, GitBranch, LayoutPanelLeft, ListMusic, ChevronRight, ChevronLeft, Play, Pause, Wrench, Cpu, Folder, AlertTriangle, Hash, Clock, FileCode, Settings2, ChevronDown, ChevronUp, Copy, Maximize2, X, Repeat, Globe, ExternalLink } from "lucide-react";
+import { ArrowLeft, Brain, Code, MessageSquare, Terminal, User, Users, FileText, Activity, Zap, Info, Sparkles, GitBranch, LayoutPanelLeft, ListMusic, ChevronRight, ChevronLeft, Play, Pause, Wrench, Cpu, Folder, AlertTriangle, Hash, Clock, FileCode, Settings2, ChevronDown, ChevronUp, Copy, Maximize2, X, Repeat, Globe, ExternalLink, Target } from "lucide-react";
 import Link from "next/link";
 import { format } from "date-fns";
 import { AgentBadge, Badge, Button, Skeleton } from "@/components/ui";
@@ -69,6 +69,8 @@ interface Session {
   end_reason?: string | null;
   /** TRACE loop metadata; present only on loop sessions (see backend /sessions) */
   loop?: any;
+  /** Goal Mode (`/goal`); a session can set several, so this is a list */
+  goals?: any[];
 }
 
 interface Event {
@@ -878,6 +880,10 @@ export default function SessionDetailPage() {
              {agent === "grok" && grokForensics && <GrokForensicsCard forensics={grokForensics} cost={sessionInfo?.tokens?.cost ?? sessionInfo?.cost} />}
              {/* Recurring loop (/loop, cron, self-perpetuating agent) — full detail */}
              {sessionInfo?.loop?.is_loop && <LoopCard loop={sessionInfo.loop} />}
+             {/* Goal mode (/goal) — one card per goal; a session can set several */}
+             {Array.isArray(sessionInfo?.goals) && sessionInfo.goals.map((g: any, i: number) => (
+               <GoalCard key={g.goal_id || i} goal={g} sessionTokens={sessionInfo?.tokens?.total} />
+             ))}
              {/* Delegated work — subagent spawns and what they actually cost */}
              {delegation && agent && <DelegationCard delegation={delegation} agent={agent} sessionId={id} onOpenSubagent={setSubagentView} />}
              <div className={splitView ? "grid grid-cols-2 gap-8" : "space-y-8"}>
@@ -2474,6 +2480,90 @@ function LoopCard({ loop }: { loop: any }) {
       )}
       <div className="mt-1 text-[10px] text-[var(--tt-fg-dim)]">
         Fires is a lower bound (counted from re-injected prompts in this session).
+      </div>
+    </div>
+  );
+}
+
+
+// One card per `/goal` (Codex Goal Mode). Codex counts a goal's tokens and
+// wall-clock itself, so every number here is REPORTED by the agent, never
+// inferred by us — see docs/design/goal-telemetry.md.
+function GoalCard({ goal, sessionTokens }: { goal: any; sessionTokens?: number }) {
+  const state: string = goal.state ?? "unknown";
+  const tone =
+    state === "active"   ? { ring: "border-emerald-500/40", dot: "bg-emerald-400", text: "text-emerald-400" } :
+    state === "complete" ? { ring: "border-sky-500/40",     dot: "bg-sky-400",     text: "text-sky-400" } :
+    state === "paused"   ? { ring: "border-amber-500/40",   dot: "bg-amber-400",   text: "text-amber-400" } :
+    state === "blocked"  ? { ring: "border-rose-500/40",    dot: "bg-rose-400",    text: "text-rose-400" } :
+                           { ring: "border-[var(--tt-border)]", dot: "bg-[var(--tt-fg-dim)]", text: "text-[var(--tt-fg-dim)]" };
+
+  const fmt = (iso?: string | null) => {
+    if (!iso) return "—";
+    const d = new Date(iso);
+    return isNaN(d.getTime()) ? String(iso) : d.toLocaleString();
+  };
+  const dur = (s?: number | null) => {
+    if (s == null) return "—";
+    if (s < 60) return `${s}s`;
+    if (s < 3600) return `${Math.floor(s / 60)}m ${s % 60}s`;
+    return `${Math.floor(s / 3600)}h ${Math.round((s % 3600) / 60)}m`;
+  };
+
+  const Row = ({ k, v, accent }: { k: string; v: React.ReactNode; accent?: string }) => (
+    <div className="flex justify-between gap-3">
+      <span className="text-[var(--tt-fg-dim)]">{k}</span>
+      <span className={accent || "text-[var(--tt-fg)]"}>{v}</span>
+    </div>
+  );
+
+  const tokens: number | null = goal.tokens ?? null;
+  // The goal's tokens are a SHARE OF the session total, never an addition to
+  // it. Showing the share inline is what stops anyone reading it as extra spend.
+  const share = (tokens != null && sessionTokens && sessionTokens > 0)
+    ? (tokens / sessionTokens) * 100
+    : null;
+
+  return (
+    <div className={`mb-8 bg-[var(--tt-panel)]/60 border ${tone.ring} rounded-[var(--tt-radius-lg)] p-5`}>
+      <div className="flex items-center justify-between mb-3">
+        <div className="text-[10px] font-black uppercase tracking-[0.2em] text-[var(--tt-fg)] flex items-center gap-2">
+          <Target size={12} strokeWidth={3} /> Goal mode
+        </div>
+        <span className={`flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.1em] ${tone.text}`}>
+          <span className={`w-1.5 h-1.5 rounded-full ${tone.dot}`} /> {state}
+        </span>
+      </div>
+
+      {goal.objective && (
+        <div className="mb-3 bg-[var(--tt-sunken)] border border-[var(--tt-border)] rounded-[var(--tt-radius)] px-3 py-2">
+          <span className="text-[9px] uppercase tracking-[0.18em] text-[var(--tt-fg-dim)] block mb-1">Objective</span>
+          <span className="text-[12px] text-[var(--tt-fg-muted)] line-clamp-3">
+            {goal.objective}{goal.objective_truncated ? "…" : ""}
+          </span>
+        </div>
+      )}
+
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-3">
+        <Stat label="Tokens used" value={tokens != null ? tokens.toLocaleString() : "—"} />
+        <Stat label="Time in goal" value={dur(goal.duration_seconds)} />
+        <Stat label="Token budget" value={goal.token_budget != null ? goal.token_budget.toLocaleString() : "none set"} />
+        <Stat label="Share of session" value={share != null ? `${share < 0.1 ? "<0.1" : share.toFixed(1)}%` : "—"} />
+      </div>
+
+      <div className="space-y-1 text-[11px] font-mono text-[var(--tt-fg-muted)]">
+        <Row k="Started" v={fmt(goal.created_at)} />
+        <Row k="Last update" v={fmt(goal.updated_at)} />
+        {goal.evidence?.status_raw && <Row k="Status (agent's own)" v={goal.evidence.status_raw} accent={tone.text} />}
+        {goal.evidence?.deferrals != null && <Row k="Continuation deferrals" v={goal.evidence.deferrals} />}
+        {goal.goal_id && <Row k="Goal id" v={goal.goal_id} />}
+      </div>
+
+      <div className="mt-3 text-[10px] text-[var(--tt-fg-dim)]">
+        {goal.state_source === "reported"
+          ? "Status and counts are reported by Codex itself, and read fresh on every load rather than cached."
+          : "Status is inferred from session breadcrumbs, not reported by the agent."}
+        {tokens != null && " These tokens are part of the session total above, not additional to it."}
       </div>
     </div>
   );


### PR DESCRIPTION
Phase 1 of [`docs/design/goal-telemetry.md`](https://github.com/VasiHemanth/tokentelemetry/pull/197) (design PR #197). Codex is the only supported agent that keeps first-class `/goal` state on disk **and** counts a goal's tokens and wall-clock itself, so it ships first and needs no inference.

Before this, a Codex session that spent 270k tokens under an unattended goal rendered as an ordinary session.


## What it does

`backend/codex_goals.py` reads `~/.codex/**/goals_1.sqlite` and returns `thread_id -> [goal]`. `thread_id` is the Codex session id verbatim (`main.py` rebuilds the same UUID from the rollout filename), so the join needs no translation layer.

The card shows the objective, Codex's own status, tokens used, time in goal, token budget, and the goal's **share of the session**.

## Three things this deliberately gets right

- **Goals attach after the per-session cache branch.** Status is live mutable state (`active → paused → complete`); caching it would freeze whichever status we saw first, exactly the trap `_annotate_loop_lifecycle` exists to avoid.
- **Codex ships two goal DBs at different migration levels, and the populated one is on the *older* schema.** So the DB is picked by row count rather than by path, and `sqlite_master` is probed before touching the v2-only deferrals table. A v1 DB reports `deferrals: null`, never a confident `0`.
- **An unrecognised status degrades to `unknown`**, not to a plausible-looking `active`, with the agent's raw string kept in `evidence.status_raw`.

Goal tokens are shown as a share (4.8% locally) because Codex counts them *inside* the session total. Presenting them as incremental spend would double-count.

## Verification

Not just unit tests. Three independent paths agree on **270,359 tokens / 2,615 s / `paused`**:

| Source | Result |
|---|---|
| `sqlite3` CLI, straight at the DB | `019ebfe9…\|paused\|270359\|2615` |
| `GET /sessions` | same, `state_source: reported` |
| Rendered card | `270,359` · `43m 35s` · `4.8%` |

The 4.77% share recomputes independently from the endpoint's session total, and the timestamps round-trip correctly through IST (`07:38:03Z` → `1:08:03 PM`).

- **27 new tests**, and the suite was **mutation-checked**: first-db-wins, `unknown→active`, and `null→0` deferrals each make it fail.
- Full backend suite: **342 passed** vs **315 on `origin/main`**, with the identical 23 pre-existing failures (verified against a clean `origin/main` worktree).
- `tsc --noEmit` clean.

## Not in this PR

Claude Code, Grok and Antigravity goals (phases 2 and 3). Those need inference and a weaker honesty model; the design doc covers why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
