### PR TITLE
feat(frontend): persist and restore scroll state across page navigations

### DIFF
--- a/frontend/src/app/hermes/page.tsx
+++ b/frontend/src/app/hermes/page.tsx
@@ -10,6 +10,8 @@ import {
   Kanban,
 } from "lucide-react";
 import { useResource } from "@/lib/api";
+import { useScrollState } from "@/lib/useScrollState";
+import { useSessionState } from "@/lib/useSessionState";
 import {
   PageHeader, Card, CardHeader, CardTitle, StatTile, EmptyState, Section,
   Table, THead, TBody, TR, TH, TD, Badge,
@@ -87,7 +89,15 @@ export default function HermesPage() {
   // "all" | "default" | profile name. Scopes the summary tiles, the sources and
   // models cards, and the grouped session tables. The Telemetry section is not
   // profile-scoped: its endpoint always covers every profile.
-  const [profileScope, setProfileScope] = useState<string>("all");
+  const [pageState, setPageState] = useSessionState("hermes_page", {
+    profileScope: "all" as string,
+  });
+  const { profileScope } = pageState;
+  const loading = sessionsRes.loading;
+
+  // Restore scroll position when data fetch is complete
+  useScrollState("key_hermes_page", !loading);
+  
   const allHermesSessions = useMemo(
     () => (sessionsRes.data ?? []).filter((s) => s.agent === "hermes"),
     [sessionsRes.data]
@@ -164,8 +174,6 @@ export default function HermesPage() {
     });
   }, [hermesSessions]);
 
