### PR TITLE
feat: endpoint presets for the OpenAI-compatible summarizer

### DIFF
--- a/UPDATE.json
+++ b/UPDATE.json
@@ -1,6 +1,17 @@
 {
   "releases": [
     {
+      "tag": "2026-08-01",
+      "title": "One-click endpoints for hosted summarizers",
+      "highlights": [
+        {
+          "title": "Endpoint presets in the OpenAI-compatible backend",
+          "description": "The summarizer's OpenAI-compatible backend now has preset buttons that fill in the endpoint and a starting model for you. MiniMax (global and China) and a local llama.cpp server are there; paste your API key and hit Test connection. Hosted providers that speak the OpenAI API work through this backend, so there's no separate setup per vendor.",
+          "href": "/settings"
+        }
+      ]
+    },
+    {
       "tag": "2026-07-30",
       "title": "See what /goal runs actually cost",
       "highlights": [

--- a/frontend/src/components/summarizer/BackendPicker.tsx
+++ b/frontend/src/components/summarizer/BackendPicker.tsx
@@ -6,7 +6,7 @@ import { getAgent } from "@/lib/agents";
 import { cn } from "@/lib/cn";
 import {
   listCodexModels, listOllamaModels, testOpenAICompat,
-  DEFAULT_OPENAI_COMPAT,
+  DEFAULT_OPENAI_COMPAT, ENDPOINT_PRESETS,
   type CodexModel, type OllamaModel, type SummarizerBackend,
   type OpenAICompatConfig,
 } from "@/lib/summarizer";
@@ -301,7 +301,29 @@ function OpenAICompatForm({ model, onModelChange, config, onChange }: OpenAIComp
   return (
     <div className="mt-2 ml-11 mr-1 space-y-3">
       <div>
-        <label className={LABEL_CLS}>Endpoint</label>
+        <div className="flex items-baseline justify-between gap-2 mb-1.5">
+          <label className={cn(LABEL_CLS, "mb-0")}>Endpoint</label>
+          <div className="flex items-center gap-1.5">
+            {ENDPOINT_PRESETS.map((p) => (
+              <button
+                key={p.label}
+                type="button"
+                onClick={() => {
+                  onChange?.({ ...config, endpoint: p.endpoint });
+                  if (p.model) onModelChange?.(p.model);
+                }}
+                className={cn(
+                  "h-6 px-2 rounded border text-[10.5px] font-medium transition-colors",
+                  config.endpoint === p.endpoint
+                    ? "border-[var(--tt-border-focus)] text-[var(--tt-fg)]"
+                    : "border-[var(--tt-border-strong)] text-[var(--tt-fg-dim)] hover:text-[var(--tt-fg)]",
+                )}
+              >
+                {p.label}
+              </button>
+            ))}
+          </div>
+        </div>
         <input
           type="text"
           spellCheck={false}
@@ -311,8 +333,8 @@ function OpenAICompatForm({ model, onModelChange, config, onChange }: OpenAIComp
           className={FIELD_CLS}
         />
         <p className="text-[10.5px] text-[var(--tt-fg-dim)] mt-1.5">
-          Base URL of any OpenAI-compatible server (llama.cpp, vLLM, LM Studio, LocalAI…).
-          We POST to <code className="font-mono">/chat/completions</code> under it.
+          Base URL of any OpenAI-compatible server (llama.cpp, vLLM, LM Studio, LocalAI…)
+          or hosted gateway. We POST to <code className="font-mono">/chat/completions</code> under it.
         </p>
       </div>
 

--- a/frontend/src/lib/summarizer.ts
+++ b/frontend/src/lib/summarizer.ts
@@ -40,6 +40,23 @@ export const DEFAULT_OPENAI_COMPAT: OpenAICompatConfig = {
   enable_thinking: false,
 };
 
+/**
+ * One-click prefill for a hosted OpenAI-compatible gateway. Only the endpoint
+ * and a starting model id — the key, sampling knobs and everything else stay
+ * the user's to fill in. Adding a provider is one entry here, not a new adapter.
+ */
+export interface EndpointPreset {
+  label: string;
+  endpoint: string;
+  model: string;
+}
+
+export const ENDPOINT_PRESETS: EndpointPreset[] = [
+  { label: "MiniMax", endpoint: "https://api.minimax.io/v1", model: "MiniMax-M3" },
+  { label: "MiniMax (China)", endpoint: "https://api.minimaxi.com/v1", model: "MiniMax-M3" },
+  { label: "Local (llama.cpp)", endpoint: "http://localhost:8080/v1", model: "" },
+];
+
 export interface SummarizerConfig {
   enabled: boolean;
   backend: string | null;


### PR DESCRIPTION
Alternative to #218, which adds a dedicated MiniMax adapter.

MiniMax speaks the OpenAI chat-completions API, so it already works through the
`openai_compat` backend. The only friction was knowing the base URL and model id.
This adds preset buttons that fill both in.

## Changes

- `ENDPOINT_PRESETS` in `frontend/src/lib/summarizer.ts` — MiniMax, MiniMax (China),
  local llama.cpp. Each entry is an endpoint plus a starting model id.
- Preset buttons above the Endpoint field in the existing `OpenAICompatForm`
  (`BackendPicker.tsx`). Clicking one fills endpoint + model; the API key and
  sampling knobs stay the user's.

Two files, ~35 lines. Adding the next provider is one array entry.

## Why not a per-vendor adapter

Verified against the live endpoint and MiniMax's docs:

- An unauthenticated POST through `OpenAICompatSummarizer` to
  `https://api.minimax.io/v1/chat/completions` returns MiniMax's 401 body, and
  `errors.classify()` already buckets it as `auth` with the correct hint.
- On the OpenAI route with `reasoning_split` unset (the default), M3 inlines its
  thinking into `content` wrapped in `<think>` tags. `openai_compat` already
  strips those (`_THINK_RE`, `openai_compat.py:53`). #218's `_extract_openai_text`
  does not, so it would hand the full chain-of-thought to `parse_narrative`.
- #218 pins a hardcoded `SUPPORTED_MODELS` tuple and `save_config` silently
  rewrites the model back to the default when it isn't in that list. A new MiniMax
  model would be unusable until we cut a release. The free-text model field has no
  such gate.

## Checks

- `npx tsc --noEmit` in `frontend/` — clean
- `python3 -c "import json; json.load(open('UPDATE.json'))"` — parses
- Live 401 probe through the existing adapter (above)

Not yet done: an authenticated end-to-end summarize. Marking draft until that runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)