### PR TITLE
feat(website): mission-control landing page revamp

### DIFF
--- a/UPDATE.json
+++ b/UPDATE.json
@@ -1,6 +1,17 @@
 {
   "releases": [
     {
+      "tag": "2026-07-29",
+      "title": "tokentelemetry.com landing redesigned",
+      "highlights": [
+        {
+          "title": "The landing page now shows the product working",
+          "description": "tokentelemetry.com opens with the real install boot sequence — agent discovery lines resolving into the live dashboard — plus a replayable session trace and per-agent coverage. Useful when you're pointing a teammate at what TokenTelemetry does before they install.",
+          "href": "https://tokentelemetry.com"
+        }
+      ]
+    },
+    {
       "tag": "2026-07-26",
       "title": "Run TokenTelemetry in Docker or Podman",
       "highlights": [

--- a/UPDATE.json
+++ b/UPDATE.json
@@ -6,7 +6,7 @@
       "highlights": [
         {
           "title": "The landing page now shows the product working",
-          "description": "tokentelemetry.com opens with the real install boot sequence — agent discovery lines resolving into the live dashboard — plus a replayable session trace and per-agent coverage. Useful when you're pointing a teammate at what TokenTelemetry does before they install.",
+          "description": "tokentelemetry.com is rebuilt as mission control: a live token-stream hero, a 90-day burn ledger, the real install boot sequence resolving into the dashboard, and a replayable session trace. Useful when you're pointing a teammate at what TokenTelemetry does before they install.",
           "href": "https://tokentelemetry.com"
         }
       ]

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -9,11 +9,12 @@
       "version": "0.1.0",
       "dependencies": {
         "@types/mdx": "^2.0.14",
-        "framer-motion": "^12.42.2",
+        "animejs": "^4.5.0",
         "fumadocs-core": "^16.10.3",
         "fumadocs-mdx": "^15.0.12",
         "fumadocs-ui": "^16.10.3",
         "lucide-react": "^1.8.0",
+        "motion": "^12.43.0",
         "next": "16.2.10",
         "react": "19.2.7",
         "react-dom": "19.2.7"
@@ -2608,6 +2609,28 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/animejs": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/animejs/-/animejs-4.5.0.tgz",
+      "integrity": "sha512-NQimYX+lz8WaXonGS9zVVoviCIAjONeJayxacUditaivYLqyXgGjFKjuyl0aUUhFKm5MriX9ty1TGovNzoJQWA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/juliangarnier"
+      },
+      "peerDependencies": {
+        "@types/three": ">=0.150.0",
+        "three": ">=0.150.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/three": {
+          "optional": true
+        },
+        "three": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/aria-hidden": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
@@ -3111,12 +3134,12 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "12.42.2",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.42.2.tgz",
-      "integrity": "sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw==",
+      "version": "12.43.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.43.0.tgz",
+      "integrity": "sha512-1eaL3RvR/kAlbG7UYcpMptEyzPoENO0c6w7ZnB3/hh2vSAz/6uGAFn6fdoqTBguNstf3MsFhJHsD/0DHiclG+g==",
       "license": "MIT",
       "dependencies": {
-        "motion-dom": "^12.42.2",
+        "motion-dom": "^12.43.0",
         "motion-utils": "^12.39.0",
         "tslib": "^2.4.0"
       },
@@ -4982,12 +5005,12 @@
       "license": "MIT"
     },
     "node_modules/motion": {
-      "version": "12.42.2",
-      "resolved": "https://registry.npmjs.org/motion/-/motion-12.42.2.tgz",
-      "integrity": "sha512-Atvv11yUKIid41cVrRBDVX5m8tF8kNpExRSlbpt6APClhDjtwQssgFHhQzejxw7/7YYbjHSPKBVbHo05BuJT5Q==",
+      "version": "12.43.0",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.43.0.tgz",
+      "integrity": "sha512-BQgQbSa9Hn3/mtbib0MK53y6JSANa+YKUKlaYnWzAVDH424RYQ5LVpV3pNiWH00BA2z4ojsSdMzqT7g2FQwjuQ==",
       "license": "MIT",
       "dependencies": {
-        "framer-motion": "^12.42.2",
+        "framer-motion": "^12.43.0",
         "tslib": "^2.4.0"
       },
       "peerDependencies": {
@@ -5008,9 +5031,9 @@
       }
     },
     "node_modules/motion-dom": {
-      "version": "12.42.2",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.42.2.tgz",
-      "integrity": "sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA==",
+      "version": "12.43.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.43.0.tgz",
+      "integrity": "sha512-azKON4d9S65PEoFUiQTMTgPheEmzf2QngdRc50AKfJp9Q9mmcBVw22c8eMq9k8kxOFHdL7+WZY7N/5F/lwiDag==",
       "license": "MIT",
       "dependencies": {
         "motion-utils": "^12.39.0"

--- a/website/package.json
+++ b/website/package.json
@@ -10,11 +10,12 @@
   },
   "dependencies": {
     "@types/mdx": "^2.0.14",
-    "framer-motion": "^12.42.2",
+    "animejs": "^4.5.0",
     "fumadocs-core": "^16.10.3",
     "fumadocs-mdx": "^15.0.12",
     "fumadocs-ui": "^16.10.3",
     "lucide-react": "^1.8.0",
+    "motion": "^12.43.0",
     "next": "16.2.10",
     "react": "19.2.7",
     "react-dom": "19.2.7"

--- a/website/src/app/globals.css
+++ b/website/src/app/globals.css
@@ -175,3 +175,70 @@ body {
 @media (prefers-reduced-motion: reduce) {
   .tt-marquee-track { animation: none; }
 }
+
+/* =========================================================================
+   Motion vocabulary (see src/components/motion/vocab.ts — keep in sync)
+   ========================================================================= */
+:root {
+  /* The one entrance curve. JS twin: EASE in vocab.ts. */
+  --tt-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  /* Lets Chromium animate block-size to `auto` (FAQ answers). No-op elsewhere. */
+  interpolate-size: allow-keywords;
+}
+
+/* One-shot glow ping — agent-colored discovery dots (hero boot script).
+   Set the color per element: style="--tt-glow: var(--agent-claude)". */
+@keyframes tt-glow-ping {
+  0%   { box-shadow: 0 0 0 0 var(--tt-glow, var(--tt-brand)); }
+  100% { box-shadow: 0 0 12px 6px transparent; }
+}
+.tt-glow-ping { animation: tt-glow-ping 300ms var(--tt-ease) 1 both; }
+
+/* Border beam — one 1200ms brand-tinted revolution around a block's border,
+   then static. Triggered by BorderBeam (adds .tt-beam-run in view, removes it
+   on animationend). The wrapper's border-radius shapes the ring. Non-Chromium
+   (no @property interpolation) degrades to a brief static highlight. */
+@property --tt-beam-angle {
+  syntax: "<angle>";
+  inherits: false;
+  initial-value: 0deg;
+}
+@keyframes tt-beam {
+  from { --tt-beam-angle: 0deg; }
+  to   { --tt-beam-angle: 360deg; }
+}
+.tt-border-beam { position: relative; }
+.tt-border-beam::after {
+  content: "";
+  pointer-events: none;
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 1px;
+  background: conic-gradient(
+    from var(--tt-beam-angle),
+    transparent 0deg,
+    color-mix(in srgb, var(--tt-brand) 25%, var(--tt-border-strong)) 40deg,
+    var(--tt-brand) 55deg,
+    transparent 80deg
+  );
+  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  mask-composite: exclude;
+  opacity: 0;
+}
+.tt-beam-run::after {
+  opacity: 1;
+  animation: tt-beam 1200ms linear 1;
+}
+
+/* Reduced motion: every CSS loop and one-shot goes still. */
+@media (prefers-reduced-motion: reduce) {
+  .tt-pulse,
+  .tt-glow-ping,
+  .tt-border-beam::after {
+    animation: none !important;
+  }
+  .tt-border-beam::after { opacity: 0 !important; }
+}

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -1,10 +1,11 @@
 import Hero from "@/components/Hero";
 import ProofStrip from "@/components/ProofStrip";
+import LiveTrace from "@/components/LiveTrace";
 import HowItWorks from "@/components/HowItWorks";
 import FeatureShowcase from "@/components/FeatureShowcase";
+import AgentsGrid from "@/components/AgentsGrid";
 import HermesSpotlight from "@/components/HermesSpotlight";
 import Privacy from "@/components/Privacy";
-import AgentsGrid from "@/components/AgentsGrid";
 import FAQ from "@/components/FAQ";
 import FinalCTA from "@/components/FinalCTA";
 import Footer from "@/components/Footer";
@@ -14,11 +15,12 @@ export default function Page() {
     <main>
       <Hero />
       <ProofStrip />
+      <LiveTrace />
       <HowItWorks />
       <FeatureShowcase />
+      <AgentsGrid />
       <HermesSpotlight />
       <Privacy />
-      <AgentsGrid />
       <FAQ />
       <FinalCTA />
       <Footer />

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -1,5 +1,6 @@
 import Hero from "@/components/Hero";
-import ProofStrip from "@/components/ProofStrip";
+import Ledger from "@/components/Ledger";
+import BootShowcase from "@/components/BootShowcase";
 import LiveTrace from "@/components/LiveTrace";
 import HowItWorks from "@/components/HowItWorks";
 import FeatureShowcase from "@/components/FeatureShowcase";
@@ -14,7 +15,8 @@ export default function Page() {
   return (
     <main>
       <Hero />
-      <ProofStrip />
+      <Ledger />
+      <BootShowcase />
       <LiveTrace />
       <HowItWorks />
       <FeatureShowcase />

--- a/website/src/components/AgentsGrid.tsx
+++ b/website/src/components/AgentsGrid.tsx
@@ -4,7 +4,8 @@ import { motion, useInView, useReducedMotion } from "motion/react";
 import { animate, stagger } from "animejs";
 import { AGENTS } from "@/data/agents";
 import { track } from "@/lib/track";
-import { Reveal, motionOk } from "@/components/motion";
+import { motionOk } from "@/components/motion";
+import SectionHead from "@/components/SectionHead";
 
 /**
  * Interactive agent cards. The CRO audit (D3) found visitors tapping the old
@@ -66,15 +67,17 @@ export default function AgentsGrid() {
   return (
     <section id="agents" className="border-t border-[var(--tt-border)]">
       <div className="max-w-[1180px] mx-auto px-5 py-12 sm:py-[72px]">
-        <Reveal y={16} className="text-center max-w-[680px] mx-auto mb-10">
-          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--tt-fg-dim)] mb-3">Coverage</p>
-          <h2 className="text-[clamp(26px,3.6vw,42px)] leading-[1.08] tracking-[-0.025em] font-semibold text-[var(--tt-fg)]">
-            13 coding agents, <span className="text-[var(--tt-brand)]">one place.</span>
-          </h2>
-          <p className="mt-3.5 text-[15.5px] text-[var(--tt-fg-muted)] leading-relaxed">
-            Tap any agent to see what TokenTelemetry captures and where it reads from.
-          </p>
-        </Reveal>
+        <SectionHead
+          index="06"
+          label="coverage"
+          title={
+            <>
+              13 coding agents,{" "}
+              <span className="text-[var(--tt-brand)]">one place.</span>
+            </>
+          }
+          sub="Tap any agent to see what TokenTelemetry captures and where it reads from."
+        />
 
         <div ref={gridRef} className="grid grid-cols-1 min-[480px]:grid-cols-2 lg:grid-cols-4 gap-2.5 items-start">
           {AGENTS.map((a, i) => {

--- a/website/src/components/AgentsGrid.tsx
+++ b/website/src/components/AgentsGrid.tsx
@@ -1,21 +1,72 @@
 "use client";
-import { useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { motion, useInView, useReducedMotion } from "motion/react";
+import { animate, stagger } from "animejs";
 import { AGENTS } from "@/data/agents";
 import { track } from "@/lib/track";
+import { Reveal, motionOk } from "@/components/motion";
 
 /**
  * Interactive agent cards. The CRO audit (D3) found visitors tapping the old
  * static agent cards expecting them to *do* something — dead clicks. Now each
  * card is a real button that expands to reveal what TokenTelemetry captures and
  * where it reads from, so the click pays off.
+ *
+ * Motion: grid cascade on first in-view (animejs, grid stagger from the first
+ * cell), status dots pulse on staggered delays so the grid reads as a bank of
+ * live indicators, and expansion animates height to "auto" via motion/react so
+ * long capture lists never clip.
  */
 export default function AgentsGrid() {
   const [open, setOpen] = useState<number | null>(null);
+  const reduced = useReducedMotion();
+  const gridRef = useRef<HTMLDivElement>(null);
+  const inView = useInView(gridRef, { once: true, amount: 0.2 });
+  const ran = useRef(false);
+
+  // Hide cards just before first client paint. Server/no-JS markup stays fully
+  // visible; reduced motion never hides (cards render static).
+  useLayoutEffect(() => {
+    const grid = gridRef.current;
+    if (!grid || !motionOk()) return;
+    grid.querySelectorAll<HTMLElement>("[data-agent-card]").forEach((el) => {
+      el.style.opacity = "0";
+      el.style.transform = "translateY(16px)";
+    });
+  }, []);
+
+  // Cascade in on first in-view. Inline styles are cleared on complete so the
+  // hover translate (CSS) takes over and nothing stays resident.
+  useEffect(() => {
+    const grid = gridRef.current;
+    if (!inView || ran.current || !grid) return;
+    ran.current = true;
+    const cards = grid.querySelectorAll<HTMLElement>("[data-agent-card]");
+    const clear = () => {
+      cards.forEach((el) => {
+        el.style.opacity = "";
+        el.style.transform = "";
+      });
+    };
+    if (!motionOk()) {
+      clear();
+      return;
+    }
+    animate(cards, {
+      opacity: [0, 1],
+      translateY: [16, 0],
+      duration: 550,
+      ease: "outQuad",
+      delay: stagger(40, { grid: [4, 4], from: "first" }),
+      onComplete: clear,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inView]);
 
   return (
     <section id="agents" className="border-t border-[var(--tt-border)]">
       <div className="max-w-[1180px] mx-auto px-5 py-12 sm:py-[72px]">
-        <div className="text-center max-w-[680px] mx-auto mb-10">
+        <Reveal y={16} className="text-center max-w-[680px] mx-auto mb-10">
           <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--tt-fg-dim)] mb-3">Coverage</p>
           <h2 className="text-[clamp(26px,3.6vw,42px)] leading-[1.08] tracking-[-0.025em] font-semibold text-[var(--tt-fg)]">
             13 coding agents, <span className="text-[var(--tt-brand)]">one place.</span>
@@ -23,44 +74,62 @@ export default function AgentsGrid() {
           <p className="mt-3.5 text-[15.5px] text-[var(--tt-fg-muted)] leading-relaxed">
             Tap any agent to see what TokenTelemetry captures and where it reads from.
           </p>
-        </div>
+        </Reveal>
 
-        <div className="grid grid-cols-1 min-[480px]:grid-cols-2 lg:grid-cols-4 gap-2.5 items-start">
+        <div ref={gridRef} className="grid grid-cols-1 min-[480px]:grid-cols-2 lg:grid-cols-4 gap-2.5 items-start">
           {AGENTS.map((a, i) => {
             const isOpen = open === i;
             return (
               <button
                 key={a.name}
+                data-agent-card
                 aria-expanded={isOpen}
                 onClick={() => {
                   setOpen(isOpen ? null : i);
                   if (!isOpen) track("feature_used", { name: "agent_expand" });
                 }}
-                className="text-left p-4 rounded-[var(--tt-radius-lg)] border border-[var(--tt-border)] bg-[var(--tt-panel)] hover:border-[var(--tt-border-strong)] hover:bg-[var(--tt-raised)] hover:-translate-y-0.5 transition-all relative flex flex-col"
+                className="text-left p-4 rounded-[var(--tt-radius-lg)] border border-[var(--tt-border)] bg-[var(--tt-panel)] hover:border-[var(--tt-border-strong)] hover:bg-[var(--tt-raised)] hover:-translate-y-0.5 transition-all relative flex flex-col w-full"
               >
                 <span className="absolute top-4 right-4 text-[14px] text-[var(--tt-fg-faint)] transition-transform"
                   style={{ transform: isOpen ? "rotate(45deg)" : "none" }}>
                   +
                 </span>
                 <span className="flex items-center gap-2.5 mb-1">
-                  <span className="w-[9px] h-[9px] rounded-full shrink-0" style={{ backgroundColor: a.hex, boxShadow: `0 0 8px ${a.hex}66` }} />
+                  <span
+                    className="tt-pulse w-[9px] h-[9px] rounded-full shrink-0"
+                    style={{
+                      backgroundColor: a.hex,
+                      boxShadow: `0 0 8px ${a.hex}66`,
+                      animationDelay: `${i * 150}ms`,
+                    }}
+                  />
                   <span className="text-[14px] font-semibold tracking-[-0.01em] text-[var(--tt-fg)]">{a.name}</span>
                 </span>
                 <span className="font-mono text-[11px] text-[var(--tt-fg-dim)] pl-[19px]">{a.vendor}</span>
 
-                <span className="overflow-hidden transition-all duration-300 ease-out pl-[19px]"
-                  style={{ maxHeight: isOpen ? 160 : 0, opacity: isOpen ? 1 : 0, marginTop: isOpen ? 8 : 0 }}>
-                  <span className="block text-[11.5px] text-[var(--tt-fg-muted)] leading-relaxed">
-                    Reads from <span className="font-mono text-[var(--tt-fg-muted)]">{a.logPath}</span>
+                <motion.span
+                  className="block overflow-hidden pl-[19px]"
+                  initial={false}
+                  animate={isOpen ? { height: "auto", opacity: 1 } : { height: 0, opacity: 0 }}
+                  transition={
+                    reduced
+                      ? { duration: 0 }
+                      : { type: "spring", stiffness: 300, damping: 30 }
+                  }
+                >
+                  <span className="block pt-2">
+                    <span className="block text-[11.5px] text-[var(--tt-fg-muted)] leading-relaxed">
+                      Reads from <span className="font-mono text-[var(--tt-fg-muted)]">{a.logPath}</span>
+                    </span>
+                    <span className="flex flex-wrap gap-1 mt-2">
+                      {a.captures.map((c) => (
+                        <span key={c} className="font-mono text-[10px] px-1.5 py-0.5 rounded-[5px] bg-[var(--tt-sunken)] border border-[var(--tt-border)] text-[var(--tt-fg-dim)]">
+                          {c}
+                        </span>
+                      ))}
+                    </span>
                   </span>
-                  <span className="flex flex-wrap gap-1 mt-2">
-                    {a.captures.map((c) => (
-                      <span key={c} className="font-mono text-[10px] px-1.5 py-0.5 rounded-[5px] bg-[var(--tt-sunken)] border border-[var(--tt-border)] text-[var(--tt-fg-dim)]">
-                        {c}
-                      </span>
-                    ))}
-                  </span>
-                </span>
+                </motion.span>
               </button>
             );
           })}

--- a/website/src/components/BootShowcase.tsx
+++ b/website/src/components/BootShowcase.tsx
@@ -1,0 +1,214 @@
+"use client";
+/**
+ * BootShowcase — 02 · SCAN. The install boot sequence, full width: a typed
+ * `tokentelemetry`, agent discovery lines in identity colors, then the frame
+ * resolves into the real dashboard. Replays on demand. SSR / no-JS / reduced
+ * motion render the resolved final state; the effect only rewinds it when the
+ * frame is in view and motion is allowed.
+ */
+import { useEffect, useRef, useState, type CSSProperties } from "react";
+import { AnimatePresence, motion, useInView, useReducedMotion } from "motion/react";
+import { Lock, TrendingUp } from "lucide-react";
+import { track } from "@/lib/track";
+import SectionHead from "@/components/SectionHead";
+import { CountUp, useDrawable, motionOk, EASE, DUR, SPRING } from "@/components/motion";
+
+const BOOT_CMD = "tokentelemetry";
+type BootLine = { at: number; text: string; dot?: string; url?: boolean };
+const BOOT_LINES: BootLine[] = [
+  { at: 450, text: "Claude Code · ~/.claude/projects · 218 sessions", dot: "var(--agent-claude)" },
+  { at: 900, text: "Codex · ~/.codex/sessions · 96 sessions", dot: "var(--agent-codex)" },
+  { at: 1350, text: "11 more agents found", dot: "var(--tt-brand)" },
+  { at: 1750, text: "13 agents · 510 sessions", dot: "var(--tt-brand)" },
+  { at: 2100, text: "http://localhost:3000", url: true },
+];
+const RESOLVE_AT = 2400;
+const TAGS_AT = 2750;
+const REPLAY_AT = 3200;
+
+/** "$599 burned" floating tag — pops in, counts up, draws its sparkline. */
+function CostTag({ run, delay }: { run: number; delay: number }) {
+  const reduced = useReducedMotion();
+  const sparkRef = useRef<SVGSVGElement>(null);
+  useDrawable(sparkRef, { duration: 700 });
+  return (
+    <motion.span
+      initial={reduced ? false : { opacity: 0, scale: 0.9 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={reduced ? { duration: DUR.fade } : { ...SPRING.pop, delay }}
+      className="hidden lg:inline-flex items-center gap-1.5 absolute z-20 bottom-[16%] -right-5 px-2.5 py-1.5 rounded-[var(--tt-radius)] text-[11.5px] font-semibold text-[#fbbf24] border border-[var(--tt-border-strong)] backdrop-blur shadow-[0_12px_30px_-14px_rgba(0,0,0,0.7)]"
+      style={{ background: "color-mix(in srgb, var(--tt-overlay) 92%, transparent)" }}
+    >
+      <TrendingUp size={13} className="text-[var(--tt-warn)]" />
+      <span>
+        <CountUp key={run} to={599} prefix="$" duration={1100} /> burned · last 90 days
+      </span>
+      <svg ref={sparkRef} width="34" height="12" viewBox="0 0 34 12" fill="none" aria-hidden className="ml-0.5 shrink-0">
+        <path d="M1 10 L6 8.5 L11 9 L16 5.5 L21 6.5 L26 3 L33 1.5" stroke="var(--tt-brand)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    </motion.span>
+  );
+}
+
+export default function BootShowcase() {
+  const frameRef = useRef<HTMLDivElement>(null);
+  const inView = useInView(frameRef, { once: true, amount: 0.45 });
+
+  const [run, setRun] = useState(0);
+  const [armed, setArmed] = useState(false);
+  const [typedLen, setTypedLen] = useState(BOOT_CMD.length);
+  const [lineCount, setLineCount] = useState(BOOT_LINES.length);
+  const [resolved, setResolved] = useState(true);
+  const [tagsOn, setTagsOn] = useState(true);
+  const [replayReady, setReplayReady] = useState(false);
+
+  // First run waits for the frame to scroll into view; replays fire directly.
+  useEffect(() => {
+    if (inView && motionOk()) setArmed(true);
+  }, [inView]);
+
+  useEffect(() => {
+    if (!armed) return;
+    setResolved(false);
+    setTagsOn(false);
+    setReplayReady(false);
+    setTypedLen(0);
+    setLineCount(0);
+    const timers: number[] = [];
+    for (let i = 1; i <= BOOT_CMD.length; i++) {
+      timers.push(window.setTimeout(() => setTypedLen(i), i * 28));
+    }
+    BOOT_LINES.forEach((l, i) => {
+      timers.push(window.setTimeout(() => setLineCount(i + 1), l.at));
+    });
+    timers.push(window.setTimeout(() => setResolved(true), RESOLVE_AT));
+    timers.push(window.setTimeout(() => setTagsOn(true), TAGS_AT));
+    timers.push(window.setTimeout(() => setReplayReady(true), REPLAY_AT));
+    return () => timers.forEach((t) => clearTimeout(t));
+  }, [armed, run]);
+
+  const replay = () => {
+    track("feature_used", { name: "boot_replay" });
+    setRun((r) => r + 1);
+  };
+
+  return (
+    <section className="py-16 sm:py-24">
+      <div className="max-w-[1180px] mx-auto px-5">
+      <SectionHead
+        index="02"
+        label="scan"
+        title={
+          <>
+            One command finds{" "}
+            <span className="text-[var(--tt-brand)]">every agent you run.</span>
+          </>
+        }
+        sub="No SDK, no config, no signup. The installer scans the logs your agents already write — read-only — and opens the dashboard on localhost."
+      />
+        <div ref={frameRef} className="relative max-w-[1000px] mx-auto">
+          <div aria-hidden className="absolute -inset-x-8 -inset-y-10 z-0 pointer-events-none blur-[48px]"
+            style={{ background: "radial-gradient(closest-side, rgba(96,165,250,0.16), transparent 75%)" }} />
+          <div className="relative z-10 rounded-[var(--tt-radius-lg)] overflow-hidden border border-[var(--tt-border-strong)] bg-[var(--tt-panel)] shadow-[0_40px_120px_-36px_rgba(96,165,250,0.32)]">
+            <div className="flex items-center gap-1.5 h-9 px-3 bg-[var(--tt-raised)] border-b border-[var(--tt-border)]">
+              <span className="w-2.5 h-2.5 rounded-full bg-rose-400/50" />
+              <span className="w-2.5 h-2.5 rounded-full bg-amber-400/50" />
+              <span className="w-2.5 h-2.5 rounded-full bg-emerald-400/50" />
+              <span className="ml-2.5 inline-flex items-center gap-1.5 h-[21px] px-2.5 rounded-md bg-[var(--tt-sunken)] font-mono text-[10.5px] text-[var(--tt-fg-dim)]">
+                {resolved ? (
+                  <>
+                    <Lock size={10} className="text-[var(--tt-success-fg,#10b981)]" /> localhost:3000
+                  </>
+                ) : (
+                  <>~ tokentelemetry</>
+                )}
+              </span>
+            </div>
+            <div className="relative aspect-[16/11] sm:aspect-[16/9] overflow-hidden bg-[var(--tt-sunken)]">
+              {/* No `initial` on the screenshot: SSR/no-JS paint it at full
+                  opacity; the boot only dims it after hydration in view. */}
+              <motion.img
+                src="/screenshots/dashboard.png" width={3200} height={3000}
+                alt="TokenTelemetry dashboard showing live token usage across detected agents"
+                className="block w-full h-auto object-cover object-top"
+                loading="lazy" decoding="async"
+                animate={{ opacity: resolved ? 1 : 0.25, scale: resolved ? 1 : 0.985 }}
+                transition={{ type: "spring", stiffness: 260, damping: 32 }}
+              />
+              <AnimatePresence>
+                {!resolved && (
+                  <motion.div
+                    key={`boot-${run}`}
+                    aria-hidden
+                    initial={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: 0.4, ease: EASE }}
+                    className="pointer-events-none absolute inset-0 p-4 sm:p-6 font-mono text-[12px] sm:text-[13px] leading-[2.05] text-left"
+                    style={{ background: "color-mix(in srgb, var(--tt-sunken) 82%, transparent)" }}
+                  >
+                    <div className="text-[var(--tt-fg)]">
+                      <span className="text-[var(--tt-fg-faint)] select-none mr-2">$</span>
+                      {BOOT_CMD.slice(0, typedLen)}
+                      <span className="inline-block w-[7px] h-[13px] ml-0.5 align-middle bg-[var(--tt-fg-muted)]" />
+                    </div>
+                    {BOOT_LINES.slice(0, lineCount).map((l, i) => (
+                      <motion.div
+                        key={`${run}-${i}`}
+                        initial={{ opacity: 0, x: -12 }}
+                        animate={{ opacity: 1, x: 0 }}
+                        transition={{ duration: DUR.line, ease: EASE }}
+                        className="flex items-center gap-2 text-[var(--tt-fg-muted)]"
+                      >
+                        {l.url ? (
+                          <span className="text-[var(--tt-brand)]">→ {l.text}</span>
+                        ) : (
+                          <>
+                            <span
+                              className="tt-glow-ping w-1.5 h-1.5 rounded-full shrink-0"
+                              style={{ backgroundColor: l.dot, "--tt-glow": l.dot } as CSSProperties}
+                            />
+                            <span>
+                              <span className="text-[var(--tt-success-fg,#10b981)] mr-1.5">✓</span>
+                              {l.text}
+                            </span>
+                          </>
+                        )}
+                      </motion.div>
+                    ))}
+                  </motion.div>
+                )}
+              </AnimatePresence>
+            </div>
+            {replayReady && (
+              <motion.button
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                transition={{ duration: DUR.fade }}
+                onClick={replay}
+                aria-label="Replay the boot sequence"
+                className="absolute z-20 bottom-2.5 right-3 font-mono text-[11px] text-[var(--tt-fg-dim)] hover:text-[var(--tt-fg)] transition-colors"
+              >
+                ↻ replay
+              </motion.button>
+            )}
+          </div>
+          {tagsOn && (
+            <>
+              <motion.span
+                key={`tag-lock-${run}`}
+                initial={{ opacity: 0, scale: 0.9 }}
+                animate={{ opacity: 1, scale: 1 }}
+                transition={SPRING.pop}
+                className="hidden lg:inline-flex items-center gap-1.5 absolute z-20 top-[14%] -left-6 px-2.5 py-1.5 rounded-[var(--tt-radius)] text-[11.5px] font-semibold text-[#86efac] border border-[var(--tt-border-strong)] backdrop-blur shadow-[0_12px_30px_-14px_rgba(0,0,0,0.7)]"
+                style={{ background: "color-mix(in srgb, var(--tt-overlay) 92%, transparent)" }}
+              >
+                <Lock size={13} className="text-[var(--tt-success-fg,#10b981)]" /> 0 bytes leave your machine
+              </motion.span>
+              <CostTag key={`tag-cost-${run}`} run={run} delay={0.15} />
+            </>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/website/src/components/BrowserFrame.tsx
+++ b/website/src/components/BrowserFrame.tsx
@@ -3,17 +3,22 @@ import type { ReactNode } from "react";
 
 /**
  * Shared "browser/app window" chrome — three traffic-light dots + a mono label.
- * Used by the hero shot and the feature showcase so the product surface always
- * reads as a real screen. Children render directly under the title bar (an
- * <img>, a <video>, or animated content), so a static screenshot today can be
- * swapped for a short looping clip later without touching callers.
+ * Used by the hero boot sequence and the feature showcase so the product
+ * surface always reads as a real screen. Children render directly under the
+ * title bar (an <img>, a <video>, or animated content), so a static screenshot
+ * today can be swapped for a short looping clip later without touching callers.
+ *
+ * `tab` replaces the default label span when provided (e.g. the hero swaps the
+ * scan label for its localhost lock pill after the boot resolves).
  */
 export default function BrowserFrame({
   label,
+  tab,
   children,
   className = "",
 }: {
   label: string;
+  tab?: ReactNode;
   children: ReactNode;
   className?: string;
 }) {
@@ -25,10 +30,12 @@ export default function BrowserFrame({
         <span className="w-2.5 h-2.5 rounded-full bg-rose-400/50" />
         <span className="w-2.5 h-2.5 rounded-full bg-amber-400/50" />
         <span className="w-2.5 h-2.5 rounded-full bg-emerald-400/50" />
-        <span className="ml-3 inline-flex items-center gap-1.5 text-[11px] font-mono text-[var(--tt-fg-dim)] truncate">
-          <Activity size={11} className="text-[var(--tt-brand)]" />
-          {label}
-        </span>
+        {tab ?? (
+          <span className="ml-3 inline-flex items-center gap-1.5 text-[11px] font-mono text-[var(--tt-fg-dim)] truncate">
+            <Activity size={11} className="text-[var(--tt-brand)]" />
+            {label}
+          </span>
+        )}
       </div>
       {children}
     </div>

--- a/website/src/components/FAQ.tsx
+++ b/website/src/components/FAQ.tsx
@@ -26,9 +26,11 @@ export default function FAQ() {
         }
       `}</style>
       <Reveal y={16} className="max-w-3xl mx-auto px-5 sm:px-8 py-14 sm:py-28">
-        <div className="text-center mb-8 sm:mb-10">
-          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--tt-fg-dim)] mb-3">FAQ</p>
-          <h2 className="text-[26px] sm:text-[38px] leading-[1.1] tracking-[-0.02em] font-semibold text-[var(--tt-fg)]">
+        <div className="mb-8 sm:mb-10 border-t border-[var(--tt-border)] pt-5">
+          <p className="font-mono text-[11.5px] tracking-[0.16em] uppercase text-[var(--tt-fg-dim)] mb-6">
+            <span className="text-[var(--tt-brand)]">09</span> · faq
+          </p>
+          <h2 className="text-[clamp(30px,4.6vw,52px)] leading-[1.02] tracking-[-0.035em] font-semibold text-[var(--tt-fg)]">
             Common questions
           </h2>
         </div>

--- a/website/src/components/FAQ.tsx
+++ b/website/src/components/FAQ.tsx
@@ -1,11 +1,31 @@
 "use client";
 import { track } from "@/lib/track";
 import { FAQ_ITEMS } from "./faq-items";
+import { Reveal } from "@/components/motion";
 
+/**
+ * Deliberate rest beat: header + list fade up as ONE block (no per-item
+ * stagger — 8 staggering `details` reads as noise). Expansion is CSS-only:
+ * `interpolate-size: allow-keywords` is on :root, so `block-size 0 → auto`
+ * transitions smoothly in Chromium and degrades to instant elsewhere.
+ * Native details/summary semantics and the faq_open track() call are kept.
+ */
 export default function FAQ() {
   return (
     <section id="faq" className="border-t border-[var(--tt-border)]">
-      <div className="max-w-3xl mx-auto px-5 sm:px-8 py-14 sm:py-28">
+      <style>{`
+        .tt-faq-item::details-content {
+          display: block;
+          block-size: 0;
+          overflow: clip;
+          transition: block-size 250ms var(--tt-ease), content-visibility 250ms allow-discrete;
+        }
+        .tt-faq-item[open]::details-content { block-size: auto; }
+        @media (prefers-reduced-motion: reduce) {
+          .tt-faq-item::details-content { transition: none; }
+        }
+      `}</style>
+      <Reveal y={16} className="max-w-3xl mx-auto px-5 sm:px-8 py-14 sm:py-28">
         <div className="text-center mb-8 sm:mb-10">
           <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--tt-fg-dim)] mb-3">FAQ</p>
           <h2 className="text-[26px] sm:text-[38px] leading-[1.1] tracking-[-0.02em] font-semibold text-[var(--tt-fg)]">
@@ -20,13 +40,13 @@ export default function FAQ() {
                 if ((e.currentTarget as HTMLDetailsElement).open)
                   track("faq_open", { question: item.q });
               }}
-              className="group rounded-[var(--tt-radius-lg)] border border-[var(--tt-border)] bg-[var(--tt-panel)] open:bg-[var(--tt-raised)] transition-colors"
+              className="tt-faq-item group rounded-[var(--tt-radius-lg)] border border-[var(--tt-border)] bg-[var(--tt-panel)] open:bg-[var(--tt-raised)] transition-colors"
             >
               <summary className="flex items-center justify-between cursor-pointer list-none gap-4 px-5 py-4">
                 <h3 className="text-[var(--tt-fg)] font-medium text-[15px] sm:text-[16px] tracking-[-0.005em]">
                   {item.q}
                 </h3>
-                <span className="text-[var(--tt-fg-dim)] text-xl leading-none transition-transform group-open:rotate-45 select-none">
+                <span className="text-[var(--tt-fg-dim)] text-xl leading-none [transition:transform_200ms_var(--tt-ease)] group-open:rotate-45 select-none">
                   +
                 </span>
               </summary>
@@ -36,7 +56,7 @@ export default function FAQ() {
             </details>
           ))}
         </div>
-      </div>
+      </Reveal>
     </section>
   );
 }

--- a/website/src/components/FeatureShowcase.tsx
+++ b/website/src/components/FeatureShowcase.tsx
@@ -4,7 +4,8 @@ import { motion, AnimatePresence, useInView, useReducedMotion } from "motion/rea
 import { FEATURES } from "@/data/features";
 import { Check } from "lucide-react";
 import BrowserFrame from "./BrowserFrame";
-import { Reveal, EASE, SPRING } from "@/components/motion";
+import { EASE, SPRING } from "@/components/motion";
+import SectionHead from "@/components/SectionHead";
 
 export default function FeatureShowcase() {
   const [active, setActive] = useState(FEATURES[0].id);
@@ -33,14 +34,16 @@ export default function FeatureShowcase() {
 
   return (
     <section id="features" className="max-w-[1320px] mx-auto px-5 sm:px-8 py-16 sm:py-24">
-      <Reveal y={16} className="text-center mb-8 sm:mb-10">
-        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--tt-fg-dim)] mb-3">
-          What you&apos;ll see
-        </p>
-        <h2 className="text-[28px] sm:text-[44px] leading-[1.1] tracking-[-0.02em] font-semibold text-[var(--tt-fg)] max-w-2xl mx-auto">
-          One dashboard. <span className="text-[var(--tt-brand)]">Every agent.</span>
-        </h2>
-      </Reveal>
+      <SectionHead
+        index="05"
+        label="see"
+        title={
+          <>
+            One dashboard.{" "}
+            <span className="text-[var(--tt-brand)]">Every agent.</span>
+          </>
+        }
+      />
 
       {/* Tabs — horizontally scrollable on mobile, wraps on larger screens */}
       <div className="-mx-5 sm:mx-auto mb-8 sm:mb-10 sm:w-fit overflow-x-auto sm:overflow-visible">

--- a/website/src/components/FeatureShowcase.tsx
+++ b/website/src/components/FeatureShowcase.tsx
@@ -1,23 +1,46 @@
 "use client";
-import { useState } from "react";
-import { motion, AnimatePresence } from "framer-motion";
+import { useRef, useState } from "react";
+import { motion, AnimatePresence, useInView, useReducedMotion } from "motion/react";
 import { FEATURES } from "@/data/features";
-import { Check, Activity } from "lucide-react";
+import { Check } from "lucide-react";
+import BrowserFrame from "./BrowserFrame";
+import { Reveal, EASE, SPRING } from "@/components/motion";
 
 export default function FeatureShowcase() {
   const [active, setActive] = useState(FEATURES[0].id);
   const feature = FEATURES.find((f) => f.id === active)!;
+  const reduced = useReducedMotion();
+
+  // One-time section reveal: the panel (screenshot frame + glow) rises once on
+  // first in-view; tab swaps after that are handled by AnimatePresence alone.
+  const panelRef = useRef<HTMLDivElement>(null);
+  const panelInView = useInView(panelRef, { once: true, amount: 0.2 });
+
+  // Bullet cards stagger 80ms per tab change (the keyed panel remounts them).
+  const bulletList = {
+    hidden: {},
+    show: { transition: { staggerChildren: reduced ? 0 : 0.08 } },
+  };
+  const bulletItem = reduced
+    ? {
+        hidden: { opacity: 0 },
+        show: { opacity: 1, transition: { duration: 0.15 } },
+      }
+    : {
+        hidden: { opacity: 0, y: 12 },
+        show: { opacity: 1, y: 0, transition: { duration: 0.25, ease: EASE } },
+      };
 
   return (
     <section id="features" className="max-w-[1320px] mx-auto px-5 sm:px-8 py-16 sm:py-24">
-      <div className="text-center mb-8 sm:mb-10">
+      <Reveal y={16} className="text-center mb-8 sm:mb-10">
         <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--tt-fg-dim)] mb-3">
           What you&apos;ll see
         </p>
         <h2 className="text-[28px] sm:text-[44px] leading-[1.1] tracking-[-0.02em] font-semibold text-[var(--tt-fg)] max-w-2xl mx-auto">
           One dashboard. <span className="text-[var(--tt-brand)]">Every agent.</span>
         </h2>
-      </div>
+      </Reveal>
 
       {/* Tabs — horizontally scrollable on mobile, wraps on larger screens */}
       <div className="-mx-5 sm:mx-auto mb-8 sm:mb-10 sm:w-fit overflow-x-auto sm:overflow-visible">
@@ -33,65 +56,95 @@ export default function FeatureShowcase() {
             }`}
           >
             {f.label}
-            {active === f.id && (
-              <span aria-hidden className="absolute inset-x-3 -bottom-px h-px bg-[var(--tt-brand)]" />
-            )}
+            {active === f.id &&
+              (reduced ? (
+                <span aria-hidden className="absolute inset-x-3 -bottom-px h-px bg-[var(--tt-brand)]" />
+              ) : (
+                <motion.span
+                  aria-hidden
+                  layoutId="feature-tab"
+                  transition={SPRING.tab}
+                  className="absolute inset-x-3 -bottom-px h-px bg-[var(--tt-brand)]"
+                />
+              ))}
           </button>
         ))}
         </div>
       </div>
 
-      <AnimatePresence mode="wait">
-        <motion.div
-          key={feature.id}
-          initial={{ opacity: 0, y: 12 }}
-          animate={{ opacity: 1, y: 0 }}
-          exit={{ opacity: 0, y: -12 }}
-          transition={{ duration: 0.25 }}
-        >
-          <h3 className="text-center text-[20px] sm:text-[32px] leading-[1.2] tracking-[-0.02em] font-semibold text-[var(--tt-fg)] max-w-3xl mx-auto mb-8 sm:mb-10">
-            {feature.headline}
-          </h3>
+      <motion.div
+        ref={panelRef}
+        initial={false}
+        animate={
+          panelInView
+            ? { opacity: 1, y: 0 }
+            : { opacity: 0, y: reduced ? 0 : 24 }
+        }
+        transition={reduced ? { duration: 0.15 } : SPRING.reveal}
+      >
+        <AnimatePresence mode="wait" initial={false}>
+          <motion.div
+            key={feature.id}
+            initial={reduced ? { opacity: 0 } : { opacity: 0, y: 12, scale: 0.995 }}
+            animate={
+              reduced
+                ? { opacity: 1, transition: { duration: 0.15 } }
+                : { opacity: 1, y: 0, scale: 1, transition: { duration: 0.3, ease: EASE } }
+            }
+            exit={
+              reduced
+                ? { opacity: 0, transition: { duration: 0.15 } }
+                : { opacity: 0, y: -8, transition: { duration: 0.18, ease: EASE } }
+            }
+          >
+            <h3 className="text-center text-[20px] sm:text-[32px] leading-[1.2] tracking-[-0.02em] font-semibold text-[var(--tt-fg)] max-w-3xl mx-auto mb-8 sm:mb-10">
+              {feature.headline}
+            </h3>
 
-          {/* Screenshot */}
-          <div className="relative mb-8 sm:mb-10">
-            <div aria-hidden className="absolute -inset-x-6 -inset-y-6 pointer-events-none bg-gradient-to-tr from-[color:var(--tt-brand-glow)] via-transparent to-emerald-500/5 blur-3xl" />
-            <div className="relative rounded-[var(--tt-radius-lg)] sm:rounded-[var(--tt-radius-xl)] overflow-hidden border border-[var(--tt-border-strong)] bg-[var(--tt-panel)] shadow-[0_30px_120px_-30px_rgba(96,165,250,0.30)]">
-              <div className="flex items-center gap-1.5 px-3 sm:px-4 h-9 bg-[var(--tt-raised)] border-b border-[var(--tt-border)]">
-                <span className="w-2.5 h-2.5 rounded-full bg-rose-400/50" />
-                <span className="w-2.5 h-2.5 rounded-full bg-amber-400/50" />
-                <span className="w-2.5 h-2.5 rounded-full bg-emerald-400/50" />
-                <span className="ml-3 inline-flex items-center gap-1.5 text-[11px] font-mono text-[var(--tt-fg-dim)] truncate">
-                  <Activity size={11} className="text-[var(--tt-brand)]" />
-                  tokentelemetry · {feature.label.toLowerCase()}
-                </span>
-              </div>
-              <img
-                src={feature.screenshot}
-                alt={feature.label}
-                className="block w-full h-auto"
-                loading="lazy"
-                decoding="async"
+            {/* Screenshot */}
+            <div className="relative mb-8 sm:mb-10">
+              {/* Glow fades in over 650ms on first in-view only; instant on tab remounts */}
+              <motion.div
+                aria-hidden
+                initial={false}
+                animate={{ opacity: panelInView ? 1 : 0 }}
+                transition={{ duration: reduced ? 0.15 : 0.65, ease: EASE }}
+                className="absolute -inset-x-6 -inset-y-6 pointer-events-none bg-gradient-to-tr from-[color:var(--tt-brand-glow)] via-transparent to-emerald-500/5 blur-3xl"
               />
+              <BrowserFrame label={`tokentelemetry · ${feature.label.toLowerCase()}`}>
+                <img
+                  src={feature.screenshot}
+                  alt={feature.label}
+                  className="block w-full h-auto"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </BrowserFrame>
             </div>
-          </div>
 
-          {/* Bullets */}
-          <div className="grid md:grid-cols-3 gap-3">
-            {feature.bullets.map((b, i) => (
-              <div
-                key={i}
-                className="flex gap-3 p-4 rounded-[var(--tt-radius-lg)] border border-[var(--tt-border)] bg-[var(--tt-panel)] hover:border-[var(--tt-border-strong)] transition-colors"
-              >
-                <span className="mt-0.5 h-5 w-5 rounded-md bg-[color:var(--tt-brand-glow)] border border-[color:var(--tt-brand)]/25 grid place-items-center shrink-0">
-                  <Check size={11} className="text-[var(--tt-brand)]" strokeWidth={3} />
-                </span>
-                <p className="text-[13.5px] text-[var(--tt-fg-muted)] leading-relaxed">{b}</p>
-              </div>
-            ))}
-          </div>
-        </motion.div>
-      </AnimatePresence>
+            {/* Bullets */}
+            <motion.div
+              variants={bulletList}
+              initial="hidden"
+              animate="show"
+              className="grid md:grid-cols-3 gap-3"
+            >
+              {feature.bullets.map((b, i) => (
+                <motion.div
+                  key={i}
+                  variants={bulletItem}
+                  className="flex gap-3 p-4 rounded-[var(--tt-radius-lg)] border border-[var(--tt-border)] bg-[var(--tt-panel)] hover:border-[var(--tt-border-strong)] transition-colors"
+                >
+                  <span className="mt-0.5 h-5 w-5 rounded-md bg-[color:var(--tt-brand-glow)] border border-[color:var(--tt-brand)]/25 grid place-items-center shrink-0">
+                    <Check size={11} className="text-[var(--tt-brand)]" strokeWidth={3} />
+                  </span>
+                  <p className="text-[13.5px] text-[var(--tt-fg-muted)] leading-relaxed">{b}</p>
+                </motion.div>
+              ))}
+            </motion.div>
+          </motion.div>
+        </AnimatePresence>
+      </motion.div>
     </section>
   );
 }

--- a/website/src/components/FinalCTA.tsx
+++ b/website/src/components/FinalCTA.tsx
@@ -28,8 +28,8 @@ export default function FinalCTA() {
     <section className="relative overflow-hidden border-t border-[var(--tt-border)] text-center">
       <div aria-hidden className="pointer-events-none absolute inset-0 z-0"
         style={{ background: "radial-gradient(800px 380px at 50% 120%, rgba(96,165,250,0.14), transparent 62%)" }} />
-      <Reveal y={16} amount={0.4} className="relative z-10 max-w-[680px] mx-auto px-5 py-14 sm:py-[72px]">
-        <h2 className="text-[clamp(28px,4vw,46px)] leading-[1.06] tracking-[-0.028em] font-semibold text-[var(--tt-fg)] mb-4">
+      <Reveal y={16} amount={0.4} className="relative z-10 max-w-[840px] mx-auto px-5 py-16 sm:py-28">
+        <h2 className="text-[clamp(34px,6vw,72px)] leading-[0.98] tracking-[-0.04em] font-semibold text-[var(--tt-fg)] mb-5 text-balance">
           Stop guessing what your agents cost.
         </h2>
         <p className="text-[16px] text-[var(--tt-fg-muted)] mb-7">

--- a/website/src/components/FinalCTA.tsx
+++ b/website/src/components/FinalCTA.tsx
@@ -3,10 +3,17 @@ import { useState } from "react";
 import { Star, Copy, Check } from "lucide-react";
 import { track } from "@/lib/track";
 import { useGithubStats } from "@/lib/useGithubStats";
+import { BorderBeam, CountUp, Reveal } from "@/components/motion";
 
 const GITHUB_URL = "https://github.com/VasiHemanth/tokentelemetry";
 const INSTALL = "curl -fsSL https://raw.githubusercontent.com/VasiHemanth/tokentelemetry/main/install.sh | bash";
 
+/**
+ * Final CTA: headline + buttons reveal at 40% in view, star count counts up
+ * once (same recipe as ProofStrip), and the install block gets one 1200ms
+ * BorderBeam revolution then goes static. Background glow stays static — the
+ * page ends at rest. Reduced motion: no beam, final star number, opacity fade.
+ */
 export default function FinalCTA() {
   const [copied, setCopied] = useState(false);
   const { stars } = useGithubStats();
@@ -21,7 +28,7 @@ export default function FinalCTA() {
     <section className="relative overflow-hidden border-t border-[var(--tt-border)] text-center">
       <div aria-hidden className="pointer-events-none absolute inset-0 z-0"
         style={{ background: "radial-gradient(800px 380px at 50% 120%, rgba(96,165,250,0.14), transparent 62%)" }} />
-      <div className="relative z-10 max-w-[680px] mx-auto px-5 py-14 sm:py-[72px]">
+      <Reveal y={16} amount={0.4} className="relative z-10 max-w-[680px] mx-auto px-5 py-14 sm:py-[72px]">
         <h2 className="text-[clamp(28px,4vw,46px)] leading-[1.06] tracking-[-0.028em] font-semibold text-[var(--tt-fg)] mb-4">
           Stop guessing what your agents cost.
         </h2>
@@ -36,20 +43,24 @@ export default function FinalCTA() {
             className="inline-flex items-center justify-center gap-2.5 h-12 px-5 rounded-[var(--tt-radius)] text-[14.5px] font-semibold bg-[var(--tt-raised)] text-[var(--tt-fg)] border border-[var(--tt-border-strong)] hover:border-[var(--tt-brand)] hover:bg-[var(--tt-overlay)] transition-colors"
           >
             <Star size={17} className="text-[var(--tt-warn)]" fill="currentColor" /> Star on GitHub
-            <span className="pl-2.5 ml-0.5 border-l border-[rgba(255,255,255,0.1)] text-[13px] font-medium text-[var(--tt-fg-muted)]">{stars} ★</span>
+            <span className="pl-2.5 ml-0.5 border-l border-[rgba(255,255,255,0.1)] text-[13px] font-medium text-[var(--tt-fg-muted)]">
+              <CountUp to={stars} duration={900} /> ★
+            </span>
           </a>
-          <div className="flex-1 min-w-[280px] flex items-center gap-1.5 p-1 rounded-[var(--tt-radius-lg)] border border-[var(--tt-border-strong)] bg-[var(--tt-sunken)]">
-            <code className="flex-1 min-w-0 px-3 py-2 font-mono text-[13px] text-[var(--tt-fg)] overflow-x-auto whitespace-nowrap [scrollbar-width:none]">
-              <span className="text-[var(--tt-fg-faint)] select-none mr-2">$</span>{INSTALL}
-            </code>
-            <button onClick={copy}
-              className="shrink-0 inline-flex items-center gap-1.5 h-[38px] px-3.5 rounded-[var(--tt-radius)] bg-[var(--tt-brand-strong)] hover:bg-[var(--tt-brand)] text-white text-[12.5px] font-semibold shadow-[0_8px_22px_-12px_var(--tt-brand-glow)] transition-colors"
-              aria-label={copied ? "Copied" : "Copy install command"}>
-              {copied ? <Check size={14} /> : <Copy size={14} />}{copied ? "Copied" : "Copy"}
-            </button>
-          </div>
+          <BorderBeam className="flex-1 min-w-[280px] rounded-[var(--tt-radius-lg)]">
+            <div className="flex items-center gap-1.5 p-1 rounded-[var(--tt-radius-lg)] border border-[var(--tt-border-strong)] bg-[var(--tt-sunken)]">
+              <code className="flex-1 min-w-0 px-3 py-2 font-mono text-[13px] text-[var(--tt-fg)] overflow-x-auto whitespace-nowrap [scrollbar-width:none]">
+                <span className="text-[var(--tt-fg-faint)] select-none mr-2">$</span>{INSTALL}
+              </code>
+              <button onClick={copy}
+                className="shrink-0 inline-flex items-center gap-1.5 h-[38px] px-3.5 rounded-[var(--tt-radius)] bg-[var(--tt-brand-strong)] hover:bg-[var(--tt-brand)] text-white text-[12.5px] font-semibold shadow-[0_8px_22px_-12px_var(--tt-brand-glow)] transition-colors"
+                aria-label={copied ? "Copied" : "Copy install command"}>
+                {copied ? <Check size={14} /> : <Copy size={14} />}{copied ? "Copied" : "Copy"}
+              </button>
+            </div>
+          </BorderBeam>
         </div>
-      </div>
+      </Reveal>
     </section>
   );
 }

--- a/website/src/components/HermesSpotlight.tsx
+++ b/website/src/components/HermesSpotlight.tsx
@@ -68,6 +68,9 @@ export default function HermesSpotlight() {
       className="relative overflow-hidden border-y border-[var(--tt-border)] bg-[radial-gradient(ellipse_at_top,rgba(234,179,8,0.08),transparent_70%)]"
     >
       <div className="max-w-[1320px] mx-auto px-5 sm:px-8 py-16 sm:py-24">
+        <p className="font-mono text-[11.5px] tracking-[0.16em] uppercase text-[var(--tt-fg-dim)] mb-10 sm:mb-14">
+          <span className="text-[#eab308]">07</span> · hermes
+        </p>
         <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.1fr)] gap-10 lg:gap-16 items-center">
           {/* Left: copy */}
           <Reveal y={16}>

--- a/website/src/components/HermesSpotlight.tsx
+++ b/website/src/components/HermesSpotlight.tsx
@@ -1,12 +1,25 @@
+"use client";
+import { useRef, type Ref } from "react";
 import Link from "next/link";
 import { ArrowRight } from "lucide-react";
 import PluginInstallBlock from "./PluginInstallBlock";
+import { CountUp, Reveal, Stagger, useDrawable } from "@/components/motion";
 
 // Inline caduceus — matches the icon shipped in the app's frontend so the
 // brand is consistent between the marketing site and the dashboard.
-function Caduceus({ size = 24 }: { size?: number }) {
+// `svgRef` lets useDrawable stroke-draw the paths on first in-view.
+function Caduceus({
+  size = 24,
+  className,
+  svgRef,
+}: {
+  size?: number;
+  className?: string;
+  svgRef?: Ref<SVGSVGElement>;
+}) {
   return (
     <svg
+      ref={svgRef}
       xmlns="http://www.w3.org/2000/svg"
       width={size}
       height={size}
@@ -16,6 +29,8 @@ function Caduceus({ size = 24 }: { size?: number }) {
       strokeWidth="2"
       strokeLinecap="round"
       strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
     >
       <line x1="12" y1="3" x2="12" y2="21" />
       <path d="M8 5L4.5 2.5L6.5 6" />
@@ -32,13 +47,21 @@ function Caduceus({ size = 24 }: { size?: number }) {
 
 const HERMES_HEX = "#eab308";
 
+// Numeric value + static suffix kept apart so CountUp only animates digits.
 const STATS = [
-  { label: "Source platforms", value: "38" },
-  { label: "Skills observable", value: "90+" },
-  { label: "Hermes stars (★)", value: "153k" },
+  { label: "Source platforms", value: 38, suffix: "", duration: 700 },
+  { label: "Skills observable", value: 90, suffix: "+", duration: 900 },
+  { label: "Hermes stars (★)", value: 153, suffix: "k", duration: 900 },
 ];
 
 export default function HermesSpotlight() {
+  const badgeRef = useRef<SVGSVGElement>(null);
+  const markRef = useRef<SVGSVGElement>(null);
+  // Badge caduceus draws on first in-view; the 140px watermark echoes it
+  // behind the right column. Reduced motion: paths render fully drawn.
+  useDrawable(badgeRef, { duration: 900, stagger: 60, amount: 0.3 });
+  useDrawable(markRef, { duration: 900, stagger: 60, amount: 0.3 });
+
   return (
     <section
       id="hermes"
@@ -47,9 +70,9 @@ export default function HermesSpotlight() {
       <div className="max-w-[1320px] mx-auto px-5 sm:px-8 py-16 sm:py-24">
         <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.1fr)] gap-10 lg:gap-16 items-center">
           {/* Left: copy */}
-          <div>
+          <Reveal y={16}>
             <div className="inline-flex items-center gap-2 mb-5 px-2.5 h-7 rounded-full text-[11px] font-medium tracking-tight text-[#eab308] bg-[#eab308]/8 border border-[#eab308]/30">
-              <Caduceus size={11} />
+              <Caduceus size={11} svgRef={badgeRef} />
               New · Hermes Agent
               <span className="text-[#eab308]/50">·</span>
               Nous Research
@@ -80,27 +103,40 @@ export default function HermesSpotlight() {
                 What is Hermes? <ArrowRight size={14} />
               </a>
             </div>
-          </div>
+          </Reveal>
 
           {/* Right: signals + install */}
-          <div className="space-y-4">
-            <div className="grid grid-cols-3 gap-3">
+          <div className="relative space-y-4">
+            {/* Watermark echo of the badge caduceus, drawn simultaneously. */}
+            <Caduceus
+              size={140}
+              svgRef={markRef}
+              className="absolute -top-10 right-0 text-[#eab308] opacity-[0.06] pointer-events-none select-none"
+            />
+            <Stagger gap={80} y={24} className="relative grid grid-cols-3 gap-3">
               {STATS.map((s) => (
-                <div
+                <Stagger.Item
                   key={s.label}
                   className="rounded-[var(--tt-radius-lg)] border border-[var(--tt-border)] bg-[var(--tt-panel)] p-4"
                 >
                   <div className="text-[10px] font-medium uppercase tracking-[0.18em] text-[var(--tt-fg-dim)] mb-1">
                     {s.label}
                   </div>
-                  <div className="text-[24px] font-semibold tracking-[-0.02em] text-[var(--tt-fg)] tabular">
-                    {s.value}
+                  <div className="text-[24px] font-semibold tracking-[-0.02em] text-[var(--tt-fg)]">
+                    <CountUp
+                      to={s.value}
+                      duration={s.duration}
+                      suffix={s.suffix || undefined}
+                    />
                   </div>
-                </div>
+                </Stagger.Item>
               ))}
-            </div>
+            </Stagger>
 
-            <PluginInstallBlock />
+            {/* Static on purpose — it converts. */}
+            <div className="relative">
+              <PluginInstallBlock />
+            </div>
           </div>
         </div>
       </div>

--- a/website/src/components/Hero.tsx
+++ b/website/src/components/Hero.tsx
@@ -1,8 +1,19 @@
 "use client";
-import { useState } from "react";
+import { useEffect, useRef, useState, type CSSProperties } from "react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { Copy, Check, Star, Lock, Monitor, TrendingUp } from "lucide-react";
 import { track } from "@/lib/track";
 import { useGithubStats } from "@/lib/useGithubStats";
+import {
+  CountUp,
+  Reveal,
+  Stagger,
+  useDrawable,
+  motionOk,
+  EASE,
+  DUR,
+  SPRING,
+} from "@/components/motion";
 
 const GITHUB_URL = "https://github.com/VasiHemanth/tokentelemetry";
 
@@ -11,10 +22,98 @@ const INSTALL: Record<"mac" | "win", string> = {
   win: "irm https://raw.githubusercontent.com/VasiHemanth/tokentelemetry/main/install.ps1 | iex",
 };
 
+/**
+ * Boot script for the hero's scan overlay. The spec names this BOOT_SCRIPT in
+ * terminal-script.ts; it lives here because the hero is its only consumer and
+ * that data file belongs to the LiveTrace slice. Move it there if both end up
+ * needing it.
+ */
+const BOOT_CMD = "tokentelemetry";
+type BootLine = { at: number; text: string; dot?: string; url?: boolean };
+const BOOT_LINES: BootLine[] = [
+  { at: 450, text: "Claude Code · ~/.claude/projects · 218 sessions", dot: "var(--agent-claude)" },
+  { at: 900, text: "Codex · ~/.codex/sessions · 96 sessions", dot: "var(--agent-codex)" },
+  { at: 1350, text: "11 more agents found", dot: "var(--tt-brand)" },
+  { at: 1750, text: "13 agents · 510 sessions", dot: "var(--tt-brand)" },
+  { at: 2100, text: "http://localhost:3000", url: true },
+];
+const RESOLVE_AT = 2400;
+const TAGS_AT = 2750;
+const REPLAY_AT = 3200;
+
+/** "$599 burned" floating tag — pops in, counts up, draws its sparkline. */
+function CostTag({ run, delay }: { run: number; delay: number }) {
+  const reduced = useReducedMotion();
+  const sparkRef = useRef<SVGSVGElement>(null);
+  useDrawable(sparkRef, { duration: 700 });
+  return (
+    <motion.span
+      initial={reduced ? false : { opacity: 0, scale: 0.9 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={reduced ? { duration: DUR.fade } : { ...SPRING.pop, delay }}
+      className="hidden lg:inline-flex items-center gap-1.5 absolute z-20 bottom-[16%] -right-4 px-2.5 py-1.5 rounded-[var(--tt-radius)] text-[11.5px] font-semibold text-[#fbbf24] border border-[var(--tt-border-strong)] backdrop-blur shadow-[0_12px_30px_-14px_rgba(0,0,0,0.7)]"
+      style={{ background: "color-mix(in srgb, var(--tt-overlay) 92%, transparent)" }}
+    >
+      <TrendingUp size={13} className="text-[var(--tt-warn)]" />
+      <span>
+        <CountUp key={run} to={599} prefix="$" duration={1100} /> burned · last 90 days
+      </span>
+      <svg
+        ref={sparkRef}
+        width="34"
+        height="12"
+        viewBox="0 0 34 12"
+        fill="none"
+        aria-hidden
+        className="ml-0.5 shrink-0"
+      >
+        <path
+          d="M1 10 L6 8.5 L11 9 L16 5.5 L21 6.5 L26 3 L33 1.5"
+          stroke="var(--tt-brand)"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    </motion.span>
+  );
+}
+
 export default function Hero() {
   const [os, setOs] = useState<"mac" | "win">("mac");
   const [copied, setCopied] = useState(false);
   const { stars } = useGithubStats();
+  const reduced = useReducedMotion();
+
+  // Boot sequence state. SSR / no-JS / reduced motion all render the resolved
+  // final state (screenshot at full opacity, tags mounted) — the effect below
+  // only rewinds and replays it when motion is allowed.
+  const [run, setRun] = useState(0);
+  const [typedLen, setTypedLen] = useState(BOOT_CMD.length);
+  const [lineCount, setLineCount] = useState(BOOT_LINES.length);
+  const [resolved, setResolved] = useState(true);
+  const [tagsOn, setTagsOn] = useState(true);
+  const [replayReady, setReplayReady] = useState(false);
+
+  useEffect(() => {
+    if (!motionOk()) return; // reduced motion: final state, no replay button
+    setResolved(false);
+    setTagsOn(false);
+    setReplayReady(false);
+    setTypedLen(0);
+    setLineCount(0);
+    const timers: number[] = [];
+    for (let i = 1; i <= BOOT_CMD.length; i++) {
+      timers.push(window.setTimeout(() => setTypedLen(i), i * 28));
+    }
+    BOOT_LINES.forEach((l, i) => {
+      timers.push(window.setTimeout(() => setLineCount(i + 1), l.at));
+    });
+    timers.push(window.setTimeout(() => setResolved(true), RESOLVE_AT));
+    timers.push(window.setTimeout(() => setTagsOn(true), TAGS_AT));
+    timers.push(window.setTimeout(() => setReplayReady(true), REPLAY_AT));
+    return () => timers.forEach((t) => clearTimeout(t));
+  }, [run]);
 
   const chooseOs = (k: "mac" | "win") => { setOs(k); track("os_toggle", { os: k }); };
   const copy = () => {
@@ -22,6 +121,10 @@ export default function Hero() {
     setCopied(true);
     track("copy_install_command", { os });
     setTimeout(() => setCopied(false), 1500);
+  };
+  const replay = () => {
+    track("feature_used", { name: "hero_replay" });
+    setRun((r) => r + 1);
   };
 
   return (
@@ -37,35 +140,40 @@ export default function Hero() {
           {/* ── Copy + CTA ── */}
           <div>
             {/* Chips */}
-            <div className="flex flex-wrap gap-1.5 mb-5 justify-center lg:justify-start">
-              <span className="inline-flex items-center gap-1.5 h-7 px-2.5 rounded-full text-[11.5px] font-medium text-[var(--tt-fg-muted)] bg-[var(--tt-panel)] border border-[var(--tt-border)]">
-                <span className="relative flex w-1.5 h-1.5">
-                  <span className="absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-60 animate-ping" />
-                  <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-emerald-400" />
+            <Stagger gap={60} y={8} delay={0.1} className="flex flex-wrap gap-1.5 mb-5 justify-center lg:justify-start">
+              <Stagger.Item>
+                <span className="inline-flex items-center gap-1.5 h-7 px-2.5 rounded-full text-[11.5px] font-medium text-[var(--tt-fg-muted)] bg-[var(--tt-panel)] border border-[var(--tt-border)]">
+                  <span className="relative flex w-1.5 h-1.5">
+                    <span className="absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-60 animate-ping" />
+                    <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-emerald-400" />
+                  </span>
+                  100% local
                 </span>
-                100% local
-              </span>
+              </Stagger.Item>
               {["MIT open source", "13 agents", "No signup"].map((c) => (
-                <span key={c} className="inline-flex items-center h-7 px-2.5 rounded-full text-[11.5px] font-medium text-[var(--tt-fg-muted)] bg-[var(--tt-panel)] border border-[var(--tt-border)]">
-                  {c}
-                </span>
+                <Stagger.Item key={c}>
+                  <span className="inline-flex items-center h-7 px-2.5 rounded-full text-[11.5px] font-medium text-[var(--tt-fg-muted)] bg-[var(--tt-panel)] border border-[var(--tt-border)]">
+                    {c}
+                  </span>
+                </Stagger.Item>
               ))}
-            </div>
+            </Stagger>
 
-            {/* Headline */}
-            <h1 className="text-[clamp(33px,5.4vw,58px)] leading-[1.04] tracking-[-0.028em] font-semibold text-[var(--tt-fg)] mb-4 text-balance">
-              See what your AI coding agents{" "}
-              <span className="text-[var(--tt-brand)]">cost, think, and do</span> —{" "}
-              <span className="bg-gradient-to-r from-[#86efac] to-[#34d399] bg-clip-text text-transparent">
-                100% on your machine.
-              </span>
-            </h1>
-
-            {/* Subhead */}
-            <p className="text-[clamp(15px,1.7vw,17px)] text-[var(--tt-fg-muted)] leading-relaxed max-w-[540px] mx-auto lg:mx-0 mb-6">
-              Read-only observability for Claude Code, Codex, Cursor, Gemini CLI &amp; 9 more. It reads the logs
-              your agents already write — no SDK, no signup, and your data never leaves your computer.
-            </p>
+            {/* Headline + subhead rise as one block. The CTA below stays
+                static so it is interactive (and visible) at first paint. */}
+            <Reveal y={16}>
+              <h1 className="text-[clamp(33px,5.4vw,58px)] leading-[1.04] tracking-[-0.028em] font-semibold text-[var(--tt-fg)] mb-4 text-balance">
+                See what your AI coding agents{" "}
+                <span className="text-[var(--tt-brand)]">cost, think, and do</span> —{" "}
+                <span className="bg-gradient-to-r from-[#86efac] to-[#34d399] bg-clip-text text-transparent">
+                  100% on your machine.
+                </span>
+              </h1>
+              <p className="text-[clamp(15px,1.7vw,17px)] text-[var(--tt-fg-muted)] leading-relaxed max-w-[540px] mx-auto lg:mx-0 mb-6">
+                Read-only observability for Claude Code, Codex, Cursor, Gemini CLI &amp; 9 more. It reads the logs
+                your agents already write — no SDK, no signup, and your data never leaves your computer.
+              </p>
+            </Reveal>
 
             {/* CTA — mobile: star primary; desktop: install primary */}
             <div id="install" className="scroll-mt-20 flex flex-col gap-3.5 max-w-[560px] mx-auto lg:mx-0">
@@ -120,7 +228,7 @@ export default function Hero() {
             </div>
           </div>
 
-          {/* ── Hero visual ── */}
+          {/* ── Hero visual: boot sequence resolves into the dashboard ── */}
           <div className="relative max-w-[620px] mx-auto lg:max-w-none w-full lg:scale-[1.04] lg:origin-left">
             <div aria-hidden className="absolute -inset-x-5 -inset-y-8 z-0 pointer-events-none blur-[40px]"
               style={{ background: "radial-gradient(closest-side, rgba(96,165,250,0.2), transparent 75%)" }} />
@@ -130,24 +238,102 @@ export default function Hero() {
                 <span className="w-2.5 h-2.5 rounded-full bg-amber-400/50" />
                 <span className="w-2.5 h-2.5 rounded-full bg-emerald-400/50" />
                 <span className="ml-2.5 inline-flex items-center gap-1.5 h-[21px] px-2.5 rounded-md bg-[var(--tt-sunken)] font-mono text-[10.5px] text-[var(--tt-fg-dim)]">
-                  <Lock size={10} className="text-[var(--tt-success-fg,#10b981)]" /> localhost:3000
+                  {resolved ? (
+                    <>
+                      <Lock size={10} className="text-[var(--tt-success-fg,#10b981)]" /> localhost:3000
+                    </>
+                  ) : (
+                    <>~ tokentelemetry</>
+                  )}
                 </span>
               </div>
-              <div className="aspect-[16/12] sm:aspect-[16/11] overflow-hidden bg-[var(--tt-sunken)]">
-                <img src="/screenshots/dashboard.png" width={3200} height={3000}
+              <div className="relative aspect-[16/12] sm:aspect-[16/11] overflow-hidden bg-[var(--tt-sunken)]">
+                {/* No `initial` on the screenshot: SSR/no-JS paint it at full
+                    opacity (it's the LCP element); the boot only dims it after
+                    hydration when motion is allowed. */}
+                <motion.img
+                  src="/screenshots/dashboard.png" width={3200} height={3000}
                   alt="TokenTelemetry dashboard showing live token usage across detected agents"
-                  className="block w-full h-auto object-cover object-top" loading="eager" decoding="async" />
+                  className="block w-full h-auto object-cover object-top"
+                  loading="eager" decoding="async"
+                  animate={{ opacity: resolved ? 1 : 0.25, scale: resolved ? 1 : 0.985 }}
+                  transition={{ type: "spring", stiffness: 260, damping: 32 }}
+                />
+                {/* Scan overlay */}
+                <AnimatePresence>
+                  {!resolved && (
+                    <motion.div
+                      key={`boot-${run}`}
+                      aria-hidden
+                      initial={{ opacity: 1 }}
+                      exit={{ opacity: 0 }}
+                      transition={{ duration: 0.4, ease: EASE }}
+                      className="pointer-events-none absolute inset-0 p-4 sm:p-5 font-mono text-[12px] sm:text-[12.5px] leading-[2] text-left"
+                      style={{ background: "color-mix(in srgb, var(--tt-sunken) 82%, transparent)" }}
+                    >
+                      <div className="text-[var(--tt-fg)]">
+                        <span className="text-[var(--tt-fg-faint)] select-none mr-2">$</span>
+                        {BOOT_CMD.slice(0, typedLen)}
+                        <span className="inline-block w-[7px] h-[13px] ml-0.5 align-middle bg-[var(--tt-fg-muted)]" />
+                      </div>
+                      {BOOT_LINES.slice(0, lineCount).map((l, i) => (
+                        <motion.div
+                          key={`${run}-${i}`}
+                          initial={{ opacity: 0, x: -12 }}
+                          animate={{ opacity: 1, x: 0 }}
+                          transition={{ duration: DUR.line, ease: EASE }}
+                          className="flex items-center gap-2 text-[var(--tt-fg-muted)]"
+                        >
+                          {l.url ? (
+                            <span className="text-[var(--tt-brand)]">→ {l.text}</span>
+                          ) : (
+                            <>
+                              <span
+                                className="tt-glow-ping w-1.5 h-1.5 rounded-full shrink-0"
+                                style={{ backgroundColor: l.dot, "--tt-glow": l.dot } as CSSProperties}
+                              />
+                              <span>
+                                <span className="text-[var(--tt-success-fg,#10b981)] mr-1.5">✓</span>
+                                {l.text}
+                              </span>
+                            </>
+                          )}
+                        </motion.div>
+                      ))}
+                    </motion.div>
+                  )}
+                </AnimatePresence>
               </div>
+              {/* Ghost replay affordance — only after the sequence finishes */}
+              {replayReady && (
+                <motion.button
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  transition={{ duration: DUR.fade }}
+                  onClick={replay}
+                  aria-label="Replay the boot sequence"
+                  className="absolute z-20 bottom-2.5 right-3 font-mono text-[11px] text-[var(--tt-fg-dim)] hover:text-[var(--tt-fg)] transition-colors"
+                >
+                  ↻ replay
+                </motion.button>
+              )}
             </div>
             {/* Floating tags (desktop) */}
-            <span className="hidden lg:inline-flex items-center gap-1.5 absolute z-20 top-[14%] -left-5 px-2.5 py-1.5 rounded-[var(--tt-radius)] text-[11.5px] font-semibold text-[#86efac] border border-[var(--tt-border-strong)] backdrop-blur shadow-[0_12px_30px_-14px_rgba(0,0,0,0.7)]"
-              style={{ background: "color-mix(in srgb, var(--tt-overlay) 92%, transparent)" }}>
-              <Lock size={13} className="text-[var(--tt-success-fg,#10b981)]" /> 0 bytes leave your machine
-            </span>
-            <span className="hidden lg:inline-flex items-center gap-1.5 absolute z-20 bottom-[16%] -right-4 px-2.5 py-1.5 rounded-[var(--tt-radius)] text-[11.5px] font-semibold text-[#fbbf24] border border-[var(--tt-border-strong)] backdrop-blur shadow-[0_12px_30px_-14px_rgba(0,0,0,0.7)]"
-              style={{ background: "color-mix(in srgb, var(--tt-overlay) 92%, transparent)" }}>
-              <TrendingUp size={13} className="text-[var(--tt-warn)]" /> $599 burned · last 90 days
-            </span>
+            {tagsOn && (
+              <>
+                <motion.span
+                  key={`tag-lock-${run}`}
+                  initial={reduced ? false : { opacity: 0, scale: 0.9 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  transition={reduced ? { duration: DUR.fade } : SPRING.pop}
+                  className="hidden lg:inline-flex items-center gap-1.5 absolute z-20 top-[14%] -left-5 px-2.5 py-1.5 rounded-[var(--tt-radius)] text-[11.5px] font-semibold text-[#86efac] border border-[var(--tt-border-strong)] backdrop-blur shadow-[0_12px_30px_-14px_rgba(0,0,0,0.7)]"
+                  style={{ background: "color-mix(in srgb, var(--tt-overlay) 92%, transparent)" }}
+                >
+                  <Lock size={13} className="text-[var(--tt-success-fg,#10b981)]" /> 0 bytes leave your machine
+                </motion.span>
+                <CostTag key={`tag-cost-${run}`} run={run} delay={0.15} />
+              </>
+            )}
           </div>
         </div>
       </div>

--- a/website/src/components/Hero.tsx
+++ b/website/src/components/Hero.tsx
@@ -1,19 +1,16 @@
 "use client";
-import { useEffect, useRef, useState, type CSSProperties } from "react";
-import { AnimatePresence, motion, useReducedMotion } from "motion/react";
-import { Copy, Check, Star, Lock, Monitor, TrendingUp } from "lucide-react";
+/**
+ * Hero — full-viewport mission control. A canvas token-field streams
+ * agent-colored tokens into a localhost core on the right; the left column
+ * is editorial: massive stacked headline, terse facts, install command.
+ * The CTA block renders static so it's interactive at first paint.
+ */
+import { useState } from "react";
+import { Copy, Check, Star } from "lucide-react";
 import { track } from "@/lib/track";
 import { useGithubStats } from "@/lib/useGithubStats";
-import {
-  CountUp,
-  Reveal,
-  Stagger,
-  useDrawable,
-  motionOk,
-  EASE,
-  DUR,
-  SPRING,
-} from "@/components/motion";
+import TokenField from "@/components/TokenField";
+import { Stagger, StaggerItem } from "@/components/motion";
 
 const GITHUB_URL = "https://github.com/VasiHemanth/tokentelemetry";
 
@@ -22,98 +19,10 @@ const INSTALL: Record<"mac" | "win", string> = {
   win: "irm https://raw.githubusercontent.com/VasiHemanth/tokentelemetry/main/install.ps1 | iex",
 };
 
-/**
- * Boot script for the hero's scan overlay. The spec names this BOOT_SCRIPT in
- * terminal-script.ts; it lives here because the hero is its only consumer and
- * that data file belongs to the LiveTrace slice. Move it there if both end up
- * needing it.
- */
-const BOOT_CMD = "tokentelemetry";
-type BootLine = { at: number; text: string; dot?: string; url?: boolean };
-const BOOT_LINES: BootLine[] = [
-  { at: 450, text: "Claude Code · ~/.claude/projects · 218 sessions", dot: "var(--agent-claude)" },
-  { at: 900, text: "Codex · ~/.codex/sessions · 96 sessions", dot: "var(--agent-codex)" },
-  { at: 1350, text: "11 more agents found", dot: "var(--tt-brand)" },
-  { at: 1750, text: "13 agents · 510 sessions", dot: "var(--tt-brand)" },
-  { at: 2100, text: "http://localhost:3000", url: true },
-];
-const RESOLVE_AT = 2400;
-const TAGS_AT = 2750;
-const REPLAY_AT = 3200;
-
-/** "$599 burned" floating tag — pops in, counts up, draws its sparkline. */
-function CostTag({ run, delay }: { run: number; delay: number }) {
-  const reduced = useReducedMotion();
-  const sparkRef = useRef<SVGSVGElement>(null);
-  useDrawable(sparkRef, { duration: 700 });
-  return (
-    <motion.span
-      initial={reduced ? false : { opacity: 0, scale: 0.9 }}
-      animate={{ opacity: 1, scale: 1 }}
-      transition={reduced ? { duration: DUR.fade } : { ...SPRING.pop, delay }}
-      className="hidden lg:inline-flex items-center gap-1.5 absolute z-20 bottom-[16%] -right-4 px-2.5 py-1.5 rounded-[var(--tt-radius)] text-[11.5px] font-semibold text-[#fbbf24] border border-[var(--tt-border-strong)] backdrop-blur shadow-[0_12px_30px_-14px_rgba(0,0,0,0.7)]"
-      style={{ background: "color-mix(in srgb, var(--tt-overlay) 92%, transparent)" }}
-    >
-      <TrendingUp size={13} className="text-[var(--tt-warn)]" />
-      <span>
-        <CountUp key={run} to={599} prefix="$" duration={1100} /> burned · last 90 days
-      </span>
-      <svg
-        ref={sparkRef}
-        width="34"
-        height="12"
-        viewBox="0 0 34 12"
-        fill="none"
-        aria-hidden
-        className="ml-0.5 shrink-0"
-      >
-        <path
-          d="M1 10 L6 8.5 L11 9 L16 5.5 L21 6.5 L26 3 L33 1.5"
-          stroke="var(--tt-brand)"
-          strokeWidth="1.5"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-      </svg>
-    </motion.span>
-  );
-}
-
 export default function Hero() {
   const [os, setOs] = useState<"mac" | "win">("mac");
   const [copied, setCopied] = useState(false);
   const { stars } = useGithubStats();
-  const reduced = useReducedMotion();
-
-  // Boot sequence state. SSR / no-JS / reduced motion all render the resolved
-  // final state (screenshot at full opacity, tags mounted) — the effect below
-  // only rewinds and replays it when motion is allowed.
-  const [run, setRun] = useState(0);
-  const [typedLen, setTypedLen] = useState(BOOT_CMD.length);
-  const [lineCount, setLineCount] = useState(BOOT_LINES.length);
-  const [resolved, setResolved] = useState(true);
-  const [tagsOn, setTagsOn] = useState(true);
-  const [replayReady, setReplayReady] = useState(false);
-
-  useEffect(() => {
-    if (!motionOk()) return; // reduced motion: final state, no replay button
-    setResolved(false);
-    setTagsOn(false);
-    setReplayReady(false);
-    setTypedLen(0);
-    setLineCount(0);
-    const timers: number[] = [];
-    for (let i = 1; i <= BOOT_CMD.length; i++) {
-      timers.push(window.setTimeout(() => setTypedLen(i), i * 28));
-    }
-    BOOT_LINES.forEach((l, i) => {
-      timers.push(window.setTimeout(() => setLineCount(i + 1), l.at));
-    });
-    timers.push(window.setTimeout(() => setResolved(true), RESOLVE_AT));
-    timers.push(window.setTimeout(() => setTagsOn(true), TAGS_AT));
-    timers.push(window.setTimeout(() => setReplayReady(true), REPLAY_AT));
-    return () => timers.forEach((t) => clearTimeout(t));
-  }, [run]);
 
   const chooseOs = (k: "mac" | "win") => { setOs(k); track("os_toggle", { os: k }); };
   const copy = () => {
@@ -122,220 +31,101 @@ export default function Hero() {
     track("copy_install_command", { os });
     setTimeout(() => setCopied(false), 1500);
   };
-  const replay = () => {
-    track("feature_used", { name: "hero_replay" });
-    setRun((r) => r + 1);
-  };
 
   return (
-    <section className="relative overflow-hidden">
-      {/* Atmospheric glow + masked grid */}
-      <div aria-hidden className="pointer-events-none absolute inset-0 z-0"
-        style={{ background: "radial-gradient(900px 460px at 78% -8%, rgba(96,165,250,0.10), transparent 60%), radial-gradient(700px 420px at 8% 8%, rgba(168,85,247,0.055), transparent 62%)" }} />
-      <div aria-hidden className="pointer-events-none absolute inset-0 z-0 opacity-50 tt-grid"
-        style={{ maskImage: "radial-gradient(800px 500px at 50% 0%, #000, transparent 75%)", WebkitMaskImage: "radial-gradient(800px 500px at 50% 0%, #000, transparent 75%)" }} />
+    <section className="relative overflow-hidden min-h-[calc(100svh-3.5rem)] flex flex-col">
+      {/* Token stream canvas — the section background */}
+      <TokenField className="absolute inset-0 w-full h-full" />
+      {/* Legibility scrim over the text column */}
+      <div aria-hidden className="pointer-events-none absolute inset-0 z-[1]"
+        style={{ background: "radial-gradient(720px 560px at 22% 45%, rgba(10,12,16,0.88), rgba(10,12,16,0.35) 60%, transparent 78%)" }} />
 
-      <div className="relative z-10 max-w-[1180px] mx-auto px-5">
-        <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,0.88fr)_minmax(0,1.12fr)] gap-8 lg:gap-10 lg:items-center pt-9 sm:pt-14 pb-6 sm:pb-10 text-center lg:text-left">
-          {/* ── Copy + CTA ── */}
-          <div>
-            {/* Chips */}
-            <Stagger gap={60} y={8} delay={0.1} className="flex flex-wrap gap-1.5 mb-5 justify-center lg:justify-start">
-              <Stagger.Item>
-                <span className="inline-flex items-center gap-1.5 h-7 px-2.5 rounded-full text-[11.5px] font-medium text-[var(--tt-fg-muted)] bg-[var(--tt-panel)] border border-[var(--tt-border)]">
-                  <span className="relative flex w-1.5 h-1.5">
-                    <span className="absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-60 animate-ping" />
-                    <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-emerald-400" />
-                  </span>
-                  100% local
-                </span>
-              </Stagger.Item>
-              {["MIT open source", "13 agents", "No signup"].map((c) => (
-                <Stagger.Item key={c}>
-                  <span className="inline-flex items-center h-7 px-2.5 rounded-full text-[11.5px] font-medium text-[var(--tt-fg-muted)] bg-[var(--tt-panel)] border border-[var(--tt-border)]">
-                    {c}
-                  </span>
-                </Stagger.Item>
-              ))}
-            </Stagger>
+      {/* localhost core label — sits on the canvas ring (74% / 50%, see TokenField) */}
+      <div aria-hidden className="hidden lg:flex absolute z-[2] left-[74%] top-1/2 -translate-x-1/2 -translate-y-1/2 flex-col items-center gap-2">
+        <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border border-[var(--tt-border-strong)] bg-[color-mix(in_srgb,var(--tt-panel)_88%,transparent)] backdrop-blur font-mono text-[11px] text-[var(--tt-fg-muted)]">
+          <span className="relative flex w-1.5 h-1.5">
+            <span className="absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-60 animate-ping" />
+            <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-emerald-400" />
+          </span>
+          localhost:3000
+        </span>
+      </div>
 
-            {/* Headline + subhead rise as one block. The CTA below stays
-                static so it is interactive (and visible) at first paint. */}
-            <Reveal y={16}>
-              <h1 className="text-[clamp(33px,5.4vw,58px)] leading-[1.04] tracking-[-0.028em] font-semibold text-[var(--tt-fg)] mb-4 text-balance">
-                See what your AI coding agents{" "}
-                <span className="text-[var(--tt-brand)]">cost, think, and do</span> —{" "}
-                <span className="bg-gradient-to-r from-[#86efac] to-[#34d399] bg-clip-text text-transparent">
-                  100% on your machine.
-                </span>
-              </h1>
-              <p className="text-[clamp(15px,1.7vw,17px)] text-[var(--tt-fg-muted)] leading-relaxed max-w-[540px] mx-auto lg:mx-0 mb-6">
-                Read-only observability for Claude Code, Codex, Cursor, Gemini CLI &amp; 9 more. It reads the logs
-                your agents already write — no SDK, no signup, and your data never leaves your computer.
+      <div className="relative z-[3] flex-1 flex items-center max-w-[1180px] w-full mx-auto px-5 py-14 sm:py-16">
+        <div className="max-w-[720px]">
+          {/* Facts line — mono, no chips */}
+          <p className="font-mono text-[11.5px] tracking-[0.16em] uppercase text-[var(--tt-fg-dim)] mb-6 sm:mb-8">
+            <span className="text-[var(--tt-brand)]">00 · observe</span>
+            <span className="mx-2 text-[var(--tt-fg-faint)]">/</span>
+            local-first telemetry for 13 coding agents
+          </p>
+
+          {/* Stacked editorial headline */}
+          <Stagger gap={80} y={24} className="mb-6 sm:mb-8">
+            <h1 className="text-[clamp(46px,9.2vw,118px)] leading-[0.95] tracking-[-0.05em] font-semibold">
+              <StaggerItem className="block text-[var(--tt-fg)]">Every token.</StaggerItem>
+              <StaggerItem className="block text-[var(--tt-fg)]">Every agent.</StaggerItem>
+              <StaggerItem className="block bg-gradient-to-r from-[#86efac] to-[#34d399] bg-clip-text text-transparent pb-[0.08em]">
+                Your machine.
+              </StaggerItem>
+            </h1>
+            <StaggerItem y={16}>
+              <p className="mt-6 text-[clamp(15px,1.8vw,18px)] text-[var(--tt-fg-muted)] leading-relaxed max-w-[560px]">
+                TokenTelemetry reads the logs Claude Code, Codex, Cursor, Gemini CLI
+                and 9 other coding agents already write, and turns them into one live
+                local dashboard — cost, tokens, traces. No SDK, no signup, and
+                nothing leaves your computer.
               </p>
-            </Reveal>
+            </StaggerItem>
+          </Stagger>
 
-            {/* CTA — mobile: star primary; desktop: install primary */}
-            <div id="install" className="scroll-mt-20 flex flex-col gap-3.5 max-w-[560px] mx-auto lg:mx-0">
-              {/* Star button — order-1 on mobile, order-2 on desktop */}
+          {/* CTA — static, interactive at first paint */}
+          <div id="install" className="scroll-mt-24 max-w-[620px]">
+            <div className="flex items-center gap-1 mb-2">
+              {(["mac", "win"] as const).map((k) => (
+                <button key={k} onClick={() => chooseOs(k)}
+                  className={`h-7 px-3 rounded-[var(--tt-radius-sm)] font-mono text-[11.5px] tracking-[-0.01em] transition-colors ${
+                    os === k ? "bg-white/[0.07] text-[var(--tt-fg)]" : "text-[var(--tt-fg-dim)] hover:text-[var(--tt-fg)]"
+                  }`}>
+                  {k === "mac" ? "macOS / Linux" : "Windows"}
+                </button>
+              ))}
+            </div>
+            <div className="flex items-center gap-1.5 p-1 rounded-[var(--tt-radius-lg)] border border-[var(--tt-border-strong)] bg-[color-mix(in_srgb,var(--tt-sunken)_92%,transparent)] backdrop-blur">
+              <code className="flex-1 min-w-0 px-3 py-2.5 font-mono text-[13px] text-[var(--tt-fg)] overflow-x-auto whitespace-nowrap [scrollbar-width:none]">
+                <span className="text-[var(--tt-fg-faint)] select-none mr-2">$</span>{INSTALL[os]}
+              </code>
+              <button onClick={copy}
+                className="shrink-0 inline-flex items-center gap-1.5 h-[40px] px-4 rounded-[var(--tt-radius)] text-[12.5px] font-semibold transition-colors bg-[var(--tt-brand-strong)] text-white hover:bg-[var(--tt-brand)] shadow-[0_8px_22px_-12px_var(--tt-brand-glow)]"
+                aria-label={copied ? "Copied" : "Copy install command"}>
+                {copied ? <Check size={14} /> : <Copy size={14} />}
+                {copied ? "Copied" : "Copy"}
+              </button>
+            </div>
+            <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2">
               <a
                 href={GITHUB_URL}
                 target="_blank" rel="noopener noreferrer"
                 onClick={() => track("click_github", { location: "hero" })}
-                className="order-1 lg:order-2 self-stretch lg:self-start inline-flex items-center justify-center gap-2.5 h-[52px] lg:h-12 px-5 rounded-[var(--tt-radius)] text-[15px] lg:text-[14.5px] font-semibold transition-colors
-                  bg-[var(--tt-brand-strong)] lg:bg-[var(--tt-raised)] text-white lg:text-[var(--tt-fg)] border border-transparent lg:border-[var(--tt-border-strong)] hover:bg-[var(--tt-brand)] lg:hover:bg-[var(--tt-overlay)] lg:hover:border-[var(--tt-brand)] shadow-[0_12px_30px_-14px_var(--tt-brand-glow)] lg:shadow-none"
+                className="inline-flex items-center gap-2 h-10 px-4 rounded-[var(--tt-radius)] text-[13.5px] font-semibold bg-[color-mix(in_srgb,var(--tt-raised)_88%,transparent)] backdrop-blur text-[var(--tt-fg)] border border-[var(--tt-border-strong)] hover:border-[var(--tt-brand)] transition-colors"
               >
-                <Star size={17} className="text-[#fde68a] lg:text-[var(--tt-warn)]" fill="currentColor" />
+                <Star size={15} className="text-[var(--tt-warn)]" fill="currentColor" />
                 Star on GitHub
-                <span className="inline-flex items-center gap-1 pl-2.5 ml-0.5 border-l border-white/25 lg:border-[var(--tt-border2,rgba(255,255,255,0.1))] text-[13px] font-medium text-white/85 lg:text-[var(--tt-fg-muted)]">
-                  {stars} ★
-                </span>
+                <span className="pl-2.5 border-l border-white/10 text-[12.5px] font-medium text-[var(--tt-fg-muted)]">{stars} ★</span>
               </a>
-
-              {/* Install block — order-2 on mobile, order-1 on desktop */}
-              <div className="order-2 lg:order-1 w-full">
-                <div className="flex gap-1 mb-2 justify-center lg:justify-start">
-                  {(["mac", "win"] as const).map((k) => (
-                    <button key={k} onClick={() => chooseOs(k)}
-                      className={`h-7 px-3 rounded-[var(--tt-radius-sm)] text-[11.5px] font-medium tracking-[-0.01em] transition-colors ${
-                        os === k ? "bg-white/[0.07] text-[var(--tt-fg)]" : "text-[var(--tt-fg-dim)] hover:text-[var(--tt-fg)]"
-                      }`}>
-                      {k === "mac" ? "macOS / Linux" : "Windows"}
-                    </button>
-                  ))}
-                </div>
-                <div className="flex items-center gap-1.5 p-1 rounded-[var(--tt-radius-lg)] border border-[var(--tt-border-strong)] bg-[var(--tt-sunken)] max-sm:border-dashed">
-                  <code className="flex-1 min-w-0 px-3 py-2 font-mono text-[13px] text-[var(--tt-fg)] overflow-x-auto whitespace-nowrap [scrollbar-width:none]">
-                    <span className="text-[var(--tt-fg-faint)] select-none mr-2">$</span>{INSTALL[os]}
-                  </code>
-                  <button onClick={copy}
-                    className="shrink-0 inline-flex items-center gap-1.5 h-[38px] px-3.5 rounded-[var(--tt-radius)] text-[12.5px] font-semibold transition-colors
-                      bg-[var(--tt-brand-strong)] text-white hover:bg-[var(--tt-brand)] shadow-[0_8px_22px_-12px_var(--tt-brand-glow)]
-                      max-sm:bg-[var(--tt-raised)] max-sm:text-[var(--tt-fg)] max-sm:border max-sm:border-[var(--tt-border-strong)] max-sm:shadow-none"
-                    aria-label={copied ? "Copied" : "Copy install command"}>
-                    {copied ? <Check size={14} /> : <Copy size={14} />}
-                    {copied ? "Copied" : "Copy"}
-                  </button>
-                </div>
-                <p className="mt-2 font-mono text-[11px] text-[var(--tt-fg-dim)] text-center lg:text-left">
-                  MIT · runs offline · needs Node 18+, Python 3.9+
-                </p>
-                <div className="hidden max-sm:flex items-center gap-1.5 mt-2 text-[12px] text-[var(--tt-fg-dim)]">
-                  <Monitor size={13} className="text-[var(--tt-brand)] shrink-0" />
-                  <span>Runs on your desktop — copy it now, paste it when you&apos;re back at your machine.</span>
-                </div>
-              </div>
+              <p className="font-mono text-[11px] text-[var(--tt-fg-dim)]">
+                MIT · runs offline · Node 18+, Python 3.9+
+              </p>
             </div>
-          </div>
-
-          {/* ── Hero visual: boot sequence resolves into the dashboard ── */}
-          <div className="relative max-w-[620px] mx-auto lg:max-w-none w-full lg:scale-[1.04] lg:origin-left">
-            <div aria-hidden className="absolute -inset-x-5 -inset-y-8 z-0 pointer-events-none blur-[40px]"
-              style={{ background: "radial-gradient(closest-side, rgba(96,165,250,0.2), transparent 75%)" }} />
-            <div className="relative z-10 rounded-[var(--tt-radius-lg)] overflow-hidden border border-[var(--tt-border-strong)] bg-[var(--tt-panel)] shadow-[0_40px_120px_-36px_rgba(96,165,250,0.32)]">
-              <div className="flex items-center gap-1.5 h-9 px-3 bg-[var(--tt-raised)] border-b border-[var(--tt-border)]">
-                <span className="w-2.5 h-2.5 rounded-full bg-rose-400/50" />
-                <span className="w-2.5 h-2.5 rounded-full bg-amber-400/50" />
-                <span className="w-2.5 h-2.5 rounded-full bg-emerald-400/50" />
-                <span className="ml-2.5 inline-flex items-center gap-1.5 h-[21px] px-2.5 rounded-md bg-[var(--tt-sunken)] font-mono text-[10.5px] text-[var(--tt-fg-dim)]">
-                  {resolved ? (
-                    <>
-                      <Lock size={10} className="text-[var(--tt-success-fg,#10b981)]" /> localhost:3000
-                    </>
-                  ) : (
-                    <>~ tokentelemetry</>
-                  )}
-                </span>
-              </div>
-              <div className="relative aspect-[16/12] sm:aspect-[16/11] overflow-hidden bg-[var(--tt-sunken)]">
-                {/* No `initial` on the screenshot: SSR/no-JS paint it at full
-                    opacity (it's the LCP element); the boot only dims it after
-                    hydration when motion is allowed. */}
-                <motion.img
-                  src="/screenshots/dashboard.png" width={3200} height={3000}
-                  alt="TokenTelemetry dashboard showing live token usage across detected agents"
-                  className="block w-full h-auto object-cover object-top"
-                  loading="eager" decoding="async"
-                  animate={{ opacity: resolved ? 1 : 0.25, scale: resolved ? 1 : 0.985 }}
-                  transition={{ type: "spring", stiffness: 260, damping: 32 }}
-                />
-                {/* Scan overlay */}
-                <AnimatePresence>
-                  {!resolved && (
-                    <motion.div
-                      key={`boot-${run}`}
-                      aria-hidden
-                      initial={{ opacity: 1 }}
-                      exit={{ opacity: 0 }}
-                      transition={{ duration: 0.4, ease: EASE }}
-                      className="pointer-events-none absolute inset-0 p-4 sm:p-5 font-mono text-[12px] sm:text-[12.5px] leading-[2] text-left"
-                      style={{ background: "color-mix(in srgb, var(--tt-sunken) 82%, transparent)" }}
-                    >
-                      <div className="text-[var(--tt-fg)]">
-                        <span className="text-[var(--tt-fg-faint)] select-none mr-2">$</span>
-                        {BOOT_CMD.slice(0, typedLen)}
-                        <span className="inline-block w-[7px] h-[13px] ml-0.5 align-middle bg-[var(--tt-fg-muted)]" />
-                      </div>
-                      {BOOT_LINES.slice(0, lineCount).map((l, i) => (
-                        <motion.div
-                          key={`${run}-${i}`}
-                          initial={{ opacity: 0, x: -12 }}
-                          animate={{ opacity: 1, x: 0 }}
-                          transition={{ duration: DUR.line, ease: EASE }}
-                          className="flex items-center gap-2 text-[var(--tt-fg-muted)]"
-                        >
-                          {l.url ? (
-                            <span className="text-[var(--tt-brand)]">→ {l.text}</span>
-                          ) : (
-                            <>
-                              <span
-                                className="tt-glow-ping w-1.5 h-1.5 rounded-full shrink-0"
-                                style={{ backgroundColor: l.dot, "--tt-glow": l.dot } as CSSProperties}
-                              />
-                              <span>
-                                <span className="text-[var(--tt-success-fg,#10b981)] mr-1.5">✓</span>
-                                {l.text}
-                              </span>
-                            </>
-                          )}
-                        </motion.div>
-                      ))}
-                    </motion.div>
-                  )}
-                </AnimatePresence>
-              </div>
-              {/* Ghost replay affordance — only after the sequence finishes */}
-              {replayReady && (
-                <motion.button
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  transition={{ duration: DUR.fade }}
-                  onClick={replay}
-                  aria-label="Replay the boot sequence"
-                  className="absolute z-20 bottom-2.5 right-3 font-mono text-[11px] text-[var(--tt-fg-dim)] hover:text-[var(--tt-fg)] transition-colors"
-                >
-                  ↻ replay
-                </motion.button>
-              )}
-            </div>
-            {/* Floating tags (desktop) */}
-            {tagsOn && (
-              <>
-                <motion.span
-                  key={`tag-lock-${run}`}
-                  initial={reduced ? false : { opacity: 0, scale: 0.9 }}
-                  animate={{ opacity: 1, scale: 1 }}
-                  transition={reduced ? { duration: DUR.fade } : SPRING.pop}
-                  className="hidden lg:inline-flex items-center gap-1.5 absolute z-20 top-[14%] -left-5 px-2.5 py-1.5 rounded-[var(--tt-radius)] text-[11.5px] font-semibold text-[#86efac] border border-[var(--tt-border-strong)] backdrop-blur shadow-[0_12px_30px_-14px_rgba(0,0,0,0.7)]"
-                  style={{ background: "color-mix(in srgb, var(--tt-overlay) 92%, transparent)" }}
-                >
-                  <Lock size={13} className="text-[var(--tt-success-fg,#10b981)]" /> 0 bytes leave your machine
-                </motion.span>
-                <CostTag key={`tag-cost-${run}`} run={run} delay={0.15} />
-              </>
-            )}
           </div>
         </div>
+      </div>
+
+      {/* Scroll cue */}
+      <div className="relative z-[3] max-w-[1180px] w-full mx-auto px-5 pb-5">
+        <p aria-hidden className="font-mono text-[11px] tracking-[0.16em] uppercase text-[var(--tt-fg-faint)]">
+          ↓ 01 · burn
+        </p>
       </div>
     </section>
   );

--- a/website/src/components/HowItWorks.tsx
+++ b/website/src/components/HowItWorks.tsx
@@ -7,7 +7,8 @@ import {
   useScroll,
   type Variants,
 } from "motion/react";
-import { CountUp, Reveal, DUR, GAP, RISE, SPRING } from "@/components/motion";
+import { CountUp, DUR, GAP, RISE, SPRING } from "@/components/motion";
+import SectionHead from "@/components/SectionHead";
 
 const STEPS = [
   {
@@ -68,19 +69,23 @@ export default function HowItWorks() {
   };
 
   return (
-    <section ref={sectionRef} className="relative max-w-[1180px] mx-auto px-5 py-12 sm:py-[72px]">
-      <Reveal className="text-center max-w-[680px] mx-auto mb-10">
-        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--tt-fg-dim)] mb-3">
-          From zero to dashboard in one command
-        </p>
-        <h2 className="text-[clamp(26px,3.6vw,42px)] leading-[1.08] tracking-[-0.025em] font-semibold text-[var(--tt-fg)]">
-          No instrumentation. <span className="text-[var(--tt-brand)]">No code changes.</span>
-        </h2>
-        <p className="mt-3.5 text-[15.5px] text-[var(--tt-fg-muted)] leading-relaxed">
-          Your agents already write logs. TokenTelemetry just reads them — so setup is one line, and there&apos;s
-          nothing to wire into your codebase.
-        </p>
-      </Reveal>
+    <section ref={sectionRef} className="relative max-w-[1180px] mx-auto px-5 py-16 sm:py-24">
+      <SectionHead
+        index="04"
+        label="setup"
+        title={
+          <>
+            No instrumentation.{" "}
+            <span className="text-[var(--tt-brand)]">No code changes.</span>
+          </>
+        }
+        sub={
+          <>
+            Your agents already write logs. TokenTelemetry just reads them — so
+            setup is one line, and there&apos;s nothing to wire into your codebase.
+          </>
+        }
+      />
       <div className="relative">
         <motion.div
           className="grid grid-cols-1 md:grid-cols-3 gap-3 sm:gap-4"

--- a/website/src/components/HowItWorks.tsx
+++ b/website/src/components/HowItWorks.tsx
@@ -1,3 +1,14 @@
+"use client";
+import { useRef, useState } from "react";
+import {
+  motion,
+  useMotionValueEvent,
+  useReducedMotion,
+  useScroll,
+  type Variants,
+} from "motion/react";
+import { CountUp, Reveal, DUR, GAP, RISE, SPRING } from "@/components/motion";
+
 const STEPS = [
   {
     n: "1",
@@ -9,7 +20,7 @@ const STEPS = [
     n: "2",
     title: "It finds your agents",
     body: "Scans the log files Claude Code, Codex, Cursor & co. already write to your disk. Read-only. Nothing is sent anywhere.",
-    code: <><span className="text-[var(--tt-success-fg,#10b981)]">✓</span> detected 13 agents · 510 sessions</>,
+    code: <><span className="text-[var(--tt-success-fg,#10b981)]">✓</span> detected <CountUp to={13} duration={500} delay={900} /> agents · <CountUp to={510} duration={700} delay={900} /> sessions</>,
   },
   {
     n: "3",
@@ -19,10 +30,46 @@ const STEPS = [
   },
 ];
 
+/** Badge fill thresholds along the section's scroll progress. */
+const FILL_AT = [0.15, 0.5, 0.85];
+
 export default function HowItWorks() {
+  const sectionRef = useRef<HTMLElement>(null);
+  const reduced = useReducedMotion();
+
+  // Scroll-linked effect #2 (page-wide budget: header chrome + this connector).
+  const { scrollYProgress } = useScroll({
+    target: sectionRef,
+    offset: ["start 0.8", "end 0.5"],
+  });
+  const [filledCount, setFilledCount] = useState(0);
+  useMotionValueEvent(scrollYProgress, "change", (v) => {
+    const n = v >= FILL_AT[2] ? 3 : v >= FILL_AT[1] ? 2 : v >= FILL_AT[0] ? 1 : 0;
+    setFilledCount((prev) => (prev === n ? prev : n));
+  });
+
+  const gridVariants: Variants = {
+    hidden: {},
+    visible: { transition: { staggerChildren: reduced ? 0 : GAP.row / 1000 } },
+  };
+  const cardVariants: Variants = reduced
+    ? {
+        hidden: { opacity: 0 },
+        visible: { opacity: 1, transition: { duration: DUR.fade } },
+      }
+    : {
+        hidden: { opacity: 0, y: RISE.card },
+        // delayChildren = card settle (~550ms) + 200ms before its code line fades in.
+        visible: { opacity: 1, y: 0, transition: { ...SPRING.reveal, delayChildren: 0.75 } },
+      };
+  const codeVariants: Variants = {
+    hidden: { opacity: 0 },
+    visible: { opacity: 1, transition: { duration: DUR.fade } },
+  };
+
   return (
-    <section className="relative max-w-[1180px] mx-auto px-5 py-12 sm:py-[72px]">
-      <div className="text-center max-w-[680px] mx-auto mb-10">
+    <section ref={sectionRef} className="relative max-w-[1180px] mx-auto px-5 py-12 sm:py-[72px]">
+      <Reveal className="text-center max-w-[680px] mx-auto mb-10">
         <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--tt-fg-dim)] mb-3">
           From zero to dashboard in one command
         </p>
@@ -33,21 +80,76 @@ export default function HowItWorks() {
           Your agents already write logs. TokenTelemetry just reads them — so setup is one line, and there&apos;s
           nothing to wire into your codebase.
         </p>
-      </div>
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-3 sm:gap-4">
-        {STEPS.map((s) => (
-          <div key={s.n} className="p-6 rounded-[var(--tt-radius-lg)] border border-[var(--tt-border)] bg-[var(--tt-panel)]">
-            <div className="inline-flex items-center justify-center w-[30px] h-[30px] rounded-lg mb-3.5 font-mono text-[12px] font-semibold text-[var(--tt-brand)] bg-[color:var(--tt-brand-glow)] border"
-              style={{ borderColor: "color-mix(in srgb, var(--tt-brand) 25%, transparent)" }}>
-              {s.n}
-            </div>
-            <h3 className="text-[16px] font-semibold tracking-[-0.01em] text-[var(--tt-fg)] mb-1.5">{s.title}</h3>
-            <p className="text-[13.5px] text-[var(--tt-fg-muted)] leading-relaxed">{s.body}</p>
-            <div className="mt-3 px-3 py-2 rounded-lg bg-[var(--tt-sunken)] border border-[var(--tt-border)] font-mono text-[11.5px] text-[var(--tt-fg-muted)] overflow-x-auto whitespace-nowrap">
-              {s.code}
-            </div>
-          </div>
-        ))}
+      </Reveal>
+      <div className="relative">
+        <motion.div
+          className="grid grid-cols-1 md:grid-cols-3 gap-3 sm:gap-4"
+          variants={gridVariants}
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true, amount: 0.3 }}
+        >
+          {STEPS.map((s, i) => (
+            <motion.div
+              key={s.n}
+              variants={cardVariants}
+              className="p-6 rounded-[var(--tt-radius-lg)] border border-[var(--tt-border)] bg-[var(--tt-panel)]"
+            >
+              <div
+                className="relative z-[1] inline-flex items-center justify-center w-[30px] h-[30px] rounded-lg mb-3.5 font-mono text-[12px] font-semibold border bg-[var(--tt-panel)] transition-[color,background-color,border-color,box-shadow] duration-200 ease-[var(--tt-ease)]"
+                style={
+                  reduced || filledCount > i
+                    ? {
+                        color: "var(--tt-brand)",
+                        backgroundColor: "var(--tt-brand-glow)",
+                        borderColor: "color-mix(in srgb, var(--tt-brand) 25%, transparent)",
+                        boxShadow: "0 0 16px var(--tt-brand-glow)",
+                      }
+                    : {
+                        color: "var(--tt-fg-dim)",
+                        borderColor: "var(--tt-border-strong)",
+                        boxShadow: "none",
+                      }
+                }
+              >
+                {s.n}
+              </div>
+              <h3 className="text-[16px] font-semibold tracking-[-0.01em] text-[var(--tt-fg)] mb-1.5">{s.title}</h3>
+              <p className="text-[13.5px] text-[var(--tt-fg-muted)] leading-relaxed">{s.body}</p>
+              <motion.div
+                variants={codeVariants}
+                className="mt-3 px-3 py-2 rounded-lg bg-[var(--tt-sunken)] border border-[var(--tt-border)] font-mono text-[11.5px] text-[var(--tt-fg-muted)] overflow-x-auto whitespace-nowrap"
+              >
+                {s.code}
+              </motion.div>
+            </motion.div>
+          ))}
+        </motion.div>
+        {/* Connector line through the step badges (desktop only). Spans badge-1
+            center → badge-3 center: badge center sits 39px (24px card padding +
+            half the 30px badge) from each card edge; card width = (100% - 2×16px
+            gaps) / 3. Sits above card panels, below the z-[1] badges. */}
+        <div
+          aria-hidden
+          className="pointer-events-none absolute top-[39px] left-[39px] right-[calc((100%-32px)/3-39px)] hidden md:block h-0.5"
+        >
+          <svg className="w-full h-full" viewBox="0 0 100 2" preserveAspectRatio="none" fill="none">
+            <line
+              x1="0" y1="1" x2="100" y2="1"
+              stroke="var(--tt-border-strong)"
+              strokeWidth="1.5"
+              vectorEffect="non-scaling-stroke"
+            />
+            <motion.line
+              x1="0" y1="1" x2="100" y2="1"
+              stroke="var(--tt-brand)"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              vectorEffect="non-scaling-stroke"
+              style={{ pathLength: reduced ? 1 : scrollYProgress, opacity: 0.8 }}
+            />
+          </svg>
+        </div>
       </div>
     </section>
   );

--- a/website/src/components/Ledger.tsx
+++ b/website/src/components/Ledger.tsx
@@ -1,0 +1,64 @@
+"use client";
+/**
+ * Ledger — 01 · BURN. Ninety days of one machine's agent spend as oversized
+ * tabular numerals. The figures match the demo dashboard in the hero
+ * screenshot; the zero is the point.
+ */
+import CountUp from "@/components/motion/CountUp";
+import Reveal from "@/components/motion/Reveal";
+import SectionHead from "@/components/SectionHead";
+
+const ROWS = [
+  {
+    value: <CountUp to={599.85} prefix="$" duration={1100} format={(n) => n.toFixed(2)} />,
+    label: "burned across every agent",
+    tone: "text-[var(--tt-warn)]",
+  },
+  {
+    value: <CountUp to={931.8} suffix="M" duration={1000} format={(n) => n.toFixed(1)} />,
+    label: "tokens metered, in and out",
+    tone: "text-[var(--tt-fg)]",
+  },
+  {
+    value: <CountUp to={510} duration={900} />,
+    label: "sessions traced end to end",
+    tone: "text-[var(--tt-fg)]",
+  },
+  {
+    value: <span>0</span>,
+    label: "bytes uploaded anywhere",
+    tone: "text-[#34d399]",
+  },
+];
+
+export default function Ledger() {
+  return (
+    <section className="py-16 sm:py-24">
+      <div className="max-w-[1180px] mx-auto px-5">
+      <SectionHead
+        index="01"
+        label="burn"
+        title={
+          <>
+            The bill is real.{" "}
+            <span className="text-[var(--tt-fg-dim)]">Now it&apos;s visible.</span>
+          </>
+        }
+        sub="Ninety days on one machine, straight off the demo dashboard below. Your numbers will be your own — that's the point."
+      />
+        <dl className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4">
+          {ROWS.map((r, i) => (
+            <Reveal key={r.label} y={24} delay={i * 0.08} className="group border-t lg:border-t-0 lg:border-l border-[var(--tt-border)] first:border-t-0 first:lg:border-l-0 py-7 lg:py-2 lg:px-7 first:lg:pl-0">
+              <dd className={`tabular font-semibold tracking-[-0.04em] leading-none whitespace-nowrap text-[clamp(40px,4.6vw,64px)] ${r.tone}`}>
+                {r.value}
+              </dd>
+              <dt className="mt-3 font-mono text-[11.5px] tracking-[0.14em] uppercase text-[var(--tt-fg-dim)]">
+                {r.label}
+              </dt>
+            </Reveal>
+          ))}
+        </dl>
+      </div>
+    </section>
+  );
+}

--- a/website/src/components/LiveTrace.tsx
+++ b/website/src/components/LiveTrace.tsx
@@ -9,6 +9,7 @@
 import { useEffect, useRef, useState } from "react";
 import { animate } from "animejs";
 import TerminalReplay from "@/components/TerminalReplay";
+import SectionHead from "@/components/SectionHead";
 import { Reveal, ANIME_EASE, EASE_CSS, motionOk } from "@/components/motion";
 
 const fmtInt = (n: number) => Math.round(n).toLocaleString("en-US");
@@ -67,19 +68,18 @@ export default function LiveTrace() {
   const onLoop = () => setPhase("waiting");
 
   return (
-    <section className="relative max-w-[1180px] mx-auto px-5 py-12 sm:py-[72px]">
-      <Reveal className="text-center max-w-[680px] mx-auto mb-10">
-        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--tt-fg-dim)] mb-3">
-          Session trace
-        </p>
-        <h2 className="text-[clamp(26px,3.6vw,42px)] leading-[1.08] tracking-[-0.025em] font-semibold text-[var(--tt-fg)]">
-          See what your agent <span className="text-[var(--tt-brand)]">actually did</span>
-        </h2>
-        <p className="mt-3.5 text-[15.5px] text-[var(--tt-fg-muted)] leading-relaxed">
-          Every session becomes a replayable trace: prompts, tool calls,
-          reasoning steps, and the exact token cost.
-        </p>
-      </Reveal>
+    <section className="relative max-w-[1180px] mx-auto px-5 py-16 sm:py-24">
+      <SectionHead
+        index="03"
+        label="trace"
+        title={
+          <>
+            See what your agent{" "}
+            <span className="text-[var(--tt-brand)]">actually did.</span>
+          </>
+        }
+        sub="Every session becomes a replayable trace: prompts, tool calls, reasoning steps, and the exact token cost."
+      />
 
       <Reveal y={24} className="max-w-[820px] mx-auto">
         <TerminalReplay onCostLine={onCostLine} onLoop={onLoop} />

--- a/website/src/components/LiveTrace.tsx
+++ b/website/src/components/LiveTrace.tsx
@@ -1,0 +1,123 @@
+"use client";
+/**
+ * LiveTrace — session-trace section between ProofStrip and HowItWorks.
+ * Replays a real-shaped session via TerminalReplay; the metric chips under
+ * the frame count up when the trace's cost line prints (once per loop,
+ * `onCostLine`) and dim back to zero when the replay wraps (`onLoop`).
+ * SSR / no-JS / reduced motion all render the final values at full strength.
+ */
+import { useEffect, useRef, useState } from "react";
+import { animate } from "animejs";
+import TerminalReplay from "@/components/TerminalReplay";
+import { Reveal, ANIME_EASE, EASE_CSS, motionOk } from "@/components/motion";
+
+const fmtInt = (n: number) => Math.round(n).toLocaleString("en-US");
+const fmtCost = (n: number) => `$${n.toFixed(2)}`;
+
+/** Mirrors the script's cost line: "tokens 12,440 · cached 8,210 · cost $0.18". */
+const METRICS = [
+  { label: "tokens", value: 12440, format: fmtInt },
+  { label: "cached", value: 8210, format: fmtInt },
+  { label: "cost", value: 0.18, format: fmtCost },
+] as const;
+
+type Phase = "static" | "waiting" | "lit";
+
+export default function LiveTrace() {
+  // static: SSR / no-JS / reduced motion — final values, full strength.
+  // waiting: replay running, cost line not printed yet — dimmed zeros.
+  // lit: cost line printed — values counted up, full strength.
+  const [phase, setPhase] = useState<Phase>("static");
+  const valueRefs = useRef<(HTMLSpanElement | null)[]>([]);
+  const animsRef = useRef<ReturnType<typeof animate>[]>([]);
+
+  useEffect(() => {
+    if (motionOk()) setPhase("waiting");
+  }, []);
+
+  useEffect(() => {
+    if (phase !== "waiting") return;
+    animsRef.current.forEach((a) => a.pause());
+    animsRef.current = [];
+    valueRefs.current.forEach((el, i) => {
+      if (el) el.textContent = METRICS[i].format(0);
+    });
+  }, [phase]);
+
+  const onCostLine = () => {
+    setPhase("lit");
+    animsRef.current.forEach((a) => a.pause());
+    animsRef.current = METRICS.map((m, i) => {
+      const el = valueRefs.current[i];
+      const state = { v: 0 };
+      return animate(state, {
+        v: m.value,
+        duration: 700,
+        ease: ANIME_EASE.countUp,
+        onUpdate: () => {
+          if (el) el.textContent = m.format(state.v);
+        },
+        onComplete: () => {
+          if (el) el.textContent = m.format(m.value);
+        },
+      });
+    });
+  };
+
+  const onLoop = () => setPhase("waiting");
+
+  return (
+    <section className="relative max-w-[1180px] mx-auto px-5 py-12 sm:py-[72px]">
+      <Reveal className="text-center max-w-[680px] mx-auto mb-10">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--tt-fg-dim)] mb-3">
+          Session trace
+        </p>
+        <h2 className="text-[clamp(26px,3.6vw,42px)] leading-[1.08] tracking-[-0.025em] font-semibold text-[var(--tt-fg)]">
+          See what your agent <span className="text-[var(--tt-brand)]">actually did</span>
+        </h2>
+        <p className="mt-3.5 text-[15.5px] text-[var(--tt-fg-muted)] leading-relaxed">
+          Every session becomes a replayable trace: prompts, tool calls,
+          reasoning steps, and the exact token cost.
+        </p>
+      </Reveal>
+
+      <Reveal y={24} className="max-w-[820px] mx-auto">
+        <TerminalReplay onCostLine={onCostLine} onLoop={onLoop} />
+        <div className="mt-4 flex flex-wrap justify-center gap-3">
+          {METRICS.map((m, i) => (
+            <div
+              key={m.label}
+              className="flex items-baseline gap-2 rounded-full border border-[var(--tt-border)] bg-[var(--tt-raised)] px-4 py-2"
+              style={{
+                opacity: phase === "waiting" ? 0.45 : 1,
+                transition: `opacity 250ms ${EASE_CSS}`,
+              }}
+            >
+              <span className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--tt-fg-dim)]">
+                {m.label}
+              </span>
+              <span className="font-mono text-[13px] tabular-nums text-[var(--tt-fg)]">
+                <span className="relative inline-block">
+                  {/* Sizer: reserves the final width so counting never shifts layout. */}
+                  <span aria-hidden="true" className="invisible">
+                    {m.format(m.value)}
+                  </span>
+                  <span
+                    ref={(el) => {
+                      valueRefs.current[i] = el;
+                    }}
+                    aria-hidden="true"
+                    className="absolute inset-0 text-right"
+                  >
+                    {m.format(m.value)}
+                  </span>
+                  <span className="sr-only">{m.format(m.value)}</span>
+                </span>
+              </span>
+            </div>
+          ))}
+        </div>
+      </Reveal>
+    </section>
+  );
+}

--- a/website/src/components/Privacy.tsx
+++ b/website/src/components/Privacy.tsx
@@ -54,32 +54,43 @@ export default function Privacy() {
   return (
     <section className="relative border-t border-[var(--tt-border)]"
       style={{ background: "radial-gradient(900px 420px at 50% 0%, rgba(16,185,129,0.06), transparent 65%)" }}>
-      <div className="max-w-[1180px] mx-auto px-5 py-12 sm:py-[72px]">
-        <Reveal y={16} className="text-center max-w-[680px] mx-auto mb-10">
-          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#34d399] mb-3">
-            Built for people who read the source
+      <div className="max-w-[1180px] mx-auto px-5 py-16 sm:py-24">
+        <div className="border-t border-[var(--tt-border)] pt-5 mb-10 sm:mb-14">
+          <p className="font-mono text-[11.5px] tracking-[0.16em] uppercase text-[var(--tt-fg-dim)] mb-6 sm:mb-9">
+            <span className="text-[#34d399]">08</span> · zero
           </p>
-          <h2 className="text-[clamp(26px,3.6vw,42px)] leading-[1.08] tracking-[-0.025em] font-semibold text-[var(--tt-fg)]">
-            Your data stays on{" "}
-            <span className="bg-gradient-to-r from-[#86efac] to-[#34d399] bg-clip-text text-transparent">your machine.</span>
-          </h2>
-          <p className="mt-3.5 text-[15.5px] text-[var(--tt-fg-muted)] leading-relaxed">
-            No cloud, no accounts. Your logs, prompts, and costs never leave your computer — the only things that go
-            out are anonymous, content-free usage stats (one-click off) and an optional update check.{" "}
-            <Link href="/privacy" className="text-[var(--tt-fg)] underline underline-offset-2 hover:text-[var(--tt-brand)] transition-colors">
-              Read the policy
-            </Link>.
-          </p>
-        </Reveal>
-        {/* Devtools-style network row: static content, pure CSS. */}
-        <div className="mb-6 flex justify-center">
-          <div className="inline-flex items-center rounded-[var(--tt-radius)] border border-[var(--tt-border)] bg-[var(--tt-sunken)] px-4 py-1.5 font-mono text-[11.5px] text-[var(--tt-fg-dim)]">
-            <span>
-              outbound requests: <span className="text-[var(--tt-success)] font-semibold">0</span>
-              <span className="mx-2 text-[var(--tt-fg-faint)]">·</span>
-              listening<span className="tt-pulse">…</span>
-            </span>
-          </div>
+          {/* Manifesto: the number IS the headline. */}
+          <Reveal y={16}>
+            <div className="grid grid-cols-1 lg:grid-cols-[auto_minmax(0,1fr)] gap-x-12 gap-y-6 items-center">
+              <span
+                aria-hidden
+                className="tabular font-semibold leading-[0.85] tracking-[-0.06em] text-[clamp(120px,22vw,280px)] bg-gradient-to-b from-[#86efac] to-[#34d399] bg-clip-text text-transparent select-none"
+              >
+                0
+              </span>
+              <div>
+                <h2 className="text-[clamp(30px,4.6vw,56px)] leading-[1.0] tracking-[-0.035em] font-semibold text-[var(--tt-fg)] text-balance">
+                  <span className="sr-only">Zero </span>
+                  Logs, prompts, and costs that leave your machine.
+                </h2>
+                <p className="mt-5 text-[clamp(15px,1.7vw,17.5px)] text-[var(--tt-fg-muted)] leading-relaxed max-w-[560px]">
+                  No cloud, no accounts. The only things that go out are anonymous,
+                  content-free usage stats (one-click off) and an optional update
+                  check.{" "}
+                  <Link href="/privacy" className="text-[var(--tt-fg)] underline underline-offset-2 hover:text-[var(--tt-brand)] transition-colors">
+                    Read the policy
+                  </Link>.
+                </p>
+                <div className="mt-6 inline-flex items-center rounded-[var(--tt-radius)] border border-[var(--tt-border)] bg-[var(--tt-sunken)] px-4 py-1.5 font-mono text-[11.5px] text-[var(--tt-fg-dim)]">
+                  <span>
+                    outbound requests: <span className="text-[var(--tt-success)] font-semibold">0</span>
+                    <span className="mx-2 text-[var(--tt-fg-faint)]">·</span>
+                    listening<span className="tt-pulse">…</span>
+                  </span>
+                </div>
+              </div>
+            </div>
+          </Reveal>
         </div>
         <Stagger gap={80} y={24} className="grid grid-cols-1 md:grid-cols-3 gap-3 sm:gap-4">
           {CARDS.map(({ icon: Icon, title, body }) => (

--- a/website/src/components/Privacy.tsx
+++ b/website/src/components/Privacy.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { Lock, BarChart3, FileCode } from "lucide-react";
+import { Reveal, Stagger, StaggerItem } from "@/components/motion";
 
 /**
  * Honest privacy section. The source mockup said "No usage tracking / no
@@ -7,6 +8,11 @@ import { Lock, BarChart3, FileCode } from "lucide-react";
  * anonymous telemetry (see docs/design/product-telemetry.md). This section keeps
  * the strong local-first promise for user DATA while disclosing the telemetry
  * truthfully, so the page can't be diffed against reality.
+ *
+ * Motion: quietest section by design. Header reveal, 24px card rise on an
+ * 80ms stagger, and a static devtools-style network row whose only movement
+ * is the CSS `tt-pulse` on the trailing ellipsis (stilled under
+ * prefers-reduced-motion by the global override).
  */
 const CARDS = [
   {
@@ -49,7 +55,7 @@ export default function Privacy() {
     <section className="relative border-t border-[var(--tt-border)]"
       style={{ background: "radial-gradient(900px 420px at 50% 0%, rgba(16,185,129,0.06), transparent 65%)" }}>
       <div className="max-w-[1180px] mx-auto px-5 py-12 sm:py-[72px]">
-        <div className="text-center max-w-[680px] mx-auto mb-10">
+        <Reveal y={16} className="text-center max-w-[680px] mx-auto mb-10">
           <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#34d399] mb-3">
             Built for people who read the source
           </p>
@@ -64,18 +70,30 @@ export default function Privacy() {
               Read the policy
             </Link>.
           </p>
+        </Reveal>
+        {/* Devtools-style network row: static content, pure CSS. */}
+        <div className="mb-6 flex justify-center">
+          <div className="inline-flex items-center rounded-[var(--tt-radius)] border border-[var(--tt-border)] bg-[var(--tt-sunken)] px-4 py-1.5 font-mono text-[11.5px] text-[var(--tt-fg-dim)]">
+            <span>
+              outbound requests: <span className="text-[var(--tt-success)] font-semibold">0</span>
+              <span className="mx-2 text-[var(--tt-fg-faint)]">·</span>
+              listening<span className="tt-pulse">…</span>
+            </span>
+          </div>
         </div>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-3 sm:gap-4">
+        <Stagger gap={80} y={24} className="grid grid-cols-1 md:grid-cols-3 gap-3 sm:gap-4">
           {CARDS.map(({ icon: Icon, title, body }) => (
-            <div key={title} className="p-6 rounded-[var(--tt-radius-lg)] border border-[var(--tt-border)] bg-[var(--tt-panel)]">
-              <div className="w-[38px] h-[38px] rounded-[var(--tt-radius)] grid place-items-center mb-4 bg-[rgba(16,185,129,0.1)] border border-[rgba(16,185,129,0.25)]">
-                <Icon size={18} className="text-[var(--tt-success-fg,#10b981)]" />
+            <StaggerItem key={title}>
+              <div className="h-full p-6 rounded-[var(--tt-radius-lg)] border border-[var(--tt-border)] bg-[var(--tt-panel)]">
+                <div className="w-[38px] h-[38px] rounded-[var(--tt-radius)] grid place-items-center mb-4 bg-[rgba(16,185,129,0.1)] border border-[rgba(16,185,129,0.25)]">
+                  <Icon size={18} className="text-[var(--tt-success-fg,#10b981)]" />
+                </div>
+                <h3 className="text-[16px] font-semibold tracking-[-0.01em] text-[var(--tt-fg)] mb-2">{title}</h3>
+                <p className="text-[13.5px] text-[var(--tt-fg-muted)] leading-relaxed">{body}</p>
               </div>
-              <h3 className="text-[16px] font-semibold tracking-[-0.01em] text-[var(--tt-fg)] mb-2">{title}</h3>
-              <p className="text-[13.5px] text-[var(--tt-fg-muted)] leading-relaxed">{body}</p>
-            </div>
+            </StaggerItem>
           ))}
-        </div>
+        </Stagger>
       </div>
     </section>
   );

--- a/website/src/components/ProofStrip.tsx
+++ b/website/src/components/ProofStrip.tsx
@@ -1,6 +1,40 @@
 "use client";
+import { motion, useReducedMotion } from "motion/react";
 import { AGENTS } from "@/data/agents";
 import { useGithubStats } from "@/lib/useGithubStats";
+import { CountUp, Stagger } from "@/components/motion";
+
+const CELL_CLASS =
+  "flex-1 min-w-[150px] py-5 px-6 border-[var(--tt-border)] [&:not(:last-child)]:border-r max-sm:basis-1/2 max-sm:border-b";
+const VALUE_CLASS =
+  "flex items-baseline gap-1.5 text-[26px] font-semibold tracking-[-0.02em] mb-0.5 tabular";
+const UNIT_CLASS = "text-[12px] text-[var(--tt-fg-dim)] font-medium";
+const LABEL_CLASS =
+  "text-[11px] uppercase tracking-[0.14em] text-[var(--tt-fg-dim)] font-medium";
+
+/**
+ * The "0" does NOT count up — it renders instantly with one 2s emerald glow
+ * cycle so the zero reads asserted, not computed. Reduced motion: no glow.
+ */
+function AssertedZero() {
+  const reduced = useReducedMotion();
+  return (
+    <span className="relative inline-block">
+      {!reduced && (
+        <motion.span
+          aria-hidden
+          className="absolute -inset-1 rounded-full"
+          initial={{ opacity: 0 }}
+          whileInView={{ opacity: [0, 1, 0] }}
+          viewport={{ once: true, amount: 0.5 }}
+          transition={{ duration: 2, ease: "easeInOut" }}
+          style={{ boxShadow: "0 0 18px 5px rgba(52,211,153,0.35)" }}
+        />
+      )}
+      <span className="relative">0</span>
+    </span>
+  );
+}
 
 export default function ProofStrip() {
   const { stars, forks } = useGithubStats();
@@ -8,36 +42,56 @@ export default function ProofStrip() {
   // agent is added. Hermes is the autonomous agent, counted separately from the
   // coding-agent headline used across the site.
   const codingAgentCount = AGENTS.filter((a) => a.name !== "Hermes Agent").length;
-  const STATS = [
-    { value: String(codingAgentCount), unit: "agents", label: "auto-detected, zero config", green: false },
-    { value: "0", unit: "bytes uploaded", label: "fully local · read-only", green: true },
-    { value: String(stars), unit: `★ · ${forks} forks`, label: "open source · MIT", green: false },
-    { value: "1", unit: "command", label: "no SDK · no signup", green: false },
-  ];
   // Duplicate the agent chips so the CSS translateX(-50%) loop is seamless.
   const chips = [...AGENTS, ...AGENTS];
   return (
     <div className="border-y border-[var(--tt-border)] bg-[var(--tt-sunken)]">
       <div className="max-w-[1180px] mx-auto px-5">
-        <div className="flex flex-wrap">
-          {STATS.map((s, i) => (
-            <div key={i} className="flex-1 min-w-[150px] py-5 px-6 border-[var(--tt-border)] [&:not(:last-child)]:border-r max-sm:basis-1/2 max-sm:border-b">
-              <div className={`flex items-baseline gap-1.5 text-[26px] font-semibold tracking-[-0.02em] mb-0.5 tabular ${s.green ? "text-[#34d399]" : "text-[var(--tt-fg)]"}`}>
-                {s.value} <span className="text-[12px] text-[var(--tt-fg-dim)] font-medium">{s.unit}</span>
-              </div>
-              <div className="text-[11px] uppercase tracking-[0.14em] text-[var(--tt-fg-dim)] font-medium">{s.label}</div>
+        <Stagger gap={80} y={12} className="flex flex-wrap">
+          <Stagger.Item className={CELL_CLASS}>
+            <div className={`${VALUE_CLASS} text-[var(--tt-fg)]`}>
+              <CountUp to={codingAgentCount} duration={700} />
+              <span className={UNIT_CLASS}>agents</span>
             </div>
-          ))}
-        </div>
+            <div className={LABEL_CLASS}>auto-detected, zero config</div>
+          </Stagger.Item>
+          <Stagger.Item className={CELL_CLASS}>
+            <div className={`${VALUE_CLASS} text-[#34d399]`}>
+              <AssertedZero />
+              <span className={UNIT_CLASS}>bytes uploaded</span>
+            </div>
+            <div className={LABEL_CLASS}>fully local · read-only</div>
+          </Stagger.Item>
+          <Stagger.Item className={CELL_CLASS}>
+            <div className={`${VALUE_CLASS} text-[var(--tt-fg)]`}>
+              <CountUp to={stars} duration={1100} />
+              <span className={UNIT_CLASS}>
+                ★ · <CountUp to={forks} duration={1100} /> forks
+              </span>
+            </div>
+            <div className={LABEL_CLASS}>open source · MIT</div>
+          </Stagger.Item>
+          <Stagger.Item className={CELL_CLASS}>
+            <div className={`${VALUE_CLASS} text-[var(--tt-fg)]`}>
+              <CountUp to={1} duration={300} />
+              <span className={UNIT_CLASS}>command</span>
+            </div>
+            <div className={LABEL_CLASS}>no SDK · no signup</div>
+          </Stagger.Item>
+        </Stagger>
       </div>
 
-      {/* Agents marquee */}
+      {/* Agents marquee — keeps its CSS loop, slowed to 28s; chip dots carry
+          the app's agent-identity glow so the colors read as one system. */}
       <div className="overflow-hidden border-t border-[var(--tt-border)] py-[15px]"
         style={{ maskImage: "linear-gradient(90deg,transparent,#000 8%,#000 92%,transparent)", WebkitMaskImage: "linear-gradient(90deg,transparent,#000 8%,#000 92%,transparent)" }}>
-        <div className="flex gap-2.5 w-max tt-marquee-track">
+        <div className="flex gap-2.5 w-max tt-marquee-track" style={{ animationDuration: "28s" }}>
           {chips.map((a, i) => (
             <span key={i} className="inline-flex items-center gap-2 h-[34px] px-3.5 rounded-full border border-[var(--tt-border)] bg-[var(--tt-panel)] text-[12.5px] font-medium text-[var(--tt-fg-muted)] whitespace-nowrap">
-              <span className="w-[7px] h-[7px] rounded-full" style={{ backgroundColor: a.hex }} />
+              <span
+                className="w-[7px] h-[7px] rounded-full"
+                style={{ backgroundColor: a.hex, boxShadow: `0 0 8px ${a.hex}66` }}
+              />
               {a.name}
             </span>
           ))}

--- a/website/src/components/SectionHead.tsx
+++ b/website/src/components/SectionHead.tsx
@@ -1,0 +1,47 @@
+import type { ReactNode } from "react";
+import Reveal from "@/components/motion/Reveal";
+
+/**
+ * SectionHead — the numbered instrument chrome every section shares.
+ * Hairline rule, mono index (`03 · TRACE`), then an oversized editorial
+ * headline. Left-aligned; sections keep their own inner layouts below it.
+ * Server component: Reveal is the only client child.
+ */
+export default function SectionHead({
+  index,
+  label,
+  title,
+  sub,
+  id,
+}: {
+  index: string;
+  label: string;
+  title: ReactNode;
+  sub?: ReactNode;
+  id?: string;
+}) {
+  return (
+    <div id={id} className="scroll-mt-24">
+      <div className="border-t border-[var(--tt-border)] pt-5 mb-10 sm:mb-14">
+        <div className="flex items-baseline justify-between gap-4 mb-6 sm:mb-9 font-mono text-[11.5px] tracking-[0.16em] uppercase">
+          <span className="text-[var(--tt-fg-dim)]">
+            <span className="text-[var(--tt-brand)]">{index}</span> · {label}
+          </span>
+          <span aria-hidden className="hidden sm:block text-[var(--tt-fg-faint)] select-none">
+            tokentelemetry
+          </span>
+        </div>
+        <Reveal y={16}>
+          <h2 className="text-[clamp(32px,6vw,72px)] leading-[0.98] tracking-[-0.04em] font-semibold text-[var(--tt-fg)] text-balance max-w-[900px]">
+            {title}
+          </h2>
+          {sub && (
+            <p className="mt-5 text-[clamp(15px,1.7vw,17.5px)] text-[var(--tt-fg-muted)] leading-relaxed max-w-[560px]">
+              {sub}
+            </p>
+          )}
+        </Reveal>
+      </div>
+    </div>
+  );
+}

--- a/website/src/components/SiteHeader.tsx
+++ b/website/src/components/SiteHeader.tsx
@@ -1,24 +1,72 @@
 "use client";
 import Link from "next/link";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import {
+  AnimatePresence,
+  motion,
+  useMotionValueEvent,
+  useReducedMotion,
+  useScroll,
+  useTransform,
+} from "motion/react";
 import { Star, Activity, Menu, X } from "lucide-react";
 import { track } from "@/lib/track";
 import { useGithubStats } from "@/lib/useGithubStats";
+import { EASE, DUR } from "@/components/motion/vocab";
 
 const GITHUB_URL = "https://github.com/VasiHemanth/tokentelemetry";
+
+/* Scroll-linked effect #1 (of exactly two on the page): the header starts
+   visually merged with the hero — no border, transparent background, no blur —
+   and gains its chrome over the first 80px of scroll. Blur is toggled via a
+   class at scrollY > 8, never animated (filter animation is off-limits).
+   Reduced motion: static full chrome, exactly the pre-redesign header. */
 
 export default function SiteHeader() {
   const { stars } = useGithubStats();
   const [menuOpen, setMenuOpen] = useState(false);
   const closeMenu = () => setMenuOpen(false);
+  const reduced = useReducedMotion();
+
+  const { scrollY } = useScroll();
+  const borderColor = useTransform(scrollY, (y) => {
+    const t = Math.min(Math.max(y / 80, 0), 1);
+    return `color-mix(in srgb, var(--tt-border) ${Math.round(t * 100)}%, transparent)`;
+  });
+  const background = useTransform(scrollY, (y) => {
+    const t = Math.min(Math.max(y / 80, 0), 1);
+    return `color-mix(in srgb, var(--tt-canvas) ${Math.round(t * 82)}%, transparent)`;
+  });
+
+  const [blurred, setBlurred] = useState(false);
+  useMotionValueEvent(scrollY, "change", (y) => setBlurred(y > 8));
+  useEffect(() => {
+    // Scroll restoration / deep links can land mid-page before any change event.
+    setBlurred(scrollY.get() > 8);
+  }, [scrollY]);
+
+  const chrome = reduced
+    ? {
+        borderColor: "var(--tt-border)",
+        background: "color-mix(in srgb, var(--tt-canvas) 82%, transparent)",
+      }
+    : { borderColor, background };
 
   return (
-    <header className="sticky top-0 z-50 border-b border-[var(--tt-border)] backdrop-blur-[14px]"
-      style={{ background: "color-mix(in srgb, var(--tt-canvas) 82%, transparent)" }}>
+    <motion.header
+      className={`sticky top-0 z-50 border-b ${
+        blurred || reduced ? "backdrop-blur-[14px]" : ""
+      }`}
+      style={chrome}
+    >
       <div className="max-w-[1180px] mx-auto px-5 h-[58px] flex items-center justify-between">
         <Link href="/" className="flex items-center gap-2.5 min-w-0" onClick={closeMenu}>
           <span className="h-7 w-7 grid place-items-center rounded-lg bg-gradient-to-br from-[var(--tt-brand-strong)] to-[var(--tt-brand-deep)] shadow-[0_6px_18px_-8px_var(--tt-brand-glow)]">
-            <Activity size={16} strokeWidth={2.4} className="text-white" />
+            <Activity
+              size={16}
+              strokeWidth={2.4}
+              className="text-white tt-pulse motion-reduce:animate-none"
+            />
           </span>
           <span className="text-[15px] font-semibold tracking-[-0.01em] text-[var(--tt-fg)]">
             Token<span className="text-[var(--tt-fg-muted)] font-medium">Telemetry</span>
@@ -72,33 +120,41 @@ export default function SiteHeader() {
       </div>
 
       {/* Mobile dropdown */}
-      {menuOpen && (
-        <div className="sm:hidden border-t border-[var(--tt-border)] bg-[var(--tt-panel)]">
-          <nav className="max-w-[1180px] mx-auto px-5 py-3 flex flex-col gap-1">
-            <Link
-              href="/docs"
-              onClick={() => { track("click_nav", { to: "docs", location: "mobile_menu" }); closeMenu(); }}
-              className="inline-flex items-center h-[40px] px-3 rounded-[var(--tt-radius)] text-[14px] font-medium text-[var(--tt-fg)] hover:bg-[var(--tt-raised)] transition-colors"
-            >
-              Docs
-            </Link>
-            <Link
-              href="/resources"
-              onClick={() => { track("click_nav", { to: "resources", location: "mobile_menu" }); closeMenu(); }}
-              className="inline-flex items-center h-[40px] px-3 rounded-[var(--tt-radius)] text-[14px] font-medium text-[var(--tt-fg)] hover:bg-[var(--tt-raised)] transition-colors"
-            >
-              Resources
-            </Link>
-            <a
-              href="#install"
-              onClick={() => { track("click_install", { location: "mobile_menu" }); closeMenu(); }}
-              className="inline-flex items-center justify-center h-[40px] px-3 mt-1 rounded-[var(--tt-radius)] bg-[var(--tt-brand-strong)] hover:bg-[var(--tt-brand)] text-white text-[14px] font-semibold transition-colors"
-            >
-              Install
-            </a>
-          </nav>
-        </div>
-      )}
-    </header>
+      <AnimatePresence initial={false}>
+        {menuOpen && (
+          <motion.div
+            initial={reduced ? { opacity: 0 } : { height: 0, opacity: 0 }}
+            animate={reduced ? { opacity: 1 } : { height: "auto", opacity: 1 }}
+            exit={reduced ? { opacity: 0 } : { height: 0, opacity: 0 }}
+            transition={{ duration: DUR.fade, ease: EASE }}
+            className="sm:hidden overflow-hidden border-t border-[var(--tt-border)] bg-[var(--tt-panel)]"
+          >
+            <nav className="max-w-[1180px] mx-auto px-5 py-3 flex flex-col gap-1">
+              <Link
+                href="/docs"
+                onClick={() => { track("click_nav", { to: "docs", location: "mobile_menu" }); closeMenu(); }}
+                className="inline-flex items-center h-[40px] px-3 rounded-[var(--tt-radius)] text-[14px] font-medium text-[var(--tt-fg)] hover:bg-[var(--tt-raised)] transition-colors"
+              >
+                Docs
+              </Link>
+              <Link
+                href="/resources"
+                onClick={() => { track("click_nav", { to: "resources", location: "mobile_menu" }); closeMenu(); }}
+                className="inline-flex items-center h-[40px] px-3 rounded-[var(--tt-radius)] text-[14px] font-medium text-[var(--tt-fg)] hover:bg-[var(--tt-raised)] transition-colors"
+              >
+                Resources
+              </Link>
+              <a
+                href="#install"
+                onClick={() => { track("click_install", { location: "mobile_menu" }); closeMenu(); }}
+                className="inline-flex items-center justify-center h-[40px] px-3 mt-1 rounded-[var(--tt-radius)] bg-[var(--tt-brand-strong)] hover:bg-[var(--tt-brand)] text-white text-[14px] font-semibold transition-colors"
+              >
+                Install
+              </a>
+            </nav>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </motion.header>
   );
 }

--- a/website/src/components/TerminalReplay.tsx
+++ b/website/src/components/TerminalReplay.tsx
@@ -1,7 +1,15 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Activity } from "lucide-react";
-import { TERMINAL_SCRIPT, SCRIPT_DURATION_MS, type ScriptLine } from "@/data/terminal-script";
+import { motion, useInView, useReducedMotion } from "motion/react";
+import { DUR } from "@/components/motion";
+import {
+  TERMINAL_SCRIPT,
+  SCRIPT_DURATION_MS,
+  REPLAY_HOLD_MS,
+  COST_LINE_DELAY_MS,
+  type ScriptLine,
+} from "@/data/terminal-script";
 
 const COLOR: Record<ScriptLine["kind"], string> = {
   header:    "text-[var(--tt-fg-faint)]",
@@ -12,22 +20,60 @@ const COLOR: Record<ScriptLine["kind"], string> = {
   cost:      "text-[var(--tt-success-fg)]",
 };
 
-export default function TerminalReplay() {
+export type TerminalReplayProps = {
+  /** Fires each time the cost line prints (once per loop). */
+  onCostLine?: () => void;
+  /** Fires when the replay wraps back to the start of the script. */
+  onLoop?: () => void;
+};
+
+/**
+ * Replays the session script while at least 40% in view; pauses off-screen and
+ * resumes where it left off. Under reduced motion the full script renders
+ * statically with a static cursor.
+ */
+export default function TerminalReplay({ onCostLine, onLoop }: TerminalReplayProps) {
+  const frameRef = useRef<HTMLDivElement>(null);
+  const inView = useInView(frameRef, { amount: 0.4 });
+  const reduced = useReducedMotion();
+
   const [elapsed, setElapsed] = useState(0);
+  const [loop, setLoop] = useState(0);
+  const elapsedRef = useRef(0);
+  const costFiredRef = useRef(false);
+  // Keep callbacks in a ref so the timer effect doesn't restart when the parent re-renders.
+  const callbacksRef = useRef({ onCostLine, onLoop });
+  callbacksRef.current = { onCostLine, onLoop };
 
   useEffect(() => {
-    const start = Date.now();
+    if (reduced || !inView) return;
+    const cycle = SCRIPT_DURATION_MS + REPLAY_HOLD_MS;
+    const start = Date.now() - elapsedRef.current;
     const id = setInterval(() => {
-      const t = (Date.now() - start) % (SCRIPT_DURATION_MS + 1500);
+      const t = (Date.now() - start) % cycle;
+      if (t < elapsedRef.current) {
+        // Wrapped: new loop.
+        costFiredRef.current = false;
+        setLoop((n) => n + 1);
+        callbacksRef.current.onLoop?.();
+      }
+      if (!costFiredRef.current && t >= COST_LINE_DELAY_MS) {
+        costFiredRef.current = true;
+        callbacksRef.current.onCostLine?.();
+      }
+      elapsedRef.current = t;
       setElapsed(t);
     }, 60);
     return () => clearInterval(id);
-  }, []);
+  }, [inView, reduced]);
 
-  const visible = TERMINAL_SCRIPT.filter((l) => l.delay <= elapsed);
+  const visible = reduced ? TERMINAL_SCRIPT : TERMINAL_SCRIPT.filter((l) => l.delay <= elapsed);
 
   return (
-    <div className="rounded-[var(--tt-radius-xl)] border border-[var(--tt-border-strong)] bg-[var(--tt-sunken)] overflow-hidden shadow-[0_30px_120px_-30px_rgba(96,165,250,0.35)]">
+    <div
+      ref={frameRef}
+      className="rounded-[var(--tt-radius-xl)] border border-[var(--tt-border-strong)] bg-[var(--tt-sunken)] overflow-hidden shadow-[0_30px_120px_-30px_rgba(96,165,250,0.35)]"
+    >
       <div className="flex items-center gap-1.5 px-4 h-9 bg-[var(--tt-raised)] border-b border-[var(--tt-border)]">
         <span className="w-2.5 h-2.5 rounded-full bg-rose-400/50" />
         <span className="w-2.5 h-2.5 rounded-full bg-amber-400/50" />
@@ -37,12 +83,24 @@ export default function TerminalReplay() {
         </span>
       </div>
       <div className="p-5 sm:p-6 font-mono text-[12px] sm:text-[13px] leading-relaxed min-h-[320px] sm:min-h-[360px] space-y-1.5">
-        {visible.map((line, i) => (
-          <div key={i} className={`${COLOR[line.kind]} transition-opacity`}>
-            {line.text}
-          </div>
-        ))}
-        <span className="inline-block w-2 h-4 bg-[var(--tt-success-fg)] align-middle animate-pulse" />
+        {visible.map((line, i) =>
+          reduced ? (
+            <div key={i} className={COLOR[line.kind]}>
+              {line.text}
+            </div>
+          ) : (
+            <motion.div
+              key={`${loop}-${i}`}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ duration: DUR.line }}
+              className={COLOR[line.kind]}
+            >
+              {line.text}
+            </motion.div>
+          ),
+        )}
+        <span className="inline-block w-2 h-4 bg-[var(--tt-success-fg)] align-middle animate-pulse motion-reduce:animate-none" />
       </div>
     </div>
   );

--- a/website/src/components/TokenField.tsx
+++ b/website/src/components/TokenField.tsx
@@ -1,0 +1,189 @@
+"use client";
+/**
+ * TokenField — the hero's full-bleed canvas. Tokens (small colored points in
+ * each agent's identity color) stream from the viewport edges along bezier
+ * paths into a "localhost core" on the right, leaving short trails. Pure
+ * canvas 2d, no deps. Reduced motion: one static scatter frame, no loop.
+ * The loop also stops while the hero is off-screen or the tab is hidden.
+ */
+import { useEffect, useRef } from "react";
+import { motionOk } from "@/components/motion";
+
+const AGENT_VARS = [
+  "--agent-claude",
+  "--agent-codex",
+  "--agent-gemini",
+  "--agent-antigravity",
+  "--agent-qwen",
+  "--agent-vibe",
+  "--agent-cursor",
+  "--agent-copilot",
+  "--agent-opencode",
+] as const;
+
+const BG = "#0a0c10"; // must match --tt-canvas: the canvas IS the section bg
+
+type P = {
+  // bezier: start → (ctrl) → core
+  sx: number; sy: number; cx: number; cy: number;
+  t: number; speed: number; size: number; color: string;
+};
+
+/** Core position as a fraction of the canvas, matching the hero's layout. */
+function corePos(w: number, h: number) {
+  return w > 1024 ? { x: w * 0.74, y: h * 0.5 } : { x: w * 0.5, y: h * 0.88 };
+}
+
+function spawn(w: number, h: number, colors: string[], t0 = 0): P {
+  // Spawn on the left / top / bottom edges so streams converge rightward.
+  const edge = Math.random();
+  let sx: number, sy: number;
+  if (edge < 0.5) { sx = -8; sy = Math.random() * h; }
+  else if (edge < 0.75) { sx = Math.random() * w * 0.9; sy = -8; }
+  else { sx = Math.random() * w * 0.9; sy = h + 8; }
+  const core = corePos(w, h);
+  // Control point: midway with a perpendicular-ish scatter for varied arcs.
+  const mx = (sx + core.x) / 2, my = (sy + core.y) / 2;
+  return {
+    sx, sy,
+    cx: mx + (Math.random() - 0.5) * w * 0.35,
+    cy: my + (Math.random() - 0.5) * h * 0.5,
+    t: t0,
+    speed: 0.0016 + Math.random() * 0.0028,
+    size: 0.9 + Math.random() * 1.4,
+    color: colors[(Math.random() * colors.length) | 0],
+  };
+}
+
+export default function TokenField({ className }: { className?: string }) {
+  const ref = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = ref.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const styles = getComputedStyle(document.documentElement);
+    const colors = AGENT_VARS
+      .map((v) => styles.getPropertyValue(v).trim())
+      .filter(Boolean);
+    if (!colors.length) colors.push("#60a5fa");
+
+    let w = 0, h = 0, dpr = 1;
+    let particles: P[] = [];
+    let raf = 0;
+    let running = false;
+    const animated = motionOk();
+
+    const resize = () => {
+      const rect = canvas.getBoundingClientRect();
+      dpr = Math.min(window.devicePixelRatio || 1, 2);
+      w = rect.width; h = rect.height;
+      canvas.width = Math.round(w * dpr);
+      canvas.height = Math.round(h * dpr);
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      const n = w > 1024 ? 110 : 55;
+      particles = Array.from({ length: n }, () =>
+        spawn(w, h, colors, Math.random()));
+      ctx.fillStyle = BG;
+      ctx.fillRect(0, 0, w, h);
+      if (!animated) drawStatic();
+    };
+
+    // Reduced motion: a quiet constellation at rest — the same points, no loop.
+    const drawStatic = () => {
+      for (const p of particles) {
+        const x = q(p.sx, p.cx, coreX(), p.t);
+        const y = q(p.sy, p.cy, coreY(), p.t);
+        ctx.globalAlpha = 0.35;
+        ctx.fillStyle = p.color;
+        ctx.beginPath();
+        ctx.arc(x, y, p.size, 0, Math.PI * 2);
+        ctx.fill();
+      }
+      ctx.globalAlpha = 1;
+      drawCore(1);
+    };
+
+    const q = (a: number, c: number, b: number, t: number) =>
+      (1 - t) * (1 - t) * a + 2 * (1 - t) * t * c + t * t * b;
+    const coreX = () => corePos(w, h).x;
+    const coreY = () => corePos(w, h).y;
+
+    let pulse = 0;
+    const drawCore = (alpha: number) => {
+      const x = coreX(), y = coreY();
+      const r = 46 + Math.sin(pulse) * 3;
+      const g = ctx.createRadialGradient(x, y, 0, x, y, r * 2.6);
+      g.addColorStop(0, "rgba(96,165,250,0.16)");
+      g.addColorStop(0.55, "rgba(96,165,250,0.05)");
+      g.addColorStop(1, "rgba(96,165,250,0)");
+      ctx.globalAlpha = alpha;
+      ctx.fillStyle = g;
+      ctx.fillRect(x - r * 2.6, y - r * 2.6, r * 5.2, r * 5.2);
+      ctx.strokeStyle = "rgba(96,165,250,0.35)";
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.arc(x, y, r, 0, Math.PI * 2);
+      ctx.stroke();
+      ctx.globalAlpha = 1;
+    };
+
+    const frame = () => {
+      if (!running) return;
+      pulse += 0.03;
+      // Translucent wash = particle trails.
+      ctx.fillStyle = "rgba(10,12,16,0.22)";
+      ctx.fillRect(0, 0, w, h);
+      const bx = coreX(), by = coreY();
+      for (let i = 0; i < particles.length; i++) {
+        const p = particles[i];
+        p.t += p.speed * (0.6 + p.t); // ease-in: tokens accelerate toward the core
+        if (p.t >= 1) { particles[i] = spawn(w, h, colors); continue; }
+        const x = q(p.sx, p.cx, bx, p.t);
+        const y = q(p.sy, p.cy, by, p.t);
+        ctx.globalAlpha = 0.28 + p.t * 0.5; // brighten as they approach
+        ctx.fillStyle = p.color;
+        ctx.beginPath();
+        ctx.arc(x, y, p.size, 0, Math.PI * 2);
+        ctx.fill();
+      }
+      ctx.globalAlpha = 1;
+      drawCore(1);
+      raf = requestAnimationFrame(frame);
+    };
+
+    const start = () => {
+      if (running || !animated) return;
+      running = true;
+      raf = requestAnimationFrame(frame);
+    };
+    const stop = () => {
+      running = false;
+      cancelAnimationFrame(raf);
+    };
+
+    resize();
+    start();
+
+    const ro = new ResizeObserver(resize);
+    ro.observe(canvas);
+    const io = new IntersectionObserver(
+      ([e]) => (e.isIntersecting ? start() : stop()),
+      { threshold: 0 },
+    );
+    io.observe(canvas);
+    const onVis = () => (document.hidden ? stop() : start());
+    document.addEventListener("visibilitychange", onVis);
+
+    return () => {
+      stop();
+      ro.disconnect();
+      io.disconnect();
+      document.removeEventListener("visibilitychange", onVis);
+    };
+  }, []);
+
+  return <canvas ref={ref} aria-hidden className={className} />;
+}

--- a/website/src/components/motion/BorderBeam.tsx
+++ b/website/src/components/motion/BorderBeam.tsx
@@ -1,0 +1,61 @@
+"use client";
+/**
+ * BorderBeam — one brand-tinted highlight revolution around the wrapped
+ * block's border when it first enters view, then static. CSS does the work
+ * (`.tt-border-beam` / `.tt-beam-run` + `@keyframes tt-beam` in globals.css);
+ * JS only observes intersection, adds the run class once, and removes it on
+ * animationend. No loop. Reduced motion: never runs (JS guard + CSS override).
+ *
+ * Give the wrapper a border-radius matching its child (the beam ring inherits
+ * `border-radius` from this element).
+ */
+import { useEffect, useRef, type ReactNode } from "react";
+import { motionOk } from "./useMotionOk";
+
+export type BorderBeamProps = {
+  children: ReactNode;
+  /** In-view threshold before the revolution fires (default 0.4). */
+  amount?: number;
+  /** Extra classes on the wrapper — include the child's border-radius, e.g. "rounded-[var(--tt-radius-lg)]". */
+  className?: string;
+};
+
+export default function BorderBeam({
+  children,
+  amount = 0.4,
+  className,
+}: BorderBeamProps) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || !motionOk()) return;
+
+    const onEnd = (e: AnimationEvent) => {
+      if (e.animationName === "tt-beam") el.classList.remove("tt-beam-run");
+    };
+    el.addEventListener("animationend", onEnd);
+
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          el.classList.add("tt-beam-run");
+          io.disconnect();
+        }
+      },
+      { threshold: amount }
+    );
+    io.observe(el);
+
+    return () => {
+      io.disconnect();
+      el.removeEventListener("animationend", onEnd);
+    };
+  }, [amount]);
+
+  return (
+    <div ref={ref} className={`tt-border-beam ${className ?? ""}`.trim()}>
+      {children}
+    </div>
+  );
+}

--- a/website/src/components/motion/CountUp.tsx
+++ b/website/src/components/motion/CountUp.tsx
@@ -1,0 +1,100 @@
+"use client";
+/**
+ * CountUp — animejs count-up with zero layout shift.
+ * Renders `prefix` + a tabular-nums span pre-sized to the FORMATTED final
+ * value (hidden sizer) + `suffix`. Counts 0→to with `outExpo` once the
+ * element is 50% in view. Server/no-JS render and reduced motion both show
+ * the final value; keep unit glyphs (`+`, `k`, `★`, `$`) in prefix/suffix,
+ * never inside the counted number.
+ */
+import { useEffect, useRef } from "react";
+import { useInView } from "motion/react";
+import { animate } from "animejs";
+import { motionOk } from "./useMotionOk";
+import { ANIME_EASE } from "./vocab";
+
+export type CountUpProps = {
+  /** Final numeric value. May arrive late (e.g. fetched star count). */
+  to: number;
+  /** Duration in ms (default 1000; band is 900–1100 for stats, 300–700 for small counts). */
+  duration?: number;
+  /** Static text before the number (e.g. "$"). Not animated. */
+  prefix?: string;
+  /** Static text after the number (e.g. "k", "+", " sessions"). Not animated. */
+  suffix?: string;
+  /** Formats the in-flight (fractional) and final value. Default: Math.round + toLocaleString("en-US"). */
+  format?: (n: number) => string;
+  /** Delay in ms after entering view (default 0). */
+  delay?: number;
+  className?: string;
+};
+
+const defaultFormat = (n: number) => Math.round(n).toLocaleString("en-US");
+
+export default function CountUp({
+  to,
+  duration = 1000,
+  prefix,
+  suffix,
+  format,
+  delay = 0,
+  className,
+}: CountUpProps) {
+  const rootRef = useRef<HTMLSpanElement>(null);
+  const valueRef = useRef<HTMLSpanElement>(null);
+  const ran = useRef(false);
+  const inView = useInView(rootRef, { once: true, amount: 0.5 });
+
+  const fmt = format ?? defaultFormat;
+  const final = fmt(to);
+
+  useEffect(() => {
+    const el = valueRef.current;
+    if (!el || !inView) return;
+    // `to` arrived/changed after the animation already ran: snap to final.
+    if (ran.current || !motionOk()) {
+      ran.current = true;
+      el.textContent = final;
+      return;
+    }
+    ran.current = true;
+    const state = { v: 0 };
+    animate(state, {
+      v: to,
+      duration,
+      delay,
+      ease: ANIME_EASE.countUp,
+      onUpdate: () => {
+        el.textContent = fmt(state.v);
+      },
+      onComplete: () => {
+        el.textContent = final;
+      },
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inView, to]);
+
+  return (
+    <span ref={rootRef} className={`tabular ${className ?? ""}`.trim()}>
+      {prefix}
+      <span className="relative inline-block">
+        {/* Sizer: reserves the final width so counting never shifts layout. */}
+        <span aria-hidden="true" className="invisible">
+          {final}
+        </span>
+        {/* Counted layer. Initial content = final value (no-JS / SSR / SEO);
+            the first animation frame overwrites it with the formatted 0. */}
+        <span
+          ref={valueRef}
+          className="absolute inset-0 text-right"
+          aria-hidden="true"
+        >
+          {final}
+        </span>
+        {/* Accessible value, never animated. */}
+        <span className="sr-only">{final}</span>
+      </span>
+      {suffix}
+    </span>
+  );
+}

--- a/website/src/components/motion/Reveal.tsx
+++ b/website/src/components/motion/Reveal.tsx
@@ -1,0 +1,70 @@
+"use client";
+/**
+ * Reveal — the workhorse once-only in-view entrance.
+ * opacity 0→1, y→0 on spring 300/34, `viewport={{ once: true, amount }}`.
+ * Reduced motion: 200ms opacity fade, no translate.
+ */
+import type { ReactNode } from "react";
+import { motion, useReducedMotion } from "motion/react";
+import { DUR, SPRING } from "./vocab";
+
+const TAGS = {
+  div: motion.div,
+  section: motion.section,
+  header: motion.header,
+  span: motion.span,
+  p: motion.p,
+  ul: motion.ul,
+  li: motion.li,
+} as const;
+
+export type RevealProps = {
+  children: ReactNode;
+  /** Rise distance: 8 (chips), 16 (text blocks, default), 24 (cards/media). */
+  y?: 8 | 16 | 24;
+  /** Delay in seconds. */
+  delay?: number;
+  /** In-view threshold (default 0.3). */
+  amount?: number;
+  /** Rendered element (default "div"). */
+  as?: keyof typeof TAGS;
+  className?: string;
+};
+
+export default function Reveal({
+  children,
+  y = 16,
+  delay = 0,
+  amount = 0.3,
+  as = "div",
+  className,
+}: RevealProps) {
+  const reduced = useReducedMotion();
+  const Tag = TAGS[as];
+
+  if (reduced) {
+    return (
+      <Tag
+        initial={{ opacity: 0 }}
+        whileInView={{ opacity: 1 }}
+        viewport={{ once: true, amount }}
+        transition={{ duration: DUR.fade, delay }}
+        className={className}
+      >
+        {children}
+      </Tag>
+    );
+  }
+
+  return (
+    <Tag
+      initial={{ opacity: 0, y }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, amount }}
+      transition={{ ...SPRING.reveal, delay }}
+      className={className}
+    >
+      {children}
+    </Tag>
+  );
+}

--- a/website/src/components/motion/Stagger.tsx
+++ b/website/src/components/motion/Stagger.tsx
@@ -1,0 +1,95 @@
+"use client";
+/**
+ * Stagger — once-only in-view container that staggers its `Stagger.Item`
+ * children. Container owns the trigger + gap; items own the per-child motion.
+ * Never stagger more than 8 items individually; group the rest.
+ * Reduced motion: items collapse to a 200ms opacity fade, no gap.
+ */
+import { createContext, useContext, type ReactNode } from "react";
+import { motion, useReducedMotion } from "motion/react";
+import { DUR, SPRING } from "./vocab";
+
+const StaggerCtx = createContext<{ y: number }>({ y: 16 });
+
+export type StaggerProps = {
+  children: ReactNode;
+  /** Gap between siblings in ms: 40 (dense grids), 60 (chips), 80 (rows, default). */
+  gap?: 40 | 60 | 80;
+  /** Rise distance for items (default 16); an Item's own `y` prop overrides. */
+  y?: number;
+  /** In-view threshold (default 0.3). */
+  amount?: number;
+  /** Delay in seconds before the first child starts. */
+  delay?: number;
+  className?: string;
+};
+
+function Stagger({
+  children,
+  gap = 80,
+  y = 16,
+  amount = 0.3,
+  delay = 0,
+  className,
+}: StaggerProps) {
+  const reduced = useReducedMotion();
+  return (
+    <StaggerCtx.Provider value={{ y }}>
+      <motion.div
+        initial="hidden"
+        whileInView="show"
+        viewport={{ once: true, amount }}
+        variants={{
+          hidden: {},
+          show: {
+            transition: {
+              staggerChildren: reduced ? 0 : gap / 1000,
+              delayChildren: delay,
+            },
+          },
+        }}
+        className={className}
+      >
+        {children}
+      </motion.div>
+    </StaggerCtx.Provider>
+  );
+}
+
+export type StaggerItemProps = {
+  children: ReactNode;
+  /** Overrides the container's `y` for this item. */
+  y?: number;
+  className?: string;
+};
+
+function Item({ children, y, className }: StaggerItemProps) {
+  const reduced = useReducedMotion();
+  const ctx = useContext(StaggerCtx);
+  const rise = y ?? ctx.y;
+
+  const variants = reduced
+    ? {
+        hidden: { opacity: 0 },
+        show: { opacity: 1, transition: { duration: DUR.fade } },
+      }
+    : {
+        hidden: { opacity: 0, y: rise },
+        show: { opacity: 1, y: 0, transition: SPRING.reveal },
+      };
+
+  return (
+    <motion.div variants={variants} className={className}>
+      {children}
+    </motion.div>
+  );
+}
+
+Stagger.Item = Item;
+/**
+ * Named export for SERVER components: the RSC client-reference proxy for the
+ * default export does not carry attached properties, so `Stagger.Item` is
+ * undefined across the server/client boundary. Client files may use either.
+ */
+export { Item as StaggerItem };
+export default Stagger;

--- a/website/src/components/motion/index.ts
+++ b/website/src/components/motion/index.ts
@@ -1,0 +1,7 @@
+export { default as Reveal, type RevealProps } from "./Reveal";
+export { default as Stagger, StaggerItem, type StaggerProps, type StaggerItemProps } from "./Stagger";
+export { default as CountUp, type CountUpProps } from "./CountUp";
+export { default as BorderBeam, type BorderBeamProps } from "./BorderBeam";
+export { useDrawable, type DrawableOptions } from "./useDrawable";
+export { useMotionOk, motionOk } from "./useMotionOk";
+export * from "./vocab";

--- a/website/src/components/motion/useDrawable.ts
+++ b/website/src/components/motion/useDrawable.ts
@@ -1,0 +1,64 @@
+"use client";
+/**
+ * useDrawable — one-shot SVG stroke draw via animejs `svg.createDrawable`.
+ * Fires once when the ref'd SVG is 50% in view; the animejs instance is
+ * created inside the in-view effect, never on mount. Gated by `motionOk()`:
+ * when motion is reduced the paths simply render complete as authored.
+ * Returns `inView` so callers can sync companion effects.
+ */
+import { useEffect, useRef, type RefObject } from "react";
+import { useInView } from "motion/react";
+import { animate, stagger as animeStagger, svg } from "animejs";
+import { motionOk } from "./useMotionOk";
+import { ANIME_EASE } from "./vocab";
+
+export type DrawableOptions = {
+  /** Per-path draw duration in ms (default 800; band 700–900, caduceus 1200). */
+  duration?: number;
+  /** Stagger between paths in ms (default 0 = all together). */
+  stagger?: number;
+  /** animejs ease name (default "outQuad"). */
+  ease?: string;
+  /** Delay in ms before the first path starts (default 0). */
+  delay?: number;
+  /** In-view threshold (default 0.5). */
+  amount?: number;
+};
+
+export function useDrawable(
+  svgRef: RefObject<SVGSVGElement | null>,
+  {
+    duration = 800,
+    stagger = 0,
+    ease = ANIME_EASE.draw,
+    delay = 0,
+    amount = 0.5,
+  }: DrawableOptions = {}
+): boolean {
+  const inView = useInView(svgRef, { once: true, amount });
+  const ran = useRef(false);
+
+  useEffect(() => {
+    if (!inView || ran.current) return;
+    const el = svgRef.current;
+    if (!el) return;
+    ran.current = true;
+    if (!motionOk()) return; // paths stay fully drawn as authored
+
+    const targets = el.querySelectorAll<SVGGeometryElement>(
+      "path, line, polyline, polygon, circle, rect, ellipse"
+    );
+    if (targets.length === 0) return;
+
+    const drawables = svg.createDrawable(targets);
+    animate(drawables, {
+      draw: ["0 0", "0 1"],
+      duration,
+      ease,
+      delay: stagger > 0 ? animeStagger(stagger, { start: delay }) : delay,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inView]);
+
+  return inView;
+}

--- a/website/src/components/motion/useMotionOk.ts
+++ b/website/src/components/motion/useMotionOk.ts
@@ -1,0 +1,36 @@
+"use client";
+/**
+ * Single source of truth for prefers-reduced-motion at animejs call sites.
+ *
+ * - `motionOk()` — plain util, safe to call inside effects/handlers (client
+ *   only). Returns false during SSR so nothing animates before hydration.
+ * - `useMotionOk()` — reactive hook; re-renders when the OS setting flips.
+ *
+ * Every animejs call MUST be gated with `if (!motionOk()) { render final
+ * state; return; }`. motion/react components should keep using
+ * `useReducedMotion()` from "motion/react"; this util exists for imperative
+ * (animejs / class-toggle) call sites.
+ */
+import { useSyncExternalStore } from "react";
+
+const QUERY = "(prefers-reduced-motion: reduce)";
+
+export function motionOk(): boolean {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return false;
+  }
+  return !window.matchMedia(QUERY).matches;
+}
+
+function subscribe(onChange: () => void): () => void {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return () => {};
+  }
+  const mql = window.matchMedia(QUERY);
+  mql.addEventListener("change", onChange);
+  return () => mql.removeEventListener("change", onChange);
+}
+
+export function useMotionOk(): boolean {
+  return useSyncExternalStore(subscribe, motionOk, () => false);
+}

--- a/website/src/components/motion/vocab.ts
+++ b/website/src/components/motion/vocab.ts
@@ -1,0 +1,66 @@
+/**
+ * Motion vocabulary — the single source of truth for durations, easings,
+ * distances, and stagger gaps across the landing page. Import from
+ * "@/components/motion". CSS twin: `--tt-ease` in globals.css.
+ */
+import type { Transition } from "motion/react";
+
+/** The one entrance curve. Same values as `--tt-ease` in globals.css. */
+export const EASE: [number, number, number, number] = [0.22, 1, 0.36, 1];
+export const EASE_CSS = "cubic-bezier(0.22, 1, 0.36, 1)";
+
+/** Durations in SECONDS (motion/react convention). animejs wants ms — multiply by 1000. */
+export const DUR = {
+  /** hover, tab color, copy button */
+  micro: 0.18,
+  /** standard reveal */
+  reveal: 0.55,
+  /** count-ups (900–1100ms band; default midpoint) */
+  countUp: 1.0,
+  /** SVG path draws (700–900ms band; default midpoint) */
+  draw: 0.8,
+  /** caduceus draw */
+  caduceus: 1.2,
+  /** terminal line arrival */
+  line: 0.15,
+  /** reduced-motion opacity fade */
+  fade: 0.2,
+} as const;
+
+/** Springs. Only where things move between states. */
+export const SPRING = {
+  /** reveals — settles ~550ms, no overshoot */
+  reveal: { type: "spring", stiffness: 300, damping: 34 } as Transition,
+  /** pop-ins (floating tags, badges) — slight bounce */
+  pop: { type: "spring", stiffness: 300, damping: 26 } as Transition,
+  /** shared-layout tab underline */
+  tab: { type: "spring", stiffness: 400, damping: 36 } as Transition,
+} as const;
+
+/** Rise distances in px. Transforms + opacity only; never width/height/layout/filter. */
+export const RISE = {
+  text: 16,
+  card: 24,
+  chip: 8,
+} as const;
+
+/** Stagger gaps in ms (animejs) — divide by 1000 for motion's staggerChildren. */
+export const GAP = {
+  /** rows of ≤6 siblings */
+  row: 80,
+  /** dense grids (AgentsGrid) */
+  grid: 40,
+  /** chip rows */
+  chip: 60,
+} as const;
+
+/** Default in-view trigger for below-fold reveals. */
+export const VIEWPORT = { once: true, amount: 0.3 } as const;
+/** Trigger for count-ups and SVG draws (numbers finish while readable). */
+export const VIEWPORT_NUM = { once: true, amount: 0.5 } as const;
+
+/** animejs ease names. */
+export const ANIME_EASE = {
+  countUp: "outExpo",
+  draw: "outQuad",
+} as const;

--- a/website/src/data/agents.ts
+++ b/website/src/data/agents.ts
@@ -3,7 +3,11 @@ export type Agent = {
   vendor: string;
   captures: string[];
   logPath: string;
-  /** Hex color used for chip + accent — matches the app's agent registry. */
+  /**
+   * Hex color used for chip + accent — matches the app's agent registry.
+   * The first nine also exist as `--agent-*` tokens in globals.css (used by
+   * the hero boot script's discovery dots); keep both in sync when editing.
+   */
   hex: string;
 };
 

--- a/website/src/data/terminal-script.ts
+++ b/website/src/data/terminal-script.ts
@@ -20,3 +20,38 @@ export const TERMINAL_SCRIPT: ScriptLine[] = [
 ];
 
 export const SCRIPT_DURATION_MS = 7000;
+
+/** Hold on the finished script before the replay loops. Loop length = SCRIPT_DURATION_MS + REPLAY_HOLD_MS. */
+export const REPLAY_HOLD_MS = 1500;
+
+/** When the cost line prints, relative to loop start. LiveTrace keys its metric count-ups off this. */
+export const COST_LINE_DELAY_MS = TERMINAL_SCRIPT.find((l) => l.kind === "cost")!.delay;
+
+/* ---- Hero boot sequence -------------------------------------------------- */
+
+export type BootLine = {
+  /** ms from boot start */
+  delay: number;
+  /**
+   * Render prefixes belong to the consumer, keyed off `kind`:
+   * command → "$ " prompt, text typed at BOOT_TYPE_MS_PER_CHAR with a block cursor;
+   * found   → "✓ " check plus a leading dot (colored via `agentVar` when present);
+   * url     → "→ " arrow.
+   */
+  kind: "command" | "found" | "url";
+  text: string;
+  /** Identity-color CSS var for the line's leading dot, e.g. "--agent-claude". Only on per-agent lines. */
+  agentVar?: string;
+};
+
+/** Typing cadence for the hero's one typed command. */
+export const BOOT_TYPE_MS_PER_CHAR = 28;
+
+export const BOOT_SCRIPT: BootLine[] = [
+  { delay: 0,    kind: "command", text: "tokentelemetry" },
+  { delay: 450,  kind: "found",   text: "Claude Code · ~/.claude/projects · 218 sessions", agentVar: "--agent-claude" },
+  { delay: 900,  kind: "found",   text: "Codex · ~/.codex/sessions · 96 sessions", agentVar: "--agent-codex" },
+  { delay: 1350, kind: "found",   text: "11 more agents found" },
+  { delay: 1750, kind: "found",   text: "13 agents · 510 sessions" },
+  { delay: 2100, kind: "url",     text: "http://localhost:3000" },
+];


### PR DESCRIPTION
## What

Full revamp of the tokentelemetry.com landing page, driven by user feedback that the old page "isn't that great". Two commits:

1. **Motion pass** — shared motion primitives (`website/src/components/motion/`: Reveal, Stagger, CountUp, useDrawable, BorderBeam, vocab constants) built on `motion` (motion.dev) + `animejs` v4; framer-motion removed. New LiveTrace section mounts the previously-orphaned TerminalReplay.
2. **Concept revamp** — the page now behaves like an instrument, not a brochure:
   - **Hero**: full-viewport canvas token-field. Agent-colored tokens stream along bezier arcs into a pulsing `localhost:3000` core, under a massive stacked headline. Install command + star CTA static and interactive at first paint.
   - **Numbered instrument chrome** on every section (`01 · burn`, `02 · scan`, …) via shared `SectionHead` with editorial-scale titles.
   - **01 · burn ledger**: 90 days of demo-machine spend as oversized count-up numerals ($599.85 / 931.8M tokens / 510 sessions / 0 bytes uploaded).
   - **02 · scan**: the install boot sequence (typed command, agent discovery lines in identity colors, resolving into the real dashboard) as a full-width, in-view-triggered, replayable showcase.
   - **08 · zero**: privacy as a manifesto — giant green 0, honest telemetry disclosure kept, sr-only "Zero" prefix so the heading reads correctly in screen readers.

## Constraints kept

- Existing `--tt-*` tokens, copy voice, `track()` calls, `#install`/`#features`/`#agents`/`#hermes` anchors
- `prefers-reduced-motion`: canvas renders a static constellation, boot/count-ups render final state
- Canvas pauses off-screen and on hidden tabs; no runtime third-party loads (local-first rule)
- Static export unchanged (34 pages, post-build OG rewrite OK)

## Verification

- `npx tsc --noEmit` clean; `npm run build` succeeds end to end
- Full-page visual sweep in Chrome at 1456px: hero, ledger (no numeral wrapping), boot replay, trace, setup, feature tabs, agents grid, Hermes, privacy, FAQ, final CTA
- No console errors on load
- UPDATE.json entry added (pre-push hook requirement for feat commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)