### PR TITLE
fix: stop pricing unpriced cloud models as local electricity

### DIFF
--- a/backend/pricing.py
+++ b/backend/pricing.py
@@ -37,6 +37,11 @@ _PROVIDER_SEP = "\x00"
 # Direct first-party pricing — used as the flat-fallback when provider unknown.
 PRICING = {
     # --- Anthropic (Claude) ---
+    # Claude 5 family. These post-date the models.dev snapshot in
+    # pricing_data.json, so without inline entries they fall through the whole
+    # lookup and get costed at $0 (see the local-model guard in calculate_cost).
+    "claude-opus-5":     {"in": 5.00,  "out": 25.00, "cached_read": 0.50},
+    "claude-mythos-5":   {"in": 10.00, "out": 50.00, "cached_read": 1.00},
     "claude-opus-4-7":   {"in": 5.00,  "out": 25.00, "cached_read": 0.50},
     "claude-opus-4-6":   {"in": 5.00,  "out": 25.00, "cached_read": 0.50},
     "claude-opus-4-5":   {"in": 5.00,  "out": 25.00, "cached_read": 0.50},
@@ -282,6 +287,42 @@ def _normalize_model_id(model: str) -> str:
     return m
 
 
+# Model families that are only ever served over a vendor API. A model whose id
+# names one of these is never a local model, however unfamiliar it looks — a
+# newly-released flagship is simply missing from the pricing tables until they
+# are refreshed. Open-weight families (llama, qwen, gemma, mistral, deepseek,
+# phi, …) are deliberately absent: those genuinely do run locally, so they keep
+# the electricity fallback.
+_CLOUD_ONLY_MARKERS = (
+    "claude", "opus", "sonnet", "haiku", "fable", "mythos",   # Anthropic
+    "gpt", "chatgpt", "codex",                                # OpenAI
+    "gemini", "antigravity",                                  # Google
+    "grok",                                                   # xAI
+)
+# OpenAI reasoning models are bare "o1"/"o3"/"o4" prefixes; matched as prefixes
+# rather than substrings so they don't collide with arbitrary version suffixes.
+_CLOUD_ONLY_PREFIXES = ("o1", "o3", "o4")
+
+
+def _is_cloud_only_model(model_name: Optional[str]) -> bool:
+    """True when the model id names a vendor-hosted-only family.
+
+    Used to stop an *unpriced* model from being mistaken for a local one. Being
+    absent from the pricing tables means "we don't know the rate yet", not
+    "it runs on this machine" — and pricing a cloud flagship by electricity
+    under-reports its cost by ~4 orders of magnitude.
+    """
+    if not model_name:
+        return False
+    m = _normalize_model_id(str(model_name))
+    if any(marker in m for marker in _CLOUD_ONLY_MARKERS):
+        return True
+    return any(
+        m == p or m.startswith(p + "-") or m.startswith(p + ".")
+        for p in _CLOUD_ONLY_PREFIXES
+    )
+
+
 def calculate_cost(
     model_name: Optional[str],
     input_tokens: int,
@@ -371,12 +412,19 @@ def calculate_cost(
             # No known API rate for this model. If the user has opted in via
             # ~/.tokentelemetry/power.json, treat it as a local model and price
             # it by electricity instead of the (wrong) _default per-token rate.
+            #
+            # Only for models that could plausibly BE local. "Unpriced" is not a
+            # synonym for "local": every newly-released cloud flagship is
+            # unpriced between its launch and the next pricing_data.json
+            # refresh, and billing one of those by electricity silently reports
+            # ~$0 against real spend. Confirmed-local sessions never reach here
+            # — is_local_session() above already claimed them.
             try:
                 from power_config import (
                     local_power_enabled, load_power_config, electricity_cost,
                     default_tok_per_sec_for_model,
                 )
-                if local_power_enabled():
+                if local_power_enabled() and not _is_cloud_only_model(model_name):
                     pc = load_power_config()
                     return electricity_cost(
                         output_tokens,

--- a/backend/test_local_power.py
+++ b/backend/test_local_power.py
@@ -60,6 +60,67 @@ def test_local_collision_not_priced_as_cloud(tmp_path, monkeypatch):
     assert local > 0
 
 
+# --- an UNPRICED cloud model must not be mistaken for a local one ----------
+# Regression: with local power enabled, any model missing from the pricing
+# tables fell through to the electricity branch. Every newly-released cloud
+# flagship is unpriced until pricing_data.json is refreshed, so its traffic
+# silently booked at ~$0 instead of vendor rates.
+def _enable_local_power(tmp_path, monkeypatch):
+    # Pin TOKENTELEMETRY_DATA_DIR, not TOKENTELEMETRY_HOME: DATA_DIR has higher
+    # precedence in tt_paths.data_dir(), and other modules in the suite set it
+    # via raw os.environ (so it can still be set when this test runs). Setting
+    # the winning variable makes these cases order-independent.
+    data = tmp_path / ".tokentelemetry"
+    data.mkdir()
+    monkeypatch.setenv("TOKENTELEMETRY_DATA_DIR", str(data))
+    monkeypatch.setenv("TOKENTELEMETRY_HOME", str(tmp_path))
+    (data / "power.json").write_text('{"loadWatts": 65, "costPerKwh": 0.20}')
+    assert pc.local_power_enabled() is True
+
+
+@pytest.mark.parametrize("model", [
+    "claude-opus-99", "claude-sonnet-99", "gpt-99",
+    "gemini-99-ultra", "grok-99", "codex-next",
+])
+def test_unpriced_cloud_model_not_priced_by_electricity(model, tmp_path, monkeypatch):
+    _enable_local_power(tmp_path, monkeypatch)
+    # 1M output tokens. Electricity for 1M tokens is cents; any real per-token
+    # rate (_default is $10/MTok out, or a fuzzy table match) is dollars.
+    assert pricing.calculate_cost(model, 0, 1_000_000) >= 1.0
+
+
+@pytest.mark.parametrize("model", [
+    "gemma4:12b-mlx", "llama-4-70b", "mistral-nemo", "deepseek-v4", "phi-5",
+])
+def test_unpriced_open_weight_still_uses_electricity(model, tmp_path, monkeypatch):
+    """Open-weight families really can run locally — they keep the fallback."""
+    _enable_local_power(tmp_path, monkeypatch)
+    assert pricing.calculate_cost(model, 0, 1_000_000) < 1.0
+
+
+def test_confirmed_local_beats_cloud_name_guard(tmp_path, monkeypatch):
+    """The guard only gates the *guess*; an explicitly-local session still wins.
+
+    Someone serving a Claude-named model through Ollama is still local, and
+    is_local_session() claims it before the pricing lookup runs.
+    """
+    _enable_local_power(tmp_path, monkeypatch)
+    assert pricing.calculate_cost("claude-opus-5", 0, 1_000_000, provider="ollama") < 1.0
+
+
+# --- Claude 5 family is priced at all -------------------------------------
+@pytest.mark.parametrize("model,in_rate,out_rate", [
+    ("claude-opus-5", 5.00, 25.00),
+    ("claude-mythos-5", 10.00, 50.00),
+    ("claude-fable-5", 10.00, 50.00),
+    ("claude-opus-4-8", 5.00, 25.00),
+])
+def test_claude_5_family_priced(model, in_rate, out_rate, tmp_path, monkeypatch):
+    _enable_local_power(tmp_path, monkeypatch)
+    assert pricing.calculate_cost(model, 1_000_000, 0) == in_rate
+    assert pricing.calculate_cost(model, 0, 1_000_000) == out_rate
+
+
 def test_measured_rate_beats_default(tmp_path, monkeypatch):
     monkeypatch.setenv("TOKENTELEMETRY_HOME", str(tmp_path))
     (tmp_path / ".tokentelemetry").mkdir()


### PR DESCRIPTION
## The bug

`calculate_cost` has a fallback that treats **any** model missing from the pricing tables as a *local* model when power tracking is enabled, pricing it by electricity rather than falling through to `_default`.

"Unpriced" is not a synonym for "local". Every newly-released cloud flagship is unpriced between its launch and the next `pricing_data.json` refresh, so its traffic silently books at ~$0 against real spend. There is no error and nothing in the UI to indicate it.

Measured on my own Claude history (deduped by `message.id`):

| model | reqs | recorded before | actual |
|---|---:|---:|---:|
| **claude-opus-5** | **4,868** | **$0.08** | **$944.33** |
| claude-opus-4-8 | 9,887 | $1265.49 | $1265.49 |
| claude-sonnet-5 | 3,053 | $117.23 | $117.23 |

A 99.99% undercount on 17.5% of requests, on the current flagship model.

Two contributing causes, both fixed here.

## 1. Claude 5 family missing from the pricing table

`backend/pricing_data.json` is a models.dev snapshot dated `2026-07-06`; its Anthropic entries stop at `opus-4.8`. `claude-opus-5` and `claude-mythos-5` resolve nowhere:

```
before:  calculate_cost('claude-opus-5', 1_000_000, 0, 0) = 0.0
after:   calculate_cost('claude-opus-5', 1_000_000, 0, 0) = 5.0
```

Added both to the inline hand-tuned table (`$5/$25` and `$10/$50`) rather than waiting on a snapshot refresh, since that table is authoritative and already overrides the overlay.

## 2. The class-level bug: unpriced treated as local

Refreshing the snapshot fixes the instance; only a guard fixes the class. `_is_cloud_only_model()` now gates the electricity fallback:

- **Vendor-API-only families** fall through to `_default`: `claude`/`opus`/`sonnet`/`haiku`/`fable`/`mythos`, `gpt`/`chatgpt`/`codex`, `gemini`, `grok`, plus the OpenAI o-series prefixes.
- **Open-weight families keep the fallback** — `llama`, `qwen`, `gemma`, `mistral`, `deepseek`, `phi` genuinely do run locally.

The confirmed-local branch above is untouched: `is_local_session()` still claims sessions with a local endpoint, provider, or billing mode *before* the pricing lookup runs, so a Claude-named model served through Ollama is still priced by electricity. A test pins that.

## Verification

Four cases pinned in `test_local_power.py` (16 tests). Confirmed they fail without the guard:

```
$ # with _is_cloud_only_model stubbed to False (pre-fix behaviour)
FAILED test_unpriced_cloud_model_not_priced_by_electricity[claude-opus-99]
  - assert 0.1203703703703704 >= 1.0
... 5 failed
```

The tests pin `TOKENTELEMETRY_DATA_DIR` rather than `TOKENTELEMETRY_HOME`: `DATA_DIR` wins in `tt_paths.data_dir()`, and other modules in the suite set it via raw `os.environ`, which would otherwise make these order-dependent.

Full backend suite:

| | passed | failed |
|---|---:|---:|
| `origin/main` | 375 | 23 |
| this branch | **391** | 23 |

16 tests added, no new failures. The 23 are pre-existing and unrelated (env-var leakage from `test_tt_paths.py` using raw `os.environ`, plus `test_update_check.py` preference-shape drift) — worth a separate cleanup.

## Not included

- No `UPDATE.json` entry: pure `fix:` branch, and per the project rule the curated feed should not carry non-feature noise.
- `claude-sonnet-5` resolves to `$3/$15` (list). Anthropic lists an intro `$2/$10` through 2026-08-31; left alone rather than hardcoding a rate that expires this month.
- No surfacing of unpriced models in the UI. The failure was *silent*, which is arguably the worst part — a diagnostic (log line or a flag on the sessions payload) would be a reasonable follow-up but is scope creep here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)