### PR TITLE
fix(antigravity): fix session trace parser and display intent extraction

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -670,14 +670,14 @@ _AG_STEP_REASONING = 15       # assistant reasoning narrative + a tool call
 _AG_STEP_TOOL_OUTPUT = 21     # result of a tool call
 _AG_STEP_SKIP = {90, 98, 23}  # system EPHEMERAL prompt, internal id, bare file ref
 _AG_TOOLNAME_RE = re.compile(rb'\x12.([a-z_]{3,40})\x1a')
-_AG_TEXT_RE = re.compile(rb'[\x09\x0a\x20-\x7e]{16,}')
+_AG_TEXT_RE = re.compile(rb'(?:[\x09\x0a\x20-\x7e]|[\xc2-\xf4][\x80-\xbf]+){10,}')
 _AG_ARGJSON_RE = re.compile(rb'\{(?:[^{}\\]|\\.|\{(?:[^{}\\]|\\.)*\})*\}')
 
 
 def _ag_best_text(payload: bytes) -> str:
     """Longest readable text run in a step blob, excluding JSON arg objects."""
     runs = [t.decode("utf-8", "ignore") for t in _AG_TEXT_RE.findall(payload or b"")]
-    runs = [r for r in runs if not r.lstrip().startswith("{")]
+    runs = [r for r in runs if not r.lstrip().startswith("{") and not re.match(r"^[a-f0-9\$-]{20,}$", r.strip(), re.IGNORECASE)]
     if not runs:
         return ""
     # Trim a leading 1-2 char protobuf framing token ("k\nicheck…" → "icheck…").
