### PR TITLE
fix(antigravity): serve the transcript trace when a session has no .db

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -6677,17 +6677,21 @@ async def get_session_detail(session_id: str, agent: str):
     elif agent in ["gemini", "antigravity"]:
         # Antigravity CLI (agy) sessions store the real per-step trajectory in
         # conversations/<id>.db — far richer than the brain markdown. Prefer it.
+        # Newer agy builds write no .db at all and keep the trajectory only in
+        # brain/<sid>/.system_generated/logs/transcript*.jsonl, so hand the path
+        # over unconditionally: _antigravity_cli_trace checks db_path.exists()
+        # itself and falls back to the transcript. Gating on the .db here would
+        # skip exactly the sessions that only have a transcript.
         if agent == "antigravity":
             cli_db = ANTIGRAVITY_CLI_DIR / "conversations" / f"{session_id}.db"
-            if cli_db.exists():
-                cli_msgs = _antigravity_cli_trace(cli_db, session_id)
-                if cli_msgs:
-                    return {
-                        "sessionId": session_id,
-                        "projectHash": "",
-                        "kind": "antigravity_cli",
-                        "messages": cli_msgs,
-                    }
+            cli_msgs = _antigravity_cli_trace(cli_db, session_id)
+            if cli_msgs:
+                return {
+                    "sessionId": session_id,
+                    "projectHash": "",
+                    "kind": "antigravity_cli",
+                    "messages": cli_msgs,
+                }
         # Antigravity brain-based session (has no .json file; synthesize from markdown artifacts)
         brain_dir = ANTIGRAVITY_BRAIN_DIR / session_id
         for _bd in ANTIGRAVITY_BRAIN_DIRS:

--- a/backend/test_antigravity_cli.py
+++ b/backend/test_antigravity_cli.py
@@ -410,6 +410,59 @@ def test_chat_scan_dedups_sids_and_drops_ghost_sessions():
         assert sum(s["tokens"]["total"] for s in rows) == 300
 
 
+def test_session_detail_uses_transcript_trace_when_there_is_no_sqlite_db():
+    """Newer agy builds write no conversations/<sid>.db at all.
+
+    _antigravity_cli_trace already falls back to transcript*.jsonl, but the
+    endpoint used to gate that call behind cli_db.exists() and so handed back
+    the much thinner brain markdown instead — the trace never rendered for
+    exactly the sessions the fallback was written for. Exercise the endpoint,
+    not the parser, because the parser was never the broken half.
+    """
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        sid = "sid-transcript-only"
+        logs = root / "brain" / sid / ".system_generated" / "logs"
+        logs.mkdir(parents=True)
+        (logs / "transcript.jsonl").write_text(
+            json.dumps({"type": "USER_INPUT", "content": "<USER_REQUEST>only in the transcript</USER_REQUEST>"})
+            + "\n",
+            encoding="utf-8",
+        )
+        # Brain markdown is present too, so this also pins the precedence:
+        # a real trajectory beats the synthesized markdown summary.
+        (root / "brain" / sid / "task.md").write_text("# Task\n\nbrain markdown\n", encoding="utf-8")
+        # conversations/ exists but deliberately holds no <sid>.db.
+        (root / "conversations").mkdir()
+
+        nowhere = root / "nowhere"
+        originals = (
+            main.ANTIGRAVITY_BRAIN_DIR,
+            main.ANTIGRAVITY_BRAIN_DIRS,
+            main.ANTIGRAVITY_CLI_DIR,
+            main.GEMINI_DIR,
+        )
+        main.ANTIGRAVITY_BRAIN_DIR = root / "brain"
+        main.ANTIGRAVITY_BRAIN_DIRS = [root / "brain"]
+        main.ANTIGRAVITY_CLI_DIR = root
+        main.GEMINI_DIR = nowhere
+        try:
+            assert not (root / "conversations" / f"{sid}.db").exists()
+            detail = asyncio.run(main.get_session_detail(sid, "antigravity"))
+        finally:
+            (
+                main.ANTIGRAVITY_BRAIN_DIR,
+                main.ANTIGRAVITY_BRAIN_DIRS,
+                main.ANTIGRAVITY_CLI_DIR,
+                main.GEMINI_DIR,
+            ) = originals
+
+        assert detail["kind"] == "antigravity_cli", f"fell through to {detail.get('kind')!r}"
+        msgs = detail["messages"]
+        assert len(msgs) == 1, msgs
+        assert msgs[0]["message"]["content"][0]["text"] == "only in the transcript"
+
+
 if __name__ == "__main__":
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     failed = 0


### PR DESCRIPTION
Follow-up to #229.

## The problem

#229 taught `_antigravity_cli_trace` to fall back to `brain/<sid>/.system_generated/logs/transcript*.jsonl` when a session has no `conversations/<sid>.db` — newer `agy` builds no longer write one. That half works.

But `get_session_detail` only called it when the `.db` existed:

```python
cli_db = ANTIGRAVITY_CLI_DIR / "conversations" / f"{session_id}.db"
if cli_db.exists():                       # <- fallback never runs without a .db
    cli_msgs = _antigravity_cli_trace(cli_db, session_id)
```

So the fallback never ran for exactly the sessions it was written for. All 29 sessions #229 restores have no `.db`; they dropped through to the brain-markdown branch, and 26 of them rendered nothing at all. The bug hwantage reported was still on screen after the merge.

This was my miss reviewing #229 — I validated `_antigravity_cli_trace(db, sid)` directly, which exercises a fallback the endpoint never reached.

## The fix

`_antigravity_cli_trace` already does `if db_path and db_path.exists()` internally, so the outer guard was redundant as well as harmful. Drop it and let the function decide.

## Measured

Over the 167 Antigravity brain sessions on this machine, through the running API:

```
sessions returning zero messages : 59   -> 35
total messages served            : 6724 -> 7814   (+1090)
kind=antigravity_cli             : 62   -> 91
```

Spot-check on two sessions that previously rendered nothing:

```
615e6853  kind=antigravity_brain  messages=1    ->  kind=antigravity_cli  messages=168
97fe56ed  kind=antigravity_brain  messages=2    ->  kind=antigravity_cli  messages=164
```

No session loses events. The guard only ever affected sessions without a `.db`, and those previously always fell through to brain markdown; the arithmetic closes exactly (`6724 + 1090 = 7814`).

The 35 still returning zero have neither a usable transcript nor a `.db` — pre-existing and out of scope here.

## Test

`test_session_detail_uses_transcript_trace_when_there_is_no_sqlite_db` drives `get_session_detail`, not the parser, since the parser was never the broken half. It also plants a `task.md` so it pins the precedence (real trajectory beats synthesized markdown).

Against the prior code it fails with `AssertionError: fell through to 'antigravity_brain'`. With the fix, `test_antigravity_cli.py` is 13 passed. Full backend suite: 382 passed, same 23 pre-existing environment failures as `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)