### PR TITLE
chore(telemetry): make Hermes usage answerable at the sub-page level

### DIFF
--- a/backend/telemetry.py
+++ b/backend/telemetry.py
@@ -131,6 +131,13 @@ _ENUMS: Dict[str, set] = {
     "route": {
         "dashboard", "analytics", "traces", "projects", "project-detail",
         "hermes", "artifacts", "local-models", "settings", "sessions", "other",
+        # Hermes sub-surfaces. "hermes" alone meant the dashboard AND all eight
+        # sub-pages, so the one question worth asking of this data — which
+        # surface people actually come for — was unanswerable. These are route
+        # names, not content: a page either exists in this set or reports
+        # "other".
+        "hermes-skills", "hermes-tools", "hermes-profiles", "hermes-soul",
+        "hermes-memory", "hermes-gateway", "hermes-kanban", "hermes-schedules",
     },
     "dimension": {"agent", "model", "local-only", "day", "other"},
     "outcome": {"ok", "error", "empty", "unavailable", "other"},
@@ -140,6 +147,19 @@ _ENUMS: Dict[str, set] = {
         "plan-library", "project-insights", "delegation-view", "power-cost",
         "billing-mode", "search", "artifact-viewer", "share-stats",
         "hermes-dashboard",
+        # Hermes in-page actions. Route counts say where people landed; these
+        # say whether they did anything once there, which is the difference
+        # between a bounce and real use. Each is a bare label — no skill name,
+        # profile name, or session id ever rides along.
+        #
+        # Only four, because only four interactions exist. The tools and
+        # schedules pages are pure read-only displays with nothing to click,
+        # and the skills page's sole control is its filter box. Adding
+        # detail-view labels for those would ship enum values that can never
+        # fire, which reads in the data as "nobody uses this" rather than
+        # "there is nothing here to use". Route counts cover those pages.
+        "hermes-telemetry", "hermes-profile-switch",
+        "hermes-session-open", "hermes-skill-filter",
         # Budgets & alerts: "budgets" = opened the editor (adoption),
         # "budget-set" = saved a budget (the configuring action). No limit
         # value/cost ever rides along — only these two enum labels.

--- a/backend/test_telemetry_redaction.py
+++ b/backend/test_telemetry_redaction.py
@@ -94,6 +94,51 @@ def test_budget_feature_labels_survive_but_values_cannot():
     assert "150" not in _blob(payload)
 
 
+def test_hermes_subroutes_survive_but_profile_names_cannot():
+    """Each Hermes surface is countable on its own, which is the whole point of
+    splitting the old single "hermes" bucket. What must NOT become countable is
+    anything the user named themselves."""
+    for route in ("hermes", "hermes-skills", "hermes-tools", "hermes-profiles",
+                  "hermes-soul", "hermes-memory", "hermes-gateway",
+                  "hermes-kanban", "hermes-schedules"):
+        assert telemetry._sanitize_props("page.viewed", {"route": route}) == {"route": route}
+    # A profile name is user-chosen and identifying. Even shaped like a real
+    # sub-route it collapses, because it is not in the enum.
+    assert telemetry._sanitize_props(
+        "page.viewed", {"route": "hermes-my-startup"}) == {"route": "other"}
+    # A path smuggled in as a route never survives either.
+    payload = telemetry.build_event("page.viewed", {"route": "/hermes/profiles/acme-corp"})
+    assert payload["props"]["route"] == "other"
+    assert "acme-corp" not in _blob(payload)
+
+
+def test_hermes_action_labels_are_bare_and_have_no_passengers():
+    for label in ("hermes-telemetry", "hermes-profile-switch",
+                  "hermes-session-open", "hermes-skill-filter"):
+        assert telemetry._sanitize_props("feature.used", {"name": label}) == {"name": label}
+    # The things these actions are ABOUT are exactly what must not ride along:
+    # a session id, a filter query, a profile name. None are allowlisted keys
+    # for feature.used, so all are dropped rather than sanitized.
+    out = telemetry._sanitize_props("feature.used", {
+        "name": "hermes-session-open",
+        "session_id": "20260625_232833_46a941",
+        "query": "deploy secrets",
+        "profile": "founder",
+    })
+    assert out == {"name": "hermes-session-open"}
+    payload = telemetry.build_event("feature.used", {
+        "name": "hermes-skill-filter", "query": "my-private-repo-name"})
+    assert "my-private-repo-name" not in _blob(payload)
+
+
+def test_unimplemented_hermes_labels_are_not_allowlisted():
+    """Guards against re-adding detail-view labels for pages that have no detail
+    view. An enum value that can never fire reads in the data as "nobody uses
+    this" rather than "there is nothing here to use"."""
+    for label in ("hermes-tool-detail", "hermes-cron-detail", "hermes-skill-detail"):
+        assert telemetry._sanitize_props("feature.used", {"name": label}) == {"name": "other"}
+
+
 def test_unknown_event_name_is_bucketed():
     payload = telemetry.build_event("evil.exfiltrate", {"x": "/etc/passwd"})
     assert payload["eventName"] == "other"

--- a/frontend/src/app/hermes/page.tsx
+++ b/frontend/src/app/hermes/page.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { format, formatDistanceToNow } from "date-fns";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   Activity, DollarSign, Cpu, Power, AlertTriangle, Clock, CheckCircle2,
   BookOpen, Brain, ArrowRight, Sparkles, Users, Wrench, Signal, Timer,
@@ -192,7 +192,12 @@ export default function HermesPage() {
             return (
               <button
                 key={name}
-                onClick={() => setProfileScope(name)}
+                onClick={() => {
+                  setProfileScope(name);
+                  // Only the act of switching is recorded, never which profile:
+                  // profile names are user-chosen and would be identifying.
+                  if (!selected) trackEvent("feature.used", { name: "hermes-profile-switch" });
+                }}
                 className={`inline-flex items-center gap-1.5 font-mono text-[11px] px-2.5 h-7 rounded-full border transition-colors ${
                   selected
                     ? "border-[var(--tt-border-strong)] bg-[var(--tt-sunken)] text-[var(--tt-fg)]"
@@ -499,7 +504,15 @@ export default function HermesPage() {
                 .slice()
                 .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
                 .map((s) => (
-                  <TR key={s.id} interactive>
+                  <TR
+                    key={s.id}
+                    interactive
+                    // One handler on the row rather than on each of the five
+                    // cell links: clicks bubble, so this counts a session open
+                    // once regardless of which column was clicked. No session
+                    // id, model, or project is sent, only that it happened.
+                    onClick={() => trackEvent("feature.used", { name: "hermes-session-open" })}
+                  >
                     <TD className="pl-5">
                       <Link href={`/sessions/${s.id}?agent=hermes&from=${encodeURIComponent(pathname)}`} className="block">
                         <span className="inline-flex items-center gap-1.5">
@@ -579,6 +592,16 @@ export default function HermesPage() {
 function TelemetrySection() {
   const res = useResource<HermesTelemetry>("/hermes/telemetry", { pollMs: 60_000 });
   const t = res.data;
+  // Counted once per mount, and only when the section actually renders with
+  // data. Firing on mount regardless would count users who have no Hermes
+  // install as having "used" this. The 60s poll re-renders, hence the guard.
+  const available = Boolean(t?.available);
+  const counted = useRef(false);
+  useEffect(() => {
+    if (!available || counted.current) return;
+    counted.current = true;
+    trackEvent("feature.used", { name: "hermes-telemetry" });
+  }, [available]);
   if (!t || !t.available) return null;
 
   const { outcomes, cost, latency, tools, log_coverage } = t;

--- a/frontend/src/app/hermes/skills/page.tsx
+++ b/frontend/src/app/hermes/skills/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useMemo, useState } from "react";
 import { ArrowLeft, BookOpen, Search } from "lucide-react";
 import { useResource } from "@/lib/api";
+import { trackEvent } from "@/lib/telemetry";
 import {
   PageHeader, Card, CardHeader, CardTitle, StatTile, EmptyState, Badge,
 } from "@/components/ui";
@@ -73,7 +74,16 @@ export default function HermesSkillsPage() {
           type="text"
           placeholder="Filter skills…"
           value={filter}
-          onChange={(e) => setFilter(e.target.value)}
+          onChange={(e) => {
+            const next = e.target.value;
+            setFilter(next);
+            // Counted once per filtering session (empty -> non-empty), never
+            // per keystroke, and the query itself is never sent: skill names
+            // are user content. This is the only interaction this page has.
+            if (!filter.trim() && next.trim()) {
+              trackEvent("feature.used", { name: "hermes-skill-filter" });
+            }
+          }}
           className="w-full pl-9 pr-3 py-2 bg-[var(--tt-sunken)] border border-[var(--tt-border)] rounded-[var(--tt-radius)] text-[13px] text-[var(--tt-fg)] placeholder:text-[var(--tt-fg-dim)] focus:outline-none focus:border-[var(--tt-border-strong)]"
         />
       </div>

--- a/frontend/src/lib/telemetry.ts
+++ b/frontend/src/lib/telemetry.ts
@@ -64,6 +64,25 @@ export function trackEvent(event: ClientEvent, props?: Record<string, string>): 
   }
 }
 
+/** Hermes sub-pages that get their own route enum. Anything under /hermes that
+ *  is not listed here reports as plain "hermes" rather than inventing a value
+ *  the backend would collapse to "other" — an unknown sub-page is still a
+ *  Hermes visit, and losing it entirely would understate the section. Keep in
+ *  sync with the `route` enum in backend/telemetry.py. */
+const HERMES_SUBROUTES = [
+  "skills", "tools", "profiles", "soul",
+  "memory", "gateway", "kanban", "schedules",
+] as const;
+
+function hermesRoute(p: string): string {
+  const rest = p.slice("/hermes".length).replace(/^\/+/, "");
+  if (!rest) return "hermes";
+  const head = rest.split("/")[0];
+  return (HERMES_SUBROUTES as readonly string[]).includes(head)
+    ? `hermes-${head}`
+    : "hermes";
+}
+
 /** Map a Next.js pathname to one of the backend's allowlisted route enums. */
 export function routeOf(pathname: string): string {
   const p = pathname.replace(/\/+$/, "") || "/";
@@ -72,7 +91,7 @@ export function routeOf(pathname: string): string {
   if (p.startsWith("/local-models")) return "local-models";
   if (p.startsWith("/sessions")) return "traces";
   if (p.startsWith("/projects")) return p === "/projects" ? "projects" : "project-detail";
-  if (p.startsWith("/hermes")) return "hermes";
+  if (p.startsWith("/hermes")) return hermesRoute(p);
   if (p.startsWith("/settings")) return "settings";
   return "other";
 }


### PR DESCRIPTION
Stacked on #228 (base is `feat/hermes-telemetry-gaps`, since the `hermes-telemetry` event needs the section that PR adds). Review after #228, or squash-merge that one first and this rebases cleanly.

## The problem

We already collect Hermes usage through the Cloudflare proxy, so the pipe works. It just can't answer the only question worth asking of it.

`routeOf()` in `frontend/src/lib/telemetry.ts` collapsed **every** `/hermes/*` path into the single route enum `"hermes"`. There are nine surfaces under there (dashboard, skills, tools, profiles, soul, memory, gateway, kanban, schedules) and all nine looked identical in the data. None of the sub-pages emitted anything of their own. So we could see that people open Hermes, but not whether they came for the kanban board or the soul file.

## What this adds

**Eight sub-route enums** alongside the existing `hermes` for the dashboard. This uses the `page.viewed` event that already fires on every route change, so it's a mapping change, not new instrumentation.

**Four in-page action labels** on `feature.used`: `hermes-telemetry`, `hermes-profile-switch`, `hermes-session-open`, `hermes-skill-filter`. Route counts say where people landed; these say whether they did anything once there.

## Four labels, not six

The original sketch had `hermes-tool-detail`, `hermes-cron-detail`, and `hermes-skill-detail`. Those pages have nothing to attach them to: `tools` is 36 lines of static display, `schedules` is read-only by design (the CRUD is deliberately commented out per the project rules), and the skills page's only control is its filter box.

Shipping them would have put enum values in the schema that can never fire. In the data that reads as "nobody uses this" rather than "there is nothing here to use", which is worse than not collecting it at all. Route counts already cover those pages. `test_unimplemented_hermes_labels_are_not_allowlisted` pins them as non-allowlisted so they don't get re-added on autopilot later.

`hermes-skill-filter` replaces `hermes-skill-detail` because it's the one interaction that page actually has.

## Privacy

Unchanged by construction, and tested rather than asserted. These are enum values, not free text. The only allowlisted prop key for `feature.used` is `name`, and a value outside the enum collapses to `"other"` before it's serialized. A profile name, filter query, or session id cannot ride along even if someone passes one carelessly.

Tests cover: every new value surviving; a route shaped like a real sub-route but user-named (`hermes-my-startup`) still collapsing to `other`; a path smuggled in as a route (`/hermes/profiles/acme-corp`) collapsing with the org name absent from the serialized blob; and a session id, query, and profile name passed alongside a valid label all being dropped.

No change to `never_collected`, and no change to the transparency preview's event list, which derives from `_EVENT_PROPS` keys rather than the enums.

## Counting is guarded so the numbers mean something

- The telemetry section counts **once per mount**, and only when it renders with data. Firing on mount regardless would count users with no Hermes install as having used it. It also survives the 60s poll re-render, which the existing `hermes-dashboard` event does not guard against.
- A profile pill re-clicked while already selected does not count.
- The skills filter counts on empty → non-empty, not per keystroke.

## Verification

Ran in the browser against the dev server, intercepting the actual POST bodies rather than trusting the code path:

- All eight sub-routes emit exactly once per visit: `hermes-skills`, `hermes-tools`, `hermes-profiles`, `hermes-soul`, `hermes-memory`, `hermes-gateway`, `hermes-kanban`, `hermes-schedules`.
- 5 filter keystrokes produced exactly 2 events (the two empty → non-empty transitions).
- Re-clicking the already-selected profile produced none; two real switches produced two.
- Backend suite 427 passed, with the same 23 pre-existing environment-dependent failures that fail identically on `origin/main`. `tsc --noEmit` clean.

Nothing was sent to the production sink during verification, and no telemetry preference was modified.

## Labelled `chore:`, not `feat:`

Per the project rule, `UPDATE.json` is a curated **user-facing** feed and mislabelled `feat:` commits should be re-labelled rather than padded with a fake entry. This adds no UI and changes nothing a user can see, so it gets no release note.

## Caveat on reading the resulting data

These are **event counts, not unique users**. There's no persisted device id, and `app.launched` is heavily bot-contaminated. "Kanban got 3× the views of Soul" is a fair read. "40 people use Kanban" is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