@@ -713,10 +713,57 @@ def _ag_event(role: str, content: list, sid: str, idx: int, order: int) -> Dict[
 
 
 def _antigravity_cli_trace(db_path: Path, session_id: str) -> List[Dict[str, Any]]:
-    """Build a Claude-format per-step trace from an agy session's SQLite steps.
+    """Build a Claude-format per-step trace from an agy session's transcript log or SQLite steps."""
+    # First, check if structured transcript.jsonl log exists in brain/
+    for brain_root in [ANTIGRAVITY_BRAIN_DIR] + list(ANTIGRAVITY_BRAIN_DIRS):
+        b_dir = brain_root / session_id / ".system_generated" / "logs"
+        for tname in ["transcript.jsonl", "transcript_full.jsonl"]:
+            tfile = b_dir / tname
+            if tfile.exists():
+                msgs: List[Dict[str, Any]] = []
+                order = 0
+                try:
+                    with open(tfile, "r", encoding="utf-8", errors="ignore") as f:
+                        for line in f:
+                            if not line.strip(): continue
+                            try: entry = json.loads(line)
+                            except Exception: continue
+                            stype = entry.get("type")
+                            content = entry.get("content", "")
+                            if stype == "USER_INPUT" and content:
+                                clean = re.sub(r"<USER_REQUEST>\s*", "", str(content))
+                                clean = re.sub(r"\s*</USER_REQUEST>.*", "", clean, flags=re.DOTALL).strip()
+                                if clean:
+                                    order += 1
+                                    msgs.append(_ag_event("user", [{"type": "text", "text": clean}], session_id, order, order))
+                            elif stype == "PLANNER_RESPONSE" or stype == "MODEL_RESPONSE":
+                                if isinstance(content, str) and content.strip():
+                                    order += 1
+                                    msgs.append(_ag_event("assistant", [{"type": "text", "text": content.strip()}], session_id, order, order))
+                                tool_calls = entry.get("tool_calls") or []
+                                for tc in tool_calls:
+                                    if isinstance(tc, dict) and tc.get("name"):
+                                        order += 1
+                                        msgs.append(_ag_event("assistant", [{
+                                            "type": "tool_use",
+                                            "id": tc.get("id", f"call-{order}"),
+                                            "name": tc.get("name"),
+                                            "input": tc.get("args") or tc.get("arguments") or {}
+                                        }], session_id, order, order))
+                            elif stype == "TOOL_RESULT":
+                                res = entry.get("output") or content or ""
+                                order += 1
+                                msgs.append(_ag_event("user", [{
+                                    "type": "tool_result",
+                                    "tool_use_id": entry.get("tool_call_id", f"call-{order}"),
+                                    "content": str(res)[:6000]
+                                }], session_id, order, order))
+                    if msgs:
+                        return msgs
+                except Exception:
+                    pass
 
-    Returns events the existing viewer renders (user / reasoning / tool / tool
-    output), or [] when nothing usable is found (caller falls back to brain)."""
+    # Fallback to SQLite steps parsing
     try:
         con = sqlite3.connect(_sqlite_ro_uri(db_path), uri=True)
     except sqlite3.Error:
@@ -748,9 +795,6 @@ def _antigravity_cli_trace(db_path: Path, session_id: str) -> List[Dict[str, Any
             msgs.append(_ag_event("user", [{"type": "tool_result", "content": text[:6000]}], session_id, idx, order))
         else:
             tool, args = _ag_tool_call(payload)
-            # Reasoning narrative and the tool call are split into separate steps
-            # so both are counted and render distinctly (thinking → reasoning, the
-            # call → tool).
             if stype == _AG_STEP_REASONING and text and not text.lstrip().startswith(("{", "<")):
                 order += 1
                 msgs.append(_ag_event("assistant", [{"type": "thinking", "text": text}], session_id, idx, order))
@@ -761,6 +805,46 @@ def _antigravity_cli_trace(db_path: Path, session_id: str) -> List[Dict[str, Any
                 order += 1
                 msgs.append(_ag_event("assistant", [{"type": "text", "text": text}], session_id, idx, order))
     return msgs
+
+
+def _antigravity_first_prompt(sid: str, fallback_text: str = "") -> str:
+    """Extract the first user prompt for an Antigravity session to use as display intent."""
+    for brain_root in [ANTIGRAVITY_BRAIN_DIR] + list(ANTIGRAVITY_BRAIN_DIRS):
+        b_dir = brain_root / sid / ".system_generated" / "logs"
+        for tname in ["transcript.jsonl", "transcript_full.jsonl"]:
+            tfile = b_dir / tname
+            if tfile.exists():
+                try:
+                    with open(tfile, "r", encoding="utf-8", errors="ignore") as f:
+                        for line in f:
+                            if not line.strip(): continue
+                            entry = json.loads(line)
+                            if entry.get("type") == "USER_INPUT":
+                                content = str(entry.get("content", ""))
+                                clean = re.sub(r"<USER_REQUEST>\s*", "", content)
+                                clean = re.sub(r"\s*</USER_REQUEST>.*", "", clean, flags=re.DOTALL).strip()
+                                if clean:
+                                    return clean[:100]
+                except Exception: pass
+
+    cli_db = ANTIGRAVITY_CLI_DIR / "conversations" / f"{sid}.db"
+    if cli_db.exists():
+        try:
+            con = sqlite3.connect(_sqlite_ro_uri(cli_db), uri=True)
+            rows = con.execute("SELECT step_payload FROM steps WHERE step_type = 14 LIMIT 5").fetchall()
+            con.close()
+            for (payload,) in rows:
+                if payload:
+                    runs = [t.decode("utf-8", "ignore") for t in _AG_TEXT_RE.findall(payload)]
+                    runs = [r for r in runs if not r.lstrip().startswith("{") and not re.match(r"^[a-f0-9\$-]{20,}$", r.strip(), re.IGNORECASE)]
+                    if runs:
+                        txt = max(runs, key=len).strip()
+                        txt = re.sub(r"^[a-zA-Z]{1,2}\n", "", txt).strip()
+                        if txt and not txt.startswith("command(") and not txt.startswith("./Users"):
+                            return txt[:100]
+        except Exception: pass
+
+    return (fallback_text or "Antigravity session")[:100]
 
 
 def _antigravity_cli_meta(cli_dir: Path = ANTIGRAVITY_CLI_DIR) -> Dict[str, Dict[str, Any]]:
@@ -5291,7 +5375,7 @@ def _scan_sessions_sync():
                 _cli = _ag_cli_meta.get(sid, {})
                 project = apply_alias(_cli.get("project") or _antigravity_infer_project((task or "") + "\n" + (plan or "")))
                 first_line = next((ln.strip() for ln in (task or plan or walkthrough).splitlines() if ln.strip() and not ln.strip().startswith("#")), "")
-                display = (first_line or "Antigravity session")[:100]
+                display = _antigravity_first_prompt(sid, first_line)
                 plans: List[dict] = []
                 if plan:
                     plans.append({"session_id": sid, "agent": "antigravity", "timestamp": latest_ts or _now(), "content": plan})

--- a/backend/main.py
+++ b/backend/main.py
@@ -547,9 +547,9 @@ def _antigravity_infer_project(text: str) -> str:
 def _estimate_antigravity_tokens(sess_dir: Path) -> dict:
     import logging
     tkns = {"input": 0, "output": 0, "cached": 0, "total": 0, "cost": 0.0}
-    tf = sess_dir / ".system_generated" / "logs" / "transcript.jsonl"
+    tf = sess_dir / ".system_generated" / "logs" / "transcript_full.jsonl"
     if not tf.exists():
-        tf = sess_dir / ".system_generated" / "logs" / "transcript_full.jsonl"
+        tf = sess_dir / ".system_generated" / "logs" / "transcript.jsonl"
     if not tf.exists():
         return tkns
         
@@ -718,6 +718,79 @@ def _ag_tool_call(payload: bytes):
     return name, args
 
 
+def _parse_gemini_chat_file(cf: Path) -> Optional[Dict[str, Any]]:
+    """Parse a Gemini/Antigravity chat log file (.json or .jsonl) into a normalized session dict."""
+    try:
+        with open(cf, "r", encoding="utf-8", errors="replace") as f:
+            raw = f.read().strip()
+        if not raw:
+            return None
+        # Try reading as single JSON object first
+        try:
+            data = json.loads(raw)
+            if isinstance(data, dict) and "sessionId" in data:
+                return data
+        except Exception:
+            pass
+
+        # Read as JSON Lines (.jsonl)
+        lines = [ln.strip() for ln in raw.splitlines() if ln.strip()]
+        header: Dict[str, Any] = {}
+        messages: List[Dict[str, Any]] = []
+        for i, line in enumerate(lines):
+            try:
+                entry = json.loads(line)
+            except Exception:
+                continue
+            if not isinstance(entry, dict):
+                continue
+            if "$set" in entry:
+                if isinstance(entry.get("$set"), dict) and "lastUpdated" in entry["$set"] and header:
+                    header["lastUpdated"] = entry["$set"]["lastUpdated"]
+                continue
+            if "sessionId" in entry and ("kind" in entry or "projectHash" in entry):
+                header = entry
+                continue
+
+            msg_type = entry.get("type", "unknown")
+            role = "user" if msg_type in ("user", "human") else ("gemini" if msg_type in ("gemini", "assistant", "model") else msg_type)
+            ts_str = entry.get("timestamp")
+
+            sid_str = header.get("sessionId", "msg")
+            msg: Dict[str, Any] = {
+                "id": entry.get("id", f"{sid_str}-{i}"),
+                "type": role,
+                "role": role,
+                "content": entry.get("content", ""),
+            }
+            if ts_str:
+                msg["timestamp"] = ts_str
+            if "thoughts" in entry:
+                msg["thoughts"] = entry["thoughts"]
+            if "toolCalls" in entry:
+                msg["toolCalls"] = entry["toolCalls"]
+            if "model" in entry:
+                msg["model"] = entry["model"]
+            if "tokens" in entry:
+                msg["tokens"] = entry["tokens"]
+            messages.append(msg)
+
+        if not header and not messages:
+            return None
+
+        return {
+            "sessionId": header.get("sessionId", ""),
+            "projectHash": header.get("projectHash", ""),
+            "startTime": header.get("startTime"),
+            "lastUpdated": header.get("lastUpdated"),
+            "kind": header.get("kind", "main"),
+            "messages": messages,
+        }
+    except Exception as exc:
+        _ag_log_warn("failed to parse gemini chat file %s: %s", cf, exc)
+        return None
+
+
 def _ag_event(role: str, content: list, sid: str, idx: int, order: int) -> Dict[str, Any]:
     return {
         "id": f"{sid}-step-{idx}",
@@ -729,11 +802,55 @@ def _ag_event(role: str, content: list, sid: str, idx: int, order: int) -> Dict[
 
 
 def _antigravity_cli_trace(db_path: Path, session_id: str) -> List[Dict[str, Any]]:
-    """Build a Claude-format per-step trace from an agy session's transcript log or SQLite steps."""
-    # First, check if structured transcript.jsonl log exists in brain/
-    for brain_root in [ANTIGRAVITY_BRAIN_DIR] + list(ANTIGRAVITY_BRAIN_DIRS):
+    """Build a Claude-format per-step trace from an agy session's SQLite steps or transcript log."""
+    # Try SQLite steps parsing first
+    if db_path and db_path.exists():
+        try:
+            con = sqlite3.connect(_sqlite_ro_uri(db_path), uri=True)
+            rows = con.execute(
+                "SELECT idx, step_type, step_payload FROM steps ORDER BY idx"
+            ).fetchall()
+            con.close()
+
+            msgs: List[Dict[str, Any]] = []
+            order = 0
+            for idx, stype, payload in rows:
+                if stype in _AG_STEP_SKIP or not payload:
+                    continue
+                text = _ag_best_text(payload)
+                if stype == _AG_STEP_USER:
+                    if not text:
+                        continue
+                    order += 1
+                    msgs.append(_ag_event("user", [{"type": "text", "text": text}], session_id, idx, order))
+                elif stype == _AG_STEP_TOOL_OUTPUT:
+                    if not text:
+                        continue
+                    order += 1
+                    msgs.append(_ag_event("user", [{"type": "tool_result", "content": text[:6000]}], session_id, idx, order))
+                else:
+                    tool, args = _ag_tool_call(payload)
+                    # Reasoning narrative and the tool call are split into separate steps
+                    # so both are counted and render distinctly (thinking → reasoning, the
+                    # call → tool).
+                    if stype == _AG_STEP_REASONING and text and not text.lstrip().startswith(("{", "<")):
+                        order += 1
+                        msgs.append(_ag_event("assistant", [{"type": "thinking", "text": text}], session_id, idx, order))
+                    if tool:
+                        order += 1
+                        msgs.append(_ag_event("assistant", [{"type": "tool_use", "name": tool, "input": args or {"preview": text[:600]}}], session_id, idx, order))
+                    elif stype != _AG_STEP_REASONING and text:
+                        order += 1
+                        msgs.append(_ag_event("assistant", [{"type": "text", "text": text}], session_id, idx, order))
+            if msgs:
+                return msgs
+        except Exception as exc:
+            _ag_log_warn("sqlite trace parse failed for %s: %s", db_path, exc)
+
+    # Fallback to structured transcript.jsonl log in brain/
+    for brain_root in ANTIGRAVITY_BRAIN_DIRS:
         b_dir = brain_root / session_id / ".system_generated" / "logs"
-        for tname in ["transcript.jsonl", "transcript_full.jsonl"]:
+        for tname in ["transcript_full.jsonl", "transcript.jsonl"]:
             tfile = b_dir / tname
             if tfile.exists():
                 msgs: List[Dict[str, Any]] = []
@@ -793,55 +910,14 @@ def _antigravity_cli_trace(db_path: Path, session_id: str) -> List[Dict[str, Any
                 except Exception as exc:
                     _ag_log_warn("transcript parse failed for %s: %s", tfile, exc)
 
-    # Fallback to SQLite steps parsing
-    try:
-        con = sqlite3.connect(_sqlite_ro_uri(db_path), uri=True)
-    except sqlite3.Error:
-        return []
-    try:
-        rows = con.execute(
-            "SELECT idx, step_type, step_payload FROM steps ORDER BY idx"
-        ).fetchall()
-    except sqlite3.Error:
-        return []
-    finally:
-        con.close()
-
-    msgs: List[Dict[str, Any]] = []
-    order = 0
-    for idx, stype, payload in rows:
-        if stype in _AG_STEP_SKIP or not payload:
-            continue
-        text = _ag_best_text(payload)
-        if stype == _AG_STEP_USER:
-            if not text:
-                continue
-            order += 1
-            msgs.append(_ag_event("user", [{"type": "text", "text": text}], session_id, idx, order))
-        elif stype == _AG_STEP_TOOL_OUTPUT:
-            if not text:
-                continue
-            order += 1
-            msgs.append(_ag_event("user", [{"type": "tool_result", "content": text[:6000]}], session_id, idx, order))
-        else:
-            tool, args = _ag_tool_call(payload)
-            if stype == _AG_STEP_REASONING and text and not text.lstrip().startswith(("{", "<")):
-                order += 1
-                msgs.append(_ag_event("assistant", [{"type": "thinking", "text": text}], session_id, idx, order))
-            if tool:
-                order += 1
-                msgs.append(_ag_event("assistant", [{"type": "tool_use", "name": tool, "input": args or {"preview": text[:600]}}], session_id, idx, order))
-            elif stype != _AG_STEP_REASONING and text:
-                order += 1
-                msgs.append(_ag_event("assistant", [{"type": "text", "text": text}], session_id, idx, order))
-    return msgs
+    return []
 
 
 def _antigravity_first_prompt(sid: str, fallback_text: str = "") -> str:
     """Extract the first user prompt for an Antigravity session to use as display intent."""
-    for brain_root in [ANTIGRAVITY_BRAIN_DIR] + list(ANTIGRAVITY_BRAIN_DIRS):
+    for brain_root in ANTIGRAVITY_BRAIN_DIRS:
         b_dir = brain_root / sid / ".system_generated" / "logs"
-        for tname in ["transcript.jsonl", "transcript_full.jsonl"]:
+        for tname in ["transcript_full.jsonl", "transcript.jsonl"]:
             tfile = b_dir / tname
             if tfile.exists():
                 try:
@@ -862,7 +938,10 @@ def _antigravity_first_prompt(sid: str, fallback_text: str = "") -> str:
     if cli_db.exists():
         try:
             con = sqlite3.connect(_sqlite_ro_uri(cli_db), uri=True)
-            rows = con.execute("SELECT step_payload FROM steps WHERE step_type = 14 ORDER BY idx ASC LIMIT 5").fetchall()
+            rows = con.execute(
+                "SELECT step_payload FROM steps WHERE step_type = ? ORDER BY idx ASC LIMIT 5",
+                (_AG_STEP_USER,),
+            ).fetchall()
             con.close()
             for (payload,) in rows:
                 if payload:
@@ -3657,7 +3736,9 @@ def _antigravity_subagent_children(sid: str) -> List[str]:
     INVOKE_SUBAGENT steps in its brain transcript. Empty when none/no transcript."""
     kids: List[str] = []
     for brain_dir in ANTIGRAVITY_BRAIN_DIRS:
-        tpath = brain_dir / sid / ".system_generated" / "logs" / "transcript.jsonl"
+        tpath = brain_dir / sid / ".system_generated" / "logs" / "transcript_full.jsonl"
+        if not tpath.exists():
+            tpath = brain_dir / sid / ".system_generated" / "logs" / "transcript.jsonl"
         try:
             if not tpath.exists():
                 continue
@@ -5155,9 +5236,11 @@ def _scan_sessions_sync():
             for _td in (GEMINI_DIR / "tmp").glob("*"):
                 _cd = _td / "chats"
                 if _cd.is_dir():
-                    for _cf in _cd.glob("*.json"):
+                    for _cf in list(_cd.glob("*.json")) + list(_cd.glob("*.jsonl")):
                         try:
-                            _all_chat_sids.add(json.loads(_cf.read_text(encoding="utf-8", errors="replace")).get("sessionId") or "")
+                            _d = _parse_gemini_chat_file(_cf)
+                            if _d and _d.get("sessionId"):
+                                _all_chat_sids.add(_d["sessionId"])
                         except Exception: pass
             _ag_surface = _antigravity_surface_map()  # session id → cli/ide/app, for sub-labels
             _seen_antigravity: set = set()  # global dedup across chat + logs + brain; first discovery wins (ensures real token versions from tmp preferred over brain estimates; kills intra-tmp chat dupes for same sid)
@@ -5175,79 +5258,77 @@ def _scan_sessions_sync():
                     project_path = apply_alias(gemini_slug_to_path.get(slug, f"System / {slug[:8]}"))
                 chat_dir = tmp_dir / "chats"
                 if chat_dir.exists():
-                    for cf in chat_dir.glob("*.json"):
+                    for cf in list(chat_dir.glob("*.json")) + list(chat_dir.glob("*.jsonl")):
                         try:
-                            with open(cf, "r", encoding="utf-8", errors="replace") as f:
-                                data = json.load(f); sid = data.get("sessionId")
-                                if not sid: continue
-                                # kind="main" means Gemini CLI; absent/other means Antigravity
-                                session_kind = data.get("kind")
-                                effective_agent = agent_type if session_kind == "main" else "antigravity"
-                                ts = _aware(datetime.fromisoformat(data.get("lastUpdated").replace('Z', '+00:00'))) if data.get("lastUpdated") else _file_mtime_utc(cf)
-                                tokens = {"input": 0, "output": 0, "cached": 0, "total": 0}
-                                mcp_tools = []; has_plan = False; first_msg = ""; plans = []
-                                tool_counts: Dict[str, int] = {}
-                                skill_counts: Dict[str, int] = {}
-                                has_user = False
-                                for msg in data.get("messages", []):
-                                    if msg.get("type") == "user":
-                                        has_user = True
-                                        txt = msg.get("content")[0].get("text", "") if isinstance(msg.get("content"), list) else str(msg.get("content"))
-                                        if not first_msg: first_msg = txt
-                                        if "/plan" in txt: has_plan = True
-                                    if msg.get("type") == "gemini":
-                                        mt = msg.get("tokens", {})
-                                        tokens["input"] += mt.get("input", 0); tokens["output"] += mt.get("output", 0)
-                                        tokens["cached"] += mt.get("cached", 0); tokens["total"] += mt.get("total", 0)
-                                    if "toolCalls" in msg:
-                                        for tc in msg["toolCalls"]:
-                                            if tc.get("name") not in mcp_tools: mcp_tools.append(tc.get("name"))
-                                            _count_tool(tool_counts, tc.get("name"))
-                                            # Gemini's structured skill signal.
-                                            if tc.get("name") == "activate_skill":
-                                                _sk = (tc.get("args") or {}).get("name")
-                                                if _sk:
-                                                    skill_counts[_sk] = skill_counts.get(_sk, 0) + 1
-                                            if tc.get("name") == "exit_plan_mode":
-                                                plan_text = ""
-                                                pp = (tc.get("args") or {}).get("plan_path")
-                                                if pp:
-                                                    try: 
-                                                        with open(pp, "r", encoding="utf-8", errors="replace") as pf:
-                                                            plan_text = pf.read()
-                                                    except Exception: plan_text = f"(plan stored at {pp})"
-                                                if not plan_text:
-                                                    plan_text = (tc.get("args") or {}).get("plan") or tc.get("resultDisplay") or ""
-                                                if plan_text:
-                                                    has_plan = True
-                                                    plans.append({"session_id": sid, "agent": effective_agent, "timestamp": ts, "content": plan_text})
+                            data = _parse_gemini_chat_file(cf)
+                            if not data: continue
+                            sid = data.get("sessionId")
+                            # kind="main" means Gemini CLI; absent/other means Antigravity
+                            session_kind = data.get("kind")
+                            effective_agent = agent_type if session_kind == "main" else "antigravity"
+                            ts = _aware(datetime.fromisoformat(data.get("lastUpdated").replace('Z', '+00:00'))) if data.get("lastUpdated") else _file_mtime_utc(cf)
+                            tokens = {"input": 0, "output": 0, "cached": 0, "total": 0}
+                            mcp_tools = []; has_plan = False; first_msg = ""; plans = []
+                            tool_counts: Dict[str, int] = {}
+                            skill_counts: Dict[str, int] = {}
+                            for msg in data.get("messages", []):
+                                if msg.get("type") == "user":
+                                    has_user = True
+                                    txt = msg.get("content")[0].get("text", "") if isinstance(msg.get("content"), list) else str(msg.get("content"))
+                                    if not first_msg: first_msg = txt
+                                    if "/plan" in txt: has_plan = True
+                                if msg.get("type") == "gemini":
+                                    mt = msg.get("tokens", {})
+                                    tokens["input"] += mt.get("input", 0); tokens["output"] += mt.get("output", 0)
+                                    tokens["cached"] += mt.get("cached", 0); tokens["total"] += mt.get("total", 0)
+                                if "toolCalls" in msg:
+                                    for tc in msg["toolCalls"]:
+                                        if tc.get("name") not in mcp_tools: mcp_tools.append(tc.get("name"))
+                                        _count_tool(tool_counts, tc.get("name"))
+                                        # Gemini's structured skill signal.
+                                        if tc.get("name") == "activate_skill":
+                                            _sk = (tc.get("args") or {}).get("name")
+                                            if _sk:
+                                                skill_counts[_sk] = skill_counts.get(_sk, 0) + 1
+                                        if tc.get("name") == "exit_plan_mode":
+                                            plan_text = ""
+                                            pp = (tc.get("args") or {}).get("plan_path")
+                                            if pp:
+                                                try: 
+                                                    with open(pp, "r", encoding="utf-8", errors="replace") as pf:
+                                                        plan_text = pf.read()
+                                                except Exception: plan_text = f"(plan stored at {pp})"
+                                            if not plan_text:
+                                                plan_text = (tc.get("args") or {}).get("plan") or tc.get("resultDisplay") or ""
+                                            if plan_text:
+                                                has_plan = True
+                                                plans.append({"session_id": sid, "agent": effective_agent, "timestamp": ts, "content": plan_text})
 
-                                # Skip "ghost" sessions
-                                if not has_user and tokens["total"] == 0 and not mcp_tools:
-                                    continue
+                            # Skip "ghost" sessions
+                            if not has_user and tokens["total"] == 0 and not mcp_tools:
+                                continue
 
-                                model = None
-                                for msg in data.get("messages", []):
-                                    if msg.get("model"): model = msg.get("model"); break
-                                    if msg.get("modelVersion"): model = msg.get("modelVersion"); break
+                            model = None
+                            for msg in data.get("messages", []):
+                                if msg.get("model"): model = msg.get("model"); break
+                                if msg.get("modelVersion"): model = msg.get("modelVersion"); break
 
-                                # Discover Antigravity chat-level media artifacts
-                                artifacts = []
-                                try:
-                                    art_dir = chat_dir.parent / "artifacts"
-                                    if art_dir.exists():
-                                        for af in art_dir.iterdir():
-                                            if af.suffix.lower() in (".mp4", ".mov"): artifacts.append({"name": af.name, "path": str(af), "type": "video"})
-                                            elif af.suffix.lower() in (".png", ".webp", ".jpg", ".jpeg"): artifacts.append({"name": af.name, "path": str(af), "type": "image"})
-                                except Exception: pass
+                            # Discover Antigravity chat-level media artifacts
+                            artifacts = []
+                            try:
+                                art_dir = chat_dir.parent / "artifacts"
+                                if art_dir.exists():
+                                    for af in art_dir.iterdir():
+                                        if af.suffix.lower() in (".mp4", ".mov"): artifacts.append({"name": af.name, "path": str(af), "type": "video"})
+                                        elif af.suffix.lower() in (".png", ".webp", ".jpg", ".jpeg"): artifacts.append({"name": af.name, "path": str(af), "type": "image"})
+                            except Exception: pass
 
-                                # Antigravity/Gemini token records expose no cache-write field; nothing to pass.
-                                tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"])
-                                if sid in _seen_antigravity: continue
-                                _seen_antigravity.add(sid)
-                                _g_sess = {"id": sid, "agent": effective_agent, "project": project_path, "timestamp": ts, "display": first_msg[:100], "tokens": tokens, "mcp_tools": mcp_tools, "has_plan": has_plan, "plans": plans, "model": model, "artifacts": artifacts, "antigravity_source": _ag_surface.get(sid), "cost": tokens["cost"]}
-                                _attach_tool_usage(_g_sess, tool_counts, skill_counts)
-                                sessions.append(_g_sess)
+                            # Antigravity/Gemini token records expose no cache-write field; nothing to pass.
+                            tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"])
+                            if sid in _seen_antigravity: continue
+                            _g_sess = {"id": sid, "agent": effective_agent, "project": project_path, "timestamp": ts, "display": first_msg[:100], "tokens": tokens, "mcp_tools": mcp_tools, "has_plan": has_plan, "plans": plans, "model": model, "artifacts": artifacts, "antigravity_source": _ag_surface.get(sid), "cost": tokens["cost"]}
+                            _attach_tool_usage(_g_sess, tool_counts, skill_counts)
+                            sessions.append(_g_sess)
                         except Exception: continue
                 # Scan logs.json for Antigravity sessions that have no chat JSON file
                 _logs_file = tmp_dir / "logs.json"
@@ -6639,21 +6720,24 @@ async def get_session_detail(session_id: str, agent: str):
                 "kind": "antigravity_brain",
                 "messages": messages,
             }
-        files = list((GEMINI_DIR / "tmp").glob(f"**/chats/session-*{session_id[:8]}*.json")) or list((GEMINI_DIR / "tmp").glob(f"**/chats/*{session_id}*.json"))
+        files = (
+            list((GEMINI_DIR / "tmp").glob(f"**/chats/session-*{session_id[:8]}*.json*"))
+            or list((GEMINI_DIR / "tmp").glob(f"**/chats/*{session_id}*.json*"))
+        )
         if files:
-            with open(files[0], "r", encoding="utf-8", errors="replace") as f:
-                data = json.load(f)
+            data = _parse_gemini_chat_file(files[0])
+            if data:
                 # Add normalized_timestamp to messages
                 for msg in data.get("messages", []):
-                    if msg.get("timestamp"):
+                    if msg.get("timestamp") and "normalized_timestamp" not in msg:
                         try:
                             ts = _aware(datetime.fromisoformat(msg["timestamp"].replace('Z', '+00:00')))
                             msg["normalized_timestamp"] = ts.timestamp() * 1000
                         except Exception: pass
                 return data
-        # Antigravity log-only sessions: synthesize messages from the per-tmp-dir
+        # Antigravity / Gemini log-only sessions: synthesize messages from the per-tmp-dir
         # logs.json that records every user/assistant turn with its sessionId.
-        if agent == "antigravity":
+        if agent in ("antigravity", "gemini"):
             log_messages = []
             log_base_ts = None
             for log_file in (GEMINI_DIR / "tmp").glob("*/logs.json"):

--- a/backend/main.py
+++ b/backend/main.py
@@ -5263,12 +5263,17 @@ def _scan_sessions_sync():
                             data = _parse_gemini_chat_file(cf)
                             if not data: continue
                             sid = data.get("sessionId")
+                            if not sid: continue
                             # kind="main" means Gemini CLI; absent/other means Antigravity
                             session_kind = data.get("kind")
                             effective_agent = agent_type if session_kind == "main" else "antigravity"
                             ts = _aware(datetime.fromisoformat(data.get("lastUpdated").replace('Z', '+00:00'))) if data.get("lastUpdated") else _file_mtime_utc(cf)
                             tokens = {"input": 0, "output": 0, "cached": 0, "total": 0}
                             mcp_tools = []; has_plan = False; first_msg = ""; plans = []
+                            # Must reset per file: this is a plain function-scope local, so a
+                            # stale True from an earlier chat file would disable the ghost
+                            # filter below for every remaining file in the scan.
+                            has_user = False
                             tool_counts: Dict[str, int] = {}
                             skill_counts: Dict[str, int] = {}
                             for msg in data.get("messages", []):
@@ -5326,6 +5331,7 @@ def _scan_sessions_sync():
                             # Antigravity/Gemini token records expose no cache-write field; nothing to pass.
                             tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"])
                             if sid in _seen_antigravity: continue
+                            _seen_antigravity.add(sid)
                             _g_sess = {"id": sid, "agent": effective_agent, "project": project_path, "timestamp": ts, "display": first_msg[:100], "tokens": tokens, "mcp_tools": mcp_tools, "has_plan": has_plan, "plans": plans, "model": model, "artifacts": artifacts, "antigravity_source": _ag_surface.get(sid), "cost": tokens["cost"]}
                             _attach_tool_usage(_g_sess, tool_counts, skill_counts)
                             sessions.append(_g_sess)

--- a/backend/main.py
+++ b/backend/main.py
@@ -674,10 +674,26 @@ _AG_TEXT_RE = re.compile(rb'(?:[\x09\x0a\x20-\x7e]|[\xc2-\xf4][\x80-\xbf]+){10,}
 _AG_ARGJSON_RE = re.compile(rb'\{(?:[^{}\\]|\\.|\{(?:[^{}\\]|\\.)*\})*\}')
 
 
+def _ag_log_warn(msg: str, *args: Any) -> None:
+    """Lazy logger for Antigravity parsing paths (avoids import-order coupling)."""
+    import logging
+    logging.getLogger("tokentelemetry.antigravity").warning(msg, *args)
+
+
+def _ag_text_runs(payload: bytes) -> List[str]:
+    """Decoded readable text runs from a step blob, excluding JSON arg objects
+    and long bare token / hex-id strings (e.g. session UUIDs)."""
+    runs = [t.decode("utf-8", "ignore") for t in _AG_TEXT_RE.findall(payload or b"")]
+    return [
+        r for r in runs
+        if not r.lstrip().startswith("{")
+        and not re.match(r"^[a-f0-9\$-]{20,}$", r.strip(), re.IGNORECASE)
+    ]
+
+
 def _ag_best_text(payload: bytes) -> str:
     """Longest readable text run in a step blob, excluding JSON arg objects."""
-    runs = [t.decode("utf-8", "ignore") for t in _AG_TEXT_RE.findall(payload or b"")]
-    runs = [r for r in runs if not r.lstrip().startswith("{") and not re.match(r"^[a-f0-9\$-]{20,}$", r.strip(), re.IGNORECASE)]
+    runs = _ag_text_runs(payload)
     if not runs:
         return ""
     # Trim a leading 1-2 char protobuf framing token ("k\nicheck…" → "icheck…").
@@ -722,6 +738,7 @@ def _antigravity_cli_trace(db_path: Path, session_id: str) -> List[Dict[str, Any
             if tfile.exists():
                 msgs: List[Dict[str, Any]] = []
                 order = 0
+                pending_tool_ids: List[str] = []
                 try:
                     with open(tfile, "r", encoding="utf-8", errors="ignore") as f:
                         for line in f:
@@ -744,24 +761,37 @@ def _antigravity_cli_trace(db_path: Path, session_id: str) -> List[Dict[str, Any
                                 for tc in tool_calls:
                                     if isinstance(tc, dict) and tc.get("name"):
                                         order += 1
+                                        tool_id = tc.get("id") or tc.get("tool_call_id") or f"call-{order}"
+                                        pending_tool_ids.append(tool_id)
                                         msgs.append(_ag_event("assistant", [{
                                             "type": "tool_use",
-                                            "id": tc.get("id", f"call-{order}"),
+                                            "id": tool_id,
                                             "name": tc.get("name"),
                                             "input": tc.get("args") or tc.get("arguments") or {}
                                         }], session_id, order, order))
                             elif stype == "TOOL_RESULT":
                                 res = entry.get("output") or content or ""
+                                tool_id = entry.get("tool_call_id") or entry.get("toolUseId")
+                                if tool_id:
+                                    try:
+                                        pending_tool_ids.remove(tool_id)
+                                    except ValueError:
+                                        pass
+                                elif pending_tool_ids:
+                                    # Some transcript versions omit the result's
+                                    # tool_call_id. Reuse the oldest pending call ID
+                                    # so the UI can still pair the result with its call.
+                                    tool_id = pending_tool_ids.pop(0)
                                 order += 1
                                 msgs.append(_ag_event("user", [{
                                     "type": "tool_result",
-                                    "tool_use_id": entry.get("tool_call_id", f"call-{order}"),
+                                    "tool_use_id": tool_id or f"call-{order}",
                                     "content": str(res)[:6000]
                                 }], session_id, order, order))
                     if msgs:
                         return msgs
-                except Exception:
-                    pass
+                except Exception as exc:
+                    _ag_log_warn("transcript parse failed for %s: %s", tfile, exc)
 
     # Fallback to SQLite steps parsing
     try:
@@ -825,24 +855,25 @@ def _antigravity_first_prompt(sid: str, fallback_text: str = "") -> str:
                                 clean = re.sub(r"\s*</USER_REQUEST>.*", "", clean, flags=re.DOTALL).strip()
                                 if clean:
                                     return clean[:100]
-                except Exception: pass
+                except Exception as exc:
+                    _ag_log_warn("first-prompt transcript read failed for %s: %s", tfile, exc)
 
     cli_db = ANTIGRAVITY_CLI_DIR / "conversations" / f"{sid}.db"
     if cli_db.exists():
         try:
             con = sqlite3.connect(_sqlite_ro_uri(cli_db), uri=True)
-            rows = con.execute("SELECT step_payload FROM steps WHERE step_type = 14 LIMIT 5").fetchall()
+            rows = con.execute("SELECT step_payload FROM steps WHERE step_type = 14 ORDER BY idx ASC LIMIT 5").fetchall()
             con.close()
             for (payload,) in rows:
                 if payload:
-                    runs = [t.decode("utf-8", "ignore") for t in _AG_TEXT_RE.findall(payload)]
-                    runs = [r for r in runs if not r.lstrip().startswith("{") and not re.match(r"^[a-f0-9\$-]{20,}$", r.strip(), re.IGNORECASE)]
+                    runs = _ag_text_runs(payload)
                     if runs:
                         txt = max(runs, key=len).strip()
                         txt = re.sub(r"^[a-zA-Z]{1,2}\n", "", txt).strip()
                         if txt and not txt.startswith("command(") and not txt.startswith("./Users"):
                             return txt[:100]
-        except Exception: pass
+        except Exception as exc:
+            _ag_log_warn("first-prompt sqlite read failed for %s: %s", cli_db, exc)
 
     return (fallback_text or "Antigravity session")[:100]
 

--- a/backend/test_antigravity_cli.py
+++ b/backend/test_antigravity_cli.py
@@ -106,6 +106,108 @@ def test_db_meta_regex_and_error_handling():
         assert main._antigravity_cli_meta(Path(d) / "does-not-exist") == {}
 
 
+def test_transcript_trace_pairs_missing_tool_result_ids_and_extracts_prompt():
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        sid = "sid-trace"
+        logs = root / "brain" / sid / ".system_generated" / "logs"
+        logs.mkdir(parents=True)
+        (logs / "transcript.jsonl").write_text(
+            "\n".join([
+                json.dumps({"type": "USER_INPUT", "content": "<USER_REQUEST>한글 요청</USER_REQUEST>"}),
+                json.dumps({"type": "MODEL_RESPONSE", "content": "진행합니다", "tool_calls": [
+                    {"name": "read_file", "args": {"path": "x"}},
+                ]}),
+                json.dumps({"type": "TOOL_RESULT", "output": "ok"}),
+            ]),
+            encoding="utf-8",
+        )
+        db = root / "session.db"
+        con = sqlite3.connect(db)
+        con.execute("CREATE TABLE steps (idx integer, step_type integer, step_payload blob)")
+        con.commit()
+        con.close()
+
+        originals = (
+            main.ANTIGRAVITY_BRAIN_DIR,
+            main.ANTIGRAVITY_BRAIN_DIRS,
+            main.ANTIGRAVITY_CLI_DIR,
+        )
+        main.ANTIGRAVITY_BRAIN_DIR = root / "brain"
+        main.ANTIGRAVITY_BRAIN_DIRS = [root / "brain"]
+        main.ANTIGRAVITY_CLI_DIR = root
+        try:
+            events = main._antigravity_cli_trace(db, sid)
+            tool = next(e for e in events if e["message"]["content"][0]["type"] == "tool_use")
+            result = next(e for e in events if e["message"]["content"][0]["type"] == "tool_result")
+            assert tool["message"]["content"][0]["id"] == "call-3"
+            assert result["message"]["content"][0]["tool_use_id"] == "call-3"
+            assert main._antigravity_first_prompt(sid) == "한글 요청"
+        finally:
+            (
+                main.ANTIGRAVITY_BRAIN_DIR,
+                main.ANTIGRAVITY_BRAIN_DIRS,
+                main.ANTIGRAVITY_CLI_DIR,
+            ) = originals
+
+
+def test_first_prompt_sqlite_fallback_is_ordered_by_step_index():
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        cli = root / "conversations"
+        cli.mkdir()
+        db = cli / "sid-order.db"
+        con = sqlite3.connect(db)
+        con.execute("CREATE TABLE steps (idx integer, step_type integer, step_payload blob)")
+        con.executemany(
+            "INSERT INTO steps VALUES (?, ?, ?)",
+            [
+                (20, 14, b"later prompt text"),
+                (10, 14, b"first prompt text"),
+            ],
+        )
+        con.commit()
+        con.close()
+
+        originals = (
+            main.ANTIGRAVITY_BRAIN_DIR,
+            main.ANTIGRAVITY_BRAIN_DIRS,
+            main.ANTIGRAVITY_CLI_DIR,
+        )
+        main.ANTIGRAVITY_BRAIN_DIR = root / "missing-brain"
+        main.ANTIGRAVITY_BRAIN_DIRS = [root / "missing-brain"]
+        main.ANTIGRAVITY_CLI_DIR = root
+        try:
+            assert main._antigravity_first_prompt("sid-order") == "first prompt text"
+        finally:
+            (
+                main.ANTIGRAVITY_BRAIN_DIR,
+                main.ANTIGRAVITY_BRAIN_DIRS,
+                main.ANTIGRAVITY_CLI_DIR,
+            ) = originals
+
+
+def test_text_runs_rejects_hex_uuids_and_json_but_keeps_unicode():
+    # (review #3/#2) `_ag_best_text` must not turn JSON arg objects, bare hex
+    # token/UUID strings, or unframed protobuf numbers into "the best text",
+    # while still surfacing real (incl. multibyte) content.
+    uuidlike = "a" * 32
+    hexid = "9f2c7b4d1e0a4632b5c8d6f7a1e3b4c5d6f7"
+    jsonobj = b'{"path": "/x/y", "mode": "write", "count": 12}'
+    korean = "한글 요청대로 파일을 수정했습니다"
+    # A payload of only hex/UUID + JSON must yield nothing usable.
+    assert main._ag_best_text(uuidlike.encode()) == ""
+    assert main._ag_best_text(hexid.encode()) == ""
+    assert main._ag_best_text(jsonobj) == ""
+    # A hex run embedded next to real text must not hijack the best-text pick.
+    mixed = f"{uuidlike} 실제 작업 내용\n{hexid}".encode()
+    best = main._ag_best_text(mixed)
+    assert best != uuidlike and best != hexid
+    assert "실제 작업 내용" in best
+    # Multibyte Korean is preserved (the reason the regex was widened).
+    assert main._ag_best_text(korean.encode()) == korean
+
+
 def test_projects_excludes_unassigned_sentinel():
     # The Antigravity "unassigned" bucket must never render as a project card,
     # while real workspaces still do. Sessions themselves remain in /sessions.

--- a/backend/test_antigravity_cli.py
+++ b/backend/test_antigravity_cli.py
@@ -343,6 +343,73 @@ def test_artifacts_serves_legit_under_allowlist():
                 pass
 
 
+def test_chat_scan_dedups_sids_and_drops_ghost_sessions():
+    """The chat branch must add every emitted sid to `_seen_antigravity` and reset
+    `has_user` per file.
+
+    Both are easy to lose when the loop body is re-indented. Without the `.add()`
+    the same session is re-emitted by the logs.json and brain branches (token
+    totals and cost inflate); without the per-file reset, `has_user` is a plain
+    function-scope local, so one chat file with a user turn disables the ghost
+    filter for every file scanned after it.
+    """
+    def chat(dirpath, name, sid, msgs):
+        (dirpath / name).write_text(json.dumps({
+            "sessionId": sid, "kind": "main", "projectHash": "proj-slug",
+            "lastUpdated": "2026-08-01T10:00:00Z", "messages": msgs,
+        }), encoding="utf-8")
+
+    user_msgs = [
+        {"type": "user", "content": "real prompt", "timestamp": "2026-08-01T10:00:00Z"},
+        {"type": "gemini", "content": "ok", "model": "gemini-2.5-pro",
+         "tokens": {"input": 100, "output": 50, "cached": 0, "total": 150}},
+    ]
+    ghost_msgs = [{"type": "gemini", "content": "",
+                   "tokens": {"input": 0, "output": 0, "cached": 0, "total": 0}}]
+
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        gem = root / "gemini"
+        chats = gem / "tmp" / "proj-slug" / "chats"
+        chats.mkdir(parents=True)
+        (gem / "projects.json").write_text(json.dumps({"projects": {"/tmp/demo": "proj-slug"}}))
+        chat(chats, "a-ghost.json", "ghost-1", ghost_msgs)
+        chat(chats, "b-real.json", "real-1", user_msgs)
+        chat(chats, "c-ghost.json", "ghost-2", ghost_msgs)
+        # Same sessionId in two files — the intra-tmp dupe `_seen_antigravity` kills.
+        chat(chats, "d-dup1.json", "dup-1", user_msgs)
+        chat(chats, "e-dup2.json", "dup-1", user_msgs)
+
+        # Point every other scanner at an empty dir so this stays hermetic and fast.
+        nowhere = root / "nowhere"
+        saved = {}
+        for attr in dir(main):
+            if not (attr.endswith(("_DIR", "_DIRS", "_BASE", "_STORAGE")) and attr.isupper()):
+                continue
+            val = getattr(main, attr)
+            if isinstance(val, Path):
+                saved[attr] = val
+                setattr(main, attr, nowhere)
+            elif isinstance(val, list) and val and all(isinstance(v, Path) for v in val):
+                saved[attr] = val
+                setattr(main, attr, [nowhere])
+        saved["GEMINI_DIR"] = saved.get("GEMINI_DIR", main.GEMINI_DIR)
+        main.GEMINI_DIR = gem
+        try:
+            found = main._scan_sessions_sync()
+        finally:
+            for attr, val in saved.items():
+                setattr(main, attr, val)
+
+        rows = [s for s in found if s["id"] in ("ghost-1", "ghost-2", "real-1", "dup-1")]
+        ids = [s["id"] for s in rows]
+        assert ids.count("dup-1") == 1, f"sid emitted twice: {ids}"
+        assert "ghost-1" not in ids and "ghost-2" not in ids, f"ghost session leaked: {ids}"
+        assert sorted(ids) == ["dup-1", "real-1"], ids
+        # 150 tokens each for real-1 and dup-1; a duplicate would read 450.
+        assert sum(s["tokens"]["total"] for s in rows) == 300
+
+
 if __name__ == "__main__":
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     failed = 0

--- a/backend/test_antigravity_cli.py
+++ b/backend/test_antigravity_cli.py
@@ -151,6 +151,59 @@ def test_transcript_trace_pairs_missing_tool_result_ids_and_extracts_prompt():
             ) = originals
 
 
+def test_cli_trace_prefers_sqlite_and_falls_back_to_transcript():
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        sid = "sid-fallback"
+        # 1. Setup valid SQLite DB with step events
+        db = root / "session.db"
+        con = sqlite3.connect(db)
+        con.execute("CREATE TABLE steps (idx integer, step_type integer, step_payload blob)")
+        con.executemany(
+            "INSERT INTO steps VALUES (?, ?, ?)",
+            [
+                (1, 14, b"sqlite prompt text"),
+                (2, 21, b"sqlite tool output"),
+            ],
+        )
+        con.commit()
+        con.close()
+
+        # 2. Setup transcript log
+        logs = root / "brain" / sid / ".system_generated" / "logs"
+        logs.mkdir(parents=True)
+        (logs / "transcript.jsonl").write_text(
+            json.dumps({"type": "USER_INPUT", "content": "<USER_REQUEST>transcript prompt</USER_REQUEST>"}) + "\n",
+            encoding="utf-8",
+        )
+
+        originals = (
+            main.ANTIGRAVITY_BRAIN_DIR,
+            main.ANTIGRAVITY_BRAIN_DIRS,
+            main.ANTIGRAVITY_CLI_DIR,
+        )
+        main.ANTIGRAVITY_BRAIN_DIR = root / "brain"
+        main.ANTIGRAVITY_BRAIN_DIRS = [root / "brain"]
+        main.ANTIGRAVITY_CLI_DIR = root
+        try:
+            # SQLite DB is valid -> returns SQLite steps (SQLite first)
+            events = main._antigravity_cli_trace(db, sid)
+            assert len(events) == 2
+            assert events[0]["message"]["content"][0]["text"] == "sqlite prompt text"
+
+            # Missing/empty SQLite DB -> falls back to transcript
+            missing_db = root / "nonexistent.db"
+            events_fb = main._antigravity_cli_trace(missing_db, sid)
+            assert len(events_fb) == 1
+            assert events_fb[0]["message"]["content"][0]["text"] == "transcript prompt"
+        finally:
+            (
+                main.ANTIGRAVITY_BRAIN_DIR,
+                main.ANTIGRAVITY_BRAIN_DIRS,
+                main.ANTIGRAVITY_CLI_DIR,
+            ) = originals
+
+
 def test_first_prompt_sqlite_fallback_is_ordered_by_step_index():
     with tempfile.TemporaryDirectory() as d:
         root = Path(d)
@@ -206,6 +259,26 @@ def test_text_runs_rejects_hex_uuids_and_json_but_keeps_unicode():
     assert "실제 작업 내용" in best
     # Multibyte Korean is preserved (the reason the regex was widened).
     assert main._ag_best_text(korean.encode()) == korean
+
+
+def test_parse_gemini_chat_file_supports_jsonl():
+    with tempfile.TemporaryDirectory() as d:
+        cf = Path(d) / "session-123.jsonl"
+        cf.write_text(
+            "\n".join([
+                json.dumps({"sessionId": "sid-jsonl", "kind": "main", "projectHash": "abc"}),
+                json.dumps({"id": "m1", "type": "user", "content": [{"text": "hello"}]}),
+                json.dumps({"id": "m2", "type": "gemini", "content": "world", "thoughts": [{"subject": "t1"}]}),
+            ]),
+            encoding="utf-8",
+        )
+        parsed = main._parse_gemini_chat_file(cf)
+        assert parsed is not None
+        assert parsed["sessionId"] == "sid-jsonl"
+        assert len(parsed["messages"]) == 2
+        assert parsed["messages"][0]["type"] == "user"
+        assert parsed["messages"][1]["type"] == "gemini"
+        assert parsed["messages"][1]["content"] == "world"
 
 
 def test_projects_excludes_unassigned_sentinel():

--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -351,7 +351,8 @@ export default function SessionDetailPage() {
         .then((res) => res.json())
         .then((data) => {
           const evts = normalizeTraceEvents(agent, data);
-          setRawEvents(Array.isArray(data) ? data : []);
+          const rawList = Array.isArray(data) ? data : (data?.messages || []);
+          setRawEvents(rawList);
           setEvents(evts);
           setPlaybackIndex(evts.length);
           setLoading(false)


### PR DESCRIPTION
## Summary
    
This PR fixes two issues with Antigravity CLI (`agy`) sessions in TokenTelemetry:
1. **Trace Viewer Error**: Fixed `"No per-step trace was found for this session"` when opening Antigravity sessions containing multi-byte (e.g. Korean) text or running from standard `transcript.jsonl` logs.
```plain
No trace available
  No per-step trace was found for this session. Antigravity CLI (agy) sessions render their full
  trajectory here; IDE/app or older log-only sessions keep just the metadata, which still appears
  in Insights and Analytics.
```
2. **Generic Session Intent**: Antigravity CLI sessions without IDE markdown artifacts (`task.md`) were previously all labeled with the generic title `"Antigravity session"`. Now, the user's actual prompt is dynamically extracted for the session intent column, consistent with Codex and Hermes sessions.

## Changes Made

#### 1. Backend (`backend/main.py`)

- **UTF-8 Support & Log Fallback in Trace Parser(`_antigravity_cli_trace`)**:
- Updated `_AG_TEXT_RE` regex to support multi-byte UTF-8 strings (such as Korean/multilingual prompts) when reading SQLite step blobs.
- Added support for reading structured `transcript.jsonl` logs under `brain/<sid>/. system_generated/logs/` as the primary source before falling back to SQLite `steps`.
- **User Prompt Extraction (`_antigravity_first_prompt`)**:
- Created a helper function to inspect `transcript.jsonl` or SQLite `steps` (`step_type = 14`) for the initial user request.
- Updated the session listing loop to populate the `display` attribute with the extracted user prompt instead of falling back to `"Antigravity session"`.

#### 2. Frontend (`frontend/src/app/sessions/[id]/page.tsx`)

- **Object Response Handling for `setRawEvents`**:
- Fixed `setRawEvents(Array.isArray(data) ? data : (data?.messages || []))` so that object responses from the Antigravity backend endpoint (`{ sessionId, kind, messages }`) correctly set `rawEvents`.

 ## Type of change

- [x] Bug fix
- [ ] New feature (new agent support, new dashboard view, etc.)
- [x] Improvement / refactor
- [ ] Docs / chore

## How to test

1. Run `./start.sh`
2. Navigate to the main dashboard or a project page containing Antigravity CLI sessions.
4. Verify that Antigravity sessions now show actual user request prompts in the **Session  intent** column instead of the generic `"Antigravity session"` label.
5. Click on an Antigravity CLI session to open its detail view  (`/sessions/<id>?agent=antigravity`).
6. Verify that per-step trace events (user prompt, assistant reasoning, tool calls, and  tool results) are parsed and rendered correctly without triggering the `"No trace available"` error.

## Checklist

 - [x] I tested this locally with `./start.sh`
 - [x] No secrets or API keys are included
 - [x] PR is focused on one change
 - [ ] README or CHANGELOG updated if needed

## Related issue
Closes #