### PR TITLE
fix(opencode): read channel-suffixed databases (opencode-<channel>.db)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -286,41 +286,64 @@ OLLAMA_DIR = HOME / ".ollama"
 PI_DIR = HOME / ".pi" / "agent"
 PI_SESSIONS_DIR = PI_DIR / "sessions"
 HF_DIR = HOME / ".cache/huggingface"
+def _opencode_dbs_in(d: Path) -> List[Path]:
+    """DB files OpenCode may have written inside data dir ``d``, canonical first.
+
+    The filename is NOT fixed either: OpenCode picks it from the *release
+    channel* it was built for. `latest`/`beta` (and builds with
+    `OPENCODE_DISABLE_CHANNEL_DB`) get plain ``opencode.db``; every other
+    channel gets ``opencode-<channel>.db``, e.g. the ``opencode-stable.db``
+    a Nix install produces. Globbing is the only way to cover that — the
+    channel string is arbitrary, so there's no finite list to hardcode.
+    ``opencode*.db`` deliberately does not match the ``-wal``/``-shm``
+    sidecars, which don't end in ``.db``.
+    """
+    canonical = d / "opencode.db"
+    out = [canonical]
+    try:
+        out.extend(sorted(p for p in d.glob("opencode*.db") if p != canonical))
+    except OSError:
+        pass
+    return out
+
+
 def _opencode_db_candidates() -> List[Path]:
     """OpenCode SQLite DB locations to probe, highest-priority first.
 
     OpenCode does NOT use one fixed path: it resolves a data dir honoring
-    ``$OPENCODE_DATA_DIR`` and ``$XDG_DATA_HOME`` with a per-OS default. We used
-    to look only at ``~/.local/share/opencode`` and so silently missed relocated
-    or non-Linux installs — the scan is gated on ``.exists()`` inside a bare
-    ``try/except``, so a wrong path means the whole agent vanishes with no error
-    (discussion #170). Probe every place the agent could have written; the scan
-    uses the first that exists. Extra non-existent candidates are harmless.
+    ``$OPENCODE_DATA_DIR`` and ``$XDG_DATA_HOME`` with a per-OS default, then
+    names the file after its release channel. We used to look only at
+    ``~/.local/share/opencode/opencode.db`` and so silently missed relocated
+    installs, non-Linux installs, and every non-`latest` channel — the scan is
+    gated on ``.exists()`` inside a bare ``try/except``, so a wrong path means
+    the whole agent vanishes with no error (discussion #170). Probe every place
+    the agent could have written. Extra non-existent candidates are harmless.
     """
-    c: List[Path] = []
+    dirs: List[Path] = []
     env = os.environ.get("OPENCODE_DATA_DIR")
     if env:
-        c.append(Path(env).expanduser() / "opencode.db")
+        dirs.append(Path(env).expanduser())
     xdg = os.environ.get("XDG_DATA_HOME")
     if xdg:
-        c.append(Path(xdg).expanduser() / "opencode" / "opencode.db")
+        dirs.append(Path(xdg).expanduser() / "opencode")
     if sys.platform == "win32":
         for var in ("APPDATA", "LOCALAPPDATA"):
             base = os.environ.get(var)
             if base:
-                c.append(Path(base) / "opencode" / "opencode.db")
+                dirs.append(Path(base) / "opencode")
     # Standard XDG data dir — the confirmed default on BOTH Linux and macOS
     # (OpenCode does not use ~/Library/Application Support, verified on 1.15.13).
-    c.append(HOME / ".local/share/opencode/opencode.db")
+    dirs.append(HOME / ".local/share/opencode")
     # macOS env-paths-style location, in case a build ever used it.
     if sys.platform == "darwin":
-        c.append(HOME / "Library/Application Support/opencode/opencode.db")
+        dirs.append(HOME / "Library/Application Support/opencode")
     seen: set = set()
     out: List[Path] = []
-    for p in c:
-        if p not in seen:
-            seen.add(p)
-            out.append(p)
+    for d in dirs:
+        for p in _opencode_dbs_in(d):
+            if p not in seen:
+                seen.add(p)
+                out.append(p)
     return out
 
 
@@ -337,6 +360,50 @@ def _opencode_db_path() -> Path:
 
 
 OPENCODE_DB = _opencode_db_path()
+
+
+def _opencode_dbs() -> List[Path]:
+    """Every OpenCode DB to actually read, primary (``OPENCODE_DB``) first.
+
+    A user who has switched release channels ends up with several DBs side by
+    side — e.g. an old ``opencode.db`` plus the live ``opencode-stable.db``.
+    Reading only the first would show stale sessions and hide current ones, so
+    scan them all. Derived from ``OPENCODE_DB.parent`` rather than re-probing
+    every candidate dir, which keeps a monkeypatched ``OPENCODE_DB`` fully in
+    control of what the scan sees.
+    """
+    out: List[Path] = []
+    seen: set = set()
+    for p in [OPENCODE_DB, *_opencode_dbs_in(OPENCODE_DB.parent)]:
+        try:
+            if p in seen or not p.exists():
+                continue
+        except OSError:
+            continue
+        seen.add(p)
+        out.append(p)
+    return out
+
+
+def _opencode_db_for_session(session_id: str) -> Optional[Path]:
+    """The channel DB that actually holds ``session_id``, or None.
+
+    Detail endpoints can't assume the primary DB: with several channel DBs
+    present, a session listed from ``opencode-stable.db`` would 404 if we only
+    ever queried ``opencode.db``.
+    """
+    for db in _opencode_dbs():
+        try:
+            conn = sqlite3.connect(_sqlite_ro_uri(db), uri=True, timeout=1.0)
+            try:
+                if conn.execute("SELECT 1 FROM session WHERE id=?",
+                                (session_id,)).fetchone():
+                    return db
+            finally:
+                conn.close()
+        except Exception:
+            continue
+    return None
 # Hermes installs to ~/.hermes by default, but the agent honors HERMES_HOME for
 # users who relocate their data dir (shared hosts, containerized setups, etc.).
 # Mirror that contract so we read from wherever the agent actually writes.
@@ -5213,14 +5280,18 @@ def _scan_sessions_sync():
                 })
             except Exception: continue
 
-    # 8. OpenCode (SQLite: session / message / part)
-    if OPENCODE_DB.exists():
+    # 8. OpenCode (SQLite: session / message / part). One DB per release
+    # channel, so a channel-switcher can have several side by side (#170).
+    # Session ids are unique per DB but the same id could in principle appear
+    # in two of them (a copied data dir); keep the count-once invariant.
+    _oc_seen_ids: set = set()
+    for _oc_db in _opencode_dbs():
         try:
             # mode=ro (via _sqlite_ro_uri) so we never take a write lock on the
             # live TUI's DB. It's a WAL database, so a read can still time out if
             # OpenCode is mid-write — that lands in the outer except, which now
             # logs instead of silently dropping the whole agent.
-            uri = _sqlite_ro_uri(OPENCODE_DB)
+            uri = _sqlite_ro_uri(_oc_db)
             conn = sqlite3.connect(uri, uri=True, timeout=1.0)
             conn.row_factory = sqlite3.Row
             try:
@@ -5253,6 +5324,9 @@ def _scan_sessions_sync():
                 rows = conn.execute(f"SELECT id, directory, title, time_created, time_updated{_parent_sel} FROM session").fetchall()
                 for srow in rows:
                     sid = srow["id"]
+                    if sid in _oc_seen_ids:
+                        continue
+                    _oc_seen_ids.add(sid)
                     ts = datetime.fromtimestamp((srow["time_updated"] or srow["time_created"] or 0) / 1000, tz=timezone.utc)
                     tokens = {"input": 0, "output": 0, "cached": 0, "total": 0}
                     model = None
@@ -5383,7 +5457,7 @@ def _scan_sessions_sync():
             # of invisible (discussion #170).
             import logging
             logging.getLogger("tokentelemetry.opencode").debug(
-                "OpenCode scan skipped (%s): %r", OPENCODE_DB, e)
+                "OpenCode scan skipped (%s): %r", _oc_db, e)
 
     # 8. Grok Build (xAI) — rich per-session directory with events, updates, chat history
     sessions.extend(_scan_grok_sessions())
@@ -6288,8 +6362,9 @@ async def get_session_detail(session_id: str, agent: str):
             if "response" in req: events.append({"type": "assistant", "payload": req["response"], "timestamp": req.get("timestamp"), "normalized_timestamp": norm_ts})
         return events
     elif agent == "opencode":
-        if not OPENCODE_DB.exists(): return {"error": "Not found"}
-        uri = _sqlite_ro_uri(OPENCODE_DB)
+        _oc_db = _opencode_db_for_session(session_id)
+        if _oc_db is None: return {"error": "Not found"}
+        uri = _sqlite_ro_uri(_oc_db)
         conn = sqlite3.connect(uri, uri=True, timeout=1.0)
         conn.row_factory = sqlite3.Row
         try:
@@ -6641,10 +6716,11 @@ async def session_delegation(session_id: str, agent: str):
         return {"error": "Not found"}
 
     if agent == "opencode":
