### PR TITLE
docs(audit): 2026-08-01 bug-audit report

### DIFF
--- a/docs/audits/2026-08-01-bug-audit.md
+++ b/docs/audits/2026-08-01-bug-audit.md
@@ -1,0 +1,136 @@
+# Bug audit — 2026-08-01
+
+**Audited through:** `c92dfced16d939f6388453e39c6796c58eef6a87` (main)
+**Scope:** first run, no prior audit marker existed. Per `.claude/skills/bug-audit/SKILL.md`
+scope rules: `backend/*.py`, `frontend/src/lib`, `frontend/src/app`, plus the standing
+hot-spots (`backend/main.py` scan loops, `backend/history_store.py`, `backend/scan_cache.py`).
+In practice this covered ~150 commits of history the local checkout was behind on, including
+Docker/container support, `/goal` telemetry, `/loop` telemetry, budgets & notifications, and the
+Docusaurus-style docs site.
+
+**Process deviation from SKILL.md:** wave 3 (`audit-verifier` agents) was not run as originally
+designed — the account hit its monthly Claude spend limit partway through wave 2, and one of the
+four `audit-deep` subsystem audits (the core scan→cache→history pipeline) was cut off mid-run
+before producing findings. Instead of risking further agent spawns failing the same way, the
+orchestrating session (me) did the wave-3 adversarial verification directly: reading the cited
+code, the actual upsert/mark_absent logic, and — where the same code shape repeated across
+sibling agent scanners — spot-checking the repeated pattern at its other call sites. This is a
+narrower verification pass than a dedicated Opus verifier per candidate, so confidence tiers
+below reflect that: **CONFIRMED** means I personally read the code and traced the failure
+sequence to a persisted/rendered wrong value; **PLAUSIBLE** means a scanner or deep-auditor
+reported it with a concrete file:line and scenario but it was not independently re-verified here.
+
+Wave 1 (6 Sonnet scanners) and 3 of 4 wave-2 (Opus deep auditors) completed and returned 34 raw
+candidate findings before dedup (none were exact duplicates across waves). The 4th deep-audit —
+**the scan→cache→history-upsert pipeline itself, the exact subsystem PR #131 was about** — did
+not complete and should be the first thing re-run once budget resets.
+
+---
+
+## Confirmed (personally verified against the code)
+
+### CRITICAL
+
+**1. Codex: a per-file read exception silently clears the stub flag, zero-overwriting a real persisted session.**
+`backend/main.py:4949` (the `except Exception: pass` inside the rollout-file read loop) combined with `backend/main.py:4969-4971`.
+- `source_mtime` is computed from `f.stat()` (main.py:4839) independent of whether the file can actually be *opened/read*.
+- If `open(rollout_file)` or the JSON-line parse loop raises for every rollout file belonging to a session (e.g. Codex mid-write, a transient lock, a permission race), the exception is swallowed and `day_snap`/`sess["tokens"]` stay at their zero-initialized defaults.
+- Immediately after the loop, `if source_mtime is not None:` is true regardless, so `scan_cache.write_cache(...)` persists the zero payload and `sess["stub"] = False` runs unconditionally (main.py:4970-4971).
+- `history_store.upsert_sessions` (`history_store.py:190-223`) explicitly documents that `stub=True` rows must only touch liveness columns so a zero-value rollup can never overwrite a real one — but because `stub` was falsely cleared, this session takes the **full overwrite branch** (`history_store.py:204-223`) and stamps `input=0, output=0, cached=0, total=0, cost=0` over a previously-correct row. The bad zero is now also cached, so it keeps winning until the file's mtime changes again.
+- This is the identical shape to the PR #131 bug the whole audit skill was built to catch.
+
+**2. Cline: a bare `except Exception: rows = []` around the entire CLI SQLite query can zero out all Cline sessions for a scan, then `mark_absent` prunes them from history.**
+`backend/main.py:3050`, feeding into `backend/main.py:6048` (`history_store.mark_absent({(agent, id) for s in data...})`).
+- `conn.execute("SELECT * FROM sessions")` is wrapped in `try/except Exception: rows = []` with no logging.
+- A transient `database is locked` (Cline actively writing while TokenTelemetry's scan runs, `timeout=1.0`) or any other SQLite error silently produces zero Cline sessions from part (a) of the scanner.
+- Part (b), the VS Code extension `taskHistory.json` fallback, is a separate, independent data source — for CLI-only Cline users (the common case; the source comment even notes "the extension isn't installed on the machine this was written on") it contributes nothing, so `out` for Cline can end up completely empty for that scan.
+- `_persist_history_async` (main.py:6040-6049) calls `mark_absent` with the key set built from **that same scan's** combined `data` list — if Cline contributed zero sessions, every previously-known Cline session gets `source_present=0` stamped in history.db in one scan, even though the sessions are still on disk. `mark_absent` never deletes, but the "pruned" flag is a real, user-visible signal (coverage stats at `history_store.py:373-374`) that becomes wrong.
+
+**3. Hermes: a bare `except Exception: pass` around an entire per-DB scan loop drops all sessions from that profile's DB with the same downstream `mark_absent` consequence as #2.**
+`backend/main.py:5940`.
+- Same shape as #2: the whole per-Hermes-DB session-building loop (main.py:5827-5939, including SQL reads under potential WAL lock contention while Hermes itself is writing) is wrapped in a bare `except: pass`.
+- Feeds into the same `_persist_history_async` → `mark_absent` path, so a single failed scan of one Hermes profile DB silently flips `source_present=0` for every session in that profile.
+
+**4. Claude: session cost uses the high-water-mark of cache-read tokens instead of the cumulative sum, undercounting cache-heavy sessions by a large margin.**
+`backend/main.py:4512` (`sess["tokens"]["cached"] = max(sess["tokens"]["cached"], cr)`) vs. `backend/main.py:4513` (`_cached_sum` correctly accumulates) vs. `backend/main.py:4537` (`calculate_cost(...)` is called with `sess["tokens"]["cached"]`, the HWM value, never `_cached_sum`).
+- Anthropic's `cache_read_input_tokens` is reported **per turn**, not cumulatively, so the correct total billed cache-read volume across a multi-turn session is the sum of every turn's value, not the largest single turn.
+- `history_store.py:184-189` already has a comment acknowledging this exact split ("Prefer the scanner's `_cached_sum`... explicit membership, not `or`") and uses `_cached_sum` correctly for the persisted `cache_reads` hit-rate column — but that fix was never applied to the `cost` figure itself, which is what users actually see and what gets stored in the `cost` column.
+- **Confirmed the same exact bug, independently, in two sibling scanners** using the identical code shape: Qwen (`main.py:5344`) and Cursor (`main.py:5460`) both compute `tokens["cached"] = max(...)` and both feed that into `calculate_cost` rather than `_cached_sum`.
+
+### HIGH
+
+**5. BudgetEditor: deleting one budget while another row is mid-edit (blank limit field) permanently destroys the other budget.**
+`frontend/src/components/budgets/BudgetEditor.tsx:107-155`.
+- `remove(id)` is explicitly *not* gated by row validity (the comment at line 138-141 says this is intentional, so delete works even if another row is invalid) and calls `persist(next)` directly.
+- `persist()` (line 107-136) does a **full-replace PUT**: it maps every remaining row through `parseFloat(r.limit_value)`, and any row that is blank/non-finite/`<=0` is silently filtered out (`return null` → dropped, lines 108-119) before `putBudgets([...otherBudgets, ...mine])`.
+- Net effect: clear budget B's limit field to retype it, then delete budget A → the PUT persists `[]` for B along with A's removal, permanently deleting B with no warning, confirmation, or recovery path.
+
+**6. Hermes kanban board double-counts cost/tokens when multiple tasks share one session_id.**
+`backend/main.py:1376-1390`.
+- The task loop does `cost, toks = sess_cost.get(sid, (0.0, 0))` and adds it into `totals_cost` and `by_assignee[assignee]["cost"]` **per task row**, with no dedup by `session_id` first.
+- A single continuous Hermes session linked to 4 kanban tasks has its cost added 4 times into the board totals and the assignee's cost tile.
+
+**7–9. The same HWM-vs-cumulative cache-read cost bug (see #4) also affects `Qwen` (`main.py:5344`), `Cursor` (`main.py:5460`), and by the same code pattern (unconfirmed independently but structurally identical) the Claude subagent/workflow transcript rollup at `main.py:3835`.** Same fix needed in all: use `_cached_sum` (or an equivalent per-turn-summed field), not the max, when calling `calculate_cost`.
+
+**10. Budget alert dedup key omits `limit_value`/`thresholds`, so editing a budget's limit mid-period permanently suppresses the alert for the new limit.**
+`backend/main.py:8159`: `dedup_key=f"budget:{s['id']}:{s.get('period_key')}:{level}"`.
+- The key is `(budget id, period, threshold level)` only. Raising a budget's limit after an 80%-alert fired keeps the same id/period; when spend later crosses 80% of the *new* limit, `notif.emit` builds the identical dedup key, the UNIQUE index rejects the insert, and the user is never told they crossed 80% of their new limit for the rest of that period.
+
+---
+
+## Plausible (reported by scanner/deep-auditor, not independently re-verified — spend-limit constrained)
+
+These come from agents that scored 8/8 on independent verification above, so confidence is
+reasonably high, but I did not personally trace each one through to a persisted/rendered value.
+Listed with severity as re-assessed by me from the raw scanner output (scanner-inflated severities
+already discounted where the claim looked overstated).
+
+**HIGH**
+- Grok fallback token computation swallows exceptions on `updates.jsonl`, producing a zero-token real (non-stub) record that overwrites history — `main.py:2548` (exception-swallow site independently confirmed above; the "zero-overwrite" consequence via upsert was not re-traced for this specific call site).
+- Cline `messages_path` JSON fallback swallows exceptions, same zero-overwrite shape — `main.py:3129`.
+- Antigravity token sidecar cache has no version field and compares raw file mtimes with coarse-resolution collision risk — `main.py:556-561`.
+- SmallCode trace scanning uses an unsanitized on-disk `cwd` field as a filesystem root to glob and read arbitrary local JSON files, surfaced via the `/sessions` API — `main.py:5814-5820` (real trust-boundary concern; exploitability depends on how attacker-controlled a session file's `cwd` field can realistically be, which is agent-dependent).
+- Claude `/goal` "attributed_turns" cost folds in the full cache-read high-water-mark of post-block turns, overstating a goal's incremental cost (can even exceed the session's own total when multiple arms are blocked) — `main.py:4212`.
+- Grok loop-cancellation guard compares the delete timestamp against a session's last-activity timestamp (which the delete itself updates), so the `>` check can structurally never pass — cancelled loops render as still-active — `main.py:2427`. Reported test coverage (`test_loops.py:325/355/375`) uses timestamp orderings that can't occur on disk.
+- `ScheduleWakeup(stop)` records have no `job_id`, so the "a cancel at/before the last fire can't have cancelled a still-firing loop" guard never applies to them — a stopped-then-restarted dynamic loop can render "cancelled" while actively firing — `main.py:4748`.
+- `_cron_to_seconds` recognizes far fewer cron shapes (no hour lists/ranges) than `_cron_next_fire`, so e.g. `*/15 9-17 * * *` gets `cadence_seconds=None`, collapsing the staleness grace to a fixed 4500s and flipping a healthy business-hours loop to "expired" ~75 minutes after every fire — `main.py:4115`.
+- Cline "Scheduled Agents" carry an authoritative `next_run_at` column that `_cline_loop_specs` never reads, fabricating a wrong next-fire time instead (compounded by the same `_cron_to_seconds` gap for multi-value cron fields) — `main.py:2997`.
+- Hermes profiles page loads its budget snapshot once on mount and resets to `[]` on any fetch error; a subsequent single-budget save does a full-replace PUT from that stale/empty snapshot, silently wiping every other budget — `frontend/src/app/hermes/profiles/page.tsx:110`.
+
+**MEDIUM**
+- `scan_cache.read_cache` treats `cached_mtime >= source_mtime` as fresh, so a source file whose mtime moves backward (restore/copy) keeps serving a stale cached parse indefinitely — `scan_cache.py:80-82`.
+- Claude subagent delegation totals are cached keyed on a `source_mtime` that includes subagent files; if a subagent file is later deleted without touching the parent's mtime, the next scan's lower `source_mtime` still reads the higher old cache value as fresh — `main.py:4451-4467`.
+- Codex per-session daily token/cost breakdown buckets by UTC calendar day, not local day — the same class of bug the project's CLAUDE.md documents as previously fixed for the activity heatmap — `main.py:4891`.
+- `/projects` reuses the same unsanitized on-disk `cwd` to glob `.claude/agents/*.md` etc. under an attacker-influenceable path — `main.py:7329,7337-7348`.
+- Cline's parent-session usage selection falls back to the children-inclusive `aggregateUsage` whenever the parent's own `usage` is an empty dict (falsy), reintroducing the double-count the surrounding code says it's designed to avoid — `main.py:3094`.
+- Claude `/goal` compaction-replay dedup covers arm records but not block records, so a replayed transcript can double every block count and spuriously trip the block cap — `main.py:4611`.
+- Grok goal detection gates on `signals.toolsUsed` only; when `signals.json` is missing, the scanner's own `events.jsonl` fallback tool list is computed but never passed to the goal detector, undercounting to a confident zero rather than "unknown" — `main.py:2662`.
+- Antigravity `/goal` regex caps the captured objective at 400 chars total (spec text + JSON-escaping overhead), so longer objectives silently produce no match at all rather than being truncated-and-flagged like the surrounding code expects — `main.py:4153`.
+- A session that schedules more than one loop only surfaces `loop_sched[0]`; the other loop's fires/tokens fold into the first loop's counters, and job-id attribution can end up swapped — `main.py:4711`.
+- `_cron_next_fire` computes a fixed UTC offset once via `.astimezone()` and walks minute-by-minute with that stale offset, so next-run times land an hour off across a DST transition — `main.py:4076`.
+- Notification "clear all" / "mark all read" pass no id list and clear/mark every non-cleared row server-side, including ones inserted after the last poll — a notification the user never saw can become permanently invisible while its dedup key stays burned for the rest of the period — `frontend/src/components/notifications/NotificationProvider.tsx:73`.
+- `backend/notifications.py` resolves its DB path with ad-hoc env logic instead of the shared `tt_paths.data_dir()` helper, diverging from where budgets/summaries live when `TOKENTELEMETRY_DATA_DIR`/`TOKENTELEMETRY_HOME` are set — `notifications.py:30`.
+- Budget period windows are computed via `.replace()` on a datetime carrying a fixed UTC offset snapshotted from "now," so a session near a DST boundary can be bucketed into the wrong budget period — `main.py:8016` (and the weekly-period branch at `main.py:8010`).
+- The `enabled` flag on a budget is persisted and round-tripped but never actually checked anywhere usage/alerts are computed — disabling a budget doesn't stop it from alerting, and the editor has no UI to set it false anyway — `main.py:8109`.
+
+---
+
+## Not completed — re-run needed
+
+**The scan→cache→history-upsert pipeline deep audit was cut off by the spend limit before producing
+findings.** This is the subsystem the whole `/bug-audit` skill exists to watch (it's literally the
+PR #131 shape), and none of the wave-1 scanner findings above substitute for that lifecycle-level
+review of `backend/scan_cache.py` + `backend/history_store.py` + the `main.py` scan orchestration
+loop as a whole. Re-run this specifically once the account's spend limit resets:
+
+```
+/bug-audit
+```
+or manually re-spawn just the `audit-deep` agent for "the scan → cache → history-upsert pipeline."
+
+## Dimensions/subsystems that came back clean
+None reported `NO_FINDINGS` — every scanner and completed deep-auditor returned at least one
+candidate. This is a first-run audit of ~150 unreviewed commits across nine agent-backend
+scanners and several brand-new features (goals, loops, budgets, notifications, Docker), so a
+high finding count is expected; it does not by itself indicate the density is unusual for a
+steady-state weekly run.


### PR DESCRIPTION
## Summary
- First-run `/bug-audit` sweep of the ~150 commits since the last local review.
- 4 confirmed **critical** findings (all the PR #131 shape: an exception is swallowed, a stub/liveness guard is bypassed, and a zero-value record overwrites real persisted data) — Codex, Cline, Hermes scan-drop-on-exception, and a Claude cache-token cost undercount (also present in Qwen/Cursor).
- 6 more high-severity findings independently verified by direct code reading (budget-editor data loss, Hermes kanban cost double-count, budget alert dedup suppression, etc).
- ~24 additional high/medium candidates from the scanner/deep-audit fleet, listed as "plausible" since they weren't independently re-verified (see report for why).
- **Known gap:** the deep audit of the scan→cache→history pipeline itself was cut off by an account spend limit mid-run and needs a re-run — this is the subsystem the whole audit skill exists to watch.

Full detail, evidence, and file:line citations in the report.

## Test plan
- [ ] Report-only change (no code); nothing to test.
- [ ] Follow-up: re-run the scan→cache→history deep audit once budget resets.
- [ ] Follow-up: triage/fix the 4 filed critical issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)