### PR TITLE
fix(sessions): sort project-scoped config first and label the colour coding

### DIFF
--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -1293,6 +1293,29 @@ function StepRow({ step, active, beyond, onClick }: { step: Step; active: boolea
   );
 }
 
+// Project-scoped entries live in the repo's own .claude/ (or equivalent) and are
+// the ones a reader is usually looking for, so they sort above the user-scoped
+// ones inherited from ~/. Ties break alphabetically.
+const byScopeThenName = (a: any, b: any) =>
+  (a?.scope === "project" ? 0 : 1) - (b?.scope === "project" ? 0 : 1) ||
+  String(a?.name ?? "").localeCompare(String(b?.name ?? ""));
+
+// Skills tint project scope cyan, MCP badges tint it blue. The swatch has to
+// match whichever section it sits under or the legend lies about the colour.
+function ScopeLegend({ tone }: { tone: "cyan" | "blue" }) {
+  const project = tone === "cyan" ? "bg-cyan-500/10 border-cyan-500/20" : "bg-blue-500/10 border-blue-500/20";
+  return (
+    <div className="flex items-center gap-3 mt-1.5 text-[9px] font-mono text-[var(--tt-fg-faint)]">
+      <span className="flex items-center gap-1">
+        <span className={`inline-block w-2 h-2 rounded-sm border ${project}`} /> project
+      </span>
+      <span className="flex items-center gap-1">
+        <span className="inline-block w-2 h-2 rounded-sm border tt-tint-2 border-[var(--tt-border-strong)]" /> user
+      </span>
+    </div>
+  );
+}
+
 function ContextPanel({ ctx }: { ctx: any }) {
   const Row = ({ k, v, mono = true }: { k: string; v?: any; mono?: boolean }) =>
     v ? (
@@ -1351,8 +1374,9 @@ function ContextPanel({ ctx }: { ctx: any }) {
               <summary className="text-[9px] font-semibold uppercase tracking-[0.16em] text-[var(--tt-fg-dim)] cursor-pointer hover:text-[var(--tt-fg)]">
                 Skills ({ctx.projectConfig.counts.skills}) ▸
               </summary>
+              <ScopeLegend tone="cyan" />
               <div className="mt-2 flex flex-wrap gap-1.5">
-                {ctx.projectConfig.skills.map((s: any, i: number) => (
+                {[...(ctx.projectConfig.skills ?? [])].sort(byScopeThenName).map((s: any, i: number) => (
                   <span
                     key={i}
                     title={`${s.scope} · ${s.agent}${s.description ? "\n" + s.description : ""}`}
@@ -1369,8 +1393,9 @@ function ContextPanel({ ctx }: { ctx: any }) {
               <summary className="text-[9px] font-semibold uppercase tracking-[0.16em] text-[var(--tt-fg-dim)] cursor-pointer hover:text-[var(--tt-fg)]">
                 MCP Servers ({ctx.projectConfig.counts.mcps}) ▸
               </summary>
+              <ScopeLegend tone="blue" />
               <div className="mt-2 space-y-1">
-                {ctx.projectConfig.mcps.map((m: any, i: number) => (
+                {[...(ctx.projectConfig.mcps ?? [])].sort(byScopeThenName).map((m: any, i: number) => (
                   <div key={i} className="flex items-center justify-between gap-2 text-[10px] font-mono bg-[var(--tt-panel)]/70 border border-[var(--tt-border)] rounded px-2 py-1">
                     <span className="text-[var(--tt-fg)] truncate" title={m.command || m.url || ""}>{m.name}</span>
                     <span className={`px-1.5 py-0.5 rounded text-[8px] font-black uppercase ${m.scope === "project" ? "bg-blue-500/10 text-[var(--tt-brand)] border border-blue-500/20" : "tt-tint-2 text-[var(--tt-fg-muted)] border border-[var(--tt-border-strong)]"}`}>{m.agent}</span>


### PR DESCRIPTION
## What

The trace sidebar's **Project Configuration** panel tinted project-scoped skills cyan and project-scoped MCP servers blue, but nothing on screen said what the tint meant. The only clue was the hover tooltip (`project · claude`).

Entries also rendered in backend walk order, so on this repo the single project-scoped skill (`bug-audit`) sat at index **48 of 49**, below every skill inherited from `~/.claude/skills/`.

## Change

- Sort project scope ahead of user scope, then alphabetically, for both Skills and MCP Servers.
- Add a two-swatch legend (`project` / `user`) under each section header.

The swatch colour follows its section (cyan for skills, blue for MCP badges) rather than picking one, because the two sections don't share a tint. Unifying them is a larger design call and is left alone here.

## Not changed

`/projects/[path]/config` already groups by scope into labelled buckets, so it reads fine as-is. The trace sidebar was the only place the distinction was colour-only.

## Verification

Against the live `/config` endpoint for this repo (49 skills: 48 user, 1 project):

```
bug-audit index before: 48  ->  after: 0
all project-scoped ahead of every user-scoped: true
no rows lost: true (49)
mcps sorted, no rows lost: true
```

`tsc --noEmit` exits 0. Rendered and confirmed in the browser: legend row appears under `SKILLS (49)` and `bug-audit` is first.

## Adjacent issues found, not fixed here

- The MCP badge shows the **agent** name (`codex`, `gemini`) but colours by **scope** — two dimensions in one chip.
- The codex MCP parser counts TOML sub-tables as separate servers (`node_repl.env`, `grok.tools.grok_search`, `open-notebook.env`), inflating the MCP count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)