-        if not OPENCODE_DB.exists():
+        _oc_db = _opencode_db_for_session(session_id)
+        if _oc_db is None:
             return {"error": "Not found"}
         try:
-            conn = sqlite3.connect(_sqlite_ro_uri(OPENCODE_DB), uri=True, timeout=1.0)
+            conn = sqlite3.connect(_sqlite_ro_uri(_oc_db), uri=True, timeout=1.0)
             try:
                 cols = {r[1] for r in conn.execute("PRAGMA table_info(session)")}
                 if "parent_id" not in cols:

--- a/backend/test_opencode_paths.py
+++ b/backend/test_opencode_paths.py
@@ -1,12 +1,17 @@
-"""Tests for OpenCode data-dir resolution (discussion #170).
+"""Tests for OpenCode data-dir + DB-filename resolution (discussion #170).
 
 Before this, TokenTelemetry only ever looked at ``~/.local/share/opencode/
-opencode.db``, so a relocated or non-Linux OpenCode install was silently
-invisible. These tests pin the candidate-probing behaviour: env override,
-``$XDG_DATA_HOME``, per-OS defaults, priority, and the fall-back-to-canonical
-when nothing exists yet.
+opencode.db``, so an OpenCode install was silently invisible if it was
+relocated, non-Linux, or — the actual cause endorama hit — built for a release
+channel other than `latest`/`beta`, which names the file
+``opencode-<channel>.db`` (a Nix `stable` build writes ``opencode-stable.db``).
+
+These tests pin both halves: the directory probing (env override,
+``$XDG_DATA_HOME``, per-OS defaults, priority, fall-back-to-canonical) and the
+filename globbing (channel suffixes found, sidecars ignored, every DB scanned).
 """
 
+import json
 import os
 import sqlite3
 import sys
@@ -16,6 +21,7 @@ import pytest
 
 sys.path.insert(0, os.path.dirname(__file__))
 import main  # noqa: E402
+from test_delegation import scan_env  # noqa: E402,F401  (hermetic scan fixture)
 
 
 def _clear_oc_env(monkeypatch):
@@ -93,3 +99,123 @@ def test_path_falls_back_to_canonical_when_nothing_exists(monkeypatch, tmp_path)
     monkeypatch.setattr(main, "HOME", tmp_path)
     got = main._opencode_db_path()
     assert got == tmp_path / ".local/share/opencode/opencode.db"
+
+
+# --- Release-channel DB filenames ------------------------------------------
+# OpenCode's getChannelPath(): `latest`/`beta` (or OPENCODE_DISABLE_CHANNEL_DB)
+# → "opencode.db"; anything else → f"opencode-{channel}.db". The channel string
+# is arbitrary, so detection has to glob rather than match a known list.
+
+
+def _make_scannable_db(path: Path, *session_ids, wal: bool = False,
+                       leave_open: bool = False):
+    """An OpenCode DB with enough schema for _scan_sessions_sync to read it.
+
+    ``leave_open`` returns the writer connection instead of closing it. That
+    matters for the WAL case: closing the last connection checkpoints and
+    deletes the ``-wal`` file, so a closed WAL database is indistinguishable
+    from a rollback-journal one and the test would prove nothing. Callers must
+    close it themselves.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    con = sqlite3.connect(str(path))
+    if wal:
+        con.execute("PRAGMA journal_mode=WAL")
+    con.execute("CREATE TABLE session (id TEXT, project_id TEXT, parent_id TEXT, "
+                "directory TEXT, title TEXT, time_created INT, time_updated INT)")
+    con.execute("CREATE TABLE message (session_id TEXT, time_created INT, data TEXT)")
+    con.execute("CREATE TABLE part (session_id TEXT, time_created INT, data TEXT)")
+    now = 1750000000000
+    for sid in session_ids:
+        con.execute("INSERT INTO session VALUES (?, 'p', NULL, '/tmp/x', ?, ?, ?)",
+                    (sid, sid, now, now))
+        con.execute("INSERT INTO message VALUES (?, ?, ?)", (sid, now, json.dumps(
+            {"role": "assistant", "modelID": "gpt-5.2-codex", "providerID": "openai"})))
+        con.execute("INSERT INTO part VALUES (?, ?, ?)", (sid, now, json.dumps(
+            {"type": "step-finish",
+             "tokens": {"input": 11, "output": 6, "cache": {"read": 0, "write": 0}}})))
+    con.commit()
+    if leave_open:
+        return con
+    con.close()
+    return None
+
+
+def test_channel_suffixed_db_is_a_candidate(monkeypatch, tmp_path):
+    """A `stable`-channel install writes opencode-stable.db, not opencode.db."""
+    _clear_oc_env(monkeypatch)
+    _mk_db(tmp_path / "opencode-stable.db")
+    found = main._opencode_dbs_in(tmp_path)
+    assert tmp_path / "opencode-stable.db" in found
+    # Canonical name is still offered first even though it doesn't exist here.
+    assert found[0] == tmp_path / "opencode.db"
+
+
+def test_path_resolves_channel_only_install(monkeypatch, tmp_path):
+    """endorama's exact environment: the ONLY db present is channel-suffixed."""
+    _clear_oc_env(monkeypatch)
+    db = tmp_path / "opencode-stable.db"
+    _mk_db(db)
+    monkeypatch.setenv("OPENCODE_DATA_DIR", str(tmp_path))
+    assert main._opencode_db_path() == db
+
+
+def test_wal_sidecars_are_not_mistaken_for_dbs(monkeypatch, tmp_path):
+    """`ls` shows opencode-stable.db{,-shm,-wal}; only the .db is a candidate."""
+    _clear_oc_env(monkeypatch)
+    _mk_db(tmp_path / "opencode-stable.db")
+    (tmp_path / "opencode-stable.db-shm").write_bytes(b"")
+    (tmp_path / "opencode-stable.db-wal").write_bytes(b"")
+    found = main._opencode_dbs_in(tmp_path)
+    assert all(str(p).endswith(".db") for p in found)
+    assert len(found) == 2  # canonical + stable, no sidecars
+
+
+def test_canonical_db_stays_first_when_both_exist(monkeypatch, tmp_path):
+    _clear_oc_env(monkeypatch)
+    _mk_db(tmp_path / "opencode.db")
+    _mk_db(tmp_path / "opencode-stable.db")
+    monkeypatch.setenv("OPENCODE_DATA_DIR", str(tmp_path))
+    assert main._opencode_db_path() == tmp_path / "opencode.db"
+
+
+def test_scan_reads_channel_only_db(scan_env):
+    """The end-to-end symptom: sessions exist but the agent shows nothing."""
+    _make_scannable_db(scan_env / "opencode-stable.db", "ses_stable")
+    got = [s for s in main._scan_sessions_sync() if s["agent"] == "opencode"]
+    assert [s["id"] for s in got] == ["ses_stable"]
+    assert got[0]["tokens"]["input"] == 11
+
+
+def test_scan_reads_channel_db_with_live_wal(scan_env):
+    """WAL is OpenCode's journal mode, and the TUI holds the DB open while you
+    use it — which is when you'd check the dashboard. Keep a writer connected
+    so the -wal/-shm sidecars endorama saw are actually present during the
+    scan, and assert the read-only scan still returns the rows."""
+    db = scan_env / "opencode-stable.db"
+    con = _make_scannable_db(db, "ses_wal", wal=True, leave_open=True)
+    try:
+        assert db.with_name(db.name + "-wal").exists(), "no live -wal to test against"
+        got = [s for s in main._scan_sessions_sync() if s["agent"] == "opencode"]
+        assert [s["id"] for s in got] == ["ses_wal"]
+    finally:
+        con.close()
+
+
+def test_scan_merges_every_channel_db(scan_env):
+    """Channel-switchers keep several DBs; show them all, each session once."""
+    _make_scannable_db(scan_env / "opencode.db", "ses_latest")
+    _make_scannable_db(scan_env / "opencode-stable.db", "ses_stable", "ses_dupe")
+    _make_scannable_db(scan_env / "opencode-nightly.db", "ses_dupe")
+    ids = [s["id"] for s in main._scan_sessions_sync() if s["agent"] == "opencode"]
+    assert sorted(ids) == ["ses_dupe", "ses_latest", "ses_stable"]
+    assert len(ids) == len(set(ids)), "a session present in two DBs was counted twice"
+
+
+def test_detail_lookup_finds_session_in_channel_db(scan_env):
+    """Otherwise the list populates but clicking a session 404s."""
+    _make_scannable_db(scan_env / "opencode.db", "ses_latest")
+    _make_scannable_db(scan_env / "opencode-stable.db", "ses_stable")
+    assert main._opencode_db_for_session("ses_stable") == scan_env / "opencode-stable.db"
+    assert main._opencode_db_for_session("ses_latest") == scan_env / "opencode.db"
+    assert main._opencode_db_for_session("ses_nope") is None

--- a/website/content/docs/reference/troubleshooting.mdx
+++ b/website/content/docs/reference/troubleshooting.mdx
@@ -33,7 +33,7 @@ The one-line installer also starts the app for you on first install — you only
    - Antigravity: `~/.gemini/antigravity/`
    - Cursor: `~/.cursor/` + workspaceStorage
    - GitHub Copilot: VS Code `chatSessions/`
-   - OpenCode: `~/.local/share/opencode/`
+   - OpenCode: `~/.local/share/opencode/` (or `$OPENCODE_DATA_DIR` / `$XDG_DATA_HOME`; the db is `opencode.db` on the `latest`/`beta` channels, `opencode-<channel>.db` otherwise)
    - Qwen CLI: `~/.qwen/`
    - Vibe: `~/.vibe/`
    - Grok Build: `~/.grok/sessions/`

--- a/website/content/docs/supported-agents.mdx
+++ b/website/content/docs/supported-agents.mdx
@@ -61,6 +61,8 @@ Reads Copilot's chat session files from VS Code's `chatSessions/` directory (ins
 
 Reads session data from `~/.local/share/opencode/`. Token counts and traces are captured; OpenCode children sessions are included in the relayed-session count (they are already counted in the parent session's token totals).
 
+The data directory follows `$OPENCODE_DATA_DIR` / `$XDG_DATA_HOME` when set, and the database filename depends on the release channel the build came from: `latest` and `beta` use `opencode.db`, everything else uses `opencode-<channel>.db` (a Nix install on the `stable` channel writes `opencode-stable.db`). TokenTelemetry reads all of them, so switching channels doesn't hide your older sessions.
+
 ### Cline
 
 TokenTelemetry reads both the Cline CLI SQLite store and the VS Code extension's JSON task history, de-duplicating sessions that appear in both.


### PR DESCRIPTION
Fixes the actual cause behind #170.

## What #179 got wrong

#179 assumed a **data-directory** mismatch and taught TT to probe `$OPENCODE_DATA_DIR`, `$XDG_DATA_HOME`, and per-OS defaults. Useful on its own, but it wasn't endorama's problem. Their DB is at the standard path — under a different **name**:

```
$ ls $HOME/.local/share/opencode/*.db*
opencode-stable.db  opencode-stable.db-shm  opencode-stable.db-wal
```

OpenCode picks the filename from the release channel the build came from ([upstream `getChannelPath()`](https://github.com/anomalyco/opencode/issues/21790#issuecomment-4219224705)): `latest` and `beta` (and builds with `OPENCODE_DISABLE_CHANNEL_DB`) get `opencode.db`; every other channel gets `opencode-<channel>.db`. A Nix install selects `stable`. TT looked for a file that was never there, found nothing, and — because the scan is gated on `.exists()` — dropped the whole agent silently.

## The fix

- **Glob, don't guess.** The channel string is arbitrary (`CHANNEL.replace(/[^a-zA-Z0-9._-]/g, "-")`), so there's no finite list to hardcode. Each candidate directory is globbed for `opencode*.db`, canonical name first. The `-wal`/`-shm` sidecars don't end in `.db`, so they're excluded.
- **Read every DB in the resolved data dir, not just the first.** A user who has switched channels has live sessions in one file and stale ones in another; first-wins would show the stale set while still hiding the current one. (Scope note: this merges DBs within `OPENCODE_DB.parent` — the winning data directory. Candidate *directories* are still first-wins, which keeps a monkeypatched `OPENCODE_DB` in full control of what the scan sees in tests.)
- **Count-once preserved.** Sessions are de-duplicated by id across DBs.
- **Both session-detail endpoints resolve which DB holds the session.** Without this the list would populate and clicking a stable-channel session would return `Not found` — a half-fix that reads as a new bug.

## Tests

7 new cases in `test_opencode_paths.py`, each verified to **fail before this change and pass after**:

- channel-only install (endorama's exact environment: the only DB present is `opencode-stable.db`)
- live WAL — a writer connection is held open across the scan so the `-wal`/`-shm` sidecars are actually present, rather than checkpointed away by closing the writer
- sidecar files not mistaken for databases
- multi-DB merge, with an explicit no-double-count assertion
- detail-endpoint DB resolution

Full backend suite run before and after: **identical failure set**, no new failures. (The 23 failures on this machine are pre-existing and environment-driven — the dev box's real `~/.tokentelemetry` config leaking into `test_power_config` / `test_billing_mode` / `test_update_check`. Unrelated to this change; worth a separate look at test hermeticity.)

## Docs

`supported-agents.mdx` and `troubleshooting.mdx` now state the channel-dependent filename, so the next person with this symptom can recognize it from `ls`.

No `UPDATE.json` entry: this is a `fix:`, which the enforcement hook allows silently by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
