### PR TITLE
docs(website): add the product demo video to the landing page and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,12 @@
 **TokenTelemetry** is a free, open-source, 100% local observability dashboard that tracks **token usage**, **LLM costs**, **tool calls**, **session traces**, and **reasoning steps** across all your AI coding agents — in one unified place. No signup. No cloud. Your logs never leave your machine.
 
 🌐 **Website & Docs:** [https://tokentelemetry.com](https://tokentelemetry.com)  
+🎥 **Demo:** [3-minute walkthrough](https://youtu.be/AXGdSFFNS_w)  
 🖥️ **macOS/Linux:** `curl -fsSL https://raw.githubusercontent.com/VasiHemanth/tokentelemetry/main/install.sh | bash`
 🧰 **Windows:** `irm https://raw.githubusercontent.com/VasiHemanth/tokentelemetry/main/install.ps1 | iex`
 🐙 **GitHub:** [github.com/VasiHemanth/tokentelemetry](https://github.com/VasiHemanth/tokentelemetry)
+
+[![Watch the TokenTelemetry demo](https://img.youtube.com/vi/AXGdSFFNS_w/maxresdefault.jpg)](https://youtu.be/AXGdSFFNS_w)
 
 ---
 

--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -11,6 +11,12 @@ description: TokenTelemetry is a free, local-first observability dashboard for A
 
 ![Dashboard](/screenshots/dashboard.png)
 
+## Watch the demo
+
+A three-minute walkthrough of the product, if you'd rather see it than read about it.
+
+<VideoEmbed id="AXGdSFFNS_w" title="TokenTelemetry product demo" />
+
 ## The local-first promise
 
 All your agent data stays in `~/.tokentelemetry/` on your machine — TokenTelemetry reads the log files agents already write and never modifies them. Two narrow outbound features exist, both content-free and both optional: an hourly update-check to GitHub (just a version request) and anonymous product telemetry (which features are used — never your code, prompts, paths, or costs). Both are on by default and can be turned off independently in Settings → *Updates & privacy*, or with `DO_NOT_TRACK=1`. See [Update Check & Privacy](/docs/configuration/privacy).

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -1,5 +1,6 @@
 import Hero from "@/components/Hero";
 import ProofStrip from "@/components/ProofStrip";
+import DemoVideo from "@/components/DemoVideo";
 import HowItWorks from "@/components/HowItWorks";
 import FeatureShowcase from "@/components/FeatureShowcase";
 import HermesSpotlight from "@/components/HermesSpotlight";
@@ -14,6 +15,7 @@ export default function Page() {
     <main>
       <Hero />
       <ProofStrip />
+      <DemoVideo />
       <HowItWorks />
       <FeatureShowcase />
       <HermesSpotlight />

--- a/website/src/components/DemoVideo.tsx
+++ b/website/src/components/DemoVideo.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState } from "react";
+import { Play } from "lucide-react";
+import BrowserFrame from "./BrowserFrame";
+import { track } from "@/lib/track";
+
+const VIDEO_ID = "AXGdSFFNS_w";
+const VIDEO_TITLE = "TokenTelemetry demo";
+
+/**
+ * Landing-page demo video. Click-to-load facade: the poster image is plain
+ * markup until the visitor clicks play, then the (autoplaying) iframe swaps in.
+ * That keeps the YouTube player — several hundred KB of JS — off every page
+ * load, and gives us a real play event to track, which a cross-origin iframe
+ * would never surface.
+ *
+ * The docs site has its own embed (`components/docs/VideoEmbed.tsx`) with the
+ * same facade approach but MDX-prose styling and a `doc_video_play` event. This
+ * one uses the landing page's BrowserFrame chrome and fires `landing_video_play`
+ * so the two surfaces stay separable in GA.
+ */
+export default function DemoVideo() {
+  const [playing, setPlaying] = useState(false);
+
+  return (
+    <section id="demo" className="relative max-w-[1180px] mx-auto px-5 py-12 sm:py-[72px]">
+      <div className="text-center max-w-[680px] mx-auto mb-8 sm:mb-10">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--tt-fg-dim)] mb-3">
+          A look at the product
+        </p>
+        <h2 className="text-[clamp(26px,3.6vw,42px)] leading-[1.08] tracking-[-0.025em] font-semibold text-[var(--tt-fg)]">
+          TokenTelemetry, <span className="text-[var(--tt-brand)]">on video.</span>
+        </h2>
+      </div>
+
+      <div className="relative max-w-[900px] mx-auto">
+        <div
+          aria-hidden
+          className="absolute -inset-x-6 -inset-y-6 pointer-events-none bg-gradient-to-tr from-[color:var(--tt-brand-glow)] via-transparent to-transparent blur-3xl"
+        />
+        <BrowserFrame label="tokentelemetry · demo" className="relative">
+          {/* Fixed 16:9 box reserves the height in both states, so swapping the
+              poster for the iframe costs no layout shift. */}
+          <div className="relative aspect-video bg-black">
+            {playing ? (
+              <iframe
+                src={`https://www.youtube-nocookie.com/embed/${VIDEO_ID}?autoplay=1`}
+                title={VIDEO_TITLE}
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                allowFullScreen
+                className="absolute inset-0 w-full h-full border-0"
+              />
+            ) : (
+              <button
+                type="button"
+                aria-label={`Play: ${VIDEO_TITLE}`}
+                onClick={() => {
+                  track("landing_video_play", { id: VIDEO_ID, location: "landing" });
+                  setPlaying(true);
+                }}
+                className="group absolute inset-0 w-full h-full cursor-pointer"
+              >
+                <img
+                  src={`https://i.ytimg.com/vi/${VIDEO_ID}/maxresdefault.jpg`}
+                  alt=""
+                  width={1280}
+                  height={720}
+                  loading="lazy"
+                  decoding="async"
+                  className="block w-full h-full object-cover"
+                />
+                <span
+                  aria-hidden
+                  className="absolute inset-0 grid place-items-center bg-black/25 group-hover:bg-black/15 transition-colors"
+                >
+                  <span className="grid place-items-center w-[58px] h-[58px] rounded-full bg-[var(--tt-brand)] text-black shadow-[0_10px_40px_-8px_rgba(0,0,0,0.7)] group-hover:scale-105 transition-transform">
+                    <Play size={22} fill="currentColor" className="translate-x-[2px]" />
+                  </span>
+                </span>
+              </button>
+            )}
+          </div>
+        </BrowserFrame>
+      </div>
+    </section>
+  );
+}

--- a/website/src/components/docs/VideoEmbed.tsx
+++ b/website/src/components/docs/VideoEmbed.tsx
@@ -36,7 +36,7 @@ export default function VideoEmbed({ id, title = "Video walkthrough" }: VideoEmb
     >
       {playing ? (
         <iframe
-          src={`https://www.youtube.com/embed/${id}?autoplay=1`}
+          src={`https://www.youtube-nocookie.com/embed/${id}?autoplay=1`}
           title={title}
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
           allowFullScreen


### PR DESCRIPTION
Adds the 3-minute product demo (`youtu.be/AXGdSFFNS_w`) to both the marketing site and the docs.

## Where it goes

- **Landing page** — a new `DemoVideo` section between `ProofStrip` and `HowItWorks`, so the opening rhythm is proof (the numbers), then the product actually moving, then the explanation (install steps, feature tabs). It reuses `BrowserFrame` and `HowItWorks`' heading classes rather than introducing a new visual style, and the frame is capped narrower than the hero screenshot so it doesn't out-scale it.
- **Docs → Introduction** — below the existing dashboard screenshot, so the intro paragraph keeps its hero image instead of being split from it.

## Click-to-load, not an autoplaying iframe

Both surfaces show a poster image and only swap in the YouTube iframe once someone clicks.

The built landing HTML contains **zero iframes**, so the YouTube player costs nothing on a visit where nobody presses play. The poster is lazy-loaded so it doesn't compete with the hero for LCP, and the box reserves its 16:9 height in both states so swapping in the player shifts no layout.

The docs side is mostly *activation* rather than new code: `VideoEmbed` already existed and was already registered in `mdx-components.tsx`, but was used nowhere.

## Two judgement calls

- **Switched `VideoEmbed` to `youtube-nocookie.com`** to match the new landing component. Serving a tracking-cookie embed from the same page that describes a local-first privacy promise was the wrong default. Nothing used the component yet, so there was no compatibility cost.
- **The "three-minute" claim is sourced, not guessed** — the watch page reports `lengthSeconds: 185`. No claim is made about what the video contains.

Play events are tracked per surface (`landing_video_play` vs the existing `doc_video_play`) so the two can be told apart.

## Verification

`tsc --noEmit` clean; site builds from a wiped `out/`; the video id appears in both `out/index.html` and `out/docs/index.html`; zero iframes in the pre-click landing HTML.

Labelled `docs(website):` rather than `feat:` on purpose — this is a marketing-site change with nothing for the in-app release banner to announce, so it shouldn't add a UPDATE.json entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