-  const loading = !sessionsRes.data;
-
   return (
     <div className="px-8 py-8 max-w-[1600px] mx-auto space-y-10 pb-20">
       <PageHeader
@@ -192,7 +200,7 @@ export default function HermesPage() {
             return (
               <button
                 key={name}
-                onClick={() => setProfileScope(name)}
+                onClick={() => setPageState({ profileScope: name })}
                 className={`inline-flex items-center gap-1.5 font-mono text-[11px] px-2.5 h-7 rounded-full border transition-colors ${
                   selected
                     ? "border-[var(--tt-border-strong)] bg-[var(--tt-sunken)] text-[var(--tt-fg)]"

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -9,6 +9,7 @@ import {
 } from "lucide-react";
 
 import { useResource } from "@/lib/api";
+import { useScrollState } from "@/lib/useScrollState";
 import { AGENTS, getAgent, type AgentKey } from "@/lib/agents";
 import SourceBadge from "@/components/SourceBadge";
 import CopilotSourceBadge from "@/components/CopilotSourceBadge";
@@ -74,6 +75,10 @@ export default function Home() {
   const totalModelSessions = modelRows.reduce((a, r) => a + r.session_count, 0) || 1;
 
   const loading = sessionsRes.loading;
+
+  // Restore scroll position when data fetch is complete
+  useScrollState("key_dashboard_page", !loading);
+  const { ref: recentActivityRef, onScroll: handleRecentActivityScroll } = useScrollState("key_dashboard_recent_activity", !loading && sessions.length > 0);
 
   const [showLocalPower, setShowLocalPower] = useState(false);
   useEffect(() => {
@@ -247,7 +252,7 @@ export default function Home() {
               description="TokenTelemetry watches local agent runtimes for activity. Run Claude Code, Cursor, Copilot, or another supported agent to populate this feed."
             />
           ) : (
-            <div className="max-h-[560px] overflow-y-auto">
+            <div ref={recentActivityRef} onScroll={handleRecentActivityScroll} className="max-h-[560px] overflow-y-auto">
               <Table>
                 <THead>
                   <TR>

--- a/frontend/src/app/projects/[path]/activity/page.tsx
+++ b/frontend/src/app/projects/[path]/activity/page.tsx
@@ -10,12 +10,17 @@ import {
   Table, THead, TBody, TR, TH, TD,
 } from "@/components/ui";
 import { useProject } from "../_lib/project-context";
+import { useScrollState } from "@/lib/useScrollState";
 import CopilotSourceBadge from "@/components/CopilotSourceBadge";
 import AntigravitySourceBadge from "@/components/AntigravitySourceBadge";
 
 export default function ActivityTab() {
   const pathname = usePathname();
   const { sessions, loading } = useProject();
+
+  // Restore scroll position when data fetch is complete
+  useScrollState(`key_project_activity_page`, !loading);
+  const { ref: sessionHistoryRef, onScroll: handleSessionHistoryScroll } = useScrollState(`key_project_activity_sessions`, !loading && sessions.length > 0);
 
   return (
     <Card padding="none">
@@ -35,7 +40,7 @@ export default function ActivityTab() {
           description="Once any agent runs in this workspace, sessions will appear here."
         />
       ) : (
-        <div className="max-h-[700px] overflow-y-auto">
+        <div ref={sessionHistoryRef} onScroll={handleSessionHistoryScroll} className="max-h-[700px] overflow-y-auto">
           <Table>
             <THead>
               <TR>

--- a/frontend/src/app/projects/page.tsx
+++ b/frontend/src/app/projects/page.tsx
@@ -3,17 +3,19 @@
 import { useMemo, useState } from "react";
 import Link from "next/link";
 import {
-  Folder, Search, ArrowRight, Wrench, Users, ClipboardList,
-  LayoutGrid, List as ListIcon, ArrowUpDown, FolderOpen,
+  Folder, Search, ArrowRight, Wrench,
+  LayoutGrid, List as ListIcon, ArrowUpDown,
   GitBranch, ChevronRight,
 } from "lucide-react";
 
 import { useResource } from "@/lib/api";
+import { useScrollState } from "@/lib/useScrollState";
+import { useSessionState } from "@/lib/useSessionState";
 import { getAgent } from "@/lib/agents";
 import { cn } from "@/lib/cn";
 import { formatTokens, formatCost } from "@/lib/format";
 import {
-  PageHeader, Section, Card, Badge, AgentBadge, Button, EmptyState, Skeleton,
+  PageHeader, Section, Card, Badge, AgentBadge, EmptyState, Skeleton,
   Table, THead, TBody, TR, TH, TD,
 } from "@/components/ui";
 
@@ -74,10 +76,16 @@ const SORTS: { key: SortKey; label: string }[] = [
 export default function ProjectsPage() {
   const { data: projects = [], loading } = useResource<Project[]>("/projects", { initial: [] });
 
-  const [search, setSearch] = useState("");
-  const [view, setView] = useState<ViewMode>("grid");
-  const [sortKey, setSortKey] = useState<SortKey>("sessions");
-  const [sortDesc, setSortDesc] = useState(true);
+  const [pageState, setPageState] = useSessionState("projects_page", {
+    search: "",
+    view: "grid" as ViewMode,
+    sortKey: "sessions" as SortKey,
+    sortDesc: true,
+  });
+  const { search, view, sortKey, sortDesc } = pageState;
+
+  // Restore scroll position when data fetch is complete
+  useScrollState("key_projects_page", !loading);
 
   const filtered = useMemo(() => {
     const q = search.toLowerCase().trim();
@@ -121,7 +129,7 @@ export default function ProjectsPage() {
             type="text"
             placeholder="Search by name or path…"
             value={search}
-            onChange={(e) => setSearch(e.target.value)}
+            onChange={(e) => setPageState({ search: e.target.value })}
             className="w-full h-9 pl-9 pr-3 rounded-[var(--tt-radius)] bg-[var(--tt-panel)] border border-[var(--tt-border)] text-[13px] text-[var(--tt-fg)] placeholder:text-[var(--tt-fg-faint)] hover:border-[var(--tt-border-strong)] focus:border-[color:var(--tt-brand)]/40 focus:outline-none focus:ring-1 focus:ring-[color:var(--tt-brand)]/30 transition-colors"
           />
         </div>
@@ -132,7 +140,7 @@ export default function ProjectsPage() {
           {SORTS.map((s) => (
             <button
               key={s.key}
-              onClick={() => (sortKey === s.key ? setSortDesc(!sortDesc) : setSortKey(s.key))}
+              onClick={() => (sortKey === s.key ? setPageState({ sortDesc: !sortDesc }) : setPageState({ sortKey: s.key }))}
               className={cn(
                 "h-9 px-2.5 text-[12px] font-medium transition-colors flex items-center gap-1",
                 sortKey === s.key ? "text-[var(--tt-fg)] tt-tint-1" : "text-[var(--tt-fg-muted)] hover:text-[var(--tt-fg)]",
@@ -154,7 +162,7 @@ export default function ProjectsPage() {
           ].map(({ v, icon: I, label }) => (
             <button
               key={v}
-              onClick={() => setView(v as ViewMode)}
+              onClick={() => setPageState({ view: v as ViewMode })}
               aria-label={label}
               className={cn(
                 "h-9 w-9 grid place-items-center transition-colors",

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -9,6 +9,7 @@ import {
 import { useResource } from "@/lib/api";
 import { ALL_AGENT_KEYS, getAgent } from "@/lib/agents";
 import { cn } from "@/lib/cn";
+import { clearPageState } from "@/lib/pageState";
 import { ThemeToggle } from "./ThemeToggle";
 import NotificationBell from "./notifications/NotificationBell";
 import HermesIcon from "./icons/HermesIcon";
@@ -129,6 +130,7 @@ function NavLink({ link, pathname, isCollapsed }: {
     <Link
       href={link.href}
       title={isCollapsed ? link.name : undefined}
+      onClick={() => {clearPageState()}}
       className={cn(
         "relative flex items-center gap-3 rounded-[var(--tt-radius)] px-2.5 py-2 text-[13px] font-medium transition-colors",
         isActive

--- a/frontend/src/lib/pageState.ts
+++ b/frontend/src/lib/pageState.ts
@@ -1,0 +1,19 @@
+"use client";
+
+/**
+ * Registry of sessionStorage keys used for persisted page state (UI + scroll).
+ */
+const registeredKeys = new Set<string>();
+
+/** Tracks a sessionStorage key so it can be purged on menu navigation. */
+export function registerStateKey(key: string): void {
+  registeredKeys.add(key);
+}
+
+/** Removes every tracked page-state and scroll-restoration key. */
+export function clearPageState(): void {
+  registeredKeys.forEach((key) => {
+    try { sessionStorage.removeItem(key); } catch {}
+  });
+  registeredKeys.clear();
+}

--- a/frontend/src/lib/useScrollState.ts
+++ b/frontend/src/lib/useScrollState.ts
@@ -1,0 +1,98 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+import { registerStateKey } from "@/lib/pageState";
+
+type ScrollTarget = HTMLElement | Window | null;
+
+function getPageContainer(): ScrollTarget {
+  if (typeof document === "undefined") return null;
+  return document.querySelector("main") ?? window;
+}
+
+function getScrollTop(target: ScrollTarget): number {
+  if (!target) return 0;
+  return "scrollTop" in target ? target.scrollTop : target.scrollY;
+}
+
+function scrollToY(target: ScrollTarget, y: number): void {
+  if (!target) return;
+  if ("scrollTop" in target) {
+    target.scrollTop = y;
+  } else {
+    target.scrollTo({ top: y, behavior: "instant" });
+  }
+}
+
+/**
+ * Persists and restores scroll position for a page or scrollable element.
+ *
+ * - Targets the page <main> container by default, or an element bound via the returned `ref` + `onScroll`. 
+ * - Positions are stored in sessionStorage under `scroll_<key>` and restored once `isReady` becomes true.
+ */
+export function useScrollState(key: string, isReady: boolean = true) {
+  const nodeRef = useRef<HTMLElement | null>(null);
+  const isRestoringRef = useRef(false);
+  const restoredRef = useRef(false);
+
+  useEffect(() => {
+    registerStateKey(`scroll_${key}`);
+  }, [key]);
+
+  const saveScrollPosition = useCallback((top: number) => {
+    if (isRestoringRef.current) return;      
+    sessionStorage.setItem(`scroll_${key}`, String(top));
+  },[key]);
+
+  const ref = useCallback((node: HTMLElement | null) => {
+    nodeRef.current = node;
+  }, []);
+
+  const onScroll = useCallback((e: React.UIEvent<HTMLElement>) => {
+    saveScrollPosition(e.currentTarget.scrollTop);
+  },[saveScrollPosition]);
+
+  useEffect(() => {
+    const target = nodeRef.current ?? getPageContainer();
+    if (!target) return;
+
+    if ("scrollRestoration" in window.history) {
+      window.history.scrollRestoration = "manual";
+    }
+
+    // Restore the saved position once, when the page is ready to paint.
+    if (isReady && !restoredRef.current) {
+      const savedStr = sessionStorage.getItem(`scroll_${key}`);
+      const savedY = savedStr ? parseInt(savedStr, 10) : 0;
+
+      if (!isNaN(savedY) && savedY > 0) {
+        isRestoringRef.current = true;
+        requestAnimationFrame(() => {
+          scrollToY(target, savedY);
+          isRestoringRef.current = false;
+          restoredRef.current = true;
+        });
+      } else {
+        restoredRef.current = true;
+      }
+    }
+
+    // Persist the position, debounced, while the user scrolls.
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const handleScrollPosition = () => {
+      if (isRestoringRef.current) return;
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => saveScrollPosition(getScrollTop(target)), 50);
+    };
+
+    target.addEventListener("scroll", handleScrollPosition, { passive: true });
+
+    return () => {
+      if (timer) clearTimeout(timer);
+      target.removeEventListener("scroll", handleScrollPosition);
+    };
+  }, [key, isReady, saveScrollPosition]);
+
+  return { ref, onScroll };
+}

--- a/frontend/src/lib/useSessionState.ts
+++ b/frontend/src/lib/useSessionState.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { registerStateKey } from "@/lib/pageState";
+
+export type StateSetter<T> = Partial<T> | ((prev: T) => T);
+
+function readStorage<T>(key: string): T | null {
+  try {
+    const item = sessionStorage.getItem(key);
+    return item !== null ? (JSON.parse(item) as T) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Custom hook that persists React state to sessionStorage under a single key.
+ *
+ * - Automatically saves state to sessionStorage and restores it on page remount.
+ * - Merges saved state with default values so missing fields are safely filled.
+ * - Supports partial state updates (patching).
+ */
+export function useSessionState<T extends object>(key: string, defaults: T): [T, (patch: StateSetter<T>) => void] {
+  const [state, setState] = useState<T>(() => {
+    if (typeof window === "undefined") return defaults;
+    const stored = readStorage<Partial<T>>(key);
+    return stored ? { ...defaults, ...stored } : defaults;
+  });
+
+  useEffect(() => {
+    registerStateKey(key);
+  }, [key]);
+
+  useEffect(() => {
+    try { sessionStorage.setItem(key, JSON.stringify(state)); } catch {}
+  }, [key, state]);
+
+  const set = useCallback((patch: StateSetter<T>) => {
+    setState((prev) =>
+      typeof patch === "function" ? patch(prev) : { ...prev, ...patch }
+    );
+  }, []);
+
+  return [state, set];
+}


### PR DESCRIPTION
## Summary
This PR addresses a key usability limitation where navigating back from session or project detail views to long list feeds (e.g., Dashboard, Projects list, Project Activity, and Hermes sessions) causes the scroll position to reset to the top.

### What was done
1. **Scroll State Persistence & Restoration**: Added `useScrollState` custom hook and `pageState` / `useSessionState` helper utilities that cache window scroll positions and inner container scroll elements (`sessionStorage`).
2. **Data-Ready Restoration**: Ensures scroll positions are restored smoothly only after page data fetching completes (`ready` state flag).
3. **Clean Reset on Primary Navigation**: Integrated `clearPageState()` into primary left navigation links (`Navigation.tsx`) so that clicking menu links cleanly resets cached scroll positions for a fresh browsing state.

---

### Development Journey & Trial/Error
* **URL-based History Back Attempt**: Initially, an approach using URL search parameters / query strings was consideredto handle history back behavior. However, sync issues arose when combining scroll parameters with active search queries, filter states, and keeping URLs clean for sharing.
* **Current Approach**: Transitioned to the `sessionStorage`-backed custom hook architecture. This cleanly decouples scroll state management from URL params.
* **User Experience**: In my local environment, this implementation provided a noticeably smoother and far more satisfying exploration experience when inspecting multiple sessions back-and-forth.

---

### Trade-offs & Concerns
1. **Maintenance Rules for New Features**: When adding new list views or stateful filter controls in the future, developers need to adhere to the following state management guidelines:
   * **Rule 1**: Assign a unique `pageKey` string for each page or scrollable container (e.g., `key_dashboard_recent_activity`).
   * **Rule 2**: Pass the `ready` boolean condition (e.g., `!loading && items.length > 0`) to `useScrollState` so restoration occurs after DOM rendering completes.
   * **Rule 3**: Call `clearPageState()` on top-level navigation triggers to ensure state resets when changing contexts.
2. **Browser Testing Scope**: Tested primarily on **Brave Browser** and **Safari** on macOS. Further cross-browser testing (Firefox, Windows Chrome/Edge) may be required.

## Type of change
- [ ] Bug fix
- [ ] New feature (new agent support, new dashboard view, etc.)
- [v] Improvement / refactor
- [ ] Docs / chore

## How to test
1. Launch TokenTelemetry (`./start.sh`)
2. Navigate to Dashboard (`/`), Projects (`/projects`), or Hermes (`/hermes`) with sufficient items to scroll down.
3. Scroll down and click on any session or activity detail item.
4. Click the browser Back button (or perform history back gesture).
5. Verify that once page data loads, the scroll position is restored to where you left off.
6. Click any main navigation item in the left sidebar and verify that the page scroll state resets back to top `(0, 0)`.

## Checklist
- [v] I tested this locally with `./start.sh`
- [v] No secrets or API keys are included
- [v] PR is focused on one change
- [v] README or CHANGELOG updated if needed

## Notes
If the maintainers prefer a more fundamental or framework-level alternative (e.g., Next.js layout state/scroll handling), this PR does not necessarily need to be merged as-is. My primary hope is that this PR serves as a helpful catalyst for discussing and improving list navigation UX in TokenTelemetry.

## Related issue
Closes #244 
