### PR TITLE
docs+fix: ban session URLs and machine identifiers; fix Windows project names

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,5 +1,57 @@
 # TokenTelemetry — Claude Code project rules
 
+## ⚠️ This repo is PUBLIC — what must never be pushed
+
+Everything below applies to commit messages, PR titles and bodies, PR comments,
+issue comments, code, tests and fixtures. All of it is world-readable and
+**cannot be reliably deleted after the fact** (see "If it leaks anyway").
+
+### Never include a Claude Code session URL
+
+Do **not** put `https://claude.ai/code/session_…` in a commit message, PR body,
+or anywhere else in the repo. Drop the `Claude-Session:` trailer and the
+session link under the "Generated with Claude Code" line.
+
+The `🤖 Generated with [Claude Code]` attribution itself is fine and should
+stay. It's only the session URL that must go.
+
+### Never include machine or account identifiers
+
+Bug reports arrive as screenshots and pasted paths from real machines,
+including work machines. Those paths carry usernames:
+
+```
+C:\Users\<corp-username>\Documents\project     <- the username is an identifier
+/Users/<username>/code/project
+/home/<username>/project
+```
+
+Before writing a path into a commit, PR, test or comment, **replace the user
+segment with a placeholder**: `C:\Users\dev\Documents\my-project`,
+`/Users/dev/code/app`. The same goes for hostnames, corporate domains, internal
+URLs, ticket ids, IPs, and the contents of screenshots.
+
+This is not hypothetical: a Windows bug report was reproduced verbatim in a PR
+body, a commit message and a test fixture, publishing the reporter's corporate
+account name three times. Sanitise at the moment you copy the path, not at
+review time.
+
+### If it leaks anyway
+
+Closing the PR and deleting the branch is **not enough**. GitHub keeps the
+orphaned commit and serves it by SHA (and from the closed PR) until its own
+garbage collection runs. The steps, in order:
+
+1. Edit the PR title/body to remove the value (this *is* effective — bodies are
+   mutable), then close the PR and delete the remote branch.
+2. Rewrite the local history so the value is gone from the message and diff,
+   and push the clean branch under a new name.
+3. For anything genuinely sensitive, **contact GitHub Support** to purge the
+   unreachable objects. Nothing you can do with `git` alone removes a commit
+   that has already been pushed and fetched.
+4. Treat any leaked credential as compromised and rotate it. A username can't
+   be rotated, which is exactly why step 0 is not leaking it.
+
 ## ⚠️ Pre-push policy (enforced by hook)
 
 **Every push to a branch destined for `main` that contains at least one

--- a/frontend/src/app/local-models/page.tsx
+++ b/frontend/src/app/local-models/page.tsx
@@ -1,3 +1,9 @@
+"use client";
+
+// Every child here is a Client Component. Declaring the boundary on the
+// page itself keeps the whole subtree on one side of it, so a stale or
+// half-rebuilt module graph can't surface a "createContext only works in
+// Client Components" error from this route.
 import { Cpu } from "lucide-react";
 import { PageHeader, Section } from "@/components/ui";
 import { PowerSettings } from "@/components/settings/PowerSettings";

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -17,6 +17,7 @@ import LocalPowerInsights from "@/components/insights/LocalPowerInsights";
 import { formatTokens, formatCost } from "@/lib/format";
 import { profileColor } from "@/lib/profileColor";
 import { costFraming, type BillingConfig } from "@/lib/billing";
+import { projectBasename } from "@/lib/paths";
 import {
   PageHeader, StatTile, Section, Card, CardHeader, CardTitle, CardEyebrow,
   Table, THead, TBody, TR, TH, TD, AgentBadge, Badge, Button, EmptyState, Skeleton,
@@ -285,7 +286,7 @@ export default function Home() {
                               )}
                             </span>
                           ) : (
-                            s.project.split("/").pop()
+                            projectBasename(s.project)
                           )}
                         </Link>
                       </TD>

--- a/frontend/src/app/projects/[path]/layout.tsx
+++ b/frontend/src/app/projects/[path]/layout.tsx
@@ -14,6 +14,7 @@ import { formatCost, formatTokens } from "@/lib/format";
 import { Card, AgentBadge } from "@/components/ui";
 import { type BudgetStatus, budgetTone } from "@/lib/budgets";
 import { ProjectProvider, type ProjectData, type SessionRow } from "./_lib/project-context";
+import { projectBasename } from "@/lib/paths";
 
 const TABS = [
   { key: "activity",  label: "Activity",  icon: Activity,      href: "activity"  },
@@ -49,7 +50,7 @@ export default function ProjectShellLayout({ children }: { children: React.React
       .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
   }, [allSessions, decodedPath]);
 
-  const projectName = decodedPath.split("/").pop() || "Unknown Project";
+  const projectName = projectBasename(decodedPath) || "Unknown Project";
   const totalTokens = sessions.reduce((sum, s) => sum + (s.tokens?.total ?? 0), 0);
   const directCost = sessions.reduce((sum, s) => sum + (s.cost ?? 0), 0);
   const subagents = (project?.configured_subagent_count ?? 0) + (project?.subagent_count ?? 0);

--- a/frontend/src/lib/paths.test.ts
+++ b/frontend/src/lib/paths.test.ts
@@ -1,0 +1,39 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { projectBasename } from "./paths";
+
+// Paths here are placeholders on purpose. Never paste a real path from a bug
+// report into a fixture — the user segment is someone's account name.
+
+test("POSIX path yields its last segment", () => {
+  assert.equal(projectBasename("/Users/dev/Documents/my-project"), "my-project");
+});
+
+test("Windows path yields its last segment", () => {
+  // The bug this fixes: split("/") alone returns the WHOLE string for a
+  // Windows path, so the project name rendered as the full C:\... path.
+  assert.equal(
+    projectBasename("C:\\Users\\dev\\Documents\\my-project"),
+    "my-project",
+  );
+});
+
+test("UNC path yields its last segment", () => {
+  assert.equal(projectBasename("\\\\server\\share\\proj"), "proj");
+});
+
+test("trailing separators are ignored", () => {
+  assert.equal(projectBasename("C:\\Users\\dev\\app\\"), "app");
+  assert.equal(projectBasename("/Users/dev/app/"), "app");
+});
+
+test("degenerate input never throws", () => {
+  assert.equal(projectBasename("C:\\"), "C:");
+  assert.equal(projectBasename(""), "");
+  assert.equal(projectBasename(null), "");
+  assert.equal(projectBasename(undefined), "");
+});
+
+test("a bare name with no separator is unchanged", () => {
+  assert.equal(projectBasename("my-project"), "my-project");
+});

--- a/frontend/src/lib/paths.ts
+++ b/frontend/src/lib/paths.ts
@@ -1,0 +1,16 @@
+/* Filesystem-path helpers.
+ *
+ * Project paths come from whatever machine the agent ran on, so they are
+ * POSIX ("/Users/dev/code/app") on macOS and Linux and Windows
+ * ("C:\\Users\\dev\\Documents\\app") on Windows. Splitting on "/" alone returns
+ * the ENTIRE Windows path instead of its last segment, which is why a Windows
+ * project rendered its full path where a name belonged.
+ */
+
+/** Last segment of a filesystem path, on either separator.
+ *  Trailing separators are ignored so "C:\\a\\b\\" still yields "b". */
+export function projectBasename(path: string | null | undefined): string {
+  if (!path) return "";
+  const parts = String(path).split(/[\\/]+/).filter(Boolean);
+  return parts.length ? parts[parts.length - 1] : "";
+}


### PR DESCRIPTION
Prompted by a leak: a Windows bug report was reproduced verbatim in a PR body, a commit message and a test fixture, publishing the reporter's corporate account name in a public repo. That PR is closed, its body scrubbed, and its branch deleted.

## New CLAUDE.md section: "This repo is PUBLIC"

- **No Claude Code session URLs** in commit messages or PR bodies. The `🤖 Generated with Claude Code` attribution stays; only the `session_…` link goes.
- **No machine or account identifiers.** Bug reports arrive as screenshots and pasted paths from real machines, including work machines, and the user segment of a path is someone's account name. Replace it with a placeholder (`C:\Users\dev\Documents\my-project`) at the moment you copy it, not at review time.
- **What to do if it leaks anyway**, including the part that's easy to get wrong: closing the PR and deleting the branch does *not* remove the commit. GitHub keeps serving it by SHA until its own GC runs, so anything genuinely sensitive needs GitHub Support.

## Fix: Windows project names rendered as the whole path

`split("/").pop()` is a POSIX-only basename, so a Windows path returns the entire string and the project header and dashboard project column showed a full drive path where a name belonged. `lib/paths.ts::projectBasename` splits on either separator and ignores trailing ones. The third `split("/")` site parses a URL pathname (always forward-slashed) and is deliberately untouched.

## Hardening: `/local-models` declares `"use client"`

That page renders only Client Components but was itself a Server Component. **This is hardening, not a proven root-cause fix.** The reported `createContext only works in Client Components` error does not reproduce here, and tracing the full server-reachable import graph from that page finds no `createContext` at all — it exists only in `ThemeProvider` and `NotificationProvider`, both already client components. A stale build cache is the likely cause; declaring the boundary at the route rules the failure mode out either way.

## Not fixed here

The 404 on a Windows project URL. It returns 200 locally on the same Next version and the app never calls `notFound()`, so it's most likely `%5C` being normalised out of the path segment before routing. Fixing it properly means not putting raw filesystem paths in URL segments, which changes every project link and existing bookmarks — that needs its own change and a real Windows repro.

## Verification

- 6 tests for `projectBasename`: POSIX, Windows, UNC, trailing separators, bare drive root, `null`/`undefined`. Fixtures use placeholder paths only.
- Frontend suite **23 passed**; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
