### PR TITLE
feat(hermes): honest telemetry for latency, cost provenance and outcomes

### DIFF
--- a/UPDATE.json
+++ b/UPDATE.json
@@ -1,6 +1,32 @@
 {
   "releases": [
     {
+      "tag": "2026-08-02",
+      "title": "Hermes telemetry that says what it doesn't know",
+      "highlights": [
+        {
+          "title": "Latency recovered from rotated logs",
+          "description": "TokenTelemetry only ever read ~/.hermes/logs/agent.log, so once Hermes rotated that file, per-call latency silently disappeared. On a real install that meant none of 22 sessions showed any timing, while 14 sessions' worth sat unread in agent.log.1. Rotated logs are now parsed too, oldest first, and sessions with no timing anywhere say \"not captured\" instead of showing zero.",
+          "href": "/hermes"
+        },
+        {
+          "title": "Every cost says where the number came from",
+          "description": "A Hermes dollar figure can come from four places: reported by Hermes, estimated by Hermes, priced by TokenTelemetry, or not priced at all. They used to render identically. Each figure now carries its source, sessions that could not be priced read \"not captured\" rather than $0.00, and a local or subscription-covered run is labelled \"no marginal cost\" instead of being shown as a $0.00 price.",
+          "href": "/hermes"
+        },
+        {
+          "title": "Completion and failure rates by source and model",
+          "description": "Hermes records why each session ended, but only three of its end reasons were ever displayed, so on a real install 9 of 22 sessions showed no outcome at all. Every end reason now maps to one of seven outcomes, broken down per source and per model. An end reason TokenTelemetry does not recognise appears by name as unknown rather than being counted as a completion.",
+          "href": "/hermes"
+        },
+        {
+          "title": "Tool reliability",
+          "description": "Tool failures were already parsed out of the Hermes log and then discarded. The Hermes page now shows which tools are used most and which fail most, counting only tools with at least three calls so a single failed call does not read as a 100% failure rate.",
+          "href": "/hermes"
+        }
+      ]
+    },
+    {
       "tag": "2026-07-30",
       "title": "See what /goal runs actually cost",
       "highlights": [

--- a/backend/hermes_telemetry.py
+++ b/backend/hermes_telemetry.py
@@ -1,0 +1,589 @@
+"""Hermes telemetry: agent.log index, outcome taxonomy, aggregate rollup.
+
+Three things live here, all pure functions over injected inputs (no import of
+`main`, so tests can monkeypatch `main.HERMES_DIR` freely):
+
+  1. A cached per-home index of ~/.hermes/logs/agent.log* keyed by session id.
+     The old per-session scan was O(logfile) per session; with rotated logs and
+     an all-sessions consumer that is 22 x 10MB per request. We parse every log
+     file ONCE and cache the result against (name, mtime, size) of the file set.
+
+  2. `classify_end_reason()` — the sessions.end_reason -> canonical outcome map.
+     Hermes's end_reason column is open-set (the gateway's PATCH endpoint and
+     the portability importer both write caller-supplied strings), so anything
+     not in the table routes to "unknown" WITH the raw string preserved. It is
+     never folded into "completed" — an unmapped value must read as
+     "unknown: <raw>" in the UI, not as a success.
+
+  3. `build_telemetry()` — the /hermes/telemetry payload.
+
+Log rotation ordering is a correctness requirement: logrotate writes the OLDEST
+content to the HIGHEST numeric suffix, so agent.log.2 precedes agent.log.1
+precedes agent.log. A lexical sort gives the reverse and silently corrupts
+model_journey and the api_calls sequence.
+"""
+from __future__ import annotations
+
+import math
+import re
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+# --------------------------------------------------------------------------- #
+# Outcome taxonomy
+# --------------------------------------------------------------------------- #
+
+# The seven canonical buckets. "errored" has no known upstream writer (every
+# Hermes end_reason is a lifecycle boundary, not a failure signal) — it stays in
+# the vocabulary so the shape is stable, but expect it to always be 0.
+OUTCOME_BUCKETS: Tuple[str, ...] = (
+    "completed", "interrupted", "timed_out", "continued", "reset", "errored", "unknown",
+)
+
+# raw sessions.end_reason -> canonical bucket. Extend by adding a row; every
+# unlisted value deliberately falls through to "unknown".
+#
+# Deliberately NOT mapped, because upstream itself treats them as carrying no
+# outcome ("recoverable accidental" reasons that promote_to_session_reset is
+# willing to clobber, or a 7-day janitor backfill):
+#   agent_close, ws_orphan_reap, orphaned_compression
+END_REASON_MAP: Dict[str, str] = {
+    # --- completed: an owner closed its own session on a normal exit path
+    "cli_close": "completed",
+    "cron_complete": "completed",
+    "tui_close": "completed",
+    # --- continued: work carries on in a child row (lineage link)
+    "compression": "continued",
+    "branched": "continued",
+    "resumed_other": "continued",
+    # --- reset: a boundary was deliberately drawn
+    "new_session": "reset",
+    "session_reset": "reset",
+    "session_switch": "reset",
+    "daily": "reset",
+    "suspended": "reset",
+    # --- timed_out: an inactivity / liveness deadline expired
+    "idle": "timed_out",
+    "idle_timeout": "timed_out",
+    "resume_pending_expired": "timed_out",
+    # --- interrupted: transport or process died under a live session
+    "ws_disconnect": "interrupted",
+    "tui_shutdown": "interrupted",
+    "lru_evict": "interrupted",
+    "compute_host_shutdown": "interrupted",
+    "compute_host_orphan": "interrupted",
+    "compute_host_sigterm": "interrupted",
+    "compute_host_stdin_closed": "interrupted",
+}
+
+# Buckets that mean "this session reached its own end deliberately". Used for
+# completion_rate; anything else (including unknown) is excluded from the
+# numerator, never from the denominator.
+_COMPLETED_BUCKET = "completed"
+
+
+def classify_end_reason(raw: Optional[str]) -> str:
+    """Map a raw sessions.end_reason to a canonical bucket.
+
+    NULL / empty -> "unknown". Any string not in END_REASON_MAP -> "unknown"
+    (the raw value is preserved by the caller and surfaced separately).
+    """
+    if raw is None:
+        return "unknown"
+    key = str(raw).strip()
+    if not key:
+        return "unknown"
+    return END_REASON_MAP.get(key, "unknown")
+
+
+def normalize_end_reason_raw(raw: Optional[str]) -> Optional[str]:
+    """The raw string to keep on a session dict — None for NULL/empty."""
+    if raw is None:
+        return None
+    key = str(raw).strip()
+    return key or None
+
+
+# --------------------------------------------------------------------------- #
+# agent.log parsing
+# --------------------------------------------------------------------------- #
+
+_LOG_TS = r"^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}),\d+"
+_SID = r"\[(\d{8}_\d{6}_[a-f0-9]+)\]"
+
+API_CALL_RE = re.compile(
+    _LOG_TS + r"[^\n]*?" + _SID + r"[^\n]*?"
+    r"API call #(\d+): model=(\S+) provider=(\S+) in=(\d+) out=(\d+) total=(\d+) "
+    r"latency=([\d.]+)s(?: cache=(\d+)/(\d+) \((\d+)%\))?"
+)
+TOOL_DONE_RE = re.compile(
+    _LOG_TS + r"[^\n]*?" + _SID + r"[^\n]*?"
+    r"tool (\S+) completed \(([\d.]+)s, (\d+) chars\)"
+)
+TOOL_FAIL_RE = re.compile(
+    _LOG_TS + r"[^\n]*?" + _SID + r"[^\n]*?"
+    r"tool (\S+) failed \(([\d.]+)s\): (.+?)$"
+)
+
+
+def parse_log_ts(s: str) -> Optional[datetime]:
+    try:
+        return datetime.strptime(s, "%Y-%m-%d %H:%M:%S").replace(tzinfo=timezone.utc)
+    except Exception:
+        return None
+
+
+def log_files_in_order(home: Path) -> List[Path]:
+    """Every agent.log* under `home`/logs in TRUE CHRONOLOGICAL order.
+
+    logrotate keeps the oldest content at the highest numeric suffix, so
+    agent.log.2 -> agent.log.1 -> agent.log. Compressed rotations (.gz) are
+    skipped, not decompressed.
+    """
+    logs = Path(home) / "logs"
+    try:
+        if not logs.is_dir():
+            return []
+        entries = list(logs.iterdir())
+    except OSError:
+        return []
+    ranked: List[Tuple[int, Path]] = []
+    for p in entries:
+        name = p.name
+        if name == "agent.log":
+            rank = 0
+        elif name.startswith("agent.log."):
+            suffix = name[len("agent.log."):]
+            if not suffix.isdigit():
+                continue  # .gz and friends: recorded nowhere, never read
+            rank = int(suffix)
+        else:
+            continue
+        try:
+            if not p.is_file():
+                continue
+        except OSError:
+            continue
+        ranked.append((rank, p))
+    # Highest suffix (oldest) first; unsuffixed agent.log (rank 0) last.
+    ranked.sort(key=lambda t: (-t[0], t[1].name))
+    return [p for _, p in ranked]
+
+
+def _api_call_from(m: "re.Match[str]") -> Dict[str, Any]:
+    ts = parse_log_ts(m.group(1))
+    return {
+        "ts": ts.isoformat() if ts else None,
+        "n": int(m.group(3)),
+        "model": m.group(4),
+        "provider": m.group(5),
+        "input": int(m.group(6)),
+        "output": int(m.group(7)),
+        "total": int(m.group(8)),
+        "latency_s": float(m.group(9)),
+        "cache_read": int(m.group(10)) if m.group(10) else None,
+        "cache_prompt": int(m.group(11)) if m.group(11) else None,
+        "cache_hit_pct": int(m.group(12)) if m.group(12) else None,
+    }
+
+
+def _slot(index: Dict[str, Dict[str, List[Dict[str, Any]]]], sid: str) -> Dict[str, List[Dict[str, Any]]]:
+    e = index.get(sid)
+    if e is None:
+        e = {"api_calls": [], "tool_calls": []}
+        index[sid] = e
+    return e
+
+
+def parse_log_file(path: Path, index: Dict[str, Dict[str, List[Dict[str, Any]]]]) -> None:
+    """Append every recognised line in `path` into `index` (keyed by session id).
+
+    Appending in file order preserves chronology as long as files are fed in
+    the order log_files_in_order() returns. We never sort by parsed timestamp:
+    the log's clock is local time that parse_log_ts() stamps as UTC, so the
+    timestamps are only trustworthy relative to each other within a file.
+    """
+    with open(path, "r", encoding="utf-8", errors="ignore") as f:
+        for line in f:
+            # Cheap substring gates first — the regexes are the expensive part
+            # and >99% of log lines match none of them.
+            if "API call #" in line:
+                m = API_CALL_RE.search(line)
+                if m:
+                    _slot(index, m.group(2))["api_calls"].append(_api_call_from(m))
+                    continue
+            if "completed (" in line:
+                m = TOOL_DONE_RE.search(line)
+                if m:
+                    ts = parse_log_ts(m.group(1))
+                    _slot(index, m.group(2))["tool_calls"].append({
+                        "ts": ts.isoformat() if ts else None,
+                        "tool": m.group(3),
+                        "duration_s": float(m.group(4)),
+                        "chars": int(m.group(5)),
+                        "status": "ok",
+                    })
+                    continue
+            if "failed (" in line:
+                m = TOOL_FAIL_RE.search(line)
+                if m:
+                    ts = parse_log_ts(m.group(1))
+                    _slot(index, m.group(2))["tool_calls"].append({
+                        "ts": ts.isoformat() if ts else None,
+                        "tool": m.group(3),
+                        "duration_s": float(m.group(4)),
+                        "status": "error",
+                        "error": m.group(5)[:200],
+                    })
+
+
+# --------------------------------------------------------------------------- #
+# Cached index
+# --------------------------------------------------------------------------- #
+
+_CACHE: Dict[str, Tuple[Tuple[Any, ...], Dict[str, Dict[str, List[Dict[str, Any]]]], List[str]]] = {}
+_CACHE_LOCK = threading.Lock()
+
+# Shared "no log lines for this session" fallback. It is handed to every caller
+# that misses the index, so it must be IMMUTABLE: a single `entry["api_calls"]
+# .append(...)` on the shared instance would leak one session's calls into every
+# other session's fallback for the life of the process. Frozen mapping + tuples:
+# mutating either raises instead of silently corrupting the index. Call sites do
+# `entry.get(k) or []`, and an empty tuple is falsy, so they still get a fresh
+# mutable list.
+EMPTY_ENTRY: Mapping[str, Sequence[Dict[str, Any]]] = MappingProxyType(
+    {"api_calls": (), "tool_calls": ()})
+
+
+def _signature(files: Sequence[Path]) -> Tuple[Any, ...]:
+    sig: List[Any] = []
+    for p in files:
+        try:
+            st = p.stat()
+            sig.append((p.name, st.st_mtime_ns, st.st_size))
+        except OSError:
+            sig.append((p.name, None, None))
+    return tuple(sig)
+
+
+def clear_cache() -> None:
+    """Drop the whole index cache (tests; not needed in normal operation)."""
+    with _CACHE_LOCK:
+        _CACHE.clear()
+
+
+def get_log_index(home: Path) -> Tuple[Dict[str, Dict[str, List[Dict[str, Any]]]], List[str]]:
+    """({session_id: {api_calls, tool_calls}}, [filenames read]) for one home.
+
+    Cached per home and invalidated when the (name, mtime, size) tuple over the
+    home's agent.log* set changes — so a rotation, an append, or a new rotated
+    file all refresh it.
+    """
+    home = Path(home)
+    key = str(home)
+    files = log_files_in_order(home)
+    sig = _signature(files)
+    with _CACHE_LOCK:
+        hit = _CACHE.get(key)
+        if hit is not None and hit[0] == sig:
+            return hit[1], hit[2]
+    index: Dict[str, Dict[str, List[Dict[str, Any]]]] = {}
+    files_read: List[str] = []
+    for path in files:
+        try:
+            parse_log_file(path, index)
+        except Exception:
+            continue
+        files_read.append(path.name)
+    with _CACHE_LOCK:
+        _CACHE[key] = (sig, index, files_read)
+    return index, files_read
+
+
+def merge_indexes(
+    parts: Iterable[Tuple[Optional[str], Dict[str, Dict[str, List[Dict[str, Any]]]], List[str]]]
+) -> Tuple[Dict[str, Dict[str, List[Dict[str, Any]]]], List[str]]:
+    """Fold per-home indexes into one. `parts` is (profile, index, files_read).
+
+    Filenames from a profile home are labelled "<profile>/<name>" so a merged
+    log_coverage.files_read stays unambiguous.
+    """
+    merged: Dict[str, Dict[str, List[Dict[str, Any]]]] = {}
+    files: List[str] = []
+    for profile, index, files_read in parts:
+        for sid, entry in index.items():
+            slot = _slot(merged, sid)
+            slot["api_calls"].extend(entry.get("api_calls") or [])
+            slot["tool_calls"].extend(entry.get("tool_calls") or [])
+        for name in files_read:
+            files.append(f"{profile}/{name}" if profile else name)
+    return merged, files
+
+
+def model_journey(api_calls: Sequence[Dict[str, Any]]) -> List[str]:
+    """Distinct models in temporal order (consecutive duplicates collapsed)."""
+    journey: List[str] = []
+    for c in api_calls:
+        if not journey or journey[-1] != c.get("model"):
+            journey.append(c.get("model"))
+    return journey
+
+
+def summarize(api_calls: Sequence[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """Per-session performance summary, or None when nothing was captured."""
+    if not api_calls:
+        return None
+    total_lat = sum(c.get("latency_s") or 0.0 for c in api_calls)
+    cache_pcts = [c["cache_hit_pct"] for c in api_calls if c.get("cache_hit_pct") is not None]
+    return {
+        "api_call_count": len(api_calls),
+        "total_latency_s": round(total_lat, 2),
+        "avg_latency_s": round(total_lat / len(api_calls), 2),
+        "cache_hit_pct": round(sum(cache_pcts) / len(cache_pcts)) if cache_pcts else None,
+        "models_used": sorted({c["model"] for c in api_calls}),
+        "providers_used": sorted({c["provider"] for c in api_calls}),
+        "log_coverage": "captured",
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Aggregate rollup
+# --------------------------------------------------------------------------- #
+
+# Where the dollar figure TT reports for a session came from, most authoritative
+# first. `zero-marginal` is a POSITIVE finding, not a missing one: TT priced the
+# session and the answer is genuinely $0 because the model runs locally or the
+# model/endpoint is covered by a subscription the user already pays for. Keeping
+# it out of `tt-computed` is the whole point: a confident "$0.00 · priced by
+# TokenTelemetry" claims the API equivalent of those tokens is zero, when what is
+# zero is the MARGINAL cost.
+COST_STATUSES: Tuple[str, ...] = (
+    "provider-reported", "provider-estimated", "tt-computed",
+    "zero-marginal", "unpriced",
+)
+
+# Hermes's own sessions.cost_status value for "billed under a flat plan".
+# Carried onto the session dict as `_hermes_cost_status` by the scan.
+HERMES_INCLUDED_STATUS = "included"
+
+
+# Outcome rates by model: keep the payload bounded (model names are open-set).
+BY_MODEL_LIMIT = 10
+
+
+def percentile(values: Sequence[float], p: float) -> Optional[float]:
+    """Nearest-rank percentile. `p` in [0, 1]. None for an empty sample."""
+    vals = sorted(v for v in values if v is not None)
+    if not vals:
+        return None
+    k = math.ceil(p * len(vals))
+    if k < 1:
+        k = 1
+    if k > len(vals):
+        k = len(vals)
+    return float(vals[k - 1])
+
+
+def _usd(x: Optional[float]) -> float:
+    return round(float(x or 0.0), 3)
+
+
+def _secs(x: Optional[float]) -> Optional[float]:
+    return None if x is None else round(float(x), 3)
+
+
+def _pct(part: int, whole: int) -> float:
+    return round(100.0 * part / whole, 1) if whole else 0.0
+
+
+def _bucket_counts_payload(counts: Dict[str, int]) -> Dict[str, int]:
+    """Only observed buckets, canonical order."""
+    return {b: counts[b] for b in OUTCOME_BUCKETS if counts.get(b)}
+
+
+def _outcomes(sessions: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
+    total = len(sessions)
+    counts: Dict[str, int] = {b: 0 for b in OUTCOME_BUCKETS}
+    raw_counts: Dict[str, int] = {}
+    by_source: Dict[str, Dict[str, int]] = {}
+    by_model: Dict[str, Dict[str, int]] = {}
+    src_totals: Dict[str, int] = {}
+    model_totals: Dict[str, int] = {}
+
+    for s in sessions:
+        bucket = s.get("outcome") or "unknown"
+        if bucket not in counts:
+            counts[bucket] = 0
+        counts[bucket] += 1
+        if bucket == "unknown":
+            raw = s.get("outcome_raw")
+            if raw:
+                raw_counts[raw] = raw_counts.get(raw, 0) + 1
+        src = s.get("source_subtype") or "unknown"
+        src_totals[src] = src_totals.get(src, 0) + 1
+        by_source.setdefault(src, {})[bucket] = by_source.setdefault(src, {}).get(bucket, 0) + 1
+        mdl = s.get("model") or "unknown"
+        model_totals[mdl] = model_totals.get(mdl, 0) + 1
+        by_model.setdefault(mdl, {})[bucket] = by_model.setdefault(mdl, {}).get(bucket, 0) + 1
+
+    buckets = [
+        {"outcome": b, "count": counts[b], "pct": _pct(counts[b], total)}
+        for b in OUTCOME_BUCKETS if counts.get(b)
+    ]
+    buckets.sort(key=lambda d: (-d["count"], OUTCOME_BUCKETS.index(d["outcome"])
+                                if d["outcome"] in OUTCOME_BUCKETS else 99))
+    unknown_raw = [{"raw": r, "count": c} for r, c in raw_counts.items()]
+    unknown_raw.sort(key=lambda d: (-d["count"], d["raw"]))
+
+    def _group(totals: Dict[str, int], grouped: Dict[str, Dict[str, int]], label: str,
+               limit: Optional[int] = None):
+        out = [
+            {label: k, "total": totals[k], "buckets": _bucket_counts_payload(grouped[k])}
+            for k in totals
+        ]
+        out.sort(key=lambda d: (-d["total"], str(d[label])))
+        return out if limit is None else out[:limit]
+
+    return {
+        "buckets": buckets,
+        "unknown_raw": unknown_raw,
+        "completion_rate": round(counts.get(_COMPLETED_BUCKET, 0) / total, 3) if total else 0.0,
+        # `source` is a small closed-ish set (cli / gateway / …) — never capped.
+        "by_source": _group(src_totals, by_source, "source"),
+        # Models are unbounded (every proxied model name is its own row). Cap at
+        # the 10 largest by session count; `models_total` says how many exist so
+        # the UI can say "top 10 of N" instead of implying the list is complete.
+        # NOTE: with more than BY_MODEL_LIMIT models, sum(by_model[].total) is
+        # LESS than session_count by construction.
+        "by_model": _group(model_totals, by_model, "model", BY_MODEL_LIMIT),
+        "models_total": len(model_totals),
+    }
+
+
+def _cost(sessions: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
+    confidence = {k: 0 for k in COST_STATUSES}
+    usd = {k: 0.0 for k in COST_STATUSES}
+    total = 0.0
+    included = 0.0
+    for s in sessions:
+        status = s.get("cost_status")
+        if status not in confidence:
+            status = "unpriced"
+        confidence[status] += 1
+        c = s.get("cost")
+        if isinstance(c, (int, float)):
+            usd[status] += float(c)
+            total += float(c)
+            # Hermes flagged the session as billed under a flat plan. TT still
+            # prices it (that's the API-equivalent number), but the user paid
+            # $0 at the margin, so `total_usd` must be qualifiable.
+            if s.get("_hermes_cost_status") == HERMES_INCLUDED_STATUS:
+                included += float(c)
+    return {
+        "total_usd": round(total, 3),
+        "subscription_included_usd": _usd(included),
+        "confidence": confidence,
+        "usd_by_confidence": {k: _usd(v) for k, v in usd.items()},
+    }
+
+
+def _latency(sessions: Sequence[Dict[str, Any]],
+             index: Dict[str, Dict[str, List[Dict[str, Any]]]]) -> Dict[str, Any]:
+    lats: List[float] = []
+    captured = 0
+    by_model: Dict[str, List[float]] = {}
+    for s in sessions:
+        calls = (index.get(s.get("id")) or EMPTY_ENTRY).get("api_calls") or []
+        if calls:
+            captured += 1
+        for c in calls:
+            lat = c.get("latency_s")
+            if lat is None:
+                continue
+            lats.append(float(lat))
+            by_model.setdefault(c.get("model") or "unknown", []).append(float(lat))
+
+    rows = []
+    for model, vals in by_model.items():
+        rows.append({
+            "model": model,
+            "calls": len(vals),
+            "avg_s": _secs(sum(vals) / len(vals)) if vals else None,
+            "p95_s": _secs(percentile(vals, 0.95)),
+        })
+    rows.sort(key=lambda d: (-d["calls"], d["model"]))
+
+    return {
+        "captured_sessions": captured,
+        "uncaptured_sessions": len(sessions) - captured,
+        "api_calls": len(lats),
+        "avg_s": _secs(sum(lats) / len(lats)) if lats else None,
+        "p50_s": _secs(percentile(lats, 0.50)),
+        "p95_s": _secs(percentile(lats, 0.95)),
+        "by_model": rows,
+    }
+
+
+def _tools(sessions: Sequence[Dict[str, Any]],
+           index: Dict[str, Dict[str, List[Dict[str, Any]]]]) -> Dict[str, Any]:
+    calls: Dict[str, int] = {}
+    fails: Dict[str, int] = {}
+    dur: Dict[str, float] = {}
+    seen = 0
+    for s in sessions:
+        for t in (index.get(s.get("id")) or EMPTY_ENTRY).get("tool_calls") or []:
+            name = t.get("tool") or "unknown"
+            seen += 1
+            calls[name] = calls.get(name, 0) + 1
+            if t.get("status") == "error":
+                fails[name] = fails.get(name, 0) + 1
+            dur[name] = dur.get(name, 0.0) + float(t.get("duration_s") or 0.0)
+
+    if not seen:
+        return {"captured": False, "top_by_calls": [], "top_by_failure_rate": []}
+
+    rows = []
+    for name, n in calls.items():
+        f = fails.get(name, 0)
+        rows.append({
+            "tool": name,
+            "calls": n,
+            "failures": f,
+            "failure_rate": round(f / n, 3) if n else 0.0,
+            "avg_duration_s": _secs(dur.get(name, 0.0) / n) if n else None,
+        })
+
+    by_calls = sorted(rows, key=lambda d: (-d["calls"], d["tool"]))[:10]
+    # A 1-call 100%-failure tool is noise, not a signal — require >= 3 calls.
+    # A tool that never failed is not a failure signal at all: without the
+    # `failures > 0` filter this list is just top_by_calls with a 0.0% column,
+    # ten rows of "highest failure rate: 0.0%". Empty is the honest answer.
+    by_fail = sorted(
+        [r for r in rows if r["calls"] >= 3 and r["failures"] > 0],
+        key=lambda d: (-d["failure_rate"], -d["calls"], d["tool"]),
+    )[:10]
+    return {"captured": True, "top_by_calls": by_calls, "top_by_failure_rate": by_fail}
+
+
+def build_telemetry(sessions: Sequence[Dict[str, Any]],
+                    index: Dict[str, Dict[str, List[Dict[str, Any]]]],
+                    files_read: Sequence[str]) -> Dict[str, Any]:
+    """The GET /hermes/telemetry payload for a list of scanned Hermes sessions."""
+    sessions = list(sessions)
+    latency = _latency(sessions, index)
+    return {
+        "available": True,
+        "session_count": len(sessions),
+        "outcomes": _outcomes(sessions),
+        "cost": _cost(sessions),
+        "latency": latency,
+        "tools": _tools(sessions, index),
+        "log_coverage": {
+            "files_read": list(files_read),
+            "sessions_with_log": latency["captured_sessions"],
+            "sessions_total": len(sessions),
+        },
+    }

--- a/backend/main.py
+++ b/backend/main.py
@@ -24,6 +24,7 @@ import notifications as notif
 from tt_paths import data_dir
 import scan_cache
 import codex_goals
+import hermes_telemetry as _ht
 import hashlib
 
 def _aware(dt):
@@ -907,120 +908,66 @@ def _hermes_home(profile: Optional[str]) -> Path:
 
 _HERMES_CWD_RE = re.compile(r"\[(\d{8}_\d{6}_[a-f0-9]+)\][^\n]*cwd=([^\s,)]+)")
 
-# Structured agent.log lines we parse (per HERMES_INTERNALS.md §2.3)
-_HERMES_LOG_TS = r"^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}),\d+"
-_HERMES_SID = r"\[(\d{8}_\d{6}_[a-f0-9]+)\]"
-_HERMES_API_CALL_RE = re.compile(
-    _HERMES_LOG_TS + r"[^\n]*?" + _HERMES_SID + r"[^\n]*?"
-    r"API call #(\d+): model=(\S+) provider=(\S+) in=(\d+) out=(\d+) total=(\d+) "
-    r"latency=([\d.]+)s(?: cache=(\d+)/(\d+) \((\d+)%\))?"
-)
-_HERMES_TOOL_DONE_RE = re.compile(
-    _HERMES_LOG_TS + r"[^\n]*?" + _HERMES_SID + r"[^\n]*?"
-    r"tool (\S+) completed \(([\d.]+)s, (\d+) chars\)"
-)
-_HERMES_TOOL_FAIL_RE = re.compile(
-    _HERMES_LOG_TS + r"[^\n]*?" + _HERMES_SID + r"[^\n]*?"
-    r"tool (\S+) failed \(([\d.]+)s\): (.+?)$"
-)
-
-
-def _parse_hermes_log_ts(s: str) -> Optional[datetime]:
-    try:
-        return datetime.strptime(s, "%Y-%m-%d %H:%M:%S").replace(tzinfo=timezone.utc)
-    except Exception:
-        return None
+# Structured agent.log lines we parse (per HERMES_INTERNALS.md §2.3) now live in
+# hermes_telemetry.py, which owns the cached whole-log index. Kept as aliases so
+# nothing that reached for these names breaks.
+_HERMES_API_CALL_RE = _ht.API_CALL_RE
+_HERMES_TOOL_DONE_RE = _ht.TOOL_DONE_RE
+_HERMES_TOOL_FAIL_RE = _ht.TOOL_FAIL_RE
+_parse_hermes_log_ts = _ht.parse_log_ts
 
 
 def _hermes_log_summary(session_id: str, profile: Optional[str] = None) -> Dict[str, Any]:
-    """Parse the owning home's logs/agent.log for one session.
+    """Per-session view of the owning home's logs/agent.log*.
 
     Each profile writes its own agent.log, so sessions recorded in a
     profile's state.db never appear in the root log — pass the profile
     or the overlay comes back empty.
 
+    Reads from hermes_telemetry's cached index (every rotated log parsed once,
+    oldest suffix first) rather than rescanning the file per session.
+
     Returns:
       api_calls: list of {ts, n, model, provider, in, out, total, latency_s, cache_hit_pct?, cache_read?}
       tool_calls: list of {ts, tool, duration_s, chars?, status, error?}
       model_journey: distinct models in temporal order
-      summary: {api_call_count, total_latency_s, avg_latency_s, cache_hit_pct, models_used}
+      summary: {api_call_count, total_latency_s, avg_latency_s, cache_hit_pct, models_used, log_coverage} | None
+      log_coverage: "captured" when the logs carry API calls for this session
     """
-    log_path = _hermes_home(profile) / "logs" / "agent.log"
-    if not log_path.exists():
-        return {"api_calls": [], "tool_calls": [], "model_journey": [], "summary": None}
-    api_calls: List[Dict[str, Any]] = []
-    tool_calls: List[Dict[str, Any]] = []
     try:
-        with open(log_path, "r", encoding="utf-8", errors="ignore") as f:
-            for line in f:
-                if session_id not in line:
-                    continue
-                m = _HERMES_API_CALL_RE.search(line)
-                if m:
-                    ts = _parse_hermes_log_ts(m.group(1))
-                    api_calls.append({
-                        "ts": ts.isoformat() if ts else None,
-                        "n": int(m.group(3)),
-                        "model": m.group(4),
-                        "provider": m.group(5),
-                        "input": int(m.group(6)),
-                        "output": int(m.group(7)),
-                        "total": int(m.group(8)),
-                        "latency_s": float(m.group(9)),
-                        "cache_read": int(m.group(10)) if m.group(10) else None,
-                        "cache_prompt": int(m.group(11)) if m.group(11) else None,
-                        "cache_hit_pct": int(m.group(12)) if m.group(12) else None,
-                    })
-                    continue
-                m = _HERMES_TOOL_DONE_RE.search(line)
-                if m:
-                    ts = _parse_hermes_log_ts(m.group(1))
-                    tool_calls.append({
-                        "ts": ts.isoformat() if ts else None,
-                        "tool": m.group(3),
-                        "duration_s": float(m.group(4)),
-                        "chars": int(m.group(5)),
-                        "status": "ok",
-                    })
-                    continue
-                m = _HERMES_TOOL_FAIL_RE.search(line)
-                if m:
-                    ts = _parse_hermes_log_ts(m.group(1))
-                    tool_calls.append({
-                        "ts": ts.isoformat() if ts else None,
-                        "tool": m.group(3),
-                        "duration_s": float(m.group(4)),
-                        "status": "error",
-                        "error": m.group(5)[:200],
-                    })
+        index, _files = _ht.get_log_index(_hermes_home(profile))
+        entry = index.get(session_id) or _ht.EMPTY_ENTRY
     except Exception:
-        pass
-
-    # Model journey — distinct models in temporal order
-    journey: List[str] = []
-    for c in api_calls:
-        if not journey or journey[-1] != c["model"]:
-            journey.append(c["model"])
-
-    if api_calls:
-        total_lat = sum(c["latency_s"] for c in api_calls)
-        cache_pcts = [c["cache_hit_pct"] for c in api_calls if c.get("cache_hit_pct") is not None]
-        summary = {
-            "api_call_count": len(api_calls),
-            "total_latency_s": round(total_lat, 2),
-            "avg_latency_s": round(total_lat / len(api_calls), 2),
-            "cache_hit_pct": round(sum(cache_pcts) / len(cache_pcts)) if cache_pcts else None,
-            "models_used": sorted({c["model"] for c in api_calls}),
-            "providers_used": sorted({c["provider"] for c in api_calls}),
-        }
-    else:
-        summary = None
+        entry = _ht.EMPTY_ENTRY
+    api_calls = entry.get("api_calls") or []
+    tool_calls = entry.get("tool_calls") or []
     return {
         "api_calls": api_calls,
         "tool_calls": tool_calls,
-        "model_journey": journey,
-        "summary": summary,
+        "model_journey": _ht.model_journey(api_calls),
+        "summary": _ht.summarize(api_calls),
+        "log_coverage": "captured" if api_calls else "not_captured",
     }
+
+
+def _hermes_log_index_all() -> Tuple[Dict[str, Any], List[str]]:
+    """Merged log index across the root home and every profile home."""
+    homes = []
+    seen = set()
+    for _db, profile in _hermes_dbs_with_profiles():
+        home = _hermes_home(profile)
+        if str(home) in seen:
+            continue
+        seen.add(str(home))
+        homes.append((profile, home))
+    parts = []
+    for profile, home in homes:
+        try:
+            index, files = _ht.get_log_index(home)
+        except Exception:
+            continue
+        parts.append((profile, index, files))
+    return _ht.merge_indexes(parts)
 
 
 def _hermes_memory_io(session_id: str) -> Dict[str, Any]:
@@ -1587,6 +1534,10 @@ async def hermes_session_overlay(session_id: str):
     return {
         "session_id": session_id,
         "profile": profile,
+        # "not_captured" is not the same as zero: Hermes rotates agent.log, and a
+        # session whose lines have aged out (or that predates log capture) has NO
+        # latency data — reporting 0s would invent a number.
+        "log_coverage": log["log_coverage"],
         "performance": log["summary"],
         "api_calls": log["api_calls"],
         "tool_calls": log["tool_calls"],
@@ -1974,6 +1925,23 @@ async def hermes_overview():
         "gateway": _hermes_gateway_state(),
         "cron_jobs": _hermes_cron_jobs(),
     }
+
+
+@app.get("/hermes/telemetry")
+async def hermes_telemetry():
+    """Aggregate Hermes outcome / cost / latency / tool-reliability rollup.
+
+    Every number is honest about its own provenance: cost carries the
+    confidence bucket the dollar figure came from, latency separates sessions
+    whose log lines still exist from those that rotated away, and an
+    end_reason we don't recognise lands in `unknown` with its raw string
+    intact rather than being counted as a completion.
+    """
+    if not _hermes_dbs():
+        return {"available": False}
+    sessions = [s for s in await get_sessions_cached() if s.get("agent") == "hermes"]
+    index, files_read = _hermes_log_index_all()
+    return _ht.build_telemetry(sessions, index, files_read)
 
 
 # --------------------------------------------------------------------------- #
@@ -5867,6 +5835,15 @@ def _scan_sessions_sync():
                     model = srow["model"]
                     # Prefer Hermes's own cost (it knows exotic models we may not price)
                     cost = srow["actual_cost_usd"] if srow["actual_cost_usd"] is not None else srow["estimated_cost_usd"]
+                    # Where the dollar figure we end up REPORTING came from. Set
+                    # by whichever branch below produces the final number — a
+                    # Hermes estimate we throw away (issue #176) is not
+                    # "provider-estimated", it's tt-computed.
+                    _cost_status = None
+                    if srow["actual_cost_usd"] is not None:
+                        _cost_status = "provider-reported"
+                    elif cost is not None:
+                        _cost_status = "provider-estimated"
                     # Hermes stores estimated_cost_usd=0.0 (not NULL) with cost_status='unknown'
                     # / cost_source='none' when it couldn't price the session itself (proxied or
                     # unrecognized endpoint, subscription-included model). Don't take that 0.0 at
@@ -5875,9 +5852,11 @@ def _scan_sessions_sync():
                     # decide the framing. Only override the *estimate*; a real actual_cost_usd wins.
                     if srow["actual_cost_usd"] is None and (srow["cost_status"] == "unknown" or srow["cost_source"] == "none"):
                         cost = None
+                        _cost_status = None
                     # Bind before the branch: it's referenced unconditionally in the
                     # session dict below, but only computed when cost must be derived.
                     _measured_tps = None
+                    _is_local = False
                     if cost is None:
                         # Only when TT has to compute the cost itself AND the session
                         # is local do we parse the agent log for a MEASURED tok/s
@@ -5885,7 +5864,8 @@ def _scan_sessions_sync():
                         # most Hermes sessions carry their own cost and skip this.
                         try:
                             from power_config import is_local_session
-                            if is_local_session(model, srow["billing_base_url"], srow["billing_provider"]):
+                            _is_local = bool(is_local_session(model, srow["billing_base_url"], srow["billing_provider"]))
+                            if _is_local:
                                 _summ = _hermes_log_summary(sid, h_profile).get("summary")
                                 if _summ and _summ.get("total_latency_s", 0) > 0 and out_t > 0:
                                     _measured_tps = out_t / _summ["total_latency_s"]
@@ -5898,6 +5878,46 @@ def _scan_sessions_sync():
                             endpoint=srow["billing_base_url"],
                             tok_per_sec=_measured_tps,
                         )
+                        # A zero from calculate_cost is only meaningful when
+                        # something DELIBERATELY prices at zero — a flat
+                        # subscription (billed monthly) or a local model whose
+                        # electricity draw rounds away. Otherwise a 0.0 means we
+                        # couldn't price the session at all; keep cost None so the
+                        # UI says "not captured" instead of a confident "$0.00".
+                        if cost is None:
+                            _cost_status = "unpriced"
+                        elif cost > 0:
+                            _cost_status = "tt-computed"
+                        else:
+                            # No tokens recorded means there was nothing to
+                            # price in the first place. "Local model, so $0
+                            # marginal" is a positive finding and would be a
+                            # lie here — we measured nothing. Unpriced wins
+                            # over deliberate-zero whenever the session is empty.
+                            _nothing_to_price = tokens["total"] == 0
+                            _deliberate_zero = _is_local and not _nothing_to_price
+                            if not _deliberate_zero and not _nothing_to_price:
+                                try:
+                                    from power_config import is_subscription_endpoint, is_subscription_model
+                                    _deliberate_zero = bool(
+                                        (srow["billing_base_url"] and is_subscription_endpoint(srow["billing_base_url"]))
+                                        or is_subscription_model(model)
+                                    )
+                                except Exception:
+                                    _deliberate_zero = False
+                            if _deliberate_zero:
+                                # Priced successfully, and the answer is a real
+                                # zero: local model, or a model/endpoint the
+                                # user already pays a flat fee for. Keep the
+                                # 0.0 (it IS the marginal cost, and aggregates
+                                # sum it), but do NOT call it "tt-computed":
+                                # that reads as "we priced these tokens and
+                                # they cost $0.00", which is false. The API
+                                # equivalent isn't zero; the MARGINAL cost is.
+                                _cost_status = "zero-marginal"
+                            else:
+                                cost = None
+                                _cost_status = "unpriced"
                     tokens["cost"] = cost
                     # First user message → display fallback when title is empty
                     first_user = ""
@@ -5927,6 +5947,20 @@ def _scan_sessions_sync():
                         "cost_anomaly": cost_anomaly,
                         "parent_session_id": srow["parent_session_id"],
                         "end_reason": srow["end_reason"],
+                        # end_reason is an OPEN set (Hermes's own API lets a
+                        # caller PATCH an arbitrary string). Anything we don't
+                        # recognise buckets as "unknown" with the raw value
+                        # preserved — never silently as a completion.
+                        "outcome": _ht.classify_end_reason(srow["end_reason"]),
+                        "outcome_raw": _ht.normalize_end_reason_raw(srow["end_reason"]),
+                        "cost_status": _cost_status or "unpriced",
+                        # Hermes's OWN cost_status column, verbatim and
+                        # unmapped. Distinct from `cost_status` above (which
+                        # describes where TT's dollar figure came from):
+                        # 'included' means the session was billed under a flat
+                        # plan, so the dollar figure we compute is an API
+                        # equivalent, not money the user spent at the margin.
+                        "_hermes_cost_status": srow["cost_status"],
                         "provider": srow["billing_provider"],
                         "endpoint": srow["billing_base_url"],
                         "tok_per_sec": _measured_tps,
@@ -7316,7 +7350,10 @@ async def get_projects(include_hidden: bool = False):
         projects[proj]["subagent_count"] += len(s.get("subagents", []))
         st = s.get("tokens", {})
         for k in ["input", "output", "cached", "total"]: projects[proj]["tokens"][k] += st.get(k, 0)
-        projects[proj]["tokens"]["cost"] += s.get("cost", 0.0)
+        # `cost` is None for an unpriced session (the key EXISTS, so a dict
+        # default never fires). An unpriced session contributes 0 to a SUM
+        # while still rendering individually as "not captured".
+        projects[proj]["tokens"]["cost"] += s.get("cost") or 0.0
         projects[proj]["plans"].extend(s.get("plans", []))
         projects[proj]["artifacts"].extend(s.get("published_artifacts", []))
     for p in projects.values():
@@ -7407,7 +7444,7 @@ async def get_projects(include_hidden: bool = False):
             agg["configured_subagent_count"] += m.get("configured_subagent_count", 0) or 0
             for k in ("input", "output", "cached", "total"):
                 agg["tokens"][k] += m.get("tokens", {}).get(k, 0)
-            agg["tokens"]["cost"] += m.get("tokens", {}).get("cost", 0.0)
+            agg["tokens"]["cost"] += m.get("tokens", {}).get("cost") or 0.0
             agg["agents"].update(m.get("agents", []))
             agg["mcp_tools"].update(m.get("mcp_tools", []))
             if m.get("is_worktree"):
@@ -8349,7 +8386,9 @@ async def get_analytics(
             by_agent[agent] = {"input": 0, "output": 0, "cached": 0, "cache_reads": 0, "total": 0, "cost": 0.0,
                                "energy_wh": 0.0, "savings_usd": 0.0, "co2_g": 0.0, "session_count": 0}
         st = s.get("tokens", {})
-        scost = s.get("cost", 0.0)
+        # None for an unpriced session; feeds three aggregates plus
+        # savings_vs_cloud() below, all of which need a number.
+        scost = s.get("cost") or 0.0
         # Local insights — energy, cloud savings, CO2 — only for local sessions.
         energy = savings = co2 = 0.0
         if is_local_session(model_name=s.get("model"), endpoint=s.get("endpoint"),

--- a/backend/test_hermes_telemetry.py
+++ b/backend/test_hermes_telemetry.py
@@ -1,0 +1,908 @@
+"""Tests for the Hermes telemetry rollup (GET /hermes/telemetry) and its index.
+
+Covers the three things this feature can get quietly wrong:
+  - ROTATION ORDER. agent.log.1 is OLDER than agent.log; a lexical sort reverses
+    it and corrupts model_journey / the api_calls sequence.
+  - CAPTURE vs ZERO. A session whose log lines rotated away has NO latency; the
+    payload must say "not_captured", never 0.
+  - OUTCOME SEMANTICS. An end_reason we don't recognise must land in "unknown"
+    with its raw string preserved, never be folded into "completed".
+
+Run: pytest backend/test_hermes_telemetry.py
+"""
+import asyncio
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+import hermes_telemetry as ht  # noqa: E402
+import main  # noqa: E402
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+_SCHEMA = (
+    "CREATE TABLE sessions (id TEXT, source TEXT, model TEXT, "
+    "parent_session_id TEXT, started_at INT, ended_at INT, "
+    "input_tokens INT, output_tokens INT, cache_read_tokens INT, "
+    "cache_write_tokens INT, reasoning_tokens INT, "
+    "estimated_cost_usd REAL, actual_cost_usd REAL, title TEXT, "
+    "billing_provider TEXT, billing_base_url TEXT, "
+    "cost_status TEXT, cost_source TEXT, end_reason TEXT)"
+)
+
+# Real Hermes session-id shape — the agent.log regexes require it.
+SID_SPAN = "20260101_000000_aaaa1111"   # calls in agent.log.1 AND agent.log
+SID_ROTATED = "20260102_000000_bbbb2222"  # calls ONLY in the rotated file
+SID_DARK = "20260103_000000_cccc3333"   # no log lines anywhere
+
+
+def _make_db(path: Path, rows):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    con = sqlite3.connect(path)
+    con.execute(_SCHEMA)
+    con.execute("CREATE TABLE messages (session_id TEXT, role TEXT, content TEXT, "
+                "timestamp INT, tool_name TEXT)")
+    con.executemany(
+        "INSERT INTO sessions VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)", rows)
+    con.commit()
+    con.close()
+
+
+def _row(sid, *, model="claude-sonnet-4-6", source="cli", est=None, actual=None,
+         cost_status=None, cost_source=None, end_reason=None, tokens=(1000, 500),
+         provider="anthropic", base_url=None):
+    return (sid, source, model, None, 1750000000, 1750000100,
+            tokens[0], tokens[1], 0, 0, 0, est, actual, "t",
+            provider, base_url, cost_status, cost_source, end_reason)
+
+
+def _isolate_other_agents(tmp_path, monkeypatch):
+    """Point every non-Hermes source at empty paths so a scan sees Hermes only."""
+    missing = tmp_path / "missing"
+    for attr in ("CODEX_DIR", "GEMINI_DIR", "QWEN_DIR", "VIBE_DIR", "OLLAMA_DIR",
+                 "GROK_SESSIONS_DIR", "VSCODE_STORAGE", "CURSOR_STORAGE",
+                 "COPILOT_CLI_DIR", "ANTIGRAVITY_BRAIN_DIR", "ANTIGRAVITY_CLI_DIR",
+                 "PI_SESSIONS_DIR"):
+        monkeypatch.setattr(main, attr, missing / attr.lower())
+    monkeypatch.setattr(main, "ANTIGRAVITY_BRAIN_SOURCES", [])
+    monkeypatch.setattr(main, "ANTIGRAVITY_BRAIN_DIRS", [])
+    monkeypatch.setattr(main, "_antigravity_cli_meta", lambda *a, **k: {})
+    monkeypatch.setattr(main, "CLAUDE_DIR", missing / "claude")
+    monkeypatch.setattr(main, "CURSOR_DIR", missing / "cursor")
+    monkeypatch.setattr(main, "OPENCODE_DB", missing / "opencode.db")
+    monkeypatch.setattr(main, "CLINE_DIR", missing / "cline")
+    monkeypatch.setattr(main, "CLINE_VSCODE_DIR", missing / "cline-vscode")
+    # SmallCode traces are project-local and its roots are derived from the
+    # projects other agents reported, so killing Cline also empties this —
+    # but only if no extra roots are configured.
+    monkeypatch.setattr(main, "SMALLCODE_EXTRA_ROOTS", [])
+    monkeypatch.setattr(main, "PROJECT_ALIASES_FILE", tmp_path / "aliases.json")
+    monkeypatch.setenv("TOKENTELEMETRY_DATA_DIR", str(tmp_path / "tt_data"))
+
+
+def _api_line(ts, sid, n, model, latency, provider="anthropic"):
+    return (f"{ts},123 INFO [{sid}] API call #{n}: model={model} "
+            f"provider={provider} in=50 out=20 total=70 latency={latency}s\n")
+
+
+def _tool_ok(ts, sid, tool, dur):
+    return f"{ts},000 INFO [{sid}] tool {tool} completed ({dur}s, 42 chars)\n"
+
+
+def _tool_fail(ts, sid, tool, dur):
+    return f"{ts},000 INFO [{sid}] tool {tool} failed ({dur}s): boom\n"
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    """A Hermes home with a rotated + current agent.log and a 3-session DB.
+
+    The rotated file (agent.log.1) is OLDER and carries model "alpha-1"; the
+    current file carries "omega-9". A reversed read order therefore produces
+    model_journey ["omega-9", "alpha-1"] and fails loudly.
+    """
+    ht.clear_cache()
+    _isolate_other_agents(tmp_path, monkeypatch)
+    home = tmp_path / ".hermes"
+    (home / "logs").mkdir(parents=True)
+    monkeypatch.setattr(main, "HERMES_DIR", home)
+    monkeypatch.setattr(main, "HERMES_DB", home / "state.db")
+    monkeypatch.setattr(main, "HERMES_PROFILES_DIR", home / "profiles")
+
+    _make_db(home / "state.db", [
+        # provider-reported (actual cost present)
+        _row(SID_SPAN, actual=0.25, est=0.30, end_reason="cli_close"),
+        # provider-estimated (estimate present, cost_source trustworthy)
+        _row(SID_ROTATED, est=0.42, cost_source="api", end_reason="compression"),
+        # tt-computed (no cost at all -> priced from tokens)
+        _row(SID_DARK, end_reason="quantum_collapse"),
+    ])
+
+    # OLDER rotation: alpha-1 calls, earlier wall-clock.
+    (home / "logs" / "agent.log.1").write_text(
+        _api_line("2026-01-01 00:00:01", SID_SPAN, 1, "alpha-1", 1.0)
+        + _api_line("2026-01-01 00:00:02", SID_SPAN, 2, "alpha-1", 3.0)
+        + _api_line("2026-01-02 00:00:01", SID_ROTATED, 1, "alpha-1", 5.0)
+        + _tool_ok("2026-01-01 00:00:03", SID_SPAN, "bash", 1.0)
+        + _tool_fail("2026-01-01 00:00:04", SID_SPAN, "web", 2.0),
+        encoding="utf-8")
+    # CURRENT log: omega-9 calls, later wall-clock.
+    (home / "logs" / "agent.log").write_text(
+        _api_line("2026-01-05 00:00:01", SID_SPAN, 3, "omega-9", 9.0)
+        + _tool_ok("2026-01-05 00:00:02", SID_SPAN, "bash", 3.0)
+        + _tool_ok("2026-01-05 00:00:03", SID_SPAN, "bash", 2.0)
+        + _tool_fail("2026-01-05 00:00:04", SID_SPAN, "web", 4.0)
+        + _tool_fail("2026-01-05 00:00:05", SID_SPAN, "web", 6.0),
+        encoding="utf-8")
+    # A compressed rotation must be ignored, not decompressed.
+    (home / "logs" / "agent.log.2.gz").write_bytes(b"\x1f\x8b\x08 not real gzip")
+    yield home
+    ht.clear_cache()
+
+
+# --------------------------------------------------------------------------- #
+# Rotation order
+# --------------------------------------------------------------------------- #
+
+def test_log_files_in_chronological_order(hermes_home):
+    names = [p.name for p in ht.log_files_in_order(hermes_home)]
+    # Oldest rotation first, current log last; .gz never read.
+    assert names == ["agent.log.1", "agent.log"]
+
+
+def test_rotation_order_is_generic(tmp_path):
+    ht.clear_cache()
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    for n in ("agent.log", "agent.log.1", "agent.log.2", "agent.log.10",
+              "agent.log.3.gz", "other.log"):
+        (logs / n).write_text("", encoding="utf-8")
+    assert [p.name for p in ht.log_files_in_order(tmp_path)] == [
+        "agent.log.10", "agent.log.2", "agent.log.1", "agent.log"]
+
+
+def test_spanning_session_merges_in_true_chronological_order(hermes_home):
+    log = main._hermes_log_summary(SID_SPAN)
+    assert [c["model"] for c in log["api_calls"]] == ["alpha-1", "alpha-1", "omega-9"]
+    assert [c["n"] for c in log["api_calls"]] == [1, 2, 3]
+    # A reversed read order would give ["omega-9", "alpha-1"].
+    assert log["model_journey"] == ["alpha-1", "omega-9"]
+    assert log["summary"]["api_call_count"] == 3
+    assert log["summary"]["total_latency_s"] == 13.0
+    assert log["log_coverage"] == "captured"
+
+
+def test_session_only_in_rotated_file_is_captured(hermes_home):
+    log = main._hermes_log_summary(SID_ROTATED)
+    assert log["summary"] is not None
+    assert log["summary"]["api_call_count"] == 1
+    assert log["summary"]["total_latency_s"] == 5.0
+    assert log["log_coverage"] == "captured"
+
+
+def test_session_with_no_log_lines_is_not_captured(hermes_home):
+    log = main._hermes_log_summary(SID_DARK)
+    # "not captured" is NOT zero — summary must be absent, not a zeroed dict.
+    assert log["summary"] is None
+    assert log["log_coverage"] == "not_captured"
+    assert log["api_calls"] == []
+
+    overlay = _run(main.hermes_session_overlay(SID_DARK))
+    assert overlay["performance"] is None
+    assert overlay["log_coverage"] == "not_captured"
+    assert overlay["performance"] != 0
+
+    captured = _run(main.hermes_session_overlay(SID_SPAN))
+    assert captured["log_coverage"] == "captured"
+    assert captured["performance"]["log_coverage"] == "captured"
+
+
+# --------------------------------------------------------------------------- #
+# Cache invalidation
+# --------------------------------------------------------------------------- #
+
+def test_index_cache_hits_then_refreshes_on_change(hermes_home):
+    idx1, files1 = ht.get_log_index(hermes_home)
+    idx2, _ = ht.get_log_index(hermes_home)
+    assert idx1 is idx2                      # cached: same object, no re-parse
+    assert files1 == ["agent.log.1", "agent.log"]
+
+    log = hermes_home / "logs" / "agent.log"
+    with open(log, "a", encoding="utf-8") as f:
+        f.write(_api_line("2026-01-06 00:00:01", SID_DARK, 1, "omega-9", 2.0))
+    # Some filesystems have coarse mtime; nudge it so the test can't false-pass
+    # on size alone being the only signal.
+    st = log.stat()
+    os.utime(log, (st.st_atime + 5, st.st_mtime + 5))
+
+    idx3, _ = ht.get_log_index(hermes_home)
+    assert idx3 is not idx1
+    assert len(idx3[SID_DARK]["api_calls"]) == 1
+
+    # A brand-new rotation also invalidates.
+    (hermes_home / "logs" / "agent.log.2").write_text(
+        _api_line("2025-12-01 00:00:01", SID_DARK, 1, "ancient-0", 1.0), encoding="utf-8")
+    idx4, files4 = ht.get_log_index(hermes_home)
+    assert idx4 is not idx3
+    assert files4 == ["agent.log.2", "agent.log.1", "agent.log"]
+    assert [c["model"] for c in idx4[SID_DARK]["api_calls"]] == ["ancient-0", "omega-9"]
+
+
+def test_missing_logs_dir_is_silent(tmp_path):
+    ht.clear_cache()
+    index, files = ht.get_log_index(tmp_path / "nope")
+    assert index == {} and files == []
+
+
+# --------------------------------------------------------------------------- #
+# Outcome taxonomy
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize("raw,bucket", [
+    ("cli_close", "completed"),
+    ("compression", "continued"),
+    ("resumed_other", "continued"),
+    ("idle_timeout", "timed_out"),
+    ("ws_disconnect", "interrupted"),
+    ("session_reset", "reset"),
+    (None, "unknown"),
+    ("", "unknown"),
+    ("   ", "unknown"),
+    # Upstream itself treats these as carrying no outcome — they must not be
+    # forced into a bucket.
+    ("agent_close", "unknown"),
+    ("ws_orphan_reap", "unknown"),
+    ("orphaned_compression", "unknown"),
+])
+def test_classify_end_reason(raw, bucket):
+    assert ht.classify_end_reason(raw) == bucket
+
+
+def test_unmapped_end_reason_is_unknown_never_completed():
+    assert ht.classify_end_reason("quantum_collapse") == "unknown"
+    assert ht.classify_end_reason("quantum_collapse") != "completed"
+    assert ht.normalize_end_reason_raw("quantum_collapse") == "quantum_collapse"
+    assert ht.normalize_end_reason_raw(None) is None
+    assert ht.normalize_end_reason_raw("") is None
+
+
+def test_scan_sets_outcome_and_raw(hermes_home):
+    by_id = {s["id"]: s for s in main._scan_sessions_sync() if s["agent"] == "hermes"}
+    assert by_id[SID_SPAN]["outcome"] == "completed"
+    assert by_id[SID_SPAN]["outcome_raw"] == "cli_close"
+    assert by_id[SID_ROTATED]["outcome"] == "continued"
+    assert by_id[SID_DARK]["outcome"] == "unknown"
+    assert by_id[SID_DARK]["outcome_raw"] == "quantum_collapse"
+
+
+# --------------------------------------------------------------------------- #
+# Percentiles
+# --------------------------------------------------------------------------- #
+
+def test_unknown_bucket_can_exceed_unknown_raw(tmp_path, monkeypatch):
+    """Two ways to be "unknown": a NULL end_reason (no raw to show) and an
+    unmapped string (raw preserved). They share the bucket, so
+    sum(unknown_raw counts) <= buckets["unknown"].count BY DESIGN."""
+    ht.clear_cache()
+    _isolate_other_agents(tmp_path, monkeypatch)
+    home = tmp_path / ".hermes"
+    monkeypatch.setattr(main, "HERMES_DIR", home)
+    monkeypatch.setattr(main, "HERMES_DB", home / "state.db")
+    monkeypatch.setattr(main, "HERMES_PROFILES_DIR", home / "profiles")
+    _make_db(home / "state.db", [
+        _row("20260401_000000_1111aaaa", end_reason=None),
+        _row("20260401_000000_2222bbbb", end_reason="quantum_collapse"),
+        _row("20260401_000000_3333cccc", end_reason="quantum_collapse"),
+        _row("20260401_000000_4444dddd", end_reason="cli_close"),
+    ])
+    t = _telemetry(monkeypatch)
+    buckets = {b["outcome"]: b for b in t["outcomes"]["buckets"]}
+    assert buckets["unknown"]["count"] == 3
+    assert t["outcomes"]["unknown_raw"] == [{"raw": "quantum_collapse", "count": 2}]
+    assert sum(r["count"] for r in t["outcomes"]["unknown_raw"]) <= buckets["unknown"]["count"]
+    # The whole point: an unrecognised string is never a completion.
+    assert buckets["completed"]["count"] == 1
+    assert t["outcomes"]["completion_rate"] == 0.25
+
+
+def test_percentile_edge_cases():
+    assert ht.percentile([], 0.5) is None
+    assert ht.percentile([], 0.95) is None
+    assert ht.percentile([7.5], 0.5) == 7.5
+    assert ht.percentile([7.5], 0.95) == 7.5
+    # Nearest-rank: p50 of 1..4 is the 2nd value; p95 of 1..100 is the 95th.
+    assert ht.percentile([1, 2, 3, 4], 0.5) == 2.0
+    assert ht.percentile(list(range(1, 101)), 0.95) == 95.0
+    assert ht.percentile(list(range(1, 101)), 0.5) == 50.0
+    assert ht.percentile([4, 1, 3, 2], 0.95) == 4.0   # unsorted input
+    assert ht.percentile([None, 2.0, None], 0.5) == 2.0
+
+
+# --------------------------------------------------------------------------- #
+# Cost status
+# --------------------------------------------------------------------------- #
+
+def test_cost_statuses(tmp_path, monkeypatch):
+    """provider-reported / provider-estimated / tt-computed / unpriced.
+
+    (`zero-marginal` has its own tests below.)
+    """
+    ht.clear_cache()
+    _isolate_other_agents(tmp_path, monkeypatch)
+    # Decouple from the developer's real ~/.tokentelemetry/power.json: adding a
+    # subscription model there must not flip 3333cccc from tt-computed.
+    import power_config
+    monkeypatch.setattr(power_config, "is_subscription_model", lambda m: False)
+    monkeypatch.setattr(power_config, "is_local_session", lambda *a, **k: False)
+    home = tmp_path / ".hermes"
+    monkeypatch.setattr(main, "HERMES_DIR", home)
+    monkeypatch.setattr(main, "HERMES_DB", home / "state.db")
+    monkeypatch.setattr(main, "HERMES_PROFILES_DIR", home / "profiles")
+    _make_db(home / "state.db", [
+        _row("20260201_000000_1111aaaa", actual=0.25, est=0.30),
+        _row("20260201_000000_2222bbbb", est=0.42, cost_source="api"),
+        # Hermes's untrustworthy 0.0 (issue #176) -> re-priced by TT.
+        _row("20260201_000000_3333cccc", est=0.0, cost_status="unknown",
+             cost_source="none", tokens=(115184, 21102)),
+        # Nothing to price: no cost, no tokens -> must stay None, never 0.0.
+        _row("20260201_000000_4444dddd", tokens=(0, 0)),
+    ])
+    by_id = {s["id"]: s for s in main._scan_sessions_sync() if s["agent"] == "hermes"}
+
+    assert by_id["20260201_000000_1111aaaa"]["cost_status"] == "provider-reported"
+    assert by_id["20260201_000000_1111aaaa"]["cost"] == 0.25
+    assert by_id["20260201_000000_2222bbbb"]["cost_status"] == "provider-estimated"
+    assert by_id["20260201_000000_2222bbbb"]["cost"] == 0.42
+    assert by_id["20260201_000000_3333cccc"]["cost_status"] == "tt-computed"
+    assert by_id["20260201_000000_3333cccc"]["cost"] > 0
+    unpriced = by_id["20260201_000000_4444dddd"]
+    assert unpriced["cost_status"] == "unpriced"
+    assert unpriced["cost"] is None          # NOT 0.0
+    assert unpriced["tokens"]["cost"] is None
+
+
+def test_subscription_zero_is_zero_marginal_not_tt_computed(tmp_path, monkeypatch):
+    """A flat-subscription session legitimately costs $0 — priced, not unpriced.
+
+    It must NOT read as `tt-computed`: that status means "TT priced these tokens
+    and the answer is this dollar figure", so a tt-computed 0.0 renders as
+    "API equiv. $0.00 · priced by TokenTelemetry" — a claim that the API
+    equivalent of the tokens is zero. It isn't; the marginal cost is.
+    """
+    ht.clear_cache()
+    _isolate_other_agents(tmp_path, monkeypatch)
+    home = tmp_path / ".hermes"
+    monkeypatch.setattr(main, "HERMES_DIR", home)
+    monkeypatch.setattr(main, "HERMES_DB", home / "state.db")
+    monkeypatch.setattr(main, "HERMES_PROFILES_DIR", home / "profiles")
+    _make_db(home / "state.db", [
+        _row("20260301_000000_5555eeee", model="sub-model", tokens=(1000, 500)),
+    ])
+    import power_config
+    monkeypatch.setattr(power_config, "is_subscription_model", lambda m: m == "sub-model")
+    by_id = {s["id"]: s for s in main._scan_sessions_sync() if s["agent"] == "hermes"}
+    row = by_id["20260301_000000_5555eeee"]
+    assert row["cost"] == 0.0                 # deliberate zero, preserved
+    assert row["tokens"]["cost"] == 0.0
+    assert row["cost_status"] == "zero-marginal"
+
+
+# --------------------------------------------------------------------------- #
+# Endpoint payload
+# --------------------------------------------------------------------------- #
+
+def _telemetry(monkeypatch):
+    sessions = main._scan_sessions_sync()
+
+    async def _fake(fresh: bool = False):
+        return sessions
+    monkeypatch.setattr(main, "get_sessions_cached", _fake)
+    return _run(main.hermes_telemetry())
+
+
+def test_telemetry_unavailable_without_a_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(main, "HERMES_DIR", tmp_path / "nope")
+    monkeypatch.setattr(main, "HERMES_DB", tmp_path / "nope" / "state.db")
+    monkeypatch.setattr(main, "HERMES_PROFILES_DIR", tmp_path / "nope" / "profiles")
+    assert _run(main.hermes_telemetry()) == {"available": False}
+
+
+def test_telemetry_payload(hermes_home, monkeypatch):
+    t = _telemetry(monkeypatch)
+    assert t["available"] is True
+    assert t["session_count"] == 3
+
+    # --- outcomes
+    o = t["outcomes"]
+    buckets = {b["outcome"]: b for b in o["buckets"]}
+    assert buckets["completed"]["count"] == 1
+    assert buckets["completed"]["pct"] == 33.3
+    assert buckets["continued"]["count"] == 1
+    assert buckets["unknown"]["count"] == 1
+    assert "quantum_collapse" not in [b["outcome"] for b in o["buckets"]]
+    assert o["unknown_raw"] == [{"raw": "quantum_collapse", "count": 1}]
+    assert o["completion_rate"] == round(1 / 3, 3)
+    assert sum(b["count"] for b in o["buckets"]) == t["session_count"]
+    src = {r["source"]: r for r in o["by_source"]}
+    assert src["cli"]["total"] == 3
+    assert src["cli"]["buckets"] == {"completed": 1, "continued": 1, "unknown": 1}
+    assert sum(r["total"] for r in o["by_model"]) == t["session_count"]
+
+    # --- cost
+    c = t["cost"]
+    assert set(c["confidence"]) == {"provider-reported", "provider-estimated",
+                                    "tt-computed", "zero-marginal", "unpriced"}
+    assert c["confidence"]["provider-reported"] == 1
+    assert c["confidence"]["provider-estimated"] == 1
+    assert c["confidence"]["tt-computed"] == 1
+    assert sum(c["confidence"].values()) == t["session_count"]
+    assert c["usd_by_confidence"]["provider-reported"] == 0.25
+    assert c["usd_by_confidence"]["provider-estimated"] == 0.42
+    assert abs(c["total_usd"] - sum(c["usd_by_confidence"].values())) < 0.002
+
+    # --- latency: 4 calls over 2 sessions (1.0, 3.0, 9.0 and 5.0)
+    lat = t["latency"]
+    assert lat["captured_sessions"] == 2
+    assert lat["uncaptured_sessions"] == 1
+    assert lat["captured_sessions"] + lat["uncaptured_sessions"] == t["session_count"]
+    assert lat["api_calls"] == 4
+    assert lat["avg_s"] == 4.5
+    assert lat["p50_s"] == 3.0      # nearest-rank of [1,3,5,9]
+    assert lat["p95_s"] == 9.0
+    by_model = {r["model"]: r for r in lat["by_model"]}
+    assert by_model["alpha-1"]["calls"] == 3
+    assert by_model["alpha-1"]["avg_s"] == 3.0
+    assert by_model["omega-9"]["calls"] == 1
+    assert by_model["omega-9"]["p95_s"] == 9.0
+    assert [r["calls"] for r in lat["by_model"]] == sorted(
+        [r["calls"] for r in lat["by_model"]], reverse=True)
+
+    # --- tools: bash 3 calls 0 fails, web 3 calls 3 fails
+    tl = t["tools"]
+    assert tl["captured"] is True
+    top = {r["tool"]: r for r in tl["top_by_calls"]}
+    assert top["bash"]["calls"] == 3 and top["bash"]["failures"] == 0
+    assert top["bash"]["failure_rate"] == 0.0
+    assert top["bash"]["avg_duration_s"] == 2.0
+    assert top["web"]["calls"] == 3 and top["web"]["failures"] == 3
+    assert tl["top_by_failure_rate"][0]["tool"] == "web"
+    assert tl["top_by_failure_rate"][0]["failure_rate"] == 1.0
+
+    # --- log coverage
+    lc = t["log_coverage"]
+    assert lc["files_read"] == ["agent.log.1", "agent.log"]
+    assert lc["sessions_with_log"] == lat["captured_sessions"]
+    assert lc["sessions_total"] == t["session_count"]
+
+
+def test_low_volume_tools_excluded_from_failure_rate(hermes_home, monkeypatch):
+    """A 1-call 100%-failure tool is noise: counted, but never a 'top failure'."""
+    with open(hermes_home / "logs" / "agent.log", "a", encoding="utf-8") as f:
+        f.write(_tool_fail("2026-01-05 00:00:09", SID_SPAN, "flaky_once", 1.0))
+    ht.clear_cache()
+    t = _telemetry(monkeypatch)
+    assert "flaky_once" in {r["tool"] for r in t["tools"]["top_by_calls"]}
+    assert "flaky_once" not in {r["tool"] for r in t["tools"]["top_by_failure_rate"]}
+
+
+def test_empty_db_reports_available_with_null_latency(tmp_path, monkeypatch):
+    """An empty profile DB (the user really has one) must not divide by zero."""
+    ht.clear_cache()
+    _isolate_other_agents(tmp_path, monkeypatch)
+    home = tmp_path / ".hermes"
+    monkeypatch.setattr(main, "HERMES_DIR", home)
+    monkeypatch.setattr(main, "HERMES_DB", home / "state.db")
+    monkeypatch.setattr(main, "HERMES_PROFILES_DIR", home / "profiles")
+    _make_db(home / "state.db", [])
+    # A profile home with a DB but no logs/ dir at all.
+    _make_db(home / "profiles" / "founder" / "state.db", [])
+
+    t = _telemetry(monkeypatch)
+    assert t["available"] is True
+    assert t["session_count"] == 0
+    assert t["outcomes"]["buckets"] == []
+    assert t["outcomes"]["unknown_raw"] == []
+    assert t["outcomes"]["completion_rate"] == 0.0
+    assert t["latency"]["avg_s"] is None
+    assert t["latency"]["p50_s"] is None
+    assert t["latency"]["p95_s"] is None
+    assert t["latency"]["api_calls"] == 0
+    assert t["tools"] == {"captured": False, "top_by_calls": [], "top_by_failure_rate": []}
+    assert t["log_coverage"]["files_read"] == []
+    assert t["cost"]["total_usd"] == 0.0
+
+
+def test_profile_logs_are_labelled_and_scoped(tmp_path, monkeypatch):
+    """A profile's sessions live in its own log; merged files_read stays unambiguous."""
+    ht.clear_cache()
+    _isolate_other_agents(tmp_path, monkeypatch)
+    home = tmp_path / ".hermes"
+    (home / "logs").mkdir(parents=True)
+    monkeypatch.setattr(main, "HERMES_DIR", home)
+    monkeypatch.setattr(main, "HERMES_DB", home / "state.db")
+    monkeypatch.setattr(main, "HERMES_PROFILES_DIR", home / "profiles")
+    _make_db(home / "state.db", [_row(SID_SPAN, end_reason="cli_close")])
+    _make_db(home / "profiles" / "coder" / "state.db",
+             [_row(SID_ROTATED, end_reason="cli_close")])
+    (home / "logs" / "agent.log").write_text(
+        _api_line("2026-01-01 00:00:01", SID_SPAN, 1, "alpha-1", 1.0), encoding="utf-8")
+    plogs = home / "profiles" / "coder" / "logs"
+    plogs.mkdir(parents=True)
+    (plogs / "agent.log").write_text(
+        _api_line("2026-01-02 00:00:01", SID_ROTATED, 1, "beta-2", 2.0), encoding="utf-8")
+
+    # Per-session lookup stays home-scoped: the root log knows nothing of the
+    # profile's session.
+    assert main._hermes_log_summary(SID_ROTATED)["summary"] is None
+    assert main._hermes_log_summary(SID_ROTATED, "coder")["summary"]["api_call_count"] == 1
+
+    t = _telemetry(monkeypatch)
+    assert t["log_coverage"]["files_read"] == ["agent.log", "coder/agent.log"]
+    assert t["latency"]["captured_sessions"] == 2
+    assert t["latency"]["api_calls"] == 2
+
+
+def test_stale_log_sessions_are_not_counted(hermes_home, monkeypatch):
+    """Log lines for a session that no longer exists in any DB are ignored."""
+    with open(hermes_home / "logs" / "agent.log", "a", encoding="utf-8") as f:
+        f.write(_api_line("2026-01-09 00:00:01", "20261231_000000_deadbeef", 1,
+                          "ghost-0", 99.0))
+    ht.clear_cache()
+    t = _telemetry(monkeypatch)
+    assert t["session_count"] == 3
+    assert t["latency"]["api_calls"] == 4          # not 5
+    assert "ghost-0" not in {r["model"] for r in t["latency"]["by_model"]}
+
+
+def test_payload_is_json_serializable(hermes_home, monkeypatch):
+    import json
+    t = _telemetry(monkeypatch)
+    json.dumps(t)   # no datetimes / Paths / sets leak into the response
+    for key in ("available", "session_count", "outcomes", "cost", "latency",
+                "tools", "log_coverage"):
+        assert key in t
+    assert set(t) == {"available", "session_count", "outcomes", "cost", "latency",
+                      "tools", "log_coverage"}
+
+
+# --------------------------------------------------------------------------- #
+# Unpriced cost (None) must not break the aggregates that CONSUME it
+#
+# `cost` is None — not 0.0 — for a session TT cannot price, and the key EXISTS
+# on the dict, so `s.get("cost", 0.0)` returns None and every `+=` downstream
+# raises TypeError. The whole /projects and /analytics pages 500'd on a single
+# tokenless Hermes row. These tests pin the two aggregation paths.
+# --------------------------------------------------------------------------- #
+
+def _mixed_priced_home(tmp_path, monkeypatch):
+    """A Hermes DB with one priceable session and one that must stay None."""
+    ht.clear_cache()
+    _isolate_other_agents(tmp_path, monkeypatch)
+    home = tmp_path / ".hermes"
+    monkeypatch.setattr(main, "HERMES_DIR", home)
+    monkeypatch.setattr(main, "HERMES_DB", home / "state.db")
+    monkeypatch.setattr(main, "HERMES_PROFILES_DIR", home / "profiles")
+    _make_db(home / "state.db", [
+        # Priced by TT from tokens.
+        _row("20260401_000000_1111aaaa", tokens=(115184, 21102),
+             end_reason="cli_close"),
+        # No tokens, no cost anywhere -> cost is None.
+        _row("20260401_000000_2222bbbb", tokens=(0, 0), end_reason="cli_close"),
+    ])
+    sessions = main._scan_sessions_sync()
+    by_id = {s["id"]: s for s in sessions}
+    assert by_id["20260401_000000_2222bbbb"]["cost"] is None   # the trigger
+    priced = by_id["20260401_000000_1111aaaa"]["cost"]
+    assert isinstance(priced, float) and priced > 0
+
+    async def _fake(fresh: bool = False):
+        return sessions
+    monkeypatch.setattr(main, "get_sessions_cached", _fake)
+    return sessions, priced
+
+
+def test_projects_aggregation_survives_an_unpriced_session(tmp_path, monkeypatch):
+    sessions, priced = _mixed_priced_home(tmp_path, monkeypatch)
+    projects = _run(main.get_projects())
+    # Both sessions have no cwd -> one "unknown" project card holding both.
+    card = next(p for p in projects if p["path"] == "unknown")
+    assert card["session_count"] == 2
+    assert card["tokens"]["cost"] == pytest.approx(priced)   # priced only
+    assert card["tokens"]["input"] == 115184
+
+
+def test_analytics_by_agent_survives_an_unpriced_session(tmp_path, monkeypatch):
+    sessions, priced = _mixed_priced_home(tmp_path, monkeypatch)
+    a = _run(main.get_analytics(from_=None, to=None, granularity="day",
+                                agents=[], models=[], projects=[]))
+    row = a["by_agent"]["hermes"]
+    assert row["session_count"] == 2
+    assert row["cost"] == pytest.approx(priced)              # priced only
+    # by_model / by_day walk the same variable and must be intact too.
+    assert sum(m["cost"] for m in a["by_model"].values()) == pytest.approx(priced)
+    assert sum(d["cost"] for d in a["by_day"]) == pytest.approx(priced)
+
+
+# --------------------------------------------------------------------------- #
+# Zero failures is not a failure ranking
+# --------------------------------------------------------------------------- #
+
+def test_no_failures_means_an_empty_failure_rate_list(hermes_home, monkeypatch):
+    """Plenty of calls, zero errors -> [], never N rows reading "0.0%"."""
+    (hermes_home / "logs" / "agent.log.1").write_text(
+        _api_line("2026-01-01 00:00:01", SID_SPAN, 1, "alpha-1", 1.0), encoding="utf-8")
+    (hermes_home / "logs" / "agent.log").write_text(
+        "".join(_tool_ok("2026-01-05 00:00:0%d" % (i % 10), SID_SPAN, "terminal", 1.0)
+                for i in range(55))
+        + "".join(_tool_ok("2026-01-05 00:00:0%d" % (i % 10), SID_SPAN, "read_file", 1.0)
+                  for i in range(12)),
+        encoding="utf-8")
+    ht.clear_cache()
+    t = _telemetry(monkeypatch)
+    tl = t["tools"]
+    assert tl["captured"] is True
+    top = {r["tool"]: r for r in tl["top_by_calls"]}
+    assert top["terminal"]["calls"] == 55 and top["terminal"]["failures"] == 0
+    assert tl["top_by_failure_rate"] == []
+
+
+def test_failure_rate_list_still_ranks_real_failures(hermes_home, monkeypatch):
+    """The `failures > 0` filter must not evict a tool that actually failed."""
+    t = _telemetry(monkeypatch)
+    fails = {r["tool"]: r for r in t["tools"]["top_by_failure_rate"]}
+    assert set(fails) == {"web"}          # bash has 3 calls but 0 failures
+    assert fails["web"]["failures"] == 3
+
+
+# --------------------------------------------------------------------------- #
+# Subscription-included qualifier on the aggregate cost
+# --------------------------------------------------------------------------- #
+
+def test_subscription_included_usd_sums_only_included_sessions(tmp_path, monkeypatch):
+    """Hermes cost_status='included' == flat-plan; $0 marginal to the user.
+
+    TT still prices those sessions (that's the API-equivalent figure), so
+    `total_usd` alone is not honest about what was actually spent. The included
+    subtotal lets the UI qualify it.
+    """
+    ht.clear_cache()
+    _isolate_other_agents(tmp_path, monkeypatch)
+    home = tmp_path / ".hermes"
+    monkeypatch.setattr(main, "HERMES_DIR", home)
+    monkeypatch.setattr(main, "HERMES_DB", home / "state.db")
+    monkeypatch.setattr(main, "HERMES_PROFILES_DIR", home / "profiles")
+    _make_db(home / "state.db", [
+        # Flat-plan sessions (Hermes's own status), re-priced by TT per #176.
+        _row("20260501_000000_1111aaaa", est=0.0, cost_status="included",
+             cost_source="none", tokens=(116295, 8982)),
+        _row("20260501_000000_2222bbbb", est=0.0, cost_status="included",
+             cost_source="none", tokens=(278448, 20893)),
+        # Not included: pay-as-you-go, same re-pricing path.
+        _row("20260501_000000_3333cccc", est=0.0, cost_status="unknown",
+             cost_source="none", tokens=(115184, 21102)),
+        # Not included and unpriceable -> contributes nothing to either figure.
+        _row("20260501_000000_4444dddd", tokens=(0, 0)),
+    ])
+    sessions = main._scan_sessions_sync()
+    by_id = {s["id"]: s for s in sessions}
+    assert by_id["20260501_000000_1111aaaa"]["_hermes_cost_status"] == "included"
+    assert by_id["20260501_000000_3333cccc"]["_hermes_cost_status"] == "unknown"
+
+    t = _telemetry(monkeypatch)
+    c = t["cost"]
+    expected_included = round(by_id["20260501_000000_1111aaaa"]["cost"]
+                              + by_id["20260501_000000_2222bbbb"]["cost"], 3)
+    assert expected_included > 0
+    assert c["subscription_included_usd"] == expected_included
+    assert c["total_usd"] == round(expected_included
+                                   + by_id["20260501_000000_3333cccc"]["cost"], 3)
+    assert c["subscription_included_usd"] < c["total_usd"]
+
+
+def test_subscription_included_usd_is_zero_without_included_sessions(hermes_home,
+                                                                     monkeypatch):
+    t = _telemetry(monkeypatch)
+    assert t["cost"]["subscription_included_usd"] == 0.0
+    assert t["cost"]["total_usd"] > 0
+
+
+# --------------------------------------------------------------------------- #
+# zero-marginal: a priced, genuinely-free session is not a priced-at-zero one
+# --------------------------------------------------------------------------- #
+
+def _zero_marginal_home(tmp_path, monkeypatch, rows, *, local=False, sub_models=()):
+    """Hermes home whose sessions all price to a deliberate $0."""
+    ht.clear_cache()
+    _isolate_other_agents(tmp_path, monkeypatch)
+    home = tmp_path / ".hermes"
+    monkeypatch.setattr(main, "HERMES_DIR", home)
+    monkeypatch.setattr(main, "HERMES_DB", home / "state.db")
+    monkeypatch.setattr(main, "HERMES_PROFILES_DIR", home / "profiles")
+    import power_config
+    monkeypatch.setattr(power_config, "is_subscription_model",
+                        lambda m: m in sub_models)
+    monkeypatch.setattr(power_config, "is_local_session", lambda *a, **k: local)
+    # Deterministic power config: the developer's real ~/.tokentelemetry/power.json
+    # must not decide whether a local session prices to zero.
+    monkeypatch.setattr(power_config, "load_power_config",
+                        lambda: {"loadWatts": 22, "costPerKwh": 0.0})
+    _make_db(home / "state.db", rows)
+    return home
+
+
+def test_local_model_session_is_zero_marginal(tmp_path, monkeypatch):
+    """A local model costs electricity, not API dollars — and with no electricity
+    rate configured that is a genuine $0, which is a FINDING, not a price."""
+    _zero_marginal_home(tmp_path, monkeypatch,
+                        [_row("20260601_000000_1111aaaa", model="qwen3-coder:30b",
+                              provider="ollama",
+                              base_url="http://localhost:11434")],
+                        local=True)
+    row = [s for s in main._scan_sessions_sync() if s["agent"] == "hermes"][0]
+    assert row["cost"] == 0.0                  # true marginal cost, kept
+    assert row["cost"] is not None             # NOT nulled into "unpriced"
+    assert row["cost_status"] == "zero-marginal"
+
+
+def test_local_model_with_a_real_electricity_rate_is_still_tt_computed(tmp_path,
+                                                                      monkeypatch):
+    """Guard the other side: a nonzero electricity figure IS a computed price."""
+    _zero_marginal_home(tmp_path, monkeypatch,
+                        [_row("20260601_000000_4444eeee", model="qwen3-coder:30b",
+                              provider="ollama",
+                              base_url="http://localhost:11434")],
+                        local=True)
+    import power_config
+    monkeypatch.setattr(power_config, "load_power_config",
+                        lambda: {"loadWatts": 22, "costPerKwh": 0.2})
+    row = [s for s in main._scan_sessions_sync() if s["agent"] == "hermes"][0]
+    assert row["cost"] > 0
+    assert row["cost_status"] == "tt-computed"
+
+
+def test_local_session_with_no_tokens_is_unpriced_not_zero_marginal(tmp_path,
+                                                                    monkeypatch):
+    """The empty-session trap: with 0 tokens there was nothing to price, so
+    "local model, therefore $0 marginal" is a claim we did not earn. Unpriced
+    must win over deliberate-zero whenever the session recorded no tokens,
+    otherwise one aborted Ollama run reads as a positive free-run finding."""
+    _zero_marginal_home(tmp_path, monkeypatch,
+                        [_row("20260601_000000_5555ffff", model="qwen3-coder:30b",
+                              provider="ollama",
+                              base_url="http://localhost:11434",
+                              tokens=(0, 0))],
+                        local=True)
+    row = [s for s in main._scan_sessions_sync() if s["agent"] == "hermes"][0]
+    assert row["tokens"]["total"] == 0
+    assert row["cost"] is None                 # "not captured", never $0.00
+    assert row["cost_status"] == "unpriced"
+    assert row["cost_status"] != "zero-marginal"
+
+
+def test_subscription_session_with_no_tokens_is_unpriced(tmp_path, monkeypatch):
+    """Same trap on the subscription side: a flat-fee model still needs tokens
+    before we can say anything about what it cost."""
+    _zero_marginal_home(tmp_path, monkeypatch,
+                        [_row("20260601_000000_6666aaaa", model="gpt-5.4",
+                              tokens=(0, 0))],
+                        sub_models={"gpt-5.4"})
+    row = [s for s in main._scan_sessions_sync() if s["agent"] == "hermes"][0]
+    assert row["cost"] is None
+    assert row["cost_status"] == "unpriced"
+
+
+def test_zero_marginal_is_not_counted_as_tt_computed(tmp_path, monkeypatch):
+    _zero_marginal_home(tmp_path, monkeypatch,
+                        [_row("20260601_000000_2222bbbb", model="gpt-5.4")],
+                        sub_models={"gpt-5.4"})
+    t = _telemetry(monkeypatch)
+    c = t["cost"]
+    assert c["confidence"]["zero-marginal"] == 1
+    assert c["confidence"]["tt-computed"] == 0
+    assert c["usd_by_confidence"]["tt-computed"] == 0.0
+
+
+def test_all_zero_marginal_reports_zero_without_claiming_a_price(tmp_path, monkeypatch):
+    """The exact case that used to render a bare, confident "API equiv. $0.00".
+
+    Every session prices to a deliberate zero, so total_usd is 0.0 — but the
+    payload now says WHY: all N sessions are zero-marginal, none tt-computed.
+    """
+    rows = [_row(f"2026060{i}_000000_{i}{i}{i}{i}cccc", model="gpt-5.4")
+            for i in range(1, 5)]
+    _zero_marginal_home(tmp_path, monkeypatch, rows, sub_models={"gpt-5.4"})
+    sessions = [s for s in main._scan_sessions_sync() if s["agent"] == "hermes"]
+    assert len(sessions) == 4
+    assert all(s["cost"] == 0.0 for s in sessions)
+
+    t = _telemetry(monkeypatch)
+    c = t["cost"]
+    assert c["confidence"]["zero-marginal"] == 4
+    assert c["confidence"]["tt-computed"] == 0
+    assert c["confidence"]["unpriced"] == 0
+    assert c["total_usd"] == 0.0
+    assert c["usd_by_confidence"]["zero-marginal"] == 0.0
+    # Hermes never claimed these were flat-plan; the inference is TT's own, so
+    # the provider-claim subtotal stays untouched.
+    assert c["subscription_included_usd"] == 0.0
+
+
+def test_confidence_dicts_are_total_not_sparse(tmp_path, monkeypatch):
+    """All five keys present in both dicts, even for empty buckets.
+
+    A sparse dict makes the frontend guess whether a missing key means zero or
+    means the backend is older than the key.
+    """
+    _zero_marginal_home(tmp_path, monkeypatch,
+                        [_row("20260601_000000_3333dddd", model="gpt-5.4")],
+                        sub_models={"gpt-5.4"})
+    c = _telemetry(monkeypatch)["cost"]
+    expected = ["provider-reported", "provider-estimated", "tt-computed",
+                "zero-marginal", "unpriced"]
+    assert list(c["confidence"]) == expected          # order too, not just membership
+    assert list(c["usd_by_confidence"]) == expected
+    assert set(ht.COST_STATUSES) == set(expected)
+    assert sum(c["confidence"].values()) == 1
+
+
+def test_empty_status_buckets_survive_an_empty_session_set():
+    c = ht._cost([])
+    assert c["confidence"] == {k: 0 for k in ht.COST_STATUSES}
+    assert c["usd_by_confidence"] == {k: 0.0 for k in ht.COST_STATUSES}
+    assert c["total_usd"] == 0.0
+
+
+# --------------------------------------------------------------------------- #
+# EMPTY_ENTRY is shared state — it must be unmutatable
+# --------------------------------------------------------------------------- #
+
+def test_empty_entry_cannot_be_mutated_through_a_caller():
+    """One append on the shared fallback would leak into every other session."""
+    with pytest.raises(TypeError):
+        ht.EMPTY_ENTRY["api_calls"] = [{"model": "poison"}]
+    with pytest.raises(AttributeError):
+        ht.EMPTY_ENTRY["api_calls"].append({"model": "poison"})
+    with pytest.raises(AttributeError):
+        ht.EMPTY_ENTRY["tool_calls"].append({"tool": "poison"})
+    assert ht.EMPTY_ENTRY == {"api_calls": (), "tool_calls": ()}
+
+
+def test_missing_session_overlay_gets_a_fresh_empty_list(tmp_path, monkeypatch):
+    """The overlay a caller receives is its own list, not the shared fallback."""
+    monkeypatch.setattr(main, "HERMES_DIR", tmp_path / "nope")
+    a = main._hermes_log_summary("20260101_000000_aaaa1111")
+    b = main._hermes_log_summary("20260101_000000_bbbb2222")
+    assert a["api_calls"] == [] and a["tool_calls"] == []
+    a["api_calls"].append({"model": "poison"})
+    assert b["api_calls"] == []
+    assert ht.EMPTY_ENTRY["api_calls"] == ()
+
+
+def test_by_model_outcomes_are_capped_at_the_ten_largest():
+    """Model names are open-set; the payload must stay bounded."""
+    sessions = []
+    for i in range(15):
+        for _ in range(i + 1):               # model-i has i+1 sessions
+            sessions.append({"model": f"model-{i:02d}", "source_subtype": "cli",
+                             "outcome": "completed"})
+    o = ht._outcomes(sessions)
+    assert len(o["by_model"]) == ht.BY_MODEL_LIMIT
+    assert o["models_total"] == 15
+    # The ten LARGEST, biggest first — not the first ten seen.
+    assert [r["model"] for r in o["by_model"]] == [f"model-{i:02d}"
+                                                   for i in range(14, 4, -1)]
+    assert [r["total"] for r in o["by_model"]] == list(range(15, 5, -1))
+    # by_source is a small closed-ish set and stays complete.
+    assert len(o["by_source"]) == 1 and o["by_source"][0]["total"] == len(sessions)

--- a/frontend/src/app/hermes/page.tsx
+++ b/frontend/src/app/hermes/page.tsx
@@ -11,9 +11,13 @@ import {
 } from "lucide-react";
 import { useResource } from "@/lib/api";
 import {
-  PageHeader, Card, CardHeader, CardTitle, StatTile, EmptyState,
+  PageHeader, Card, CardHeader, CardTitle, StatTile, EmptyState, Section,
   Table, THead, TBody, TR, TH, TD, Badge,
 } from "@/components/ui";
+import {
+  HermesTelemetry, CostStatus, COST_STATUS_ORDER, COST_STATUS_HINTS,
+  COST_STATUS_LABELS, outcomeBucketLabel, outcomeBucketSplit,
+} from "@/lib/hermesTelemetry";
 import SourceBadge from "@/components/SourceBadge";
 import HermesIcon from "@/components/icons/HermesIcon";
 import { formatTokens, formatCost } from "@/lib/format";
@@ -80,7 +84,9 @@ export default function HermesPage() {
   const profilesRes = useResource<{ profiles: { name: string }[] }>("/hermes/profiles", { pollMs: 60_000 });
   const gateway = overviewRes.data?.gateway;
   const cronJobs = overviewRes.data?.cron_jobs ?? [];
-  // "all" | "default" | profile name — scopes every number and list below.
+  // "all" | "default" | profile name. Scopes the summary tiles, the sources and
+  // models cards, and the grouped session tables. The Telemetry section is not
+  // profile-scoped: its endpoint always covers every profile.
   const [profileScope, setProfileScope] = useState<string>("all");
   const allHermesSessions = useMemo(
     () => (sessionsRes.data ?? []).filter((s) => s.agent === "hermes"),
@@ -384,6 +390,9 @@ export default function HermesPage() {
         </div>
       )}
 
+      {/* Telemetry: outcomes, cost provenance, latency, tool reliability */}
+      <TelemetrySection />
+
       {/* Cron jobs */}
       {cronJobs.length > 0 && (
         <Card>
@@ -559,6 +568,364 @@ export default function HermesPage() {
           </Table>
         </Card>
       ))}
+    </div>
+  );
+}
+
+/** Telemetry from /hermes/telemetry. The endpoint is not profile-scoped, so
+ *  this section always covers every profile regardless of the pill selection.
+ *  Renders nothing while loading, on error (older backend without the route),
+ *  or when Hermes isn't installed. The page's own empty state covers that. */
+function TelemetrySection() {
+  const res = useResource<HermesTelemetry>("/hermes/telemetry", { pollMs: 60_000 });
+  const t = res.data;
+  if (!t || !t.available) return null;
+
+  const { outcomes, cost, latency, tools, log_coverage } = t;
+  const latencySessions = latency.captured_sessions + latency.uncaptured_sessions;
+  // Sessions in the unknown bucket split two ways: ones whose raw end_reason
+  // has no mapping yet (listed by name) and ones where Hermes recorded no
+  // end_reason at all (no raw string to list, so they need saying separately).
+  const unknownTotal = outcomes.buckets.find((b) => b.outcome === "unknown")?.count ?? 0;
+  const unknownNamed = outcomes.unknown_raw.reduce((acc, u) => acc + u.count, 0);
+  const unknownBlank = Math.max(0, unknownTotal - unknownNamed);
+  // Statuses that carry a real API-equivalent figure. `zero-marginal` and
+  // `unpriced` both sit at $0 for different reasons and neither belongs here.
+  const PRICED: CostStatus[] = ["provider-reported", "provider-estimated", "tt-computed"];
+  const pricedSessions = PRICED.reduce((acc, k) => acc + (cost.confidence[k] ?? 0), 0);
+  const zeroMarginalSessions = cost.confidence["zero-marginal"] ?? 0;
+  // Nothing could be priced: total_usd is 0 because there was nothing to price,
+  // not because the sessions cost nothing.
+  const nothingPriced = pricedSessions === 0 && zeroMarginalSessions === 0;
+  // Everything priceable priced out at $0 because the models are local or
+  // subscription-covered. total_usd is 0 and that IS the answer, but it is an
+  // answer about marginal cost, not about what the tokens would cost at API
+  // rates. Printing "API equiv. $0.00" here would be the false claim.
+  const allZeroMarginal = pricedSessions === 0 && zeroMarginalSessions > 0;
+  // Slice of total_usd covered by a flat subscription. Older backends don't send
+  // the field, so treat a missing value as 0 and drop the line rather than
+  // rendering "$NaN". The share is only meaningful against a non-zero total.
+  const includedUsd = cost.subscription_included_usd ?? 0;
+  const includedPct = cost.total_usd > 0 ? (includedUsd / cost.total_usd) * 100 : null;
+  // Same reason as subscription_included_usd above: a dev running this build
+  // against an older backend gets no breakdowns, and an undefined .length here
+  // would white-screen the page instead of dropping two panels.
+  const bySource = outcomes.by_source ?? [];
+  const byModel = outcomes.by_model ?? [];
+  // by_model is capped at the 10 largest, so it can sum to less than
+  // session_count. Say so rather than letting the numbers quietly not add up.
+  const modelsTotal = outcomes.models_total ?? byModel.length;
+  const modelsHidden = Math.max(0, modelsTotal - byModel.length);
+  const latencyStats = [
+    ["avg", latency.avg_s],
+    ["p50", latency.p50_s],
+    ["p95", latency.p95_s],
+  ] as const;
+
+  return (
+    <Section
+      title="Telemetry"
+      description="Outcomes, cost provenance, latency and tool reliability across every Hermes profile."
+    >
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        {/* Outcomes */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Session outcomes</CardTitle>
+            <div className="ml-auto text-[11px] tabular text-[var(--tt-fg-muted)]">
+              {(outcomes.completion_rate * 100).toFixed(1)}% completed · {t.session_count} sessions
+            </div>
+          </CardHeader>
+          <div className="px-5 pb-5 space-y-2">
+            {outcomes.buckets.map((b) => (
+              <div key={b.outcome} className="flex items-center justify-between text-[12px]">
+                <span className="text-[var(--tt-fg)]">{outcomeBucketLabel(b.outcome)}</span>
+                <span className="tabular text-[var(--tt-fg-muted)]">
+                  {b.count} · {b.pct.toFixed(1)}%
+                </span>
+              </div>
+            ))}
+            {outcomes.buckets.some((b) => b.outcome === "continued") && (
+              <p className="text-[10px] text-[var(--tt-fg-dim)] pt-1 leading-snug">
+                Continued means the session handed off to a child through compression, a branch, or
+                a resume. That is neither a completion nor a failure, so it is left out of the
+                completed share above.
+              </p>
+            )}
+            {(outcomes.unknown_raw.length > 0 || unknownBlank > 0) && (
+              <div className="pt-2 space-y-1 border-t border-[var(--tt-border)]">
+                {outcomes.unknown_raw.map((u) => (
+                  <div key={u.raw} className="flex items-center justify-between text-[11px]">
+                    <span className="font-mono text-[var(--tt-fg-muted)] truncate max-w-[70%]" title={u.raw}>
+                      unknown: {u.raw}
+                    </span>
+                    <span className="tabular text-[var(--tt-fg-dim)]">({u.count})</span>
+                  </div>
+                ))}
+                {unknownBlank > 0 && (
+                  <div className="flex items-center justify-between text-[11px]">
+                    <span className="text-[var(--tt-fg-muted)]">no end_reason recorded</span>
+                    <span className="tabular text-[var(--tt-fg-dim)]">({unknownBlank})</span>
+                  </div>
+                )}
+                <p className="text-[10px] text-[var(--tt-fg-dim)] pt-1 leading-snug">
+                  {outcomes.unknown_raw.length > 0
+                    ? "Values Hermes reports that TokenTelemetry has no mapping for. They stay unknown instead of counting as completed."
+                    : "Hermes left these sessions without an end_reason, so there is nothing to classify. They stay unknown instead of counting as completed."}
+                </p>
+              </div>
+            )}
+            {bySource.length > 0 && (
+              <OutcomeBreakdown
+                title="By source"
+                rows={bySource.map((r) => ({ key: r.source, total: r.total, buckets: r.buckets }))}
+              />
+            )}
+            {byModel.length > 0 && (
+              <OutcomeBreakdown
+                title="By model"
+                rows={byModel.map((r) => ({ key: r.model, total: r.total, buckets: r.buckets }))}
+                note={
+                  modelsHidden > 0
+                    ? `Top ${byModel.length} of ${modelsTotal} models. ${modelsHidden} smaller model${modelsHidden === 1 ? "" : "s"} not shown, so these rows sum to less than ${t.session_count}.`
+                    : undefined
+                }
+              />
+            )}
+          </div>
+        </Card>
+
+        {/* Cost provenance */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Cost confidence</CardTitle>
+            <div className="ml-auto flex items-center gap-1.5 text-[11px] tabular text-[var(--tt-fg-muted)]">
+              {/* Same labels the session pill uses. "API equiv." is what the
+                  tokens would cost at API rates, which is not what the user was
+                  billed for subscription-included sessions. When every priced
+                  session is zero-marginal the total is a statement about
+                  marginal cost instead, so the label says that. */}
+              <span
+                className="text-[10px] font-medium text-[var(--tt-fg-dim)] uppercase tracking-[0.14em]"
+                title={allZeroMarginal ? COST_STATUS_HINTS["zero-marginal"] : undefined}
+              >
+                {allZeroMarginal ? "Marginal cost" : "API equiv."}
+              </span>
+              {/* formatCost renders 0 as "$0.00", which reads as "these sessions
+                  were free". When nothing could be priced there is no total to
+                  show, so say that instead of printing a zero. */}
+              {nothingPriced ? (
+                <span className="text-[var(--tt-fg-dim)]">not captured</span>
+              ) : allZeroMarginal ? (
+                formatCost(0)
+              ) : (
+                formatCost(cost.total_usd)
+              )}
+            </div>
+          </CardHeader>
+          <div className="px-5 pb-5 space-y-2">
+            {COST_STATUS_ORDER.map((k) => {
+              const n = cost.confidence[k] ?? 0;
+              const usd = cost.usd_by_confidence[k] ?? 0;
+              return (
+                <div key={k} className="flex items-center justify-between text-[12px]">
+                  {/* Readable label, not the wire key: a `title` tooltip does
+                      not exist on touch devices, so the jargon must not be the
+                      only discoverable text. */}
+                  <span className="text-[11px] text-[var(--tt-fg)]" title={COST_STATUS_HINTS[k]}>
+                    {COST_STATUS_LABELS[k]}
+                  </span>
+                  <span className="tabular text-[var(--tt-fg-muted)]">
+                    {n} session{n === 1 ? "" : "s"} ·{" "}
+                    {k === "unpriced" ? (
+                      <span className="text-[var(--tt-fg-dim)]">not captured</span>
+                    ) : (
+                      formatCost(usd)
+                    )}
+                  </span>
+                </div>
+              );
+            })}
+            {/* Session-count gate, not a dollar gate. Zero-marginal sessions
+                contribute $0 to every total on this card, so gating their
+                explanation on dollars suppressed it exactly when the zeros
+                needed explaining. */}
+            {zeroMarginalSessions > 0 && (
+              <p className="text-[10px] text-[var(--tt-fg-dim)] pt-1 leading-snug">
+                {zeroMarginalSessions} session{zeroMarginalSessions === 1 ? "" : "s"} ran on a local
+                model or a model covered by a subscription you already pay for. Their marginal cost
+                is {formatCost(0)}, which is an answer, not a missing number. What the same tokens
+                would cost at API rates is not counted in the total above.
+              </p>
+            )}
+            {/* Prose, not another row: this is a slice of the total above, and
+                another justify-between row would read as a bucket that sums
+                with the rest. Kept on its own dollar gate because it describes
+                a share of a non-zero total, unlike the line above. */}
+            {includedUsd > 0 && (
+              <p className="text-[10px] text-[var(--tt-fg-dim)] pt-1 leading-snug">
+                Of that total, {formatCost(includedUsd)}
+                {includedPct == null ? "" : ` (${includedPct.toFixed(1)}%)`} came from sessions
+                Hermes marked subscription-included, so it carries no marginal cost.
+              </p>
+            )}
+            <p className="text-[10px] text-[var(--tt-fg-dim)] pt-1 leading-snug">
+              Reported by Hermes means Hermes returned the number itself; priced by TokenTelemetry
+              means the tokens were priced locally from public rates.
+            </p>
+          </div>
+        </Card>
+
+        {/* Latency */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Latency</CardTitle>
+            <div className="ml-auto text-[11px] tabular text-[var(--tt-fg-muted)]">
+              {latency.api_calls.toLocaleString()} API call{latency.api_calls === 1 ? "" : "s"}
+            </div>
+          </CardHeader>
+          <div className="px-5 pb-5 space-y-3">
+            <div className="grid grid-cols-3 gap-2">
+              {latencyStats.map(([label, v]) => (
+                <div
+                  key={label}
+                  className="bg-[var(--tt-sunken)] border border-[var(--tt-border)] rounded-[var(--tt-radius)] px-3 py-2"
+                >
+                  <div className="text-[9px] uppercase tracking-[0.18em] text-[var(--tt-fg-dim)]">{label}</div>
+                  {v == null ? (
+                    <div className="text-[11px] text-[var(--tt-fg-dim)]">not captured</div>
+                  ) : (
+                    <div className="text-[14px] font-mono tabular text-[var(--tt-fg)]">{v}s</div>
+                  )}
+                </div>
+              ))}
+            </div>
+            <div className="text-[11px] text-[var(--tt-fg-muted)]">
+              Captured for {latency.captured_sessions} of {latencySessions} session
+              {latencySessions === 1 ? "" : "s"}. Hermes only writes API-call timings to its
+              rotating log, so older sessions lose them.
+            </div>
+            {latency.by_model.length > 0 && (
+              <div className="space-y-1 pt-1 border-t border-[var(--tt-border)]">
+                {latency.by_model.slice(0, 4).map((m) => (
+                  <div key={m.model} className="flex items-center justify-between text-[11px] pt-1">
+                    <span className="font-mono text-[var(--tt-fg-muted)] truncate max-w-[50%]" title={m.model}>
+                      {m.model}
+                    </span>
+                    <span className="tabular text-[var(--tt-fg-dim)]">
+                      {m.calls} · avg {m.avg_s == null ? "not captured" : `${m.avg_s}s`}
+                      {m.p95_s == null ? "" : ` · p95 ${m.p95_s}s`}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </Card>
+
+        {/* Tools */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Tools</CardTitle>
+          </CardHeader>
+          <div className="px-5 pb-5 space-y-3">
+            {!tools.captured ? (
+              <div className="text-[12px] text-[var(--tt-fg-dim)]">
+                Tool calls not captured. No tool lines were found in the Hermes logs.
+              </div>
+            ) : (
+              <>
+                {tools.top_by_calls.length > 0 && (
+                  <div className="space-y-1">
+                    <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--tt-fg-dim)]">
+                      Most used
+                    </div>
+                    {tools.top_by_calls.map((row) => (
+                      <div key={row.tool} className="flex items-center justify-between text-[12px]">
+                        <span className="font-mono text-[var(--tt-fg)] truncate max-w-[50%]" title={row.tool}>
+                          {row.tool}
+                        </span>
+                        <span className="tabular text-[var(--tt-fg-muted)]">
+                          {row.calls} call{row.calls === 1 ? "" : "s"} ·{" "}
+                          {row.avg_duration_s == null ? "duration not captured" : `${row.avg_duration_s}s avg`}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+                {/* The backend only lists tools that actually failed, so an empty
+                    list means no failures were found, not that failures went
+                    unread. Say which, or the panel disappears without a word. */}
+                <div className="space-y-1 pt-2 border-t border-[var(--tt-border)]">
+                  <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--tt-fg-dim)]">
+                    Highest failure rate
+                  </div>
+                  {tools.top_by_failure_rate.length === 0 ? (
+                    <div className="text-[12px] text-[var(--tt-fg-muted)]">
+                      No failures recorded for tools with at least 3 calls.
+                    </div>
+                  ) : (
+                    <>
+                      {tools.top_by_failure_rate.map((row) => (
+                        <div key={row.tool} className="flex items-center justify-between text-[12px]">
+                          <span className="font-mono text-[var(--tt-fg)] truncate max-w-[50%]" title={row.tool}>
+                            {row.tool}
+                          </span>
+                          <span className="tabular text-[var(--tt-fg-muted)]">
+                            {(row.failure_rate * 100).toFixed(1)}% of {row.calls} call
+                            {row.calls === 1 ? "" : "s"}
+                          </span>
+                        </div>
+                      ))}
+                      <p className="text-[10px] text-[var(--tt-fg-dim)] pt-1 leading-snug">
+                        Tools with at least 3 calls only.
+                      </p>
+                    </>
+                  )}
+                </div>
+              </>
+            )}
+          </div>
+        </Card>
+      </div>
+
+      <div className="text-[10px] text-[var(--tt-fg-dim)] px-0.5 leading-snug">
+        {log_coverage.files_read.length > 0
+          ? `Read from ${log_coverage.files_read.join(", ")}.`
+          : "No Hermes log files were readable."}{" "}
+        {log_coverage.sessions_with_log} of {log_coverage.sessions_total} sessions have log lines.
+      </div>
+    </Section>
+  );
+}
+
+/** Outcome split for one dimension (source or model). Rows carry the total plus
+ *  the bucket breakdown, so a source that never completes is visible instead of
+ *  being averaged into the page-wide completion rate. Unknown buckets are shown
+ *  like any other; the raw end_reason strings stay in the list above. */
+function OutcomeBreakdown({
+  title, rows, note,
+}: {
+  title: string;
+  rows: { key: string; total: number; buckets: Record<string, number> }[];
+  note?: string;
+}) {
+  return (
+    <div className="pt-2 space-y-1 border-t border-[var(--tt-border)]">
+      <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--tt-fg-dim)]">
+        {title}
+      </div>
+      {rows.map((r) => (
+        <div key={r.key} className="flex items-baseline justify-between gap-3 text-[11px]">
+          <span className="font-mono text-[var(--tt-fg-muted)] truncate max-w-[45%]" title={r.key}>
+            {r.key}
+          </span>
+          <span className="tabular text-[var(--tt-fg-dim)] text-right">
+            {r.total} · {outcomeBucketSplit(r.buckets)}
+          </span>
+        </div>
+      ))}
+      {note && <p className="text-[10px] text-[var(--tt-fg-dim)] pt-1 leading-snug">{note}</p>}
     </div>
   );
 }

--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -5,7 +5,7 @@ import { createPortal } from "react-dom";
 import { useParams, useSearchParams, useRouter } from "next/navigation";
 import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { ArrowLeft, Brain, Code, MessageSquare, Terminal, User, Users, FileText, Activity, Zap, Info, Sparkles, GitBranch, LayoutPanelLeft, ListMusic, ChevronRight, ChevronLeft, Play, Pause, Wrench, Cpu, Folder, AlertTriangle, Hash, Clock, FileCode, Settings2, ChevronDown, ChevronUp, Copy, Maximize2, X, Repeat, Globe, ExternalLink, Target } from "lucide-react";
+import { ArrowLeft, Brain, Code, MessageSquare, Terminal, User, Users, FileText, Activity, Zap, Info, Sparkles, GitBranch, LayoutPanelLeft, ListMusic, ChevronRight, ChevronLeft, Play, Pause, Wrench, Cpu, Folder, AlertTriangle, Hash, Clock, FileCode, Settings2, ChevronDown, ChevronUp, Copy, Maximize2, X, Repeat, Globe, ExternalLink, Target, DollarSign } from "lucide-react";
 import Link from "next/link";
 import { format } from "date-fns";
 import { AgentBadge, Badge, Button, Skeleton } from "@/components/ui";
@@ -16,6 +16,7 @@ import SummaryPanel from "@/components/summarizer/SummaryPanel";
 import { apiFetch, artifactUrl } from "@/lib/api";
 import { formatTokens, formatCost } from "@/lib/format";
 import { resolveSessionBackTarget } from "@/lib/navigation";
+import { CostStatus, COST_STATUS_LABELS, COST_STATUS_HINTS, outcomeLabel } from "@/lib/hermesTelemetry";
 import { coerceReasoningText } from "@/lib/reasoning";
 
 interface Artifact {
@@ -67,6 +68,12 @@ interface Session {
   hermes_profile?: string;
   parent_session_id?: string | null;
   end_reason?: string | null;
+  /** Hermes-only: how the cost figure was arrived at (absent on other agents). */
+  cost_status?: CostStatus;
+  /** Hermes-only: canonical outcome bucket for end_reason. */
+  outcome?: string | null;
+  /** Hermes-only: the raw end_reason behind `outcome`, null when there was none. */
+  outcome_raw?: string | null;
   /** TRACE loop metadata; present only on loop sessions (see backend /sessions) */
   loop?: any;
   /** Goal Mode (`/goal`); a session can set several, so this is a list */
@@ -732,6 +739,18 @@ export default function SessionDetailPage() {
                     </Badge>
                   );
                 })()}
+                {/* Hermes: how the session ended, and how its cost was arrived at.
+                    Lives in this always-visible row rather than the chain banner,
+                    which only mounts for chained (compression) sessions. */}
+                {agent === "hermes" && sessionInfo && (
+                  <HermesOutcomeBadge outcome={sessionInfo.outcome} raw={sessionInfo.outcome_raw} />
+                )}
+                {agent === "hermes" && sessionInfo && (
+                  <HermesCostPill
+                    cost={sessionInfo.tokens?.cost ?? sessionInfo.cost}
+                    status={sessionInfo.cost_status}
+                  />
+                )}
               </div>
               {sessionInfo?.tokens && (
                 <div className="hidden lg:flex items-center gap-3 bg-[var(--tt-sunken)] px-3 h-9 rounded-[var(--tt-radius)] border border-[var(--tt-border)]">
@@ -1210,6 +1229,63 @@ function StatPill({ icon, label, value, tone }: { icon: React.ReactNode; label: 
       <span className="text-[var(--tt-fg-faint)]">{icon}</span>
       <span className="text-[10px] font-medium text-[var(--tt-fg-dim)] uppercase tracking-[0.14em]">{label}</span>
       <span className={`text-[12px] font-semibold tabular ${toneCls}`}>{value}</span>
+    </div>
+  );
+}
+
+/** How this Hermes session ended. An outcome the backend couldn't map renders
+ *  as `unknown: <raw>` so a value nobody has classified yet stays visible
+ *  instead of being folded into a bucket it doesn't belong to. */
+function HermesOutcomeBadge({ outcome, raw }: { outcome?: string | null; raw?: string | null }) {
+  const label = outcomeLabel(outcome, raw);
+  if (!label) return null;
+  const unknown = label.startsWith("unknown");
+  return (
+    <Badge
+      variant={unknown ? "outline" : "neutral"}
+      size="sm"
+      className="normal-case font-mono"
+      title={raw ? `Hermes end_reason: ${raw}` : "Hermes recorded no end_reason for this session"}
+    >
+      {label}
+    </Badge>
+  );
+}
+
+/** Session cost plus where the number came from. Three shapes, because $0.00
+ *  under an "API equiv." label makes two different false claims:
+ *   - `unpriced`: nothing to price, so show "not captured" instead of a figure.
+ *   - `zero-marginal`: priced, and the answer really is $0 because the model is
+ *     local or subscription-covered. The API equivalent of those tokens is NOT
+ *     zero, so the label switches to "Marginal cost" rather than printing a
+ *     zero under a claim about API rates.
+ *   - anything else: the API-equivalent figure plus its provenance. */
+function HermesCostPill({ cost, status }: { cost?: number; status?: CostStatus }) {
+  const zeroMarginal = status === "zero-marginal";
+  const unpriced = !zeroMarginal && (status === "unpriced" || cost == null);
+  return (
+    <div className="inline-flex items-center gap-1.5 bg-[var(--tt-panel)] border border-[var(--tt-border)] rounded-md px-2 h-7">
+      <span className="text-[var(--tt-fg-faint)]"><DollarSign size={11} /></span>
+      <span
+        className="text-[10px] font-medium text-[var(--tt-fg-dim)] uppercase tracking-[0.14em]"
+        title={zeroMarginal ? COST_STATUS_HINTS["zero-marginal"] : undefined}
+      >
+        {zeroMarginal ? "Marginal cost" : "API equiv."}
+      </span>
+      <span className={`text-[12px] font-semibold tabular ${unpriced ? "text-[var(--tt-fg-dim)]" : "text-[var(--tt-fg)]"}`}>
+        {zeroMarginal ? formatCost(0) : unpriced ? "not captured" : formatCost(cost)}
+      </span>
+      {/* No provenance tail for zero-marginal: the "Marginal cost" label above
+          already carries the claim, and repeating "no marginal cost" beside a
+          $0.00 is noise. */}
+      {status && !unpriced && !zeroMarginal && (
+        <span
+          className="text-[9px] text-[var(--tt-fg-dim)] border-l border-[var(--tt-border)] pl-1.5"
+          title={COST_STATUS_HINTS[status]}
+        >
+          {COST_STATUS_LABELS[status]}
+        </span>
+      )}
     </div>
   );
 }
@@ -2726,7 +2802,11 @@ function HermesOverlayCard({ overlay }: { overlay: any }) {
   const journey: string[] = overlay?.model_journey || [];
   const mem = overlay?.memory_io;
   const apiCalls = overlay?.api_calls || [];
-  if (!perf && journey.length === 0 && (!mem || mem.total === 0)) return null;
+  // "not_captured" = no API-call lines survive for this session (Hermes rotates
+  // agent.log). Worth saying out loud rather than rendering nothing.
+  const notCaptured =
+    (perf?.log_coverage ?? overlay?.log_coverage) === "not_captured";
+  if (!perf && journey.length === 0 && (!mem || mem.total === 0) && !notCaptured) return null;
   return (
     <div className="mb-8 bg-[var(--tt-panel)]/60 border border-[#eab308]/30 rounded-[var(--tt-radius-lg)] p-5 group">
       <div className="flex items-center justify-between mb-3">
@@ -2750,6 +2830,12 @@ function HermesOverlayCard({ overlay }: { overlay: any }) {
           <Stat label="Total latency" value={`${perf.total_latency_s}s`} />
           <Stat label="Avg latency" value={`${perf.avg_latency_s}s`} />
           <Stat label="Cache hit" value={perf.cache_hit_pct != null ? `${perf.cache_hit_pct}%` : "—"} />
+        </div>
+      )}
+      {notCaptured && (
+        <div className="text-[11px] text-[var(--tt-fg-dim)] mb-3 leading-snug">
+          Per-call latency not captured for this session. Hermes writes API-call timings
+          to a rotating log, so older sessions no longer have them.
         </div>
       )}
       {mem && mem.total > 0 && (
@@ -2988,11 +3074,18 @@ function HermesChainBanner({ current, all, from }: { current: Session; all: Sess
     : null;
   const children = all.filter((s) => s.parent_session_id === current.id);
   if (!parent && children.length === 0) return null;
-  const reasonLabel = (r?: string | null) =>
-    r === "compression" ? "compression continuation" :
-    r === "orphaned_compression" ? "orphaned compression" :
-    r === "branched" ? "branched" : null;
-  const cur = reasonLabel(current.end_reason);
+  // Chain-specific phrasing where the raw reason has one, otherwise the
+  // canonical outcome label (which renders `unknown: <raw>` for anything the
+  // backend has no mapping for, rather than dropping it).
+  const chainRaw = (s: Session) => s.outcome_raw ?? s.end_reason ?? null;
+  const chainLabel = (s: Session) => {
+    const raw = chainRaw(s);
+    if (raw === "compression") return "compression continuation";
+    if (raw === "orphaned_compression") return "orphaned compression";
+    if (raw === "branched") return "branched";
+    return outcomeLabel(s.outcome, raw);
+  };
+  const cur = chainLabel(current);
   return (
     <div className="mb-6 bg-violet-500/5 border border-violet-500/20 rounded-[var(--tt-radius-lg)] p-3">
       <div className="text-[9px] font-black uppercase tracking-[0.2em] text-violet-300 mb-2 flex items-center gap-2">
@@ -3018,7 +3111,7 @@ function HermesChainBanner({ current, all, from }: { current: Session; all: Sess
           >
             <span className="truncate max-w-[200px]">{c.display || c.id}</span>
             <ChevronRight size={11} />
-            {reasonLabel(c.end_reason) === "branched" && (
+            {chainRaw(c) === "branched" && (
               <span className="text-[9px] text-violet-300 ml-0.5">branched</span>
             )}
           </Link>

--- a/frontend/src/lib/hermesTelemetry.ts
+++ b/frontend/src/lib/hermesTelemetry.ts
@@ -1,0 +1,214 @@
+"use client";
+
+import { api } from "./api";
+
+// Mirrors the backend payload returned by GET /hermes/telemetry.
+// Field names are wire-format: a typo here type-checks fine and breaks at
+// runtime, so keep them byte-identical to the endpoint.
+
+/** How a session's dollar figure was arrived at.
+ *  `zero-marginal` is a priced answer that happens to be $0 (local model, or a
+ *  model/endpoint listed in power.json subscriptionModels). It is a positive
+ *  claim about marginal cost, not a missing value like `unpriced`, and it must
+ *  never be rendered as an API-equivalent dollar figure. */
+export type CostStatus =
+  | "provider-reported"
+  | "provider-estimated"
+  | "tt-computed"
+  | "zero-marginal"
+  | "unpriced";
+
+/** Canonical session-outcome buckets. Anything Hermes reports that isn't in
+ *  the backend mapping table lands in "unknown" and keeps its raw string. */
+export type OutcomeBucket =
+  | "completed"
+  | "interrupted"
+  | "timed_out"
+  | "continued"
+  | "reset"
+  | "errored"
+  | "unknown";
+
+export interface OutcomeCount {
+  outcome: string;
+  count: number;
+  /** Already a percentage (36.4 means 36.4%), not a 0..1 fraction. */
+  pct: number;
+}
+
+export interface UnknownOutcome {
+  raw: string;
+  count: number;
+}
+
+export interface OutcomeBySource {
+  source: string;
+  total: number;
+  /** bucket name -> count; sparse, only non-zero buckets appear. */
+  buckets: Record<string, number>;
+}
+
+export interface OutcomeByModel {
+  model: string;
+  total: number;
+  buckets: Record<string, number>;
+}
+
+export interface HermesOutcomes {
+  buckets: OutcomeCount[];
+  unknown_raw: UnknownOutcome[];
+  /** 0..1 fraction; multiply by 100 to display. */
+  completion_rate: number;
+  by_source: OutcomeBySource[];
+  /** Capped at the 10 largest models, so this can sum to less than
+   *  `session_count`. Compare against `models_total` before trusting it as a
+   *  full breakdown. `by_source` is never capped. */
+  by_model: OutcomeByModel[];
+  /** How many distinct models exist before the `by_model` cap. Older backends
+   *  don't send it; fall back to `by_model.length`. */
+  models_total?: number;
+}
+
+export interface HermesCost {
+  total_usd: number;
+  /** Portion of `total_usd` from sessions Hermes marked cost_status='included',
+   *  i.e. covered by a flat subscription. A subset of the total, not an extra
+   *  amount: never add it to `total_usd` or render it as its own bucket. */
+  subscription_included_usd: number;
+  /** Session counts per provenance. */
+  confidence: Record<CostStatus, number>;
+  /** Dollars per provenance. `unpriced` is always 0 and means "not captured",
+   *  not "free". Never render it as a dollar figure. */
+  usd_by_confidence: Record<CostStatus, number>;
+}
+
+export interface LatencyByModel {
+  model: string;
+  calls: number;
+  /** null when the model has no timed API calls. Never 0-as-missing. */
+  avg_s: number | null;
+  p95_s: number | null;
+}
+
+export interface HermesLatency {
+  captured_sessions: number;
+  uncaptured_sessions: number;
+  api_calls: number;
+  /** null (not 0) when api_calls === 0. */
+  avg_s: number | null;
+  p50_s: number | null;
+  p95_s: number | null;
+  by_model: LatencyByModel[];
+}
+
+export interface ToolStat {
+  tool: string;
+  calls: number;
+  failures: number;
+  /** 0..1 fraction; multiply by 100 to display. */
+  failure_rate: number;
+  /** null when no duration was captured for the tool. Never 0-as-missing. */
+  avg_duration_s: number | null;
+}
+
+export interface HermesTools {
+  /** false when no tool lines were parsed out of the logs; both lists are []. */
+  captured: boolean;
+  top_by_calls: ToolStat[];
+  /** Only tools with calls >= 3; a single failed call isn't a signal. */
+  top_by_failure_rate: ToolStat[];
+}
+
+export interface HermesLogCoverage {
+  /** Log file names actually read, e.g. ["agent.log.1", "agent.log"]. */
+  files_read: string[];
+  sessions_with_log: number;
+  sessions_total: number;
+}
+
+export interface HermesTelemetryData {
+  available: true;
+  session_count: number;
+  outcomes: HermesOutcomes;
+  cost: HermesCost;
+  latency: HermesLatency;
+  tools: HermesTools;
+  log_coverage: HermesLogCoverage;
+}
+
+/** Union, not an optional-field interface: the endpoint returns nothing but
+ *  `{available: false}` when no Hermes DB exists, so the guard is mandatory. */
+export type HermesTelemetry = { available: false } | HermesTelemetryData;
+
+export const getHermesTelemetry = () => api<HermesTelemetry>("/hermes/telemetry");
+
+// --- Display helpers -------------------------------------------------------
+
+/** Order the cost split is always rendered in (most trustworthy first). */
+export const COST_STATUS_ORDER: CostStatus[] = [
+  "provider-reported",
+  "provider-estimated",
+  "tt-computed",
+  "zero-marginal",
+  "unpriced",
+];
+
+/** Visible text for a status. These are the labels users read; the raw wire
+ *  keys are never rendered. Both maps are total Records on purpose: adding a
+ *  status to the union fails the build until it has a label and a hint. */
+export const COST_STATUS_LABELS: Record<CostStatus, string> = {
+  "provider-reported": "reported by Hermes",
+  "provider-estimated": "estimated by Hermes",
+  "tt-computed": "priced by TokenTelemetry",
+  "zero-marginal": "no marginal cost",
+  unpriced: "not captured",
+};
+
+export const COST_STATUS_HINTS: Record<CostStatus, string> = {
+  "provider-reported": "Hermes recorded the actual charge for this session.",
+  "provider-estimated": "Hermes recorded its own estimate, not a billed amount.",
+  "tt-computed": "TokenTelemetry priced the token counts locally.",
+  "zero-marginal":
+    "TokenTelemetry priced it and the answer is $0: the model runs locally or is covered by a subscription you already pay for.",
+  unpriced: "No cost and no token counts to price. Not captured, not zero.",
+};
+
+const OUTCOME_LABELS: Record<OutcomeBucket, string> = {
+  completed: "completed",
+  interrupted: "interrupted",
+  timed_out: "timed out",
+  continued: "continued",
+  reset: "reset",
+  errored: "errored",
+  unknown: "unknown",
+};
+
+/** Human label for a bucket. An unrecognised bucket is treated as unknown so a
+ *  future backend value can never masquerade as a known outcome. */
+export function outcomeBucketLabel(outcome: string): string {
+  return OUTCOME_LABELS[outcome as OutcomeBucket] ?? "unknown";
+}
+
+/**
+ * One-line split of a sparse bucket map, e.g. "13 continued, 8 completed".
+ * Ordered by count desc then bucket name, so the same data always renders the
+ * same way. Zero-count buckets never appear (the backend omits them).
+ */
+export function outcomeBucketSplit(buckets: Record<string, number>): string {
+  return Object.entries(buckets)
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([bucket, n]) => `${n} ${outcomeBucketLabel(bucket)}`)
+    .join(", ");
+}
+
+/**
+ * Label for one session's outcome. Unmapped values render as
+ * `unknown: <raw>` so an outcome nobody has classified yet is visible rather
+ * than silently folded into a bucket it doesn't belong to.
+ */
+export function outcomeLabel(outcome?: string | null, raw?: string | null): string | null {
+  if (!outcome) return null;
+  const known = outcome in OUTCOME_LABELS && outcome !== "unknown";
+  if (known) return OUTCOME_LABELS[outcome as OutcomeBucket];
+  return raw ? `unknown: ${raw}` : "unknown";
+}


### PR DESCRIPTION
Closes four gaps in the Hermes reader, all cases where TokenTelemetry already had the data and either dropped it or rendered a confident number it had not earned. Prompted by the umbrella observability issue upstream, NousResearch/hermes-agent#6642.

## What was wrong

Measured against the real `~/.hermes` on this machine (22 sessions) before any code changed:

| | before | after |
|---|---|---|
| sessions showing per-call latency | 0 of 22 | 14 of 22, other 8 say "not captured" |
| sessions showing an outcome | 13 of 22 | 22 of 22 |
| cost figures labelled with their source | none | all |
| tool failure rates | parsed, then discarded | shown |

## Latency

`_hermes_log_summary` only ever opened `~/.hermes/logs/agent.log`. Once Hermes rotated it the timing vanished, silently, with no indication anything was missing. All 328 API-call lines on this machine are in `agent.log.1`.

Rotated files are now parsed too. Ordering is a correctness requirement, not a detail: `agent.log.1` is *older* than `agent.log`, so a lexical glob sort reverses the timeline and corrupts `model_journey`. The index sorts on `(-numeric_suffix, name)`, oldest first, and handles `.10` vs `.9` numerically.

Reading N files per session would be O(sessions x lines), so the parse happens once into a module-level index keyed by session id, invalidated on `(name, st_mtime_ns, st_size)` under a lock. Cold parse of 10MB is ~18ms; warm lookups ~0.2ms. A session with no timing anywhere reports `log_coverage: "not_captured"` rather than zero.

## Cost provenance

The dollar figure could come from Hermes's `actual_cost_usd`, its `estimated_cost_usd`, or our own `calculate_cost`, and all three rendered identically. Each session now carries `cost_status`.

Five states, because a zero has three different meanings:

- `provider-reported` / `provider-estimated` — the number came from Hermes
- `tt-computed` — TokenTelemetry priced it and got a real figure
- `zero-marginal` — priced successfully and the answer is genuinely $0, because the model runs locally or is covered by a subscription. This is a finding, not a missing value, and it is not the same claim as "the API equivalent is $0.00"
- `unpriced` — could not be priced, renders "not captured", never `$0.00`

A session with no tokens at all is `unpriced` regardless of model: there was nothing to price, so "local model, therefore free" would be a claim we did not earn.

Note on this machine's data: `provider-estimated` is 0 even though 17 sessions have a non-null `estimated_cost_usd`. All 17 hold the literal sentinel `0.0` with `cost_source='none'`, which the pre-existing #176 override discards and re-prices. No dollar figure shown came from Hermes, so labelling any of them "provider-estimated" would misdescribe it. The bucket stays in the schema for installs where Hermes does report estimates.

The aggregate total is labelled API-equivalent and states how much came from sessions Hermes marked subscription-included ($6.45 of $7.34 here), since an unqualified total is ~88% flat-subscription usage on this machine.

## Outcomes

`end_reason` was stored but only three values were displayed, so `cli_close` and `resumed_other` rendered as nothing at all. Every value now maps to one of seven buckets, aggregated by source and model, which is the "completion/failure rates by source and model" ask from the upstream issue.

An unmapped value routes to `unknown` and keeps its raw string on screen (`unknown: session_switch (3)`) rather than being folded into `completed`. That is the failure mode #6642 warns about most: shipping metrics before outcome semantics are settled produces numbers that do not mean what people think. The mapping was grounded by reading the upstream source rather than guessing, but the design does not depend on the map being complete.

`continued` (compression, branch, resume) is deliberately excluded from the completion share, since a handoff to a child session is neither a completion nor a failure. The card says so, because "36.4% completed" otherwise reads as "most of my sessions don't finish".

## Verification

- 22 sessions; latency captured 14 / uncaptured 8; outcomes 8 completed / 13 continued / 1 unknown; cost 17 `tt-computed` / 5 `unpriced` totalling $7.337. Each number independently recomputed from `/sessions` and from a separate log re-parse, not by calling the new code.
- All 35 GET endpoints return 200, swept over real uvicorn servers and compared against an `origin/main` server reading a frozen copy of the same `~/.hermes` and `~/.tokentelemetry`. 29 of 34 shared responses byte-identical; the 5 that differ are the intended cost-status additions.
- `backend/test_hermes_telemetry.py`: 49 tests. Full suite 424 passed, with the same 23 pre-existing environment-dependent failures that fail identically on `origin/main`.
- `tsc --noEmit` clean.

An earlier revision of this branch crashed `/projects` and `/analytics` with a `TypeError` (a null cost reaching `+=`, where the `s.get("cost", 0.0)` default never applies because the key exists with value `None`). Caught by the endpoint sweep, fixed, and regression-tested at the consumer rather than only at the producer.

## Known remaining

- `backend/history_store.py:241` coerces `float(r.get("cost", 0.0) or 0.0)`, so a session that reads "not captured" live comes back as a confident `$0.00` once `/analytics` serves it from stored history. Pre-existing, but this change is what makes the distinction meaningful, so it is worth a follow-up.
- **No `PROCESS EVENT` extractor.** The newest comment on #6642 asks for provider-neutral usage in Hermes's process-lifecycle cards. There are zero occurrences of `PROCESS EVENT` across both log files and both state DBs on this machine, so an extractor would be untestable code written against a format we cannot observe. The `cost_status` and "not captured" semantics added here are the slot it drops into when Hermes ships it. Related: a Hermes-launched `claude -p` child is currently attributed to `claude` with no link back to the Hermes session that caused it, since our delegation linkage only follows `parent_session_id` (Hermes to Hermes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
