### PR TITLE
feat(goals): /goal telemetry for all four agents that ship it

### DIFF
--- a/UPDATE.json
+++ b/UPDATE.json
@@ -1,6 +1,21 @@
 {
   "releases": [
     {
+      "tag": "2026-07-26",
+      "title": "See what Codex Goal Mode actually cost",
+      "highlights": [
+        {
+          "title": "Goal Mode on the session trace",
+          "description": "Sessions where you ran Codex's /goal now show a Goal Mode card: the objective, Codex's own status (active, paused, complete or blocked), tokens used, time spent in the goal, and any token budget. A long unattended goal is no longer indistinguishable from an ordinary session.",
+          "href": "/sessions"
+        },
+        {
+          "title": "Goal cost shown as a share, not a second bill",
+          "description": "The card reports a goal's tokens as a percentage of its session total, because Codex counts them inside that total. The numbers come from Codex itself rather than being estimated, and status is re-read on every load so a finished goal never keeps showing as running."
+        }
+      ]
+    },
+    {
       "tag": "2026-07-23",
       "title": "Active loops now show their next run",
       "highlights": [

--- a/UPDATE.json
+++ b/UPDATE.json
@@ -2,16 +2,20 @@
   "releases": [
     {
       "tag": "2026-07-26",
-      "title": "See what Codex Goal Mode actually cost",
+      "title": "See what /goal runs actually cost",
       "highlights": [
         {
-          "title": "Goal Mode on the session trace",
-          "description": "Sessions where you ran Codex's /goal now show a Goal Mode card: the objective, Codex's own status (active, paused, complete or blocked), tokens used, time spent in the goal, and any token budget. A long unattended goal is no longer indistinguishable from an ordinary session.",
+          "title": "Goal cards on the session trace",
+          "description": "Sessions where you set a goal now show a Goal Mode card. Codex reports the objective, status, tokens and time itself. Claude Code shows how many times the goal blocked the agent from stopping and the extra tokens those turns cost. Grok shows its progress checkpoints, and Antigravity shows the goal you typed. An unattended overnight run is no longer indistinguishable from an ordinary session.",
           "href": "/sessions"
         },
         {
-          "title": "Goal cost shown as a share, not a second bill",
-          "description": "The card reports a goal's tokens as a percentage of its session total, because Codex counts them inside that total. The numbers come from Codex itself rather than being estimated, and status is re-read on every load so a finished goal never keeps showing as running."
+          "title": "Every goal says where its status came from",
+          "description": "Only Codex records real goal status, so only Codex cards show it as fact. Everything else is marked \"inferred\", and a Claude goal is never shown as finished because Claude writes no completion event. The card would rather say \"unknown\" than guess."
+        },
+        {
+          "title": "Goal cost is never double-counted",
+          "description": "Cost means three different things here, and each card says which. Codex tokens are shown as a share of the session that already contains them, Claude shows only the extra turns a blocked stop caused, and Grok and Antigravity say plainly that the session is the goal."
         }
       ]
     },

--- a/backend/codex_goals.py
+++ b/backend/codex_goals.py
@@ -1,0 +1,189 @@
+"""Codex Goal Mode (`/goal`) telemetry.
+
+Codex is the only supported agent that keeps first-class goal state on disk, and
+the only one that counts a goal's tokens and wall-clock *itself*. Everything here
+is therefore **reported**, never inferred: we copy Codex's own numbers and its
+own status string, and we never synthesise a status it didn't write.
+
+Design notes in `docs/design/goal-telemetry.md`. Two of them matter for reading
+this file:
+
+1. **Two copies of the DB exist at different migration levels**, and on this
+   machine the *populated* one is on the OLDER schema (v1, no
+   `thread_goal_continuation_deferrals`). So pick the DB by row count rather than
+   by path, and probe `sqlite_master` before touching the v2-only table.
+2. **Goal status is live mutable state** (`active -> paused -> complete`). The
+   caller must attach it outside the session cache, the way loop lifecycle is
+   recomputed per request, or a stale `active` sticks forever.
+
+Reads never raise: a missing, locked, or unexpected DB yields no goals.
+"""
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# Relative to ~/.codex. Order is only a tie-break; row count decides.
+_DB_CANDIDATES = ("sqlite/goals_1.sqlite", "goals_1.sqlite")
+
+_GOALS_TABLE = "thread_goals"
+_DEFERRALS_TABLE = "thread_goal_continuation_deferrals"
+
+# Codex's own vocabulary, normalised. Anything we don't recognise becomes
+# "unknown" rather than being guessed at, but the raw string is kept in
+# evidence.status_raw so the UI can still show what Codex actually said.
+_STATUS_MAP = {
+    "active": "active",
+    "running": "active",
+    "in_progress": "active",
+    "paused": "paused",
+    "complete": "complete",
+    "completed": "complete",
+    "done": "complete",
+    "blocked": "blocked",
+}
+
+OBJECTIVE_MAX = 200
+
+
+def _connect(path: Path) -> Optional[sqlite3.Connection]:
+    """Read-only connection, or None if the file is missing/unreadable."""
+    try:
+        if not path.is_file():
+            return None
+        con = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+        con.execute("PRAGMA busy_timeout=500")
+        return con
+    except (sqlite3.Error, OSError):
+        return None
+
+
+def _tables(con: sqlite3.Connection) -> set:
+    try:
+        return {r[0] for r in con.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'")}
+    except sqlite3.Error:
+        return set()
+
+
+def _pick_db(codex_dir: Path) -> Optional[Path]:
+    """Choose the goals DB that actually has rows.
+
+    Codex leaves an empty newer-schema DB alongside a populated older-schema one,
+    so "newest path wins" and "first path wins" both pick the wrong file. Fall
+    back to any readable DB (so a fresh install with zero goals still resolves)
+    and finally None.
+    """
+    fallback: Optional[Path] = None
+    for rel in _DB_CANDIDATES:
+        path = codex_dir / rel
+        con = _connect(path)
+        if con is None:
+            continue
+        try:
+            if _GOALS_TABLE not in _tables(con):
+                continue
+            if fallback is None:
+                fallback = path
+            try:
+                if con.execute(f"SELECT 1 FROM {_GOALS_TABLE} LIMIT 1").fetchone():
+                    return path
+            except sqlite3.Error:
+                continue
+        finally:
+            con.close()
+    return fallback
+
+
+def _iso(ms: Any) -> Optional[str]:
+    """Epoch milliseconds -> aware UTC ISO string."""
+    try:
+        return datetime.fromtimestamp(int(ms) / 1000, tz=timezone.utc).isoformat()
+    except (TypeError, ValueError, OSError, OverflowError):
+        return None
+
+
+def _int_or_none(v: Any) -> Optional[int]:
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def _deferral_counts(con: sqlite3.Connection) -> Optional[Dict[str, int]]:
+    """thread_id -> deferral count, or None when the table predates migration v2.
+
+    None and 0 mean different things here: 0 is "Codex recorded no deferrals",
+    None is "this Codex version cannot record them", and the UI must not show
+    a confident zero for the latter.
+    """
+    if _DEFERRALS_TABLE not in _tables(con):
+        return None
+    try:
+        return {str(tid): int(n) for tid, n in con.execute(
+            f"SELECT thread_id, COUNT(*) FROM {_DEFERRALS_TABLE} GROUP BY thread_id")}
+    except sqlite3.Error:
+        return None
+
+
+def read_goals(codex_dir: Path) -> Dict[str, List[Dict[str, Any]]]:
+    """Map Codex `thread_id` -> list of goals, oldest first.
+
+    The thread id is exactly the session id `_scan_sessions_sync` builds for
+    Codex (it rebuilds the same UUID from the rollout filename), so callers can
+    join on it directly with no translation.
+    """
+    out: Dict[str, List[Dict[str, Any]]] = {}
+    db = _pick_db(codex_dir)
+    if db is None:
+        return out
+    con = _connect(db)
+    if con is None:
+        return out
+    try:
+        deferrals = _deferral_counts(con)
+        try:
+            rows = con.execute(
+                f"SELECT thread_id, goal_id, objective, status, token_budget, "
+                f"tokens_used, time_used_seconds, created_at_ms, updated_at_ms "
+                f"FROM {_GOALS_TABLE}"
+            ).fetchall()
+        except sqlite3.Error:
+            return out
+
+        for (thread_id, goal_id, objective, status, budget,
+             tokens_used, time_used, created_ms, updated_ms) in rows:
+            if not thread_id:
+                continue
+            raw = (str(status).strip().lower() if status is not None else "")
+            obj = str(objective or "").strip()
+            goal = {
+                "source": "codex",
+                "goal_id": str(goal_id) if goal_id else None,
+                "objective": obj[:OBJECTIVE_MAX],
+                "objective_truncated": len(obj) > OBJECTIVE_MAX,
+                "created_at": _iso(created_ms),
+                "updated_at": _iso(updated_ms),
+                # Codex wrote this down; we are not guessing.
+                "state": _STATUS_MAP.get(raw, "unknown"),
+                "state_source": "reported",
+                "tokens": _int_or_none(tokens_used),
+                "duration_seconds": _int_or_none(time_used),
+                "token_budget": _int_or_none(budget),
+                # Native counts: a SHARE OF the session total, never an addition.
+                "cost_basis": "native",
+                "evidence": {
+                    "status_raw": str(status) if status is not None else None,
+                    "deferrals": (deferrals.get(str(thread_id), 0)
+                                  if deferrals is not None else None),
+                },
+            }
+            out.setdefault(str(thread_id), []).append(goal)
+    finally:
+        con.close()
+
+    for goals in out.values():
+        goals.sort(key=lambda g: (g.get("created_at") or "", g.get("goal_id") or ""))
+    return out

--- a/backend/main.py
+++ b/backend/main.py
@@ -24,6 +24,7 @@ import notifications as notif
 from tt_paths import data_dir
 import scan_cache
 import codex_goals
+import hashlib
 
 def _aware(dt):
     """Ensure datetime is timezone-aware UTC. Naive inputs are assumed to be UTC."""
@@ -2591,6 +2592,14 @@ def _scan_grok_sessions() -> List[Dict[str, Any]]:
             if loop:
                 sess["loop"] = loop
 
+            goal = _grok_goal_detect(
+                sess_id_dir,
+                tools_used if isinstance(tools_used, list) else [],
+                created, updated,
+            )
+            if goal:
+                sess["goals"] = [goal]
+
             if grok_spawns:
                 by_type: Dict[str, Dict[str, Any]] = {}
                 for sp in grok_spawns:
@@ -2616,6 +2625,138 @@ def _scan_grok_sessions() -> List[Dict[str, Any]]:
             child = grok_by_id.get(cid)
             if child is not None:
                 child["parent_session_id"] = s["id"]
+    return out
+
+
+def _grok_goal_detect(sess_dir: Path, tools_used: List[str],
+                      created: Optional[str], updated: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Detect Grok Build's autonomous goal from `update_goal` tool calls.
+
+    Grok reports progress through an `update_goal` tool rather than a stop
+    condition, so the evidence is a stream of checkpoints, the last of which may
+    carry `completed: true`.
+
+    Two things this refuses to claim, both established from local data:
+
+    - **The objective is not recoverable.** All 25 local sessions using
+      `update_goal` did so with no `/goal` user message anywhere, i.e. the tool
+      was in the toolset and the model drove it from skill instructions. So we
+      surface the latest progress message and leave `objective` null rather than
+      passing a status line off as the user's objective.
+    - **No completion flag does not mean "still running".** A finished session
+      that never reported `completed` is genuinely unknown, so it gets
+      "unknown", not "active".
+
+    Gated on `update_goal` appearing in signals.toolsUsed, so the file read is
+    skipped for the overwhelming majority of sessions.
+    """
+    if "update_goal" not in (tools_used or []):
+        return None
+    path = sess_dir / GROK_CHAT_HISTORY
+    checkpoints: List[str] = []
+    completed = False
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            for line in f:
+                if "update_goal" not in line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except Exception:
+                    continue
+                for tc in rec.get("tool_calls") or []:
+                    if not isinstance(tc, dict):
+                        continue
+                    name = tc.get("name") or (tc.get("function") or {}).get("name")
+                    if name != "update_goal":
+                        continue
+                    args = tc.get("arguments")
+                    if isinstance(args, str):
+                        try:
+                            args = json.loads(args)
+                        except Exception:
+                            args = {}
+                    if not isinstance(args, dict):
+                        continue
+                    msg = str(args.get("message") or "").strip()
+                    if msg:
+                        checkpoints.append(msg)
+                    if args.get("completed") is True:
+                        completed = True
+    except OSError:
+        return None
+    if not checkpoints and not completed:
+        return None
+    return {
+        "source": "grok",
+        "goal_id": None,
+        "objective": None,
+        "objective_truncated": False,
+        "created_at": created,
+        "updated_at": updated,
+        "state": "complete" if completed else "unknown",
+        "state_source": "inferred",
+        # Checkpoints carry no timestamps and no token accounting, so there is
+        # no per-goal boundary to cost. The session IS the goal here.
+        "tokens": None,
+        "duration_seconds": None,
+        "token_budget": None,
+        "cost_basis": "session",
+        "evidence": {
+            "checkpoints": len(checkpoints),
+            "completed": completed,
+            "latest_message": checkpoints[-1][:codex_goals.OBJECTIVE_MAX] if checkpoints else None,
+            "objective_recoverable": False,
+        },
+    }
+
+
+def _antigravity_goal_detect(transcript: Path) -> List[Dict[str, Any]]:
+    """Detect Antigravity `/goal` markers.
+
+    Antigravity's `/goal` is a prompt marker, not machinery: the request arrives
+    wrapped as `<USER_REQUEST>/goal <text>/goal</USER_REQUEST>` and the agent's
+    context explains it as work "intended to run for a long time without user
+    input". There is no status and no completion signal, so every one of these
+    is `unknown` by construction — but unlike Grok, the objective IS the marker
+    text, so it can be shown.
+    """
+    out: List[Dict[str, Any]] = []
+    seen: set = set()
+    try:
+        with open(transcript, "r", encoding="utf-8", errors="replace") as f:
+            for line in f:
+                if "/goal" not in line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except Exception:
+                    continue
+                blob = json.dumps(rec)
+                for m in _ANTIGRAVITY_GOAL_RE.finditer(blob):
+                    text = m.group(1).replace("\\n", " ").replace('\\"', '"').strip()
+                    text = text.split("/goal")[0].strip()
+                    key = text[:80]
+                    if not text or key in seen:
+                        continue
+                    seen.add(key)
+                    out.append({
+                        "source": "antigravity",
+                        "goal_id": None,
+                        "objective": text[:codex_goals.OBJECTIVE_MAX],
+                        "objective_truncated": len(text) > codex_goals.OBJECTIVE_MAX,
+                        "created_at": rec.get("timestamp") or rec.get("ts"),
+                        "updated_at": None,
+                        "state": "unknown",
+                        "state_source": "inferred",
+                        "tokens": None,
+                        "duration_seconds": None,
+                        "token_budget": None,
+                        "cost_basis": "session",
+                        "evidence": {"marker_only": True},
+                    })
+    except OSError:
+        return []
     return out
 
 
@@ -3374,6 +3515,29 @@ def _antigravity_link_subagents(sessions: List[Dict[str, Any]]) -> None:
                     child["parent_session_id"] = sid
 
 
+def _antigravity_attach_goals(sessions: List[Dict[str, Any]]) -> None:
+    """Attach `/goal` markers to Antigravity sessions.
+
+    `transcript.jsonl` and `transcript_full.jsonl` duplicate each other, so only
+    the former is read; reading both would double every goal.
+    """
+    ag = [s for s in sessions if s.get("agent") == "antigravity"]
+    if not ag:
+        return
+    for sess in ag:
+        for brain_dir in ANTIGRAVITY_BRAIN_DIRS:
+            tpath = brain_dir / sess["id"] / ".system_generated" / "logs" / "transcript.jsonl"
+            try:
+                if not tpath.exists():
+                    continue
+            except OSError:
+                continue
+            goals = _antigravity_goal_detect(tpath)
+            if goals:
+                sess["goals"] = goals
+            break
+
+
 # Brain dirs Antigravity itself manages — NOT user-facing artifacts.
 _ANTIGRAVITY_INTERNAL_DIRS = {".system_generated", ".agents"}
 _ANTIGRAVITY_IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".webp"}
@@ -3905,10 +4069,118 @@ def _annotate_loop_lifecycle(sessions: List[Dict[str, Any]], now: datetime) -> N
         lp["next_fire_at"] = nxt.isoformat() if nxt else None
 
 
+# --- /goal detection (Claude Code) -----------------------------------------
+# `/goal` arms a session-scoped Stop hook: each time Claude tries to end its
+# turn an evaluator checks the condition, and an unmet condition BLOCKS the
+# stop so the agent keeps working. Claude persists no goal state anywhere
+# (verified: no files, no DB under ~/.claude), so the transcript is the only
+# evidence and all of it is text.
+#
+# The honesty constraint that shapes this code: there is NO terminal event.
+# Nothing is ever written when a goal is met, cleared, or abandoned. So a
+# Claude goal may only ever be "armed", "blocked" or "unknown" — never
+# "complete". Inferring completion here would be inventing a fact.
+# Antigravity wraps the request as <USER_REQUEST>\n/goal <text>/goal\n</...>.
+# Matched against the json.dumps'd record, so the newline is the two characters
+# \ and n rather than a real newline.
+_ANTIGRAVITY_GOAL_RE = re.compile(r"<USER_REQUEST>(?:\\n|\s)*/goal\s+(.{1,400}?)</USER_REQUEST>", re.S)
+_GOAL_ARM_RE = re.compile(
+    r'session-scoped Stop hook is now active with condition:\s*"?(.{0,400})',
+    re.S)
+_GOAL_BLOCK_PREFIX = "Stop hook feedback"
+# Blocks closer together than this belong to the same burst (the agent being
+# pushed back repeatedly on one stop attempt) rather than to separate turns.
+# Calibrated against real data rather than guessed: inside a genuine run the
+# observed gaps are 42s and below, while the nearest true break is 169s. 120s
+# separates them cleanly and makes the longest burst come out at exactly 8,
+# which is the documented cap firing. A looser 300s merges the break and
+# reports 9, i.e. a cap that appears to have been exceeded.
+_GOAL_BURST_GAP_SEC = 120
+# Claude Code ends the turn with a warning after this many CONSECUTIVE blocks
+# (changelog; overridable in the CLI via CLAUDE_CODE_STOP_HOOK_BLOCK_CAP, and
+# absent from the public hooks docs). Used only to flag a burst that looks like
+# it hit the ceiling, never to age a goal out.
+_GOAL_BLOCK_CAP = 8
+
+
+def _goal_key(ts: Any, condition: str) -> str:
+    """Identity for de-duplication.
+
+    A compacted transcript replays earlier records, so the same arm shows up at
+    two line numbers with an identical timestamp and condition.
+    """
+    return f"{ts}|{hashlib.sha1((condition or '').encode('utf-8', 'replace')).hexdigest()[:12]}"
+
+
+def _claude_build_goals(arms: List[Dict[str, Any]],
+                        blocks: List[Dict[str, Any]],
+                        usage_by_arm: Dict[int, Dict[str, int]],
+                        model: Optional[str]) -> List[Dict[str, Any]]:
+    """Assemble Claude `/goal` records from arm + block breadcrumbs.
+
+    `arms` are already de-duplicated and in file order; each block carries the
+    index of the arm that was live when it fired, so a session that armed
+    several goals attributes each block to the right one.
+    """
+    out: List[Dict[str, Any]] = []
+    for i, arm in enumerate(arms):
+        mine = [b for b in blocks if b.get("arm") == i]
+        stamps = [b["ts"] for b in mine if b.get("ts")]
+        stamps.sort()
+
+        # Group into bursts: a run of blocks against one stop attempt.
+        bursts: List[int] = []
+        prev: Optional[datetime] = None
+        for s in stamps:
+            t = _loop_parse_ts(s)
+            if t is None:
+                continue
+            if prev is not None and (t - prev).total_seconds() <= _GOAL_BURST_GAP_SEC:
+                bursts[-1] += 1
+            else:
+                bursts.append(1)
+            prev = t
+
+        u = usage_by_arm.get(i) or {}
+        tokens = (u.get("input", 0) + u.get("output", 0) + u.get("cached", 0)) or None
+        cond = (arm.get("condition") or "").strip()
+        created = arm.get("ts")
+        out.append({
+            "source": "claude",
+            "goal_id": None,
+            "objective": cond[:codex_goals.OBJECTIVE_MAX],
+            "objective_truncated": len(cond) > codex_goals.OBJECTIVE_MAX,
+            "created_at": created,
+            "updated_at": (stamps[-1] if stamps else created),
+            # Never "complete": Claude emits no terminal event to justify it.
+            "state": ("unknown" if not created else ("blocked" if stamps else "armed")),
+            "state_source": "inferred",
+            "tokens": tokens,
+            "duration_seconds": None,
+            "token_budget": None,
+            # Only the turns that exist BECAUSE a stop was blocked; this is
+            # incremental, unlike Codex's whole-goal native count.
+            "cost_basis": "attributed_turns",
+            "cost": (calculate_cost(model, u.get("input", 0), u.get("output", 0),
+                                    u.get("cached", 0),
+                                    cache_creation_tokens=u.get("cache_creation", 0),
+                                    cache_creation_1h_tokens=u.get("cache_creation_1h", 0))
+                     if tokens else None),
+            "evidence": {
+                "blocks": len(stamps),
+                "first_block": stamps[0] if stamps else None,
+                "last_block": stamps[-1] if stamps else None,
+                "block_bursts": bursts,
+                "cap_hit": bool(bursts and max(bursts) >= _GOAL_BLOCK_CAP),
+            },
+        })
+    return out
+
+
 _CLAUDE_CACHE_FIELDS = (
     "tokens", "model", "cost", "mcp_tools", "has_plan", "plans",
     "delegation", "delegated_cost", "tool_counts", "mcp_usage", "skills_used",
-    "loop", "published_artifacts",
+    "loop", "published_artifacts", "goals",
 )
 
 
@@ -4145,6 +4417,11 @@ def _scan_sessions_sync():
                                   "cache_creation": 0, "cache_creation_1h": 0}  # loop's OWN footprint
                     artifact_calls: Dict[str, Dict[str, Any]] = {}  # Artifact tool_use_id -> input meta
                     published_arts: Dict[str, Dict[str, Any]] = {}  # hosted url -> published-artifact record
+                    goal_arms: List[Dict[str, Any]] = []     # /goal arms, de-duplicated
+                    goal_arm_keys: set = set()               # (ts, condition) seen — compaction replays them
+                    goal_blocks: List[Dict[str, Any]] = []   # each blocked stop, tagged with its arm
+                    goal_span_arm: Optional[int] = None      # arm index owning the current post-block span
+                    goal_usage_by_arm: Dict[int, Dict[str, int]] = {}  # arm idx -> attributed footprint
                     try:
                         with open(session_file, "r", encoding="utf-8", errors="replace") as f:
                             for line in f:
@@ -4177,6 +4454,18 @@ def _scan_sessions_sync():
                                             loop_usage["cached"] = max(loop_usage["cached"], cr)
                                             loop_usage["cache_creation"] += cc
                                             loop_usage["cache_creation_1h"] += cc_1h
+                                        if goal_span_arm is not None:
+                                            # This turn exists only because a stop was BLOCKED, so
+                                            # it is the goal's incremental cost. Same span technique
+                                            # as the loop footprint above.
+                                            gu = goal_usage_by_arm.setdefault(goal_span_arm, {
+                                                "input": 0, "output": 0, "cached": 0,
+                                                "cache_creation": 0, "cache_creation_1h": 0})
+                                            gu["input"] += usage.get("input_tokens", 0) or 0
+                                            gu["output"] += usage.get("output_tokens", 0) or 0
+                                            gu["cached"] = max(gu["cached"], cr)
+                                            gu["cache_creation"] += cc
+                                            gu["cache_creation_1h"] += cc_1h
                                     sess["tokens"]["total"] = sess["tokens"]["input"] + sess["tokens"]["output"] + sess["tokens"]["cached"]
                                     sess["cost"] = calculate_cost(sess.get("model"), sess["tokens"]["input"], sess["tokens"]["output"], sess["tokens"]["cached"], cache_creation_tokens=sess["tokens"].get("cache_creation", 0), cache_creation_1h_tokens=sess["tokens"].get("cache_creation_1h", 0))
                                     for item in msg.get("content", []):
@@ -4233,6 +4522,29 @@ def _scan_sessions_sync():
                                 if data.get("type") == "user":
                                     u_msg = data.get("message", {})
                                     u_content = u_msg.get("content", "")
+                                    # /goal breadcrumbs. Deliberately restricted to STRING content
+                                    # on a user record: tool_result blocks arrive as lists and can
+                                    # quote these markers verbatim (any session that greps its own
+                                    # transcript), and assistant prose discussing the feature would
+                                    # otherwise be counted as a real block.
+                                    _goal_block_now = False
+                                    if isinstance(u_content, str) and "Stop hook" in u_content:
+                                        _gm = _GOAL_ARM_RE.search(u_content)
+                                        if _gm:
+                                            _gcond = _gm.group(1).split('". Briefly acknowledge')[0]
+                                            _gkey = _goal_key(data.get("timestamp"), _gcond)
+                                            if _gkey not in goal_arm_keys:
+                                                goal_arm_keys.add(_gkey)
+                                                goal_arms.append({"ts": data.get("timestamp"),
+                                                                  "condition": _gcond})
+                                            goal_span_arm = None
+                                        elif u_content.lstrip().startswith(_GOAL_BLOCK_PREFIX) and goal_arms:
+                                            # Attribute to the goal that was live at this point; a
+                                            # session can arm several in sequence.
+                                            goal_blocks.append({"ts": data.get("timestamp"),
+                                                                "arm": len(goal_arms) - 1})
+                                            goal_span_arm = len(goal_arms) - 1
+                                            _goal_block_now = True
                                     if "/plan" in str(u_content):
                                         sess["has_plan"] = True
                                     for cmd in _COMMAND_NAME_RE.findall(str(u_content)):
@@ -4306,6 +4618,12 @@ def _scan_sessions_sync():
                                         in_loop_span = True
                                     elif _strip_context_tags(u_text).strip():
                                         in_loop_span = False
+                                    # A real user message ends the goal's attributed span; the
+                                    # block record itself must not close the span it just opened.
+                                    if (not _goal_block_now and goal_span_arm is not None
+                                            and _strip_context_tags(
+                                                u_content if isinstance(u_content, str) else u_text).strip()):
+                                        goal_span_arm = None
                     except Exception: continue
                     if last_real_ts:
                         try:
@@ -4316,6 +4634,12 @@ def _scan_sessions_sync():
                         sess["published_artifacts"] = sorted(
                             published_arts.values(),
                             key=lambda a: str(a.get("timestamp") or ""), reverse=True)
+                    if goal_arms:
+                        # Static once the session is written (no wall-clock aging, unlike
+                        # loops and unlike Codex's mutable goal status), so this is safe
+                        # to cache.
+                        sess["goals"] = _claude_build_goals(
+                            goal_arms, goal_blocks, goal_usage_by_arm, sess.get("model"))
                     if loop_sched:
                         primary = loop_sched[0]
                         job_id = next((sc.get("job_id") for sc in loop_sched if sc.get("job_id")), None)
@@ -5555,6 +5879,7 @@ def _scan_sessions_sync():
 
     # Antigravity subagent linkage (needs the full session list to pair ids).
     _antigravity_link_subagents(sessions)
+    _antigravity_attach_goals(sessions)
 
     # Every session gets an explicit delegation marker: agents whose logs carry
     # no spawn signal report supported=False (an honest "n/a", never a fake 0).

--- a/backend/main.py
+++ b/backend/main.py
@@ -23,6 +23,7 @@ from harness_config import (
 import notifications as notif
 from tt_paths import data_dir
 import scan_cache
+import codex_goals
 
 def _aware(dt):
     """Ensure datetime is timezone-aware UTC. Naive inputs are assumed to be UTC."""
@@ -4600,6 +4601,21 @@ def _scan_sessions_sync():
             if kids:
                 s["delegation"] = {"supported": True, "tokens_recorded": False,
                                    "linked_children": len(kids)}
+        # Goal Mode (`/goal`). Attached HERE, after the per-session cache
+        # branch, precisely because a goal's status is live mutable state
+        # (active -> paused -> complete): caching it would freeze the first
+        # status we ever saw, the same trap `_annotate_loop_lifecycle` exists
+        # to avoid. `thread_id` is the session id verbatim, so this is a
+        # straight join. One cheap SQLite read for the whole scan.
+        try:
+            goals_by_thread = codex_goals.read_goals(CODEX_DIR)
+        except Exception:
+            goals_by_thread = {}
+        if goals_by_thread:
+            for s in codex_sessions.values():
+                g = goals_by_thread.get(s["id"])
+                if g:
+                    s["goals"] = g
         sessions.extend(codex_sessions.values())
 
     # 3 & 7. Gemini & Antigravity

--- a/backend/scan_cache.py
+++ b/backend/scan_cache.py
@@ -34,7 +34,7 @@ logger = logging.getLogger("tokentelemetry.scan_cache")
 # update that affects cached costs. `_mtime` only detects source-transcript
 # changes; this detects code changes. A mismatch is a miss, so stale entries
 # are transparently reparsed and rewritten — never migrated in place.
-CACHE_VERSION = 5  # v2: added "loop" field; v3: added loop footprint_tokens/footprint_cost; v4: added published_artifacts; v5: page artifacts carry source path
+CACHE_VERSION = 6  # v2: added "loop" field; v3: added loop footprint_tokens/footprint_cost; v4: added published_artifacts; v5: page artifacts carry source path; v6: added "goals" (/goal)
 
 
 def _require_safe_component(candidate: str) -> str:

--- a/backend/test_goals.py
+++ b/backend/test_goals.py
@@ -208,3 +208,333 @@ def test_every_goal_declares_a_known_state_and_reported_source(codex_dir):
             assert g["state"] in allowed
             assert g["state_source"] == "reported"
             assert g["cost_basis"] == "native"
+
+
+# ===========================================================================
+# Claude Code / Grok / Antigravity — the inferred agents.
+#
+# These have no first-class goal store, so the tests below are mostly about
+# what the parser must REFUSE to conclude.
+# ===========================================================================
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+import main  # noqa: E402
+
+ARM = ('A session-scoped Stop hook is now active with condition: "{cond}". '
+       "Briefly acknowledge the goal, then immediately start working toward it.")
+GOAL_SID = "11111111-2222-3333-4444-555555555555"
+
+
+@pytest.fixture
+def scan_env(tmp_path, monkeypatch):
+    """Hermetic scan: every agent store points at empty tmp paths, so only the
+    Claude tree we build is discovered."""
+    missing = tmp_path / "missing"
+    for attr in ("CODEX_DIR", "GEMINI_DIR", "QWEN_DIR", "VIBE_DIR", "OLLAMA_DIR",
+                 "GROK_SESSIONS_DIR", "VSCODE_STORAGE", "CURSOR_STORAGE",
+                 "COPILOT_CLI_DIR", "ANTIGRAVITY_BRAIN_DIR", "ANTIGRAVITY_CLI_DIR",
+                 "HERMES_DIR", "PI_SESSIONS_DIR"):
+        monkeypatch.setattr(main, attr, missing / attr.lower())
+    monkeypatch.setattr(main, "ANTIGRAVITY_BRAIN_SOURCES", [])
+    monkeypatch.setattr(main, "ANTIGRAVITY_BRAIN_DIRS", [])
+    monkeypatch.setattr(main, "_antigravity_cli_meta", lambda *a, **k: {})
+    monkeypatch.setattr(main, "CLAUDE_DIR", tmp_path / ".claude")
+    monkeypatch.setattr(main, "CURSOR_DIR", tmp_path / ".cursor")
+    monkeypatch.setattr(main, "OPENCODE_DB", tmp_path / "opencode.db")
+    monkeypatch.setattr(main, "HERMES_DB", tmp_path / "hermes-state.db")
+    monkeypatch.setattr(main, "HERMES_PROFILES_DIR", missing / "hermes-profiles")
+    monkeypatch.setattr(main, "PROJECT_ALIASES_FILE", tmp_path / "aliases.json")
+    monkeypatch.setenv("TOKENTELEMETRY_DATA_DIR", str(tmp_path / "tt_data"))
+    return tmp_path
+
+
+def claude_session(tmp_path, lines, sid=GOAL_SID):
+    proj = tmp_path / ".claude" / "projects" / "-tmp-goal"
+    proj.mkdir(parents=True, exist_ok=True)
+    (proj / f"{sid}.jsonl").write_text(
+        "".join(json.dumps(x) + "\n" for x in lines), encoding="utf-8")
+
+
+def scan_goals(sid=GOAL_SID):
+    for s in main._scan_sessions_sync():
+        if s.get("id") == sid:
+            return s.get("goals") or []
+    return []
+
+
+def arm_rec(cond="finish the migration", ts="2026-07-20T00:00:00Z"):
+    return {"type": "user", "timestamp": ts, "cwd": "/tmp/goal",
+            "message": {"role": "user", "content": ARM.format(cond=cond)}}
+
+
+def block_rec(ts, cond="finish the migration"):
+    return {"type": "user", "timestamp": ts,
+            "message": {"role": "user", "content": f"Stop hook feedback:\n[{cond}]"}}
+
+
+def assistant_rec(ts, inp=100, out=50):
+    return {"type": "assistant", "timestamp": ts,
+            "message": {"model": "claude-opus-4-8",
+                        "usage": {"input_tokens": inp, "output_tokens": out},
+                        "content": []}}
+
+
+# --- Claude: arming -------------------------------------------------------
+
+def test_claude_arm_is_detected(scan_env):
+    claude_session(scan_env, [arm_rec()])
+    goals = scan_goals()
+    assert len(goals) == 1
+    assert goals[0]["source"] == "claude"
+    assert goals[0]["state"] == "armed"
+    assert goals[0]["state_source"] == "inferred"
+    assert goals[0]["objective"].startswith("finish the migration")
+
+
+def test_claude_compaction_replay_does_not_double_count(scan_env):
+    """A compacted transcript replays the arm at a second line with an
+    identical timestamp; that is one goal, not two."""
+    a = arm_rec()
+    claude_session(scan_env, [a, assistant_rec("2026-07-20T00:00:01Z"), a])
+    assert len(scan_goals()) == 1
+
+
+def test_claude_two_different_goals_are_two_records(scan_env):
+    claude_session(scan_env, [
+        arm_rec("first goal", "2026-07-20T00:00:00Z"),
+        arm_rec("second goal", "2026-07-20T01:00:00Z"),
+    ])
+    goals = scan_goals()
+    assert len(goals) == 2
+    assert goals[0]["objective"].startswith("first goal")
+    assert goals[1]["objective"].startswith("second goal")
+
+
+# --- Claude: the false-positive classes -----------------------------------
+
+def test_claude_tool_result_quoting_the_marker_is_not_a_goal(scan_env):
+    """A session that greps its own transcript sees these strings in a
+    tool_result. That is evidence of research, not of a goal."""
+    claude_session(scan_env, [{
+        "type": "user", "timestamp": "2026-07-20T00:00:00Z", "cwd": "/tmp/goal",
+        "message": {"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": "t1",
+             "content": ARM.format(cond="not a real goal")}]}}])
+    assert scan_goals() == []
+
+
+def test_claude_assistant_prose_is_not_a_block(scan_env):
+    """Writing ABOUT the feature must not register as having run it — this
+    exact false positive was 2 of 17 blocks machine-wide during research."""
+    claude_session(scan_env, [
+        arm_rec(),
+        {"type": "assistant", "timestamp": "2026-07-20T00:00:01Z",
+         "message": {"model": "claude-opus-4-8", "usage": {},
+                     "content": [{"type": "text",
+                                  "text": "Stop hook feedback: is how blocks appear."}]}},
+    ])
+    goals = scan_goals()
+    assert goals[0]["evidence"]["blocks"] == 0
+    assert goals[0]["state"] == "armed"
+
+
+def test_claude_blocks_without_an_arm_are_ignored(scan_env):
+    """A user-configured Stop hook can block without any /goal involved."""
+    claude_session(scan_env, [block_rec("2026-07-20T00:00:00Z")])
+    assert scan_goals() == []
+
+
+# --- Claude: blocks, bursts, the cap --------------------------------------
+
+def test_claude_blocks_flip_state_and_are_counted(scan_env):
+    claude_session(scan_env, [
+        arm_rec(),
+        block_rec("2026-07-20T00:10:00Z"),
+        block_rec("2026-07-20T00:10:30Z"),
+    ])
+    g = scan_goals()[0]
+    assert g["state"] == "blocked"
+    assert g["evidence"]["blocks"] == 2
+
+
+def test_claude_burst_grouping_matches_the_documented_cap(scan_env):
+    """8 blocks inside the burst window is the cap firing; a gap longer than
+    the window starts a new run instead of inflating the first."""
+    recs = [arm_rec()]
+    for i in range(8):                       # 20s apart -> one burst of 8
+        recs.append(block_rec(f"2026-07-20T00:{10 + (i * 20) // 60:02d}:{(i * 20) % 60:02d}Z"))
+    recs.append(block_rec("2026-07-20T01:00:00Z"))   # far later -> its own run
+    claude_session(scan_env, recs)
+    g = scan_goals()[0]
+    assert g["evidence"]["block_bursts"] == [8, 1]
+    assert g["evidence"]["cap_hit"] is True
+
+
+def test_claude_seven_blocks_do_not_report_the_cap(scan_env):
+    recs = [arm_rec()]
+    for i in range(7):
+        recs.append(block_rec(f"2026-07-20T00:{10 + (i * 20) // 60:02d}:{(i * 20) % 60:02d}Z"))
+    claude_session(scan_env, recs)
+    g = scan_goals()[0]
+    assert g["evidence"]["block_bursts"] == [7]
+    assert g["evidence"]["cap_hit"] is False
+
+
+def test_claude_goal_is_never_complete(scan_env):
+    """Claude emits no terminal event, so no input may yield "complete"."""
+    claude_session(scan_env, [
+        arm_rec(),
+        block_rec("2026-07-20T00:10:00Z"),
+        {"type": "user", "timestamp": "2026-07-20T00:20:00Z",
+         "message": {"role": "user", "content": "thanks, the goal is met, all done"}},
+    ])
+    assert scan_goals()[0]["state"] in ("armed", "blocked", "unknown")
+
+
+def test_claude_blocks_attach_to_the_goal_that_was_live(scan_env):
+    claude_session(scan_env, [
+        arm_rec("first goal", "2026-07-20T00:00:00Z"),
+        block_rec("2026-07-20T00:05:00Z"),
+        arm_rec("second goal", "2026-07-20T01:00:00Z"),
+        block_rec("2026-07-20T01:05:00Z"),
+        block_rec("2026-07-20T01:05:30Z"),
+    ])
+    goals = scan_goals()
+    assert goals[0]["evidence"]["blocks"] == 1
+    assert goals[1]["evidence"]["blocks"] == 2
+
+
+# --- Claude: attributed cost ----------------------------------------------
+
+def test_claude_only_post_block_turns_are_attributed(scan_env):
+    """Work before the first block is ordinary session cost; only turns that
+    ran BECAUSE a stop was blocked belong to the goal."""
+    claude_session(scan_env, [
+        arm_rec(),
+        assistant_rec("2026-07-20T00:01:00Z", inp=9000, out=9000),   # before any block
+        block_rec("2026-07-20T00:10:00Z"),
+        assistant_rec("2026-07-20T00:10:05Z", inp=100, out=50),      # caused by the block
+    ])
+    g = scan_goals()[0]
+    assert g["tokens"] == 150
+    assert g["cost_basis"] == "attributed_turns"
+
+
+def test_claude_user_reply_closes_the_attributed_span(scan_env):
+    claude_session(scan_env, [
+        arm_rec(),
+        block_rec("2026-07-20T00:10:00Z"),
+        assistant_rec("2026-07-20T00:10:05Z", inp=100, out=50),
+        {"type": "user", "timestamp": "2026-07-20T00:11:00Z",
+         "message": {"role": "user", "content": "actually, do something else"}},
+        assistant_rec("2026-07-20T00:11:05Z", inp=7000, out=7000),   # not the goal's
+    ])
+    assert scan_goals()[0]["tokens"] == 150
+
+
+def test_claude_armed_goal_with_no_blocks_has_no_attributed_tokens(scan_env):
+    claude_session(scan_env, [arm_rec(), assistant_rec("2026-07-20T00:01:00Z")])
+    assert scan_goals()[0]["tokens"] is None
+
+
+# --- Grok -----------------------------------------------------------------
+
+def write_grok(tmp_path, calls):
+    d = tmp_path / "grok-session"
+    d.mkdir(parents=True, exist_ok=True)
+    lines = [{"type": "assistant", "tool_calls": [
+        {"id": f"c{i}", "name": "update_goal", "arguments": json.dumps(a)}]}
+        for i, a in enumerate(calls)]
+    (d / main.GROK_CHAT_HISTORY).write_text(
+        "".join(json.dumps(x) + "\n" for x in lines), encoding="utf-8")
+    return d
+
+
+def test_grok_requires_the_tool_in_the_toolset(tmp_path):
+    """Gate: "tool available" is not "tool called". Skipping this check is what
+    turned 1,808 candidate files into 88 real invocations during research."""
+    d = write_grok(tmp_path, [{"message": "working"}])
+    assert main._grok_goal_detect(d, [], None, None) is None
+
+
+def test_grok_checkpoints_are_counted(tmp_path):
+    d = write_grok(tmp_path, [{"message": "step one"}, {"message": "step two"}])
+    g = main._grok_goal_detect(d, ["update_goal"], "t0", "t1")
+    assert g["evidence"]["checkpoints"] == 2
+    assert g["evidence"]["latest_message"] == "step two"
+
+
+def test_grok_completed_flag_yields_complete(tmp_path):
+    d = write_grok(tmp_path, [{"message": "a"}, {"completed": True, "message": "done"}])
+    g = main._grok_goal_detect(d, ["update_goal"], None, None)
+    assert g["state"] == "complete"
+    assert g["evidence"]["completed"] is True
+
+
+def test_grok_without_completion_is_unknown_not_active(tmp_path):
+    """An ended session that never reported completion is genuinely unknown;
+    calling it "active" would assert something the data does not support."""
+    d = write_grok(tmp_path, [{"message": "still going"}])
+    assert main._grok_goal_detect(d, ["update_goal"], None, None)["state"] == "unknown"
+
+
+def test_grok_objective_is_not_faked_from_a_progress_message(tmp_path):
+    d = write_grok(tmp_path, [{"message": "Starting the migration"}])
+    g = main._grok_goal_detect(d, ["update_goal"], None, None)
+    assert g["objective"] is None
+    assert g["evidence"]["objective_recoverable"] is False
+    assert g["cost_basis"] == "session"
+    assert g["tokens"] is None
+
+
+def test_grok_missing_file_is_survivable(tmp_path):
+    assert main._grok_goal_detect(tmp_path / "nope", ["update_goal"], None, None) is None
+
+
+# --- Antigravity ----------------------------------------------------------
+
+def write_ag(tmp_path, requests):
+    p = tmp_path / "transcript.jsonl"
+    p.write_text("".join(
+        json.dumps({"role": "user",
+                    "content": f"<USER_REQUEST>\n/goal {r}/goal\n</USER_REQUEST>"}) + "\n"
+        for r in requests), encoding="utf-8")
+    return p
+
+
+def test_antigravity_marker_is_parsed(tmp_path):
+    goals = main._antigravity_goal_detect(write_ag(tmp_path, ["fix the build"]))
+    assert len(goals) == 1
+    assert goals[0]["source"] == "antigravity"
+    assert "fix the build" in goals[0]["objective"]
+    assert goals[0]["state"] == "unknown"
+    assert goals[0]["evidence"]["marker_only"] is True
+
+
+def test_antigravity_repeated_marker_is_deduped(tmp_path):
+    assert len(main._antigravity_goal_detect(
+        write_ag(tmp_path, ["fix the build", "fix the build"]))) == 1
+
+
+def test_antigravity_no_marker_yields_nothing(tmp_path):
+    p = tmp_path / "transcript.jsonl"
+    p.write_text(json.dumps({"content": "just a normal message"}) + "\n", encoding="utf-8")
+    assert main._antigravity_goal_detect(p) == []
+
+
+def test_antigravity_missing_file_is_survivable(tmp_path):
+    assert main._antigravity_goal_detect(tmp_path / "nope.jsonl") == []
+
+
+# --- cross-agent invariants -----------------------------------------------
+
+def test_no_inferred_agent_ever_claims_native_cost(tmp_path):
+    """cost_basis "native" means the agent counted the tokens itself. Only
+    Codex may claim it; the rest must not, or the numbers get summed."""
+    d = write_grok(tmp_path, [{"message": "x"}])
+    assert main._grok_goal_detect(d, ["update_goal"], None, None)["cost_basis"] == "session"
+    ag = main._antigravity_goal_detect(write_ag(tmp_path, ["y"]))
+    assert ag[0]["cost_basis"] == "session"

--- a/backend/test_goals.py
+++ b/backend/test_goals.py
@@ -1,0 +1,210 @@
+"""Tests for Codex Goal Mode (`/goal`) telemetry.
+
+Mirrors test_loops.py: build throwaway SQLite DBs on disk, then assert on what
+`codex_goals.read_goals` returns. The cases that matter are the ones that keep
+the feature HONEST (never invent a status, never show a confident zero for a
+field the agent cannot record) and the ones that survive Codex's real-world
+oddity of shipping two goal DBs at different migration levels.
+"""
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+import codex_goals
+
+
+# --- helpers ---------------------------------------------------------------
+
+V1_SCHEMA = """
+CREATE TABLE thread_goals (
+    thread_id TEXT, goal_id TEXT, objective TEXT, status TEXT,
+    token_budget INTEGER, tokens_used INTEGER, time_used_seconds INTEGER,
+    created_at_ms INTEGER, updated_at_ms INTEGER
+);
+"""
+
+V2_EXTRA = "CREATE TABLE thread_goal_continuation_deferrals (thread_id TEXT);"
+
+
+def make_db(path: Path, rows=(), *, v2=False, deferrals=()):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    con = sqlite3.connect(path)
+    con.executescript(V1_SCHEMA)
+    if v2:
+        con.executescript(V2_EXTRA)
+        con.executemany("INSERT INTO thread_goal_continuation_deferrals VALUES (?)",
+                        [(t,) for t in deferrals])
+    con.executemany("INSERT INTO thread_goals VALUES (?,?,?,?,?,?,?,?,?)", rows)
+    con.commit()
+    con.close()
+
+
+def row(thread="t1", goal="g1", objective="ship it", status="active",
+        budget=None, used=1000, secs=60, created=1_781_336_283_882,
+        updated=1_781_342_475_254):
+    return (thread, goal, objective, status, budget, used, secs, created, updated)
+
+
+@pytest.fixture
+def codex_dir(tmp_path):
+    return tmp_path / ".codex"
+
+
+# --- basic mapping ---------------------------------------------------------
+
+def test_reads_a_goal_and_reports_native_counts(codex_dir):
+    make_db(codex_dir / "goals_1.sqlite", [row(used=270359, secs=2615)])
+    goals = codex_goals.read_goals(codex_dir)
+    assert list(goals) == ["t1"]
+    g = goals["t1"][0]
+    assert g["source"] == "codex"
+    assert g["tokens"] == 270359
+    assert g["duration_seconds"] == 2615
+    assert g["cost_basis"] == "native"
+    # Codex wrote the status down, so we must not label it a guess.
+    assert g["state_source"] == "reported"
+
+
+def test_timestamps_become_aware_utc_iso(codex_dir):
+    make_db(codex_dir / "goals_1.sqlite", [row()])
+    g = codex_goals.read_goals(codex_dir)["t1"][0]
+    assert g["created_at"].startswith("2026-06-13T07:38:03")
+    assert g["created_at"].endswith("+00:00")
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("active", "active"), ("running", "active"), ("in_progress", "active"),
+    ("paused", "paused"), ("complete", "complete"), ("completed", "complete"),
+    ("blocked", "blocked"), ("ACTIVE", "active"), ("  paused ", "paused"),
+])
+def test_status_vocabulary_is_normalised(codex_dir, raw, expected):
+    make_db(codex_dir / "goals_1.sqlite", [row(status=raw)])
+    assert codex_goals.read_goals(codex_dir)["t1"][0]["state"] == expected
+
+
+def test_unknown_status_is_not_guessed_but_raw_is_kept(codex_dir):
+    """A status we don't recognise must degrade to "unknown", never to a
+    plausible-looking "active"."""
+    make_db(codex_dir / "goals_1.sqlite", [row(status="hibernating")])
+    g = codex_goals.read_goals(codex_dir)["t1"][0]
+    assert g["state"] == "unknown"
+    assert g["evidence"]["status_raw"] == "hibernating"
+
+
+def test_objective_is_truncated_and_flagged(codex_dir):
+    make_db(codex_dir / "goals_1.sqlite", [row(objective="x" * 500)])
+    g = codex_goals.read_goals(codex_dir)["t1"][0]
+    assert len(g["objective"]) == codex_goals.OBJECTIVE_MAX
+    assert g["objective_truncated"] is True
+
+
+def test_short_objective_not_flagged_truncated(codex_dir):
+    make_db(codex_dir / "goals_1.sqlite", [row(objective="short")])
+    assert codex_goals.read_goals(codex_dir)["t1"][0]["objective_truncated"] is False
+
+
+# --- the two-DB / migration-level trap -------------------------------------
+
+def test_populated_db_wins_over_empty_one_regardless_of_path(codex_dir):
+    """Codex leaves an empty newer-schema DB beside a populated older one, so
+    neither "first path" nor "newest schema" picks correctly."""
+    make_db(codex_dir / "sqlite" / "goals_1.sqlite", [row(goal="real")])
+    make_db(codex_dir / "goals_1.sqlite", [], v2=True)
+    goals = codex_goals.read_goals(codex_dir)
+    assert goals["t1"][0]["goal_id"] == "real"
+
+
+def test_populated_db_wins_in_the_other_arrangement(codex_dir):
+    make_db(codex_dir / "sqlite" / "goals_1.sqlite", [])
+    make_db(codex_dir / "goals_1.sqlite", [row(goal="real")], v2=True)
+    assert codex_goals.read_goals(codex_dir)["t1"][0]["goal_id"] == "real"
+
+
+def test_v1_db_yields_null_deferrals_not_zero(codex_dir):
+    """None means "this Codex build cannot record deferrals"; 0 would be a
+    confident claim the agent never made."""
+    make_db(codex_dir / "goals_1.sqlite", [row()])
+    assert codex_goals.read_goals(codex_dir)["t1"][0]["evidence"]["deferrals"] is None
+
+
+def test_v2_db_counts_deferrals(codex_dir):
+    make_db(codex_dir / "goals_1.sqlite", [row()], v2=True,
+            deferrals=["t1", "t1", "other"])
+    assert codex_goals.read_goals(codex_dir)["t1"][0]["evidence"]["deferrals"] == 2
+
+
+def test_v2_db_reports_zero_deferrals_when_table_is_empty(codex_dir):
+    make_db(codex_dir / "goals_1.sqlite", [row()], v2=True)
+    assert codex_goals.read_goals(codex_dir)["t1"][0]["evidence"]["deferrals"] == 0
+
+
+# --- robustness: reads never raise -----------------------------------------
+
+def test_missing_dir_yields_no_goals(tmp_path):
+    assert codex_goals.read_goals(tmp_path / "nope") == {}
+
+
+def test_db_without_goals_table_yields_no_goals(codex_dir):
+    codex_dir.mkdir(parents=True)
+    con = sqlite3.connect(codex_dir / "goals_1.sqlite")
+    con.executescript("CREATE TABLE unrelated (x INTEGER);")
+    con.close()
+    assert codex_goals.read_goals(codex_dir) == {}
+
+
+def test_garbage_file_yields_no_goals(codex_dir):
+    codex_dir.mkdir(parents=True)
+    (codex_dir / "goals_1.sqlite").write_bytes(b"not a database at all")
+    assert codex_goals.read_goals(codex_dir) == {}
+
+
+def test_null_and_bad_values_do_not_raise(codex_dir):
+    make_db(codex_dir / "goals_1.sqlite", [
+        ("t1", None, None, None, None, None, None, None, None),
+        ("t2", "g", "o", "active", "notanint", "notanint", "x", "y", "z"),
+    ])
+    goals = codex_goals.read_goals(codex_dir)
+    assert goals["t1"][0]["tokens"] is None
+    assert goals["t1"][0]["state"] == "unknown"
+    assert goals["t1"][0]["created_at"] is None
+    assert goals["t2"][0]["tokens"] is None
+
+
+def test_rows_without_thread_id_are_dropped(codex_dir):
+    make_db(codex_dir / "goals_1.sqlite", [row(thread=None), row(thread="t2")])
+    assert list(codex_goals.read_goals(codex_dir)) == ["t2"]
+
+
+# --- multiple goals --------------------------------------------------------
+
+def test_multiple_goals_on_one_thread_are_ordered_oldest_first(codex_dir):
+    make_db(codex_dir / "goals_1.sqlite", [
+        row(goal="second", created=2_000_000_000_000),
+        row(goal="first", created=1_000_000_000_000),
+    ])
+    ids = [g["goal_id"] for g in codex_goals.read_goals(codex_dir)["t1"]]
+    assert ids == ["first", "second"]
+
+
+def test_goals_split_across_threads(codex_dir):
+    make_db(codex_dir / "goals_1.sqlite", [row(thread="a"), row(thread="b")])
+    goals = codex_goals.read_goals(codex_dir)
+    assert set(goals) == {"a", "b"}
+    assert len(goals["a"]) == 1
+
+
+# --- the honesty invariant -------------------------------------------------
+
+def test_every_goal_declares_a_known_state_and_reported_source(codex_dir):
+    allowed = {"active", "paused", "complete", "blocked", "unknown"}
+    make_db(codex_dir / "goals_1.sqlite", [
+        row(thread=f"t{i}", status=s)
+        for i, s in enumerate(["active", "paused", "complete", "blocked",
+                               "weird", None, ""])
+    ])
+    for goals in codex_goals.read_goals(codex_dir).values():
+        for g in goals:
+            assert g["state"] in allowed
+            assert g["state_source"] == "reported"
+            assert g["cost_basis"] == "native"

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -13,3 +13,4 @@ it in the feature's PR.
 | Durable history + analytics date filters | [durable-history.md](durable-history.md) | [ADR-0002](../adr/0002-durable-history-rollup.md) |
 | Delegation & ecosystem telemetry | [`../../DESIGN.md`](../../DESIGN.md) | — (pre-ADR) |
 | Documentation site + community resources | [documentation-site.md](documentation-site.md) | [ADR-0003](../adr/0003-docs-site-fumadocs.md) |
+| `/goal` telemetry (plan) | [goal-telemetry.md](goal-telemetry.md) | — |

--- a/docs/design/goal-telemetry.md
+++ b/docs/design/goal-telemetry.md
@@ -5,7 +5,9 @@ Companion to the `/loop` support already in `backend/main.py`
 question, different feature: when a user hands an agent an objective and walks
 away, what did that cost and how did it end?
 
-Status: plan. Nothing here is implemented yet.
+Status: **implemented** for all four agents. Where the build deviated from the
+original plan, the reason is recorded inline under "Changed during
+implementation".
 
 ## What `/goal` actually is
 
@@ -184,9 +186,26 @@ Allowed states per agent, enforced in the annotator so a lie is impossible:
 | Agent | States it may emit |
 |---|---|
 | Codex | `active`, `paused`, `complete`, `blocked` (all `reported`) |
-| Grok | `complete` when a checkpoint carries `completed:true`, else `active` (`inferred`) |
+| Grok | `complete` when a checkpoint carries `completed:true`, else `unknown` (`inferred`) |
 | Claude | `armed`, `blocked`, `unknown`. **Never `complete`.** |
 | Antigravity | `unknown` only |
+
+### Changed during implementation
+
+Two things the plan got wrong, both corrected against local data:
+
+1. **Grok falls back to `unknown`, not `active`.** The plan said a Grok goal
+   with no completion flag is "active". That is an assertion the data does not
+   support: these sessions ended long ago, and a goal that never reported
+   completion may have finished, stalled, or been abandoned. `unknown` is the
+   honest reading, and it keeps Grok consistent with Claude.
+2. **Grok's objective is not recoverable at all.** All 25 local sessions that
+   call `update_goal` do so with **no `/goal` user message anywhere**: the tool
+   sits in the toolset and the model drives it from skill instructions. So
+   `objective` stays null and the UI shows the latest progress message under a
+   "Latest progress" label instead. Passing a status line off as the user's
+   objective would have been the easy, wrong thing. Antigravity is the opposite
+   case: its marker *is* the objective, so that one is shown.
 
 ## Detection
 
@@ -211,9 +230,14 @@ Two traps, both hit during research:
   blocks, which is 12% of the naive machine-wide total. Count blocks only from
   `type: "user"` records, and require the session to have armed a goal first.
 
-Block bursts: group block events with gaps under 5 minutes. Local data shows one
-burst of exactly 8 rapid blocks (15:51:06 to 15:53:39) then a stop, which is the
-documented cap firing, and a later burst of 5.
+Block bursts: group block events by gap. The threshold was **calibrated against
+the real spacing rather than guessed**, because it decides whether `cap_hit`
+means anything. In the one local session with a long run, gaps inside a genuine
+run are 42s and below (43, 23, 23, 20, 19, 11, 11) while the nearest true break
+is 169s. A 120s threshold separates them cleanly and yields bursts of
+`[1, 1, 8, 5]`, i.e. a longest run of exactly 8, which is the documented cap
+firing. The originally-planned 300s threshold merges the break and reports 9,
+which would show a cap that had apparently been exceeded.
 
 ### Codex
 

--- a/docs/design/goal-telemetry.md
+++ b/docs/design/goal-telemetry.md
@@ -1,0 +1,317 @@
+# Design: `/goal` telemetry
+
+Companion to the `/loop` support already in `backend/main.py`
+(`_annotate_loop_lifecycle`, `_grok_loop_detect`, `_cline_loop_specs`). Same
+question, different feature: when a user hands an agent an objective and walks
+away, what did that cost and how did it end?
+
+Status: plan. Nothing here is implemented yet.
+
+## What `/goal` actually is
+
+`/goal` is not one feature. Four agents ship a command with that name and all
+four mean something different by it, with very different amounts of evidence
+left on disk. Everything below was verified against local docs bundles, the
+Claude Code changelog, and this machine's own session data (read-only).
+
+### Claude Code
+
+Built-in. From `~/.claude/cache/changelog.md`:
+
+> Added `/goal` command: set a completion condition and Claude keeps working
+> across turns until it's met. Works in interactive, `-p`, and Remote Control.
+> Shows live elapsed/turns/tokens as an overlay panel
+
+Mechanically it arms a session-scoped **Stop hook**. Each time the agent tries
+to end its turn, an evaluator checks the condition; if unmet, the stop is
+blocked and the agent keeps going. The same changelog records the safety valve:
+
+> Fixed stop hooks that block repeatedly looping forever: the turn now ends with
+> a warning after 8 consecutive blocks (override via
+> `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP`)
+
+The 8-block cap is **not** in the public hooks docs (checked
+`code.claude.com/docs/en/hooks`); the changelog is the only source, and local
+data agrees (see below). Treat it as a real but version-dependent constant, and
+read `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP` before assuming 8.
+
+### Codex
+
+The richest of the four, and the only one with a purpose-built store:
+`~/.codex/sqlite/goals_1.sqlite`.
+
+```
+thread_goals(thread_id, goal_id, objective, status, token_budget,
+             tokens_used, time_used_seconds, created_at_ms, updated_at_ms)
+thread_goal_continuation_deferrals(thread_id)     -- migration v2 only
+```
+
+Codex counts a goal's tokens and wall-clock **itself**. Statuses seen in its
+internal prompt: `complete`, `blocked`, plus `paused` observed in the data. The
+prompt also instructs the model to report final consumed budget against
+`token_budget` when a goal completes.
+
+Two copies of this DB exist on disk and they are **at different migration
+levels**, which matters more than it looks:
+
+| Path | Migrations | Tables | Rows |
+|---|---|---|---|
+| `~/.codex/sqlite/goals_1.sqlite` | v1 | `thread_goals` only | 1 |
+| `~/.codex/goals_1.sqlite` | v1, v2 | + `thread_goal_continuation_deferrals` | 0 |
+
+So the populated DB is on the *older* schema and does not have the deferrals
+table at all. The reader must pick the DB by row count, and must probe
+`sqlite_master` before touching `thread_goal_continuation_deferrals` rather than
+assuming the newer schema. Querying it blindly raises
+`no such table` (hit while researching this doc).
+
+### Grok Build
+
+From its local docs bundle, `~/.grok/docs/user-guide/04-slash-commands.md`:
+
+> Set, manage, or check an autonomous goal. Grok works toward the objective
+> across turns and reports progress.
+> Arguments: `<objective>`, `status`, `pause`, `resume`, or `clear`.
+> **Availability:** appears only when the goal feature is enabled and the
+> `update_goal` tool is in the session toolset.
+
+Progress is reported through an `update_goal` **tool call** carrying
+`{"message": "..."}` and, at the end, `{"completed": true, "message": "..."}`.
+This is a checkpoint stream, not a stop-blocking condition.
+
+### Antigravity
+
+`/goal` wraps the user's request as a marker rather than driving any machinery.
+The transcript carries `<USER_REQUEST>\n/goal <text>/goal\n</USER_REQUEST>`, and
+the agent's own context explains it as a task "intended to run for a long time
+without user input, e.g. overnight". No status, no completion signal.
+
+### Support matrix
+
+Counts are from this machine, deduped, read-only.
+
+| Agent | Has `/goal` | Mechanism | Durable evidence | Local usage |
+|---|---|---|---|---|
+| Claude Code | yes | Stop-hook completion condition + evaluator | transcript text only | 15 sessions armed, 30 goals, 17 block events |
+| Codex | yes | `thread_goals` SQLite + `update_goal` tool | dedicated DB with native token/time accounting | 1 goal (270,359 tokens, 2,615 s, `paused`) |
+| Grok Build | yes (feature-gated) | `update_goal` progress tool | `chat_history.jsonl` tool calls | 88 calls across 24 sessions |
+| Antigravity | yes | prompt marker | `transcript.jsonl` user request | ~19 invocations across 10 conversations |
+| Gemini CLI, Cursor, Copilot, OpenCode, Qwen, Vibe, Pi, Cline, Hermes, Omnigent | no evidence found | — | — | — |
+
+So: four of roughly fourteen supported agents, not "most". That is still worth
+building for, because all four are agents this user actually runs unattended,
+and because the Codex row alone shows a single goal burning 270k tokens.
+
+## Why goals cannot reuse the loop schema
+
+`/loop` got one shared shape across agents because a recurring timer really is
+the same object everywhere: a cadence, a fire count, a last fire. Goals are not.
+
+1. **A session holds many goals.** A loop is effectively one per session. Local
+   Claude sessions arm goals repeatedly: one session armed five distinct
+   conditions, another four. The field must be a **list**, `sess["goals"]`, not
+   the singleton `sess["loop"]`.
+2. **Terminal state is knowable for exactly one agent.** Codex writes `status`.
+   Nobody else does. Claude Code, verified explicitly, emits **no terminal
+   event at all**: every hook-related record in a goal session is either "Goal
+   set" or "Stop hook feedback". Nothing marks a goal met, cleared, or
+   abandoned. 13 of 15 Claude goal sessions recorded zero blocks, meaning the
+   only honest reading is "armed, outcome unknown".
+3. **"Cost of a goal" means three different things** (see below).
+
+The design therefore is a shared **envelope** plus per-agent **evidence**, with
+one annotator branching on `source`, exactly as `_annotate_loop_lifecycle`
+already branches on `mode`. What must not ship is a single set of state names
+that is truthful for Codex and invented for everyone else.
+
+## Data model
+
+`sess["goals"]: List[Goal]`, each:
+
+```jsonc
+{
+  "source": "claude" | "codex" | "grok" | "antigravity",
+  "goal_id": "588ec6b8-…",      // codex only; else synthesized from (ts, hash)
+  "objective": "…",              // truncated to 200 chars, never full text
+  "created_at": "2026-06-13T13:08:03.882Z",
+  "updated_at": "2026-06-13T14:51:15.254Z",
+
+  "state": "active" | "paused" | "complete" | "blocked" | "armed" | "unknown",
+  "state_source": "reported" | "inferred",   // <- the honesty flag
+
+  "evidence": { … per-agent, see below … },
+
+  "tokens": 270359,              // null unless the agent counts it natively
+  "duration_seconds": 2615,      // null unless natively counted
+  "token_budget": null,
+  "cost_basis": "native" | "attributed_turns" | "session"
+}
+```
+
+`state_source` is the load-bearing field. `reported` means the agent wrote that
+status down. `inferred` means TokenTelemetry guessed from breadcrumbs, and the
+UI must render it differently (muted, with a tooltip). Only Codex ever produces
+`reported`.
+
+Per-agent `evidence`:
+
+- **claude**: `{blocks: int, first_block, last_block, block_bursts: [int],
+  cap_hit: bool}`. `cap_hit` is `max(burst) >= 8`, flagged as a heuristic.
+- **codex**: `{status_raw, token_budget, deferrals: int | null}`. `deferrals` is
+  `null`, not `0`, when the DB predates migration v2 and has no such table.
+- **grok**: `{checkpoints: int, first_ts, last_ts, completed: bool}`.
+- **antigravity**: `{marker_only: true}`.
+
+Allowed states per agent, enforced in the annotator so a lie is impossible:
+
+| Agent | States it may emit |
+|---|---|
+| Codex | `active`, `paused`, `complete`, `blocked` (all `reported`) |
+| Grok | `complete` when a checkpoint carries `completed:true`, else `active` (`inferred`) |
+| Claude | `armed`, `blocked`, `unknown`. **Never `complete`.** |
+| Antigravity | `unknown` only |
+
+## Detection
+
+### Claude (`_scan_sessions_sync`, alongside the existing loop parse)
+
+Two markers, both in `type: "user"` records:
+
+- arm: `A session-scoped Stop hook is now active with condition: "<cond>"`,
+  paired with the `<command-name>/goal</command-name>` +
+  `<local-command-stdout>Goal set: …` record at the same timestamp.
+- block: a record containing `Stop hook feedback`.
+
+Two traps, both hit during research:
+
+- **Compaction duplicates.** A compacted transcript replays earlier records, so
+  the same arm appears at two line numbers with an identical timestamp. Dedupe
+  on `(timestamp, sha1(condition)[:12])`.
+- Records whose content is a `tool_result` may quote these strings verbatim (a
+  session that greps for them, like the research that produced this doc).
+  Skip `tool_result` blocks.
+
+Block bursts: group block events with gaps under 5 minutes. Local data shows one
+burst of exactly 8 rapid blocks (15:51:06 to 15:53:39) then a stop, which is the
+documented cap firing, and a later burst of 5.
+
+### Codex
+
+Read both candidate paths and use whichever has rows (see the migration-level
+table above), via read-only URI and `PRAGMA busy_timeout`, wrapped so a locked,
+missing, or older-schema DB yields no goals rather than an error. Join `thread_id` to the Codex session id already
+parsed from `~/.codex/sessions/**/rollout-*.jsonl` (the rollout filename
+contains the thread id, confirmed: thread `019ebfe9-f0a5-78a3-ba8b-05d68bd72a00`
+matches `rollout-2026-06-13T13-07-20-019ebfe9-….jsonl`).
+
+Unlike everything else in the scan, this is **live mutable state**: status moves
+`active → paused → complete`. Treat it like loop lifecycle, not like a cached
+fact, and re-read per request rather than freezing it into the session cache.
+
+### Grok
+
+`chat_history.jsonl`, `tool_calls[]` entries where `name == "update_goal"`.
+Parse `arguments` for `message` and `completed`. Reuse the session/project
+resolution `_grok_loop_detect` already does.
+
+Do **not** count `updates.jsonl` `params.update._meta."x.ai/tool"` mentions:
+those are the tool being announced, not invoked. This distinction cut 1,808
+candidate files down to 88 real calls.
+
+### Antigravity
+
+`~/.gemini/antigravity-cli/brain/<id>/.system_generated/logs/transcript.jsonl`,
+regex `<USER_REQUEST>\s*/goal`. `transcript.jsonl` and `transcript_full.jsonl`
+duplicate each other; read one. Note `~/.gemini/everything-claude-code/` is a
+checked-out third-party repo about Claude Code and is pure noise for any Gemini
+or Antigravity scan; exclude it.
+
+## Cost semantics, and the double-counting trap
+
+Three different meanings, and the UI must label which one it is showing.
+
+- **Codex, `cost_basis: "native"`.** `tokens_used` and `time_used_seconds` come
+  from Codex. Authoritative. But the same tokens are already inside the thread's
+  session total that TokenTelemetry reports, so the goal figure is a **share of**
+  the session, never an addition to it. Render as "270,359 of the session's N".
+- **Claude, `cost_basis: "attributed_turns"`.** The only incremental number
+  available: usage of assistant turns that exist *because* a stop was blocked,
+  i.e. turns between a `Stop hook feedback` record and the next stop attempt.
+  This is the direct analog of the existing `loop_usage` fire-response span in
+  the loop parser, and should reuse that span technique.
+- **Grok / Antigravity, `cost_basis: "session"`.** No per-goal boundary exists.
+  Show the session cost and say so. Never present it as incremental.
+
+Any rollup that sums "goal cost" across agents is meaningless and should not be
+built. Aggregate within a `cost_basis`, not across.
+
+## Surfaces
+
+Deliberately smaller than the loop UI, because for two of four agents there is
+little to say.
+
+1. **Session trace page**: a `GoalCard` next to the existing `LoopCard`, one
+   card per goal in `sess["goals"]`. Objective, state chip (muted when
+   `inferred`), and whichever of tokens/duration/blocks/checkpoints exists.
+   Absent fields are omitted, not zero-filled.
+2. **Analytics**: extend the existing loops section rather than adding a page.
+   A goals table: agent, objective, state, cost basis, cost. Sorted by tokens
+   where known.
+3. **Project Config tab**: goal count per project, mirroring the loop cards.
+
+No "next fire" analog exists: goals are not scheduled.
+
+## Caching
+
+`sess["goals"]` splits along the same line the loop code already established:
+
+- Cacheable raw facts: objective, created_at, block/checkpoint counts, evidence.
+  Add `"goals"` to `_CLAUDE_CACHE_FIELDS` and bump `CACHE_VERSION`.
+- Never cached: Codex `status` (live DB), and any `state` derived from it.
+
+Claude goal state, unlike loop state, does **not** age with wall-clock time.
+There is no recurring fire to go stale, so `armed` stays `armed`. That means no
+per-request recomputation for Claude, which is simpler than loops.
+
+## Tests (`backend/test_goals.py`, mirroring `test_loops.py`)
+
+1. Claude: arm parsed; condition truncated; duplicate arm across a compaction
+   boundary collapses to one goal.
+2. Claude: `tool_result` records quoting the markers produce zero goals.
+3. Claude: block bursts grouped; `cap_hit` true at 8, false at 7.
+4. Claude: state never `complete`, for any input.
+5. Codex: row maps to a goal; `state_source == "reported"`; missing DB yields
+   `[]`; locked DB yields `[]` and does not raise.
+6. Codex: the DB with rows wins over the empty one regardless of which path it
+   sits at, and a v1 DB (no `thread_goal_continuation_deferrals`) yields
+   `deferrals: null` instead of raising.
+7. Grok: toolset announcements in `updates.jsonl` produce zero goals; only real
+   `tool_calls` count.
+8. Grok: `completed:true` checkpoint yields `complete`, otherwise `active`.
+9. Antigravity: marker parsed once despite `transcript`/`transcript_full`
+   duplication.
+10. Multi-goal session returns goals in creation order.
+11. No agent emits a state outside its allowed set.
+
+## Phasing
+
+- **Phase 1 (highest value per unit work): Codex.** The data is already
+  structured, already includes tokens and duration, and needs no inference. One
+  reader plus the `GoalCard`.
+- **Phase 2: Claude.** Most sessions, least evidence. Ships the `armed` /
+  `blocked` / `unknown` honesty model and the attributed-turn cost.
+- **Phase 3: Grok, then Antigravity.** Checkpoints, then the bare marker.
+
+Rough effort: phase 1 half a day, phase 2 a day (the turn-attribution span is
+the fiddly part), phase 3 half a day.
+
+## Open questions
+
+1. Does `/goal` in Claude Code write anything outside the transcript in newer
+   versions? Verified today that it does not (no goal files, no DB under
+   `~/.claude`), but the changelog mentions a live overlay with turns and
+   tokens, so a future version may persist it. Re-check before phase 2.
+2. Codex `token_budget` was null in the only local sample. Confirm the field
+   populates when a budget is set explicitly, before building budget-vs-used UI.
+3. Is Grok's goal feature on by default now, or still gated on the toolset flag?
+   Affects how many users would see anything.

--- a/docs/design/goal-telemetry.md
+++ b/docs/design/goal-telemetry.md
@@ -92,15 +92,31 @@ Counts are from this machine, deduped, read-only.
 
 | Agent | Has `/goal` | Mechanism | Durable evidence | Local usage |
 |---|---|---|---|---|
-| Claude Code | yes | Stop-hook completion condition + evaluator | transcript text only | 15 sessions armed, 30 goals, 17 block events |
+| Claude Code | yes | Stop-hook completion condition + evaluator | transcript text only | 15 sessions armed, 30 goals, 15 real block events (all in one session) |
 | Codex | yes | `thread_goals` SQLite + `update_goal` tool | dedicated DB with native token/time accounting | 1 goal (270,359 tokens, 2,615 s, `paused`) |
 | Grok Build | yes (feature-gated) | `update_goal` progress tool | `chat_history.jsonl` tool calls | 88 calls across 24 sessions |
 | Antigravity | yes | prompt marker | `transcript.jsonl` user request | ~19 invocations across 10 conversations |
-| Gemini CLI, Cursor, Copilot, OpenCode, Qwen, Vibe, Pi, Cline, Hermes, Omnigent | no evidence found | — | — | — |
+| Cursor, Copilot, OpenCode | not natively | third-party `cursor-goal` port | `~/.cursor-goal/data/goal.json` **if installed** | not installed here |
+| Gemini CLI, Qwen, Vibe, Pi, Cline, Hermes, Omnigent | no | — | — | — |
 
-So: four of roughly fourteen supported agents, not "most". That is still worth
-building for, because all four are agents this user actually runs unattended,
-and because the Codex row alone shows a single goal burning 270k tokens.
+So: four of roughly fourteen supported agents ship it natively, not "most".
+That is still worth building for, because all four are agents this user actually
+runs unattended, and because the Codex row alone shows a single goal burning
+270k tokens.
+
+Both halves of that count were checked two ways, local artifacts **and**
+documentation, because the Codex case proves local emptiness means nothing: its
+feature was fully shipped while one of its two DBs sat empty. Codex `/goal`
+("Goal Mode") reached GA in CLI 0.133 on 2026-05-21, which lines up with the
+`thread goals` migration stamped 2026-05-23 on this machine.
+
+The `cursor-goal` row is the one genuinely optional surface. It is a community
+project, not an official feature, that ports Claude Code's `/goal` to Cursor,
+Copilot and OpenCode using a stop hook plus an evaluator subagent, and it keeps
+runtime state in `~/.cursor-goal/data/goal.json`. That file would be trivial to
+read if a user has it, but it is absent here, so it is explicitly **out of scope
+for the phased build below** and noted only so a future contributor knows the
+hook exists.
 
 ## Why goals cannot reuse the loop schema
 
@@ -115,8 +131,9 @@ the same object everywhere: a cadence, a fire count, a last fire. Goals are not.
    Nobody else does. Claude Code, verified explicitly, emits **no terminal
    event at all**: every hook-related record in a goal session is either "Goal
    set" or "Stop hook feedback". Nothing marks a goal met, cleared, or
-   abandoned. 13 of 15 Claude goal sessions recorded zero blocks, meaning the
-   only honest reading is "armed, outcome unknown".
+   abandoned. 13 of the 15 Claude goal sessions recorded zero blocks, and every
+   genuine block on this machine (15 of them) sits in a single session, so for
+   almost every goal the only honest reading is "armed, outcome unknown".
 3. **"Cost of a goal" means three different things** (see below).
 
 The design therefore is a shared **envelope** plus per-agent **evidence**, with
@@ -187,9 +204,12 @@ Two traps, both hit during research:
 - **Compaction duplicates.** A compacted transcript replays earlier records, so
   the same arm appears at two line numbers with an identical timestamp. Dedupe
   on `(timestamp, sha1(condition)[:12])`.
-- Records whose content is a `tool_result` may quote these strings verbatim (a
-  session that greps for them, like the research that produced this doc).
-  Skip `tool_result` blocks.
+- **Sessions that merely discuss goals look like sessions that ran them.**
+  Skipping `tool_result` blocks is necessary but not sufficient: a session
+  *writing about* the feature puts "Stop hook feedback" into `assistant` prose
+  too. The research session behind this doc produced exactly two such phantom
+  blocks, which is 12% of the naive machine-wide total. Count blocks only from
+  `type: "user"` records, and require the session to have armed a goal first.
 
 Block bursts: group block events with gaps under 5 minutes. Local data shows one
 burst of exactly 8 rapid blocks (15:51:06 to 15:53:39) then a stop, which is the
@@ -199,10 +219,19 @@ documented cap firing, and a later burst of 5.
 
 Read both candidate paths and use whichever has rows (see the migration-level
 table above), via read-only URI and `PRAGMA busy_timeout`, wrapped so a locked,
-missing, or older-schema DB yields no goals rather than an error. Join `thread_id` to the Codex session id already
-parsed from `~/.codex/sessions/**/rollout-*.jsonl` (the rollout filename
-contains the thread id, confirmed: thread `019ebfe9-f0a5-78a3-ba8b-05d68bd72a00`
-matches `rollout-2026-06-13T13-07-20-019ebfe9-….jsonl`).
+missing, or older-schema DB yields no goals rather than an error.
+
+**The join is a straight equality, verified end to end rather than assumed.**
+The scanner builds its Codex session id at `backend/main.py:4411` as
+`sid = "-".join(f.stem.split("-")[-5:])`, which reconstructs the thread UUID out
+of the rollout filename. Checked against the running API: the local goal's
+`thread_id` `019ebfe9-f0a5-78a3-ba8b-05d68bd72a00` matches a live session
+(project `Developer/experiments`, 5,664,120 tokens, $5.07). So
+`thread_goals.thread_id == sess["id"]` needs no translation layer, and phase 1
+really is the cheap one.
+
+That same pair illustrates the double-counting trap below: the goal's 270,359
+tokens are about 5% **of** that session's 5.66M, not an extra 270k on top.
 
 Unlike everything else in the scan, this is **live mutable state**: status moves
 `active → paused → complete`. Treat it like loop lifecycle, not like a cached

--- a/frontend/src/app/projects/[path]/_lib/goals.ts
+++ b/frontend/src/app/projects/[path]/_lib/goals.ts
@@ -1,0 +1,208 @@
+/* Project-scoped `/goal` derivation.
+ *
+ * Mirrors _lib/loops.ts: a pure client-side fold over the session rows the
+ * project context already holds, so it stays in lockstep with the project
+ * filter and needs no extra fetch.
+ *
+ * Where this deliberately DIFFERS from loops, and why:
+ *
+ *  - **A session has many goals.** `loop` is one object per session; `goals` is
+ *    a list, because a session can arm several in sequence. So the fold is over
+ *    (session x goal) pairs, and the key has to include the goal.
+ *
+ *  - **There is no single "goal cost" to total.** Cost means three unrelated
+ *    things (see cost_basis) and summing across them is meaningless:
+ *      native            Codex counted the tokens itself; they are a SHARE OF a
+ *                        session total we already report.
+ *      attributed_turns  Claude's extra turns caused by a blocked stop; genuinely
+ *                        incremental.
+ *      session           Grok/Antigravity have no per-goal boundary at all.
+ *    So the summary keeps them in SEPARATE buckets and the UI never adds them.
+ *
+ *  - **State is not uniformly trustworthy.** Only Codex reports real status;
+ *    everything else is inferred from breadcrumbs, which `stateSource` carries
+ *    so the UI can mute it.
+ */
+import type { SessionRow } from "./project-context";
+
+export type GoalState =
+  | "active" | "paused" | "complete" | "blocked" | "armed" | "unknown";
+
+export type GoalCostBasis = "native" | "attributed_turns" | "session";
+
+export interface GoalRow {
+  key: string;
+  sessionId: string;
+  agent: string;
+  source: string;
+  objective: string;          // "" when the agent doesn't record one
+  objectiveTruncated: boolean;
+  latestMessage?: string | null;
+  state: GoalState;
+  stateSource: "reported" | "inferred";
+  costBasis: GoalCostBasis;
+  tokens: number | null;      // null unless the agent gives us a real number
+  cost: number | null;
+  durationSeconds?: number | null;
+  tokenBudget?: number | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  sessionTokens: number;
+  sessionCost: number;
+  blocks: number;             // Claude only
+  bursts: number[];           // Claude only
+  capHit: boolean;            // Claude only
+  checkpoints: number;        // Grok only
+  statusRaw?: string | null;  // Codex only
+  goalId?: string | null;
+}
+
+export interface GoalSummary {
+  total: number;
+  goalSessions: number;
+  /** Still-running or resumable work: reported states only. */
+  live: number;
+  complete: number;
+  /** Goals whose outcome the agent never recorded. */
+  outcomeUnknown: number;
+  reported: number;
+  inferred: number;
+  /** Kept apart on purpose — never add these together. */
+  nativeTokens: number;
+  attributedTokens: number;
+  attributedCost: number;
+  sessionBasisSessions: number;
+  totalBlocks: number;
+}
+
+const STATES: GoalState[] = ["active", "paused", "complete", "blocked", "armed", "unknown"];
+
+function normState(s?: string): GoalState {
+  return (STATES as string[]).includes(s || "") ? (s as GoalState) : "unknown";
+}
+
+export interface ProjectGoals {
+  rows: GoalRow[];
+  summary: GoalSummary;
+}
+
+export function deriveProjectGoals(sessions: SessionRow[]): ProjectGoals {
+  const summary: GoalSummary = {
+    total: 0, goalSessions: 0, live: 0, complete: 0, outcomeUnknown: 0,
+    reported: 0, inferred: 0, nativeTokens: 0, attributedTokens: 0,
+    attributedCost: 0, sessionBasisSessions: 0, totalBlocks: 0,
+  };
+  const rows: GoalRow[] = [];
+
+  for (const s of sessions) {
+    const goals = s.goals;
+    if (!Array.isArray(goals) || goals.length === 0) continue;
+    summary.goalSessions += 1;
+    let countedSessionBasis = false;
+
+    goals.forEach((g, i) => {
+      const state = normState(g.state);
+      const basis = (g.cost_basis || "session") as GoalCostBasis;
+      const ev = g.evidence || {};
+      summary.total += 1;
+
+      if (state === "active" || state === "paused") summary.live += 1;
+      else if (state === "complete") summary.complete += 1;
+      // "armed"/"blocked"/"unknown" all mean the agent never recorded an
+      // outcome — that is the honest bucket, not a failure bucket.
+      else summary.outcomeUnknown += 1;
+
+      if (g.state_source === "reported") summary.reported += 1;
+      else summary.inferred += 1;
+
+      const tokens = typeof g.tokens === "number" ? g.tokens : null;
+      if (basis === "native" && tokens) summary.nativeTokens += tokens;
+      if (basis === "attributed_turns") {
+        if (tokens) summary.attributedTokens += tokens;
+        if (typeof g.cost === "number") summary.attributedCost += g.cost;
+      }
+      if (basis === "session" && !countedSessionBasis) {
+        summary.sessionBasisSessions += 1;
+        countedSessionBasis = true;
+      }
+      summary.totalBlocks += Number(ev.blocks || 0);
+
+      rows.push({
+        key: `${s.id}:${g.goal_id || i}`,
+        sessionId: s.id,
+        agent: s.agent,
+        source: g.source || s.agent,
+        objective: g.objective || "",
+        objectiveTruncated: Boolean(g.objective_truncated),
+        latestMessage: ev.latest_message ?? null,
+        state,
+        stateSource: g.state_source === "reported" ? "reported" : "inferred",
+        costBasis: basis,
+        tokens,
+        cost: typeof g.cost === "number" ? g.cost : null,
+        durationSeconds: g.duration_seconds ?? null,
+        tokenBudget: g.token_budget ?? null,
+        createdAt: g.created_at,
+        updatedAt: g.updated_at,
+        sessionTokens: s.tokens?.total || 0,
+        sessionCost: s.cost || 0,
+        blocks: Number(ev.blocks || 0),
+        bursts: Array.isArray(ev.block_bursts) ? ev.block_bursts : [],
+        capHit: Boolean(ev.cap_hit),
+        checkpoints: Number(ev.checkpoints || 0),
+        statusRaw: ev.status_raw ?? null,
+        goalId: g.goal_id ?? null,
+      });
+    });
+  }
+
+  // Live work first (it's the only actionable kind), then by how much the goal
+  // actually cost, then newest.
+  const liveRank = (r: GoalRow) => (r.state === "active" || r.state === "paused" ? 0 : 1);
+  rows.sort((a, b) =>
+    liveRank(a) - liveRank(b) ||
+    (b.tokens || 0) - (a.tokens || 0) ||
+    String(b.createdAt || "").localeCompare(String(a.createdAt || "")));
+
+  summary.attributedCost = Number(summary.attributedCost.toFixed(6));
+  return { rows, summary };
+}
+
+/* ── Presentation helpers (shared by config + insights tabs) ── */
+
+export const GOAL_STATE: Record<GoalState, { dot: string; label: string; ring: string }> = {
+  active:   { dot: "bg-emerald-400", label: "text-emerald-300", ring: "border-emerald-500/40" },
+  paused:   { dot: "bg-amber-400",   label: "text-amber-300",   ring: "border-amber-500/40" },
+  complete: { dot: "bg-sky-400",     label: "text-sky-300",     ring: "border-sky-500/40" },
+  blocked:  { dot: "bg-rose-400",    label: "text-rose-300",    ring: "border-rose-500/40" },
+  armed:    { dot: "bg-[var(--tt-brand)]", label: "text-[var(--tt-brand)]", ring: "border-[var(--tt-brand)]/30" },
+  unknown:  { dot: "bg-transparent border border-[var(--tt-border-strong)]", label: "text-[var(--tt-fg-muted)]", ring: "border-[var(--tt-border)]" },
+};
+
+export function goalStateTone(s: GoalState) {
+  return GOAL_STATE[s] ?? GOAL_STATE.unknown;
+}
+
+/** What this agent's cost number actually means. Shown next to every figure so
+ *  a native count is never read as extra spend. */
+export function goalCostLabel(basis: GoalCostBasis): string {
+  return {
+    native: "counted by the agent, part of the session total",
+    attributed_turns: "extra turns caused by a blocked stop",
+    session: "no per-goal boundary — the session is the goal",
+  }[basis];
+}
+
+export function goalStateLabel(r: Pick<GoalRow, "state" | "source">): string {
+  if (r.state === "armed") return "armed, outcome unknown";
+  if (r.state === "blocked") return "blocked from stopping";
+  if (r.state === "unknown") return "outcome not recorded";
+  return r.state;
+}
+
+export function goalDuration(s?: number | null): string {
+  if (s == null) return "";
+  if (s < 60) return `${s}s`;
+  if (s < 3600) return `${Math.floor(s / 60)}m ${s % 60}s`;
+  return `${Math.floor(s / 3600)}h ${Math.round((s % 3600) / 60)}m`;
+}

--- a/frontend/src/app/projects/[path]/_lib/project-context.tsx
+++ b/frontend/src/app/projects/[path]/_lib/project-context.tsx
@@ -60,12 +60,45 @@ export interface SessionRow {
      backend scan; footprint_* are the loop's own fire-turn tokens, not the
      whole session. See SessionLoop and _lib/loops.ts. */
   loop?: SessionLoop;
+  /** `/goal` runs. A list, not a singleton: a session can arm several. */
+  goals?: SessionGoal[];
   published_artifacts?: PublishedArtifact[];
 }
 
 /* Mirror of backend sess["loop"] (backend/main.py) — raw facts plus the
    per-request lifecycle annotation. All fields optional/loose because the
    shape is owned by the scanner; consumers guard on `is_loop`. */
+/** One `/goal` run. Shapes differ per agent, so most fields are optional and
+ *  `evidence` carries whatever that agent actually recorded. */
+export interface SessionGoal {
+  source: string;
+  goal_id?: string | null;
+  objective?: string | null;
+  objective_truncated?: boolean;
+  created_at?: string | null;
+  updated_at?: string | null;
+  state?: string;
+  /** "reported" only when the agent wrote the status down (Codex). */
+  state_source?: string;
+  tokens?: number | null;
+  cost?: number | null;
+  duration_seconds?: number | null;
+  token_budget?: number | null;
+  cost_basis?: string;
+  evidence?: {
+    blocks?: number;
+    block_bursts?: number[];
+    cap_hit?: boolean;
+    checkpoints?: number;
+    completed?: boolean;
+    latest_message?: string | null;
+    objective_recoverable?: boolean;
+    status_raw?: string | null;
+    deferrals?: number | null;
+    marker_only?: boolean;
+  };
+}
+
 export interface SessionLoop {
   is_loop?: boolean;
   mode?: string;                // "fixed_cron" | "dynamic"

--- a/frontend/src/app/projects/[path]/config/page.tsx
+++ b/frontend/src/app/projects/[path]/config/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import {
   Settings2, Folder, Puzzle, Users, BookOpen, Terminal, Wrench, FileText,
-  Globe, Package, Repeat, ChevronRight,
+  Globe, Package, Repeat, ChevronRight, Target,
 } from "lucide-react";
 
 import { apiFetch } from "@/lib/api";
@@ -19,6 +19,10 @@ import {
   deriveProjectLoops, loopStateTone, loopInterval, loopRel, loopFmtNum,
   type LoopRow,
 } from "../_lib/loops";
+import {
+  deriveProjectGoals, goalStateTone, goalStateLabel, goalCostLabel, goalDuration,
+  type GoalRow, type GoalSummary,
+} from "../_lib/goals";
 
 interface ConfigItem { name: string; agent: string; scope: "project" | "user"; description?: string; source?: string; pluginRef?: string; [k: string]: unknown }
 interface SubagentItem extends ConfigItem { model?: string; tools?: string }
@@ -48,6 +52,7 @@ export default function ConfigTab() {
   const { decodedPath, project, sessions } = useProject();
   const projectAgents = project?.agents ?? [];
   const loops = useMemo(() => deriveProjectLoops(sessions), [sessions]);
+  const goals = useMemo(() => deriveProjectGoals(sessions), [sessions]);
   const [config, setConfig] = useState<ProjectConfig | null>(null);
   const [usage, setUsage] = useState<UsageData | null>(null);
   const [loading, setLoading] = useState(true);
@@ -119,6 +124,9 @@ export default function ConfigTab() {
           Sits with the rest of the project's configured surface; the Insights
           tab carries the token/cost breakdown. Self-hides when there are none. */}
       <ProjectLoopsInventory rows={loops.rows} decodedPath={decodedPath} />
+      {/* Goals set in this project. Not schedules: each is a run that already
+          happened, apart from a resumable Codex goal. */}
+      <ProjectGoalsInventory rows={goals.rows} summary={goals.summary} decodedPath={decodedPath} />
 
       {/* Summary tiles */}
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3">
@@ -471,6 +479,102 @@ function LoopInventoryCard({ row, decodedPath }: { row: LoopRow; decodedPath: st
           {row.tokens > 0 && <span>{loopFmtNum(row.tokens)} tok · ${row.cost.toFixed(2)} loop turns</span>}
         </div>
       )}
+    </Link>
+  );
+}
+
+/* ─────────────────────── Goals (/goal) — config inventory ─────────────────── */
+
+function ProjectGoalsInventory({ rows, summary, decodedPath }:
+  { rows: GoalRow[]; summary: GoalSummary; decodedPath: string }) {
+  if (rows.length === 0) return null;
+  return (
+    <Section
+      title={<span className="flex items-center gap-2"><Target size={12} className="text-[var(--tt-brand)]" /> Goals</span>}
+      description="Sessions in this project that were handed an objective with /goal. Unlike loops these don't re-fire — each one is a run that already happened, except a Codex goal left active or paused, which is genuinely resumable. Only Codex records real status; everything else is inferred from the transcript."
+      actions={
+        <Badge variant={summary.live > 0 ? "success" : "neutral"} size="sm">
+          {summary.live > 0 ? `${summary.live} live · ` : ""}{rows.length} total
+        </Badge>
+      }
+    >
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        {rows.map((r) => <GoalInventoryCard key={r.key} row={r} decodedPath={decodedPath} />)}
+      </div>
+    </Section>
+  );
+}
+
+function GoalInventoryCard({ row, decodedPath }: { row: GoalRow; decodedPath: string }) {
+  const tone = goalStateTone(row.state);
+  const href = `/sessions/${encodeURIComponent(row.sessionId)}?agent=${encodeURIComponent(row.agent)}&back=${encodeURIComponent(`/projects/${encodeURIComponent(decodedPath)}/config`)}`;
+  // Grok records progress but not the objective, so fall back to its latest
+  // status note rather than showing an empty card.
+  const text = row.objective || row.latestMessage || "";
+  return (
+    <Link
+      href={href}
+      className={cn(
+        "group block rounded-[var(--tt-radius-lg)] border bg-[var(--tt-panel)] p-4 transition-colors hover:tt-tint-1",
+        tone.ring,
+      )}
+    >
+      <div className="flex items-start justify-between gap-3 mb-2">
+        <span className="flex items-center gap-1.5 min-w-0">
+          <Target size={12} className="text-[var(--tt-brand)] shrink-0" />
+          <span className="text-[11px] font-semibold uppercase tracking-[0.14em] flex items-center gap-1.5">
+            <span className={cn("w-1.5 h-1.5 rounded-full shrink-0", tone.dot)} />
+            <span className={tone.label}>{row.state}</span>
+          </span>
+          {row.stateSource === "inferred" && (
+            <span className="text-[9px] text-[var(--tt-fg-faint)] normal-case"
+                  title="Derived from the transcript — this agent doesn't record goal status">
+              inferred
+            </span>
+          )}
+        </span>
+        <span className="flex items-center gap-1.5 shrink-0">
+          <AgentBadge agent={row.agent} />
+          <ChevronRight size={13} className="text-[var(--tt-fg-faint)] group-hover:text-[var(--tt-brand)] group-hover:translate-x-0.5 transition-all" />
+        </span>
+      </div>
+
+      {text ? (
+        <p className="text-[12px] text-[var(--tt-fg)] leading-relaxed line-clamp-2 mb-2.5" title={text}>
+          {text}{row.objectiveTruncated ? "…" : ""}
+        </p>
+      ) : (
+        <p className="text-[12px] text-[var(--tt-fg-dim)] italic mb-2.5">(this agent records no objective)</p>
+      )}
+
+      <div className="flex flex-wrap items-center gap-1.5">
+        <Badge variant="brand" size="xs" className="normal-case">{goalStateLabel(row)}</Badge>
+        {row.blocks > 0 && (
+          <Badge variant="neutral" size="xs" className="normal-case">{row.blocks} stop{row.blocks === 1 ? "" : "s"} blocked</Badge>
+        )}
+        {row.checkpoints > 0 && (
+          <Badge variant="neutral" size="xs" className="normal-case">{row.checkpoints} checkpoint{row.checkpoints === 1 ? "" : "s"}</Badge>
+        )}
+        {row.capHit && <Badge variant="warn" size="xs" className="normal-case">hit the 8-block cap</Badge>}
+        {row.durationSeconds != null && (
+          <Badge variant="neutral" size="xs" className="normal-case">{goalDuration(row.durationSeconds)}</Badge>
+        )}
+      </div>
+
+      <div className="mt-2.5 flex flex-wrap gap-x-4 gap-y-0.5 text-[10px] text-[var(--tt-fg-dim)] tabular">
+        {row.createdAt && <span>started {loopRel(row.createdAt)}</span>}
+        {/* Always paired with what the number MEANS: a native count is part of
+            the session total, an attributed one is extra work the goal caused. */}
+        {row.tokens != null && row.tokens > 0 && (
+          <span title={goalCostLabel(row.costBasis)}>
+            {loopFmtNum(row.tokens)} tok
+            {row.costBasis === "native" && row.sessionTokens > 0 &&
+              ` · ${((row.tokens / row.sessionTokens) * 100).toFixed(1)}% of session`}
+            {row.costBasis === "attributed_turns" && " · extra turns from blocks"}
+          </span>
+        )}
+        {row.costBasis === "session" && <span>cost = whole session</span>}
+      </div>
     </Link>
   );
 }

--- a/frontend/src/app/projects/[path]/insights/page.tsx
+++ b/frontend/src/app/projects/[path]/insights/page.tsx
@@ -4,7 +4,7 @@ import { Fragment, useMemo, useState } from "react";
 import Link from "next/link";
 import {
   Sparkles, Activity, Flame, Clock4, Wrench, GitBranch, Zap, Cpu,
-  Repeat, TrendingUp, DollarSign,
+  Repeat, TrendingUp, DollarSign, Target,
 } from "lucide-react";
 
 import { getAgent } from "@/lib/agents";
@@ -18,6 +18,10 @@ import {
   deriveProjectLoops, loopStateTone, loopInterval, loopRel, loopFmtNum,
   type LoopRow, type LoopSummary,
 } from "../_lib/loops";
+import {
+  deriveProjectGoals, goalStateTone, goalCostLabel,
+  type GoalRow, type GoalSummary,
+} from "../_lib/goals";
 
 const DOW_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
@@ -192,6 +196,7 @@ export default function InsightsTab() {
   // but scoped to these sessions. Footprint tokens/cost are the loop's own fire
   // turns, already part of the totals above (an attribution view).
   const loops = useMemo(() => deriveProjectLoops(sessions), [sessions]);
+  const goals = useMemo(() => deriveProjectGoals(sessions), [sessions]);
 
   const totalTokens = insights.agents.reduce((a, [, x]) => a + x.tokens, 0);
   const totalSessions = insights.agents.reduce((a, [, x]) => a + x.count, 0);
@@ -411,6 +416,8 @@ export default function InsightsTab() {
       {/* Recurring loops — this project's /loop automations, broken down by
           state and by the token/cost footprint of their own fire turns. */}
       <RecurringLoopsBreakdown rows={loops.rows} summary={loops.summary} decodedPath={decodedPath} />
+      {/* Goal economics — kept separate from loops because the cost bases differ. */}
+      <GoalRunsBreakdown rows={goals.rows} summary={goals.summary} decodedPath={decodedPath} />
 
       {/* Leaderboard + migration ribbon */}
       <Card padding="lg">
@@ -815,4 +822,131 @@ function fmtNum(n: number) {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
   return String(n);
+}
+
+/* Goals (/goal), scoped to this project.
+ *
+ * The deliberate difference from the loops card above: there is NO single
+ * "goal cost" tile, because goal cost means three unrelated things and adding
+ * them would be a fabricated number. Codex counts a goal's tokens itself and
+ * those tokens are already inside the session total; Claude's are the extra
+ * turns a blocked stop caused, which IS incremental; Grok and Antigravity have
+ * no per-goal boundary at all. So the tiles keep them apart and each figure
+ * carries the basis it was measured on. Self-hides at zero. */
+function GoalRunsBreakdown({
+  rows, summary, decodedPath,
+}: { rows: GoalRow[]; summary: GoalSummary; decodedPath: string }) {
+  if (summary.total === 0) return null;
+  return (
+    <Card padding="lg">
+      <CardHeader>
+        <div>
+          <CardTitle><Target size={14} className="text-[var(--tt-brand)]" /> Goal runs</CardTitle>
+          <p className="text-[11px] text-[var(--tt-fg-dim)] mt-0.5">
+            Sessions handed an objective with /goal. Cost is reported per agent and the bases are not
+            comparable, so they are never added together.
+          </p>
+        </div>
+        <CardEyebrow>{rows.length} goal{rows.length === 1 ? "" : "s"}</CardEyebrow>
+      </CardHeader>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-5">
+        <StatTile
+          label="Goals set"
+          value={String(summary.total)}
+          hint={`across ${summary.goalSessions} session${summary.goalSessions === 1 ? "" : "s"}`}
+          icon={<Target size={16} />}
+          accent="var(--tt-brand)"
+        />
+        <StatTile
+          label="Outcome unknown"
+          value={String(summary.outcomeUnknown)}
+          hint={summary.complete > 0 ? `${summary.complete} reported complete` : "no agent recorded an outcome"}
+          icon={<Target size={16} />}
+          accent="var(--tt-fg-dim)"
+        />
+        <StatTile
+          label="Stops blocked"
+          value={summary.totalBlocks.toLocaleString()}
+          hint="times a goal kept the agent working"
+          icon={<TrendingUp size={16} />}
+          accent="var(--tt-warn)"
+        />
+        <StatTile
+          label="Extra token cost"
+          value={loopFmtNum(summary.attributedTokens)}
+          hint={summary.attributedCost > 0
+            ? `$${summary.attributedCost.toFixed(2)} of additional turns`
+            : "turns caused by blocked stops"}
+          icon={<DollarSign size={16} />}
+          accent="var(--tt-danger)"
+        />
+      </div>
+
+      {(summary.nativeTokens > 0 || summary.sessionBasisSessions > 0) && (
+        <p className="text-[10px] text-[var(--tt-fg-faint)] -mt-2 mb-4">
+          Counted separately on purpose:
+          {summary.nativeTokens > 0 &&
+            ` ${loopFmtNum(summary.nativeTokens)} tok inside Codex goals (already part of those sessions)`}
+          {summary.nativeTokens > 0 && summary.sessionBasisSessions > 0 && " ·"}
+          {summary.sessionBasisSessions > 0 &&
+            ` ${summary.sessionBasisSessions} session${summary.sessionBasisSessions === 1 ? "" : "s"} where the goal has no boundary of its own`}
+          .
+        </p>
+      )}
+
+      <div className="space-y-2 max-h-[420px] overflow-y-auto pr-1">
+        {rows.map((r) => {
+          const tone = goalStateTone(r.state);
+          const href = `/sessions/${encodeURIComponent(r.sessionId)}?agent=${encodeURIComponent(r.agent)}&back=${encodeURIComponent(`/projects/${encodeURIComponent(decodedPath)}/insights`)}`;
+          const meta = getAgent(r.agent);
+          const text = r.objective || r.latestMessage || "";
+          return (
+            <Link
+              key={r.key}
+              href={href}
+              className="group flex items-center justify-between gap-3 rounded-[var(--tt-radius)] border border-transparent hover:border-[var(--tt-border)] hover:tt-tint-1 px-2 py-1.5 -mx-1 transition-colors"
+            >
+              <span className="min-w-0 flex items-start gap-2">
+                <span className={cn("w-1.5 h-1.5 rounded-full shrink-0 mt-1.5", tone.dot)} />
+                <span className="min-w-0 flex flex-col">
+                  <span className="text-[12px] text-[var(--tt-fg)] truncate" title={text}>
+                    {text || "(this agent records no objective)"}
+                  </span>
+                  <span className="text-[10px] text-[var(--tt-fg-dim)] truncate flex items-center gap-1.5">
+                    <span className={cn("uppercase tracking-[0.1em]", tone.label)}>{r.state}</span>
+                    {r.stateSource === "inferred" && <span title="not recorded by the agent">· inferred</span>}
+                    <span className="hidden sm:inline" style={{ color: meta.hex }}>· {meta.label}</span>
+                    {r.blocks > 0 && <span className="hidden md:inline">· {r.blocks} block{r.blocks === 1 ? "" : "s"}</span>}
+                    {r.checkpoints > 0 && <span className="hidden md:inline">· {r.checkpoints} checkpoints</span>}
+                    {r.capHit && <span className="hidden md:inline text-amber-400">· hit the cap</span>}
+                  </span>
+                </span>
+              </span>
+              <span className="text-right shrink-0">
+                {r.tokens != null && r.tokens > 0 ? (
+                  <>
+                    <span className="block tabular font-semibold text-[12px] text-[var(--tt-fg)]"
+                          title={goalCostLabel(r.costBasis)}>
+                      {loopFmtNum(r.tokens)} tok
+                    </span>
+                    <span className="block tabular text-[10px] text-[var(--tt-fg-faint)]">
+                      {r.costBasis === "native"
+                        ? `${r.sessionTokens > 0 ? ((r.tokens / r.sessionTokens) * 100).toFixed(1) : "?"}% of session`
+                        : "extra turns"}
+                    </span>
+                  </>
+                ) : (
+                  <span className="block tabular text-[10px] text-[var(--tt-fg-faint)]"
+                        title={goalCostLabel(r.costBasis)}>
+                    {r.costBasis === "session" ? "whole session" : "no extra cost"}
+                  </span>
+                )}
+              </span>
+            </Link>
+          );
+        })}
+      </div>
+    </Card>
+  );
 }

--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -2523,47 +2523,90 @@ function GoalCard({ goal, sessionTokens }: { goal: any; sessionTokens?: number }
   const share = (tokens != null && sessionTokens && sessionTokens > 0)
     ? (tokens / sessionTokens) * 100
     : null;
+  const basis: string = goal.cost_basis ?? "session";
+  const bursts: number[] = Array.isArray(goal.evidence?.block_bursts) ? goal.evidence.block_bursts : [];
+  const AGENT_LABEL: Record<string, string> = {
+    codex: "Codex", claude: "Claude Code", grok: "Grok Build", antigravity: "Antigravity",
+  };
 
   return (
     <div className={`mb-8 bg-[var(--tt-panel)]/60 border ${tone.ring} rounded-[var(--tt-radius-lg)] p-5`}>
       <div className="flex items-center justify-between mb-3">
         <div className="text-[10px] font-black uppercase tracking-[0.2em] text-[var(--tt-fg)] flex items-center gap-2">
           <Target size={12} strokeWidth={3} /> Goal mode
+          <span className="text-[9px] font-semibold tracking-[0.1em] text-[var(--tt-fg-dim)]">
+            {AGENT_LABEL[goal.source] || goal.source}
+          </span>
         </div>
         <span className={`flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.1em] ${tone.text}`}>
           <span className={`w-1.5 h-1.5 rounded-full ${tone.dot}`} /> {state}
+          {goal.state_source === "inferred" && (
+            <span className="text-[9px] font-normal normal-case tracking-normal text-[var(--tt-fg-dim)]"
+                  title="Derived from transcript breadcrumbs — this agent does not record goal status">
+              inferred
+            </span>
+          )}
         </span>
       </div>
 
-      {goal.objective && (
+      {(goal.objective || goal.evidence?.latest_message) && (
         <div className="mb-3 bg-[var(--tt-sunken)] border border-[var(--tt-border)] rounded-[var(--tt-radius)] px-3 py-2">
-          <span className="text-[9px] uppercase tracking-[0.18em] text-[var(--tt-fg-dim)] block mb-1">Objective</span>
+          <span className="text-[9px] uppercase tracking-[0.18em] text-[var(--tt-fg-dim)] block mb-1">
+            {goal.objective ? "Objective" : "Latest progress"}
+          </span>
           <span className="text-[12px] text-[var(--tt-fg-muted)] line-clamp-3">
-            {goal.objective}{goal.objective_truncated ? "…" : ""}
+            {goal.objective || goal.evidence?.latest_message}{goal.objective_truncated ? "…" : ""}
           </span>
         </div>
       )}
 
+      {/* Cost means three different things across agents and the label has to
+          say which, or a native count reads as incremental spend. */}
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-3">
-        <Stat label="Tokens used" value={tokens != null ? tokens.toLocaleString() : "—"} />
-        <Stat label="Time in goal" value={dur(goal.duration_seconds)} />
-        <Stat label="Token budget" value={goal.token_budget != null ? goal.token_budget.toLocaleString() : "none set"} />
-        <Stat label="Share of session" value={share != null ? `${share < 0.1 ? "<0.1" : share.toFixed(1)}%` : "—"} />
+        {basis === "native" && <>
+          <Stat label="Tokens used" value={tokens != null ? tokens.toLocaleString() : "—"} />
+          <Stat label="Time in goal" value={dur(goal.duration_seconds)} />
+          <Stat label="Token budget" value={goal.token_budget != null ? goal.token_budget.toLocaleString() : "none set"} />
+          <Stat label="Share of session" value={share != null ? `${share < 0.1 ? "<0.1" : share.toFixed(1)}%` : "—"} />
+        </>}
+        {basis === "attributed_turns" && <>
+          <Stat label="Stops blocked" value={(goal.evidence?.blocks ?? 0).toLocaleString()} />
+          <Stat label="Extra tokens" value={tokens != null ? tokens.toLocaleString() : "none"} />
+          <Stat label="Longest run" value={bursts.length ? `${Math.max(...bursts)} blocks` : "—"} />
+          <Stat label="Share of session" value={share != null ? `${share < 0.1 ? "<0.1" : share.toFixed(1)}%` : "—"} />
+        </>}
+        {basis === "session" && <>
+          <Stat label="Checkpoints" value={goal.evidence?.checkpoints != null ? String(goal.evidence.checkpoints) : "—"} />
+          <Stat label="Goal cost" value="whole session" />
+          <Stat label="Session tokens" value={sessionTokens != null ? sessionTokens.toLocaleString() : "—"} />
+          <Stat label="Reported done" value={goal.evidence?.completed ? "yes" : "not reported"} />
+        </>}
       </div>
 
       <div className="space-y-1 text-[11px] font-mono text-[var(--tt-fg-muted)]">
-        <Row k="Started" v={fmt(goal.created_at)} />
-        <Row k="Last update" v={fmt(goal.updated_at)} />
+        {goal.created_at && <Row k="Started" v={fmt(goal.created_at)} />}
+        {goal.updated_at && <Row k={basis === "attributed_turns" ? "Last block" : "Last update"} v={fmt(goal.updated_at)} />}
         {goal.evidence?.status_raw && <Row k="Status (agent's own)" v={goal.evidence.status_raw} accent={tone.text} />}
         {goal.evidence?.deferrals != null && <Row k="Continuation deferrals" v={goal.evidence.deferrals} />}
+        {bursts.length > 1 && <Row k="Block runs" v={bursts.join(" · ")} />}
+        {goal.evidence?.cap_hit && <Row k="Hit the block cap" v="yes (8 consecutive)" accent="text-amber-400" />}
         {goal.goal_id && <Row k="Goal id" v={goal.goal_id} />}
       </div>
 
-      <div className="mt-3 text-[10px] text-[var(--tt-fg-dim)]">
-        {goal.state_source === "reported"
-          ? "Status and counts are reported by Codex itself, and read fresh on every load rather than cached."
-          : "Status is inferred from session breadcrumbs, not reported by the agent."}
-        {tokens != null && " These tokens are part of the session total above, not additional to it."}
+      <div className="mt-3 text-[10px] text-[var(--tt-fg-dim)] space-y-1">
+        <div>
+          {goal.state_source === "reported"
+            ? "Status and counts are reported by the agent itself, and read fresh on every load rather than cached."
+            : "Status is inferred from session breadcrumbs. This agent records no completion event, so a goal is never shown as finished."}
+        </div>
+        {basis === "native" && tokens != null &&
+          <div>These tokens are part of the session total above, not additional to it.</div>}
+        {basis === "attributed_turns" &&
+          <div>Counts only the turns that ran because a stop was blocked, so this is additional work the goal caused.</div>}
+        {basis === "session" &&
+          <div>No per-goal boundary exists for this agent, so the session cost is the goal cost. It is not extra spend.</div>}
+        {goal.evidence?.objective_recoverable === false &&
+          <div>This agent records progress updates but not the objective itself, so the latest progress note is shown instead.</div>}
       </div>
     </div>
   );

--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -5,7 +5,7 @@ import { createPortal } from "react-dom";
 import { useParams, useSearchParams, useRouter } from "next/navigation";
 import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { ArrowLeft, Brain, Code, MessageSquare, Terminal, User, Users, FileText, Activity, Zap, Info, Sparkles, GitBranch, LayoutPanelLeft, ListMusic, ChevronRight, ChevronLeft, Play, Pause, Wrench, Cpu, Folder, AlertTriangle, Hash, Clock, FileCode, Settings2, ChevronDown, ChevronUp, Copy, Maximize2, X, Repeat, Globe, ExternalLink } from "lucide-react";
+import { ArrowLeft, Brain, Code, MessageSquare, Terminal, User, Users, FileText, Activity, Zap, Info, Sparkles, GitBranch, LayoutPanelLeft, ListMusic, ChevronRight, ChevronLeft, Play, Pause, Wrench, Cpu, Folder, AlertTriangle, Hash, Clock, FileCode, Settings2, ChevronDown, ChevronUp, Copy, Maximize2, X, Repeat, Globe, ExternalLink, Target } from "lucide-react";
 import Link from "next/link";
 import { format } from "date-fns";
 import { AgentBadge, Badge, Button, Skeleton } from "@/components/ui";
@@ -69,6 +69,8 @@ interface Session {
   end_reason?: string | null;
   /** TRACE loop metadata; present only on loop sessions (see backend /sessions) */
   loop?: any;
+  /** Goal Mode (`/goal`); a session can set several, so this is a list */
+  goals?: any[];
 }
 
 interface Event {
@@ -878,6 +880,10 @@ export default function SessionDetailPage() {
              {agent === "grok" && grokForensics && <GrokForensicsCard forensics={grokForensics} cost={sessionInfo?.tokens?.cost ?? sessionInfo?.cost} />}
              {/* Recurring loop (/loop, cron, self-perpetuating agent) — full detail */}
              {sessionInfo?.loop?.is_loop && <LoopCard loop={sessionInfo.loop} />}
+             {/* Goal mode (/goal) — one card per goal; a session can set several */}
+             {Array.isArray(sessionInfo?.goals) && sessionInfo.goals.map((g: any, i: number) => (
+               <GoalCard key={g.goal_id || i} goal={g} sessionTokens={sessionInfo?.tokens?.total} />
+             ))}
              {/* Delegated work — subagent spawns and what they actually cost */}
              {delegation && agent && <DelegationCard delegation={delegation} agent={agent} sessionId={id} onOpenSubagent={setSubagentView} />}
              <div className={splitView ? "grid grid-cols-2 gap-8" : "space-y-8"}>
@@ -2474,6 +2480,90 @@ function LoopCard({ loop }: { loop: any }) {
       )}
       <div className="mt-1 text-[10px] text-[var(--tt-fg-dim)]">
         Fires is a lower bound (counted from re-injected prompts in this session).
+      </div>
+    </div>
+  );
+}
+
+
+// One card per `/goal` (Codex Goal Mode). Codex counts a goal's tokens and
+// wall-clock itself, so every number here is REPORTED by the agent, never
+// inferred by us — see docs/design/goal-telemetry.md.
+function GoalCard({ goal, sessionTokens }: { goal: any; sessionTokens?: number }) {
+  const state: string = goal.state ?? "unknown";
+  const tone =
+    state === "active"   ? { ring: "border-emerald-500/40", dot: "bg-emerald-400", text: "text-emerald-400" } :
+    state === "complete" ? { ring: "border-sky-500/40",     dot: "bg-sky-400",     text: "text-sky-400" } :
+    state === "paused"   ? { ring: "border-amber-500/40",   dot: "bg-amber-400",   text: "text-amber-400" } :
+    state === "blocked"  ? { ring: "border-rose-500/40",    dot: "bg-rose-400",    text: "text-rose-400" } :
+                           { ring: "border-[var(--tt-border)]", dot: "bg-[var(--tt-fg-dim)]", text: "text-[var(--tt-fg-dim)]" };
+
+  const fmt = (iso?: string | null) => {
+    if (!iso) return "—";
+    const d = new Date(iso);
+    return isNaN(d.getTime()) ? String(iso) : d.toLocaleString();
+  };
+  const dur = (s?: number | null) => {
+    if (s == null) return "—";
+    if (s < 60) return `${s}s`;
+    if (s < 3600) return `${Math.floor(s / 60)}m ${s % 60}s`;
+    return `${Math.floor(s / 3600)}h ${Math.round((s % 3600) / 60)}m`;
+  };
+
+  const Row = ({ k, v, accent }: { k: string; v: React.ReactNode; accent?: string }) => (
+    <div className="flex justify-between gap-3">
+      <span className="text-[var(--tt-fg-dim)]">{k}</span>
+      <span className={accent || "text-[var(--tt-fg)]"}>{v}</span>
+    </div>
+  );
+
+  const tokens: number | null = goal.tokens ?? null;
+  // The goal's tokens are a SHARE OF the session total, never an addition to
+  // it. Showing the share inline is what stops anyone reading it as extra spend.
+  const share = (tokens != null && sessionTokens && sessionTokens > 0)
+    ? (tokens / sessionTokens) * 100
+    : null;
+
+  return (
+    <div className={`mb-8 bg-[var(--tt-panel)]/60 border ${tone.ring} rounded-[var(--tt-radius-lg)] p-5`}>
+      <div className="flex items-center justify-between mb-3">
+        <div className="text-[10px] font-black uppercase tracking-[0.2em] text-[var(--tt-fg)] flex items-center gap-2">
+          <Target size={12} strokeWidth={3} /> Goal mode
+        </div>
+        <span className={`flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.1em] ${tone.text}`}>
+          <span className={`w-1.5 h-1.5 rounded-full ${tone.dot}`} /> {state}
+        </span>
+      </div>
+
+      {goal.objective && (
+        <div className="mb-3 bg-[var(--tt-sunken)] border border-[var(--tt-border)] rounded-[var(--tt-radius)] px-3 py-2">
+          <span className="text-[9px] uppercase tracking-[0.18em] text-[var(--tt-fg-dim)] block mb-1">Objective</span>
+          <span className="text-[12px] text-[var(--tt-fg-muted)] line-clamp-3">
+            {goal.objective}{goal.objective_truncated ? "…" : ""}
+          </span>
+        </div>
+      )}
+
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-3">
+        <Stat label="Tokens used" value={tokens != null ? tokens.toLocaleString() : "—"} />
+        <Stat label="Time in goal" value={dur(goal.duration_seconds)} />
+        <Stat label="Token budget" value={goal.token_budget != null ? goal.token_budget.toLocaleString() : "none set"} />
+        <Stat label="Share of session" value={share != null ? `${share < 0.1 ? "<0.1" : share.toFixed(1)}%` : "—"} />
+      </div>
+
+      <div className="space-y-1 text-[11px] font-mono text-[var(--tt-fg-muted)]">
+        <Row k="Started" v={fmt(goal.created_at)} />
+        <Row k="Last update" v={fmt(goal.updated_at)} />
+        {goal.evidence?.status_raw && <Row k="Status (agent's own)" v={goal.evidence.status_raw} accent={tone.text} />}
+        {goal.evidence?.deferrals != null && <Row k="Continuation deferrals" v={goal.evidence.deferrals} />}
+        {goal.goal_id && <Row k="Goal id" v={goal.goal_id} />}
+      </div>
+
+      <div className="mt-3 text-[10px] text-[var(--tt-fg-dim)]">
+        {goal.state_source === "reported"
+          ? "Status and counts are reported by Codex itself, and read fresh on every load rather than cached."
+          : "Status is inferred from session breadcrumbs, not reported by the agent."}
+        {tokens != null && " These tokens are part of the session total above, not additional to it."}
       </div>
     </div>
   );


### PR DESCRIPTION
Implements `/goal` telemetry end to end. The design doc (`docs/design/goal-telemetry.md`) is included here rather than landing separately, replacing the two earlier draft PRs (#197, #201).

Four of roughly fourteen supported agents ship a `/goal` command, and **all four mean something different by it**. Verified against local docs bundles, the Claude Code changelog, and this machine's session data.

| Agent | Mechanism | Evidence | Detected locally |
|---|---|---|---|
| **Codex** | `thread_goals` SQLite | native tokens / duration / status — **reported** | 1 goal, 270,359 tokens over 44 min |
| **Claude Code** | session-scoped Stop hook | arms + blocked stops, no terminal event | 15 sessions, 30 goals |
| **Grok Build** | `update_goal` checkpoints | progress messages + `completed` flag | 22 sessions |
| **Antigravity** | prompt marker | the `/goal` text itself | 9 sessions |

Live scan: **68 goals across 47 sessions.**

## The honesty model is the point

`/loop` got one shared schema because a recurring timer really is the same object everywhere. Goals aren't, so this is a shared envelope plus per-agent evidence:

- **`state_source`** separates what an agent *wrote down* from what we inferred. Only Codex ever reports; the UI mutes inferred states.
- **Per-agent allowed-state sets** make a lie structurally impossible. Claude can never emit `complete`, because Claude records **no terminal event** — every hook record is either an arm or a block, and 13 of 15 local goal sessions recorded zero blocks. "Armed, outcome unknown" is the truth.
- **Three cost bases that must never be summed.** Codex tokens are a *share of* the session that already contains them; Claude's are the incremental turns a blocked stop caused; Grok and Antigravity have no per-goal boundary, so the session *is* the goal and the card says so.

## Two corrections the data forced on the plan

1. **Grok falls back to `unknown`, not `active`.** A long-ended session that never reported completion has not been shown to be running.
2. **Grok's objective is not recoverable.** All 25 local sessions calling `update_goal` have *no* `/goal` user message — the tool is driven by skill instructions. So `objective` stays null and the latest progress note is labelled "Latest progress" rather than passed off as the user's objective.

**Burst grouping was calibrated, not guessed.** Real gaps inside a block run are ≤42s; the nearest true break is 169s. A 120s threshold gives `[1, 1, 8, 5]` — a longest run of exactly 8, matching the documented cap. The originally planned 300s merges the break and reports 9, i.e. a cap that looks exceeded.

## Detection traps, each covered by a test

- Compaction replays the arm record at a second line with an identical timestamp.
- A `tool_result` quoting the markers is *research*, not a goal.
- Assistant prose *about* the feature is not a block (this was 2 of 17 blocks machine-wide during research).
- "Tool in the toolset" ≠ "tool called": 1,808 candidate Grok files vs 88 real calls.
- Codex ships two goal DBs **at different migration levels**, and the populated one is on the *older* schema.

## Verification

- Codex numbers agree across three independent paths: `sqlite3` CLI, `GET /sessions`, and the rendered card — 270,359 tokens / 2,615 s / `paused`, 4.77% share.
- **52 goal tests**, and the suite is **mutation-checked**: naive content flattening, a loosened burst gap, Grok `unknown→active`, and a dropped toolset gate each make it fail.
- Full backend suite **367 passed** vs **315 on `origin/main`**, with the identical 23 pre-existing failures.
- `tsc --noEmit` clean; no compile or runtime errors in the dev server.

**Verification gap worth stating:** the card was confirmed visually for Codex, but the screenshot tooling timed out on the heavier Claude/Grok/Antigravity trace pages, so those three were verified via the API payload and a clean 200 from the route rather than a screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
