### PR TITLE
feat: add Hermes session explorer and clean Codex traces

### DIFF
--- a/UPDATE.json
+++ b/UPDATE.json
@@ -1,6 +1,22 @@
 {
   "releases": [
     {
+      "tag": "2026-08-08",
+      "title": "Find any Hermes session without loading them all",
+      "highlights": [
+        {
+          "title": "Hermes session explorer",
+          "description": "The Hermes dashboard now keeps the overview compact and links to a dedicated session explorer. Search, filter by project, source, or model, sort by time, cost, or tokens, and move through the history 50 sessions at a time.",
+          "href": "/hermes/sessions"
+        },
+        {
+          "title": "Cleaner Codex trace timelines",
+          "description": "Codex traces now collapse mirrored messages and repeated reasoning snapshots, so the Step Index and conversation show each visible turn once instead of replaying the rollout's internal projections.",
+          "href": "/sessions"
+        }
+      ]
+    },
+    {
       "tag": "2026-08-02",
       "title": "Hermes telemetry that says what it doesn't know",
       "highlights": [

--- a/backend/main.py
+++ b/backend/main.py
@@ -6611,6 +6611,82 @@ def _parse_session_jsonl_cached(path: Path) -> List[Dict[str, Any]]:
     return events
 
 
+def _codex_visible_signatures(event: Dict[str, Any]) -> List[tuple]:
+    """Return visible-content signatures used to identify Codex mirrors.
+
+    Codex rollouts can persist both a canonical ``response_item`` and a nearby
+    ``event_msg`` projection for the same user, assistant, or reasoning text.
+    Keep event-only records for older rollouts, and remove a projection only
+    when its canonical counterpart is present nearby.
+    """
+    payload = event.get("payload")
+    if not isinstance(payload, dict):
+        return []
+
+    event_type = event.get("type")
+    payload_type = payload.get("type")
+    if event_type == "event_msg":
+        if payload_type == "user_message":
+            text, kind = payload.get("message"), "user"
+        elif payload_type == "agent_message":
+            text, kind = payload.get("message"), "assistant"
+        elif payload_type == "agent_reasoning":
+            text, kind = payload.get("text"), "reasoning"
+        else:
+            return []
+        normalized = str(text or "").strip()
+        return [(kind, normalized)] if normalized else []
+
+    if event_type != "response_item":
+        return []
+    if payload_type == "reasoning":
+        return [
+            ("reasoning", str(item.get("text") or "").strip())
+            for item in payload.get("summary") or []
+            if isinstance(item, dict) and str(item.get("text") or "").strip()
+        ]
+    if payload_type != "message" or payload.get("role") not in {"user", "assistant"}:
+        return []
+
+    text = "".join(
+        str(item.get("text") or "")
+        for item in payload.get("content") or []
+        if isinstance(item, dict) and item.get("type") in {"input_text", "output_text"}
+    ).strip()
+    return [(payload["role"], text)] if text else []
+
+
+def _canonicalize_codex_trace(events: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Remove only event_msg records mirrored by nearby response_item data."""
+    canonical: Dict[tuple, List[tuple]] = {}
+    for index, event in enumerate(events):
+        if event.get("type") != "response_item":
+            continue
+        timestamp = event.get("normalized_timestamp")
+        for signature in _codex_visible_signatures(event):
+            canonical.setdefault(signature, []).append((index, timestamp))
+
+    result = []
+    for index, event in enumerate(events):
+        signatures = _codex_visible_signatures(event)
+        if event.get("type") == "event_msg" and signatures:
+            timestamp = event.get("normalized_timestamp")
+            matches_canonical = any(
+                abs(index - canonical_index) <= 4
+                and (
+                    not isinstance(timestamp, (int, float))
+                    or not isinstance(canonical_timestamp, (int, float))
+                    or abs(timestamp - canonical_timestamp) <= 100
+                )
+                for signature in signatures
+                for canonical_index, canonical_timestamp in canonical.get(signature, [])
+            )
+            if matches_canonical:
+                continue
+        result.append(event)
+    return result
+
+
 @app.get("/sessions/{session_id}")
 async def get_session_detail(session_id: str, agent: str):
     if agent == "claude":
@@ -6620,7 +6696,7 @@ async def get_session_detail(session_id: str, agent: str):
     elif agent == "codex":
         files = list(CODEX_DIR.glob(f"sessions/**/rollout-*{session_id}*.jsonl"))
         if not files: return {"error": "Not found"}
-        return _parse_session_jsonl_cached(files[0])
+        return _canonicalize_codex_trace(_parse_session_jsonl_cached(files[0]))
     elif agent == "grok":
         # Grok Build dialogue. chat_history.jsonl is the canonical conversation in
         # FILE ORDER and carries NO per-message timestamps, so we normalize each

--- a/backend/main.py
+++ b/backend/main.py
@@ -6657,7 +6657,7 @@ def _codex_visible_signatures(event: Dict[str, Any]) -> List[tuple]:
 
 
 def _canonicalize_codex_trace(events: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    """Remove only event_msg records mirrored by nearby response_item data."""
+    """Return one visible Codex timeline from mirrored and streamed records."""
     canonical: Dict[tuple, List[tuple]] = {}
     for index, event in enumerate(events):
         if event.get("type") != "response_item":
@@ -6684,7 +6684,45 @@ def _canonicalize_codex_trace(events: List[Dict[str, Any]]) -> List[Dict[str, An
             if matches_canonical:
                 continue
         result.append(event)
-    return result
+
+    # Reasoning is streamed as snapshots. A snapshot may repeat the previous
+    # summary, extend it, or contain no visible text at all. The UI should show
+    # the most complete nearby snapshot once, not one Step Index row per write.
+    collapsed: List[Dict[str, Any]] = []
+    for event in result:
+        if event.get("type") != "response_item" or (event.get("payload") or {}).get("type") != "reasoning":
+            collapsed.append(event)
+            continue
+
+        current_text = "\n\n".join(
+            text for kind, text in _codex_visible_signatures(event) if kind == "reasoning" and text
+        )
+        if not current_text:
+            continue
+
+        previous_index = len(collapsed) - 1
+        while previous_index >= 0:
+            previous = collapsed[previous_index]
+            previous_payload = previous.get("payload") or {}
+            if previous.get("type") == "event_msg" and previous_payload.get("type") == "token_count":
+                previous_index -= 1
+                continue
+            break
+
+        if previous_index >= 0:
+            previous = collapsed[previous_index]
+            previous_payload = previous.get("payload") or {}
+            if previous.get("type") == "response_item" and previous_payload.get("type") == "reasoning":
+                previous_text = "\n\n".join(
+                    text for kind, text in _codex_visible_signatures(previous) if kind == "reasoning" and text
+                )
+                if previous_text == current_text or previous_text.startswith(current_text) or current_text.startswith(previous_text):
+                    if len(current_text) >= len(previous_text):
+                        collapsed[previous_index] = event
+                    continue
+
+        collapsed.append(event)
+    return collapsed
 
 
 @app.get("/sessions/{session_id}")

--- a/backend/main.py
+++ b/backend/main.py
@@ -2143,6 +2143,16 @@ _HERMES_SESSION_SORTS = {
     "tokens_desc", "tokens_asc", "project", "model",
 }
 
+_HERMES_SESSION_PUBLIC_FIELDS = (
+    "id", "agent", "project", "timestamp", "display", "text", "source_subtype",
+    "model", "tokens", "cost", "cost_anomaly", "hermes_profile",
+)
+
+
+def _hermes_session_public_view(session: Dict[str, Any]) -> Dict[str, Any]:
+    """Return only the session-list fields consumed by the Hermes explorer."""
+    return {field: session[field] for field in _HERMES_SESSION_PUBLIC_FIELDS if field in session}
+
 
 def _hermes_session_source(session: Dict[str, Any]) -> str:
     """Return the stable source label used by the Hermes explorer contract."""
@@ -2258,7 +2268,7 @@ async def hermes_sessions(
     total_pages = (total + page_size - 1) // page_size if total else 0
     public_sessions = []
     for session in page_sessions:
-        public = _session_public_view(session)
+        public = _hermes_session_public_view(session)
         public.setdefault("source", _hermes_session_source(session))
         public_sessions.append(public)
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -2138,6 +2138,141 @@ async def hermes_telemetry():
     return _ht.build_telemetry(sessions, index, files_read)
 
 
+_HERMES_SESSION_SORTS = {
+    "newest", "oldest", "cost_desc", "cost_asc",
+    "tokens_desc", "tokens_asc", "project", "model",
+}
+
+
+def _hermes_session_source(session: Dict[str, Any]) -> str:
+    """Return the stable source label used by the Hermes explorer contract."""
+    source = session.get("source_subtype") or session.get("source")
+    return str(source or "unknown")
+
+
+def _hermes_session_timestamp(session: Dict[str, Any]) -> datetime:
+    timestamp = session.get("timestamp")
+    if isinstance(timestamp, datetime):
+        return _aware(timestamp)
+    if isinstance(timestamp, str):
+        try:
+            return _aware(datetime.fromisoformat(timestamp.replace("Z", "+00:00")))
+        except ValueError:
+            pass
+    return datetime.min.replace(tzinfo=timezone.utc)
+
+
+def _hermes_session_number(session: Dict[str, Any], field: str) -> float:
+    value = session.get(field)
+    if field == "tokens":
+        value = (session.get("tokens") or {}).get("total", 0)
+    try:
+        return float(value or 0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _hermes_session_matches(
+    session: Dict[str, Any],
+    *,
+    search: Optional[str],
+    project: Optional[str],
+    source: Optional[str],
+    model: Optional[str],
+) -> bool:
+    source_value = _hermes_session_source(session)
+    searchable = " ".join(
+        str(session.get(field) or "")
+        for field in ("id", "display", "project", "model", "provider")
+    ) + " " + source_value
+    if search and search.casefold() not in searchable.casefold():
+        return False
+    for requested, actual in (
+        (project, session.get("project")),
+        (source, source_value),
+        (model, session.get("model")),
+    ):
+        if requested and requested.casefold() not in str(actual or "").casefold():
+            return False
+    return True
+
+
+def _hermes_session_sort_key(session: Dict[str, Any], sort: str):
+    if sort in {"newest", "oldest"}:
+        return (_hermes_session_timestamp(session), str(session.get("id") or ""))
+    if sort in {"cost_desc", "cost_asc"}:
+        return (_hermes_session_number(session, "cost"), str(session.get("id") or ""))
+    if sort in {"tokens_desc", "tokens_asc"}:
+        return (_hermes_session_number(session, "tokens"), str(session.get("id") or ""))
+    if sort == "project":
+        return (str(session.get("project") or "").casefold(), str(session.get("id") or ""))
+    return (str(session.get("model") or "").casefold(), str(session.get("id") or ""))
+
+
+@app.get("/hermes/sessions")
+async def hermes_sessions(
+    page: int = 1,
+    page_size: int = 50,
+    search: Optional[str] = None,
+    project: Optional[str] = None,
+    source: Optional[str] = None,
+    model: Optional[str] = None,
+    sort: str = "newest",
+    fresh: bool = False,
+):
+    """Return a paginated, filterable Hermes session list.
+
+    The endpoint deliberately reuses the canonical session scan, keeping its
+    fields and timestamp/cost semantics aligned with ``/sessions``. Results
+    are sorted deterministically, including the session id as a tie-breaker.
+    """
+    if page < 1:
+        from fastapi import HTTPException
+        raise HTTPException(status_code=422, detail="page must be at least 1")
+    if page_size < 1 or page_size > 200:
+        from fastapi import HTTPException
+        raise HTTPException(status_code=422, detail="page_size must be between 1 and 200")
+    if sort not in _HERMES_SESSION_SORTS:
+        allowed = ", ".join(sorted(_HERMES_SESSION_SORTS))
+        from fastapi import HTTPException
+        raise HTTPException(status_code=422, detail=f"sort must be one of: {allowed}")
+
+    sessions = await get_sessions_cached(fresh=fresh)
+    filtered = [
+        session for session in sessions
+        if session.get("agent") == "hermes"
+        and _hermes_session_matches(
+            session,
+            search=search,
+            project=project,
+            source=source,
+            model=model,
+        )
+    ]
+    reverse = sort in {"newest", "cost_desc", "tokens_desc"}
+    filtered.sort(key=lambda session: _hermes_session_sort_key(session, sort), reverse=reverse)
+
+    total = len(filtered)
+    start = (page - 1) * page_size
+    page_sessions = filtered[start:start + page_size]
+    total_pages = (total + page_size - 1) // page_size if total else 0
+    public_sessions = []
+    for session in page_sessions:
+        public = _session_public_view(session)
+        public.setdefault("source", _hermes_session_source(session))
+        public_sessions.append(public)
+
+    return {
+        "sessions": public_sessions,
+        "pagination": {
+            "page": page,
+            "page_size": page_size,
+            "total": total,
+            "total_pages": total_pages,
+        },
+    }
+
+
 # --------------------------------------------------------------------------- #
 # Update checker — compares local git HEAD to remote main, pulls curated
 # highlights from UPDATE.json at the repo root. The "What's new" banner in

--- a/backend/test_codex_trace.py
+++ b/backend/test_codex_trace.py
@@ -1,0 +1,95 @@
+"""Regression tests for Codex rollout mirror filtering."""
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(__file__))
+import main  # noqa: E402
+
+
+def _write_rollout(root: Path, session_id: str, events: list[dict]) -> None:
+    path = root / "sessions" / "2026" / "08" / f"rollout-test-{session_id}.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(json.dumps(event) + "\n" for event in events), encoding="utf-8")
+
+
+def test_codex_detail_removes_event_msg_mirrors(tmp_path, monkeypatch):
+    session_id = "duplicate-trace"
+    events = [
+        {
+            "timestamp": "2026-08-07T10:00:00.000Z",
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "Fix the trace"}],
+            },
+        },
+        {
+            "timestamp": "2026-08-07T10:00:00.010Z",
+            "type": "event_msg",
+            "payload": {"type": "user_message", "message": "Fix the trace"},
+        },
+        {
+            "timestamp": "2026-08-07T10:00:01.000Z",
+            "type": "response_item",
+            "payload": {
+                "type": "reasoning",
+                "summary": [{"type": "summary_text", "text": "Checking"}],
+            },
+        },
+        {
+            "timestamp": "2026-08-07T10:00:01.010Z",
+            "type": "event_msg",
+            "payload": {"type": "agent_reasoning", "text": "Checking"},
+        },
+        {
+            "timestamp": "2026-08-07T10:00:02.000Z",
+            "type": "event_msg",
+            "payload": {"type": "agent_message", "message": "Done"},
+        },
+        {
+            "timestamp": "2026-08-07T10:00:02.010Z",
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "Done"}],
+            },
+        },
+    ]
+    _write_rollout(tmp_path, session_id, events)
+    monkeypatch.setattr(main, "CODEX_DIR", tmp_path)
+
+    result = asyncio.run(main.get_session_detail(session_id, "codex"))
+
+    assert [event["type"] for event in result] == [
+        "response_item",
+        "response_item",
+        "response_item",
+    ]
+
+
+def test_codex_detail_keeps_event_only_records(tmp_path, monkeypatch):
+    session_id = "legacy-trace"
+    events = [
+        {
+            "timestamp": "2025-01-01T00:00:00Z",
+            "type": "event_msg",
+            "payload": {"type": "user_message", "message": "Legacy prompt"},
+        },
+        {
+            "timestamp": "2025-01-01T00:00:01Z",
+            "type": "event_msg",
+            "payload": {"type": "agent_message", "message": "Legacy answer"},
+        },
+    ]
+    _write_rollout(tmp_path, session_id, events)
+    monkeypatch.setattr(main, "CODEX_DIR", tmp_path)
+
+    result = asyncio.run(main.get_session_detail(session_id, "codex"))
+
+    assert len(result) == 2

--- a/backend/test_codex_trace.py
+++ b/backend/test_codex_trace.py
@@ -93,3 +93,42 @@ def test_codex_detail_keeps_event_only_records(tmp_path, monkeypatch):
     result = asyncio.run(main.get_session_detail(session_id, "codex"))
 
     assert len(result) == 2
+
+
+def test_codex_detail_collapses_empty_and_streaming_reasoning_snapshots():
+    events = [
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "reasoning",
+                "summary": [{"type": "summary_text", "text": "Planning"}],
+            },
+        },
+        {
+            "type": "event_msg",
+            "payload": {"type": "agent_reasoning", "text": "Planning"},
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "reasoning",
+                "summary": [{"type": "summary_text", "text": "Planning"}],
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "reasoning",
+                "summary": [{"type": "summary_text", "text": "Planning the fix"}],
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {"type": "reasoning", "summary": []},
+        },
+    ]
+
+    result = main._canonicalize_codex_trace(events)
+
+    assert len(result) == 1
+    assert result[0]["payload"]["summary"][0]["text"] == "Planning the fix"

--- a/backend/test_hermes_sessions_api.py
+++ b/backend/test_hermes_sessions_api.py
@@ -32,6 +32,7 @@ def _session(
         "model": model,
         "tokens": {"input": tokens, "output": 0, "cached": 0, "total": tokens},
         "cost": cost,
+        "artifacts": [{"name": "state.db", "path": "/private/hermes/state.db", "type": "document"}],
     }
 
 
@@ -83,6 +84,7 @@ def test_hermes_sessions_paginates_and_reports_metadata(hermes_sessions):
     result = _run(main.hermes_sessions(page=2, page_size=2, sort="newest"))
 
     assert [session["id"] for session in result["sessions"]] == ["h-old"]
+    assert "artifacts" not in result["sessions"][0]
     assert result["pagination"] == {
         "page": 2,
         "page_size": 2,

--- a/backend/test_hermes_sessions_api.py
+++ b/backend/test_hermes_sessions_api.py
@@ -1,0 +1,132 @@
+"""Focused contract tests for the paginated Hermes session explorer API."""
+
+import asyncio
+import os
+import sys
+from datetime import datetime, timezone
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+import main  # noqa: E402
+
+
+def _session(
+    session_id: str,
+    *,
+    timestamp: str,
+    project: str = "/workspace/app",
+    source: str = "cli",
+    model: str = "claude-sonnet-4-6",
+    display: str = "Investigate traces",
+    tokens: int = 100,
+    cost: float = 0.01,
+) -> dict:
+    return {
+        "id": session_id,
+        "agent": "hermes",
+        "project": project,
+        "timestamp": datetime.fromisoformat(timestamp).replace(tzinfo=timezone.utc),
+        "display": display,
+        "source_subtype": source,
+        "model": model,
+        "tokens": {"input": tokens, "output": 0, "cached": 0, "total": tokens},
+        "cost": cost,
+    }
+
+
+@pytest.fixture
+def hermes_sessions(monkeypatch):
+    sessions = [
+        _session(
+            "h-new",
+            timestamp="2026-08-07T12:00:00",
+            project="/workspace/app",
+            source="gateway",
+            model="gpt-5.2-codex",
+            display="Fix trace replication",
+            tokens=500,
+            cost=0.50,
+        ),
+        _session(
+            "h-middle",
+            timestamp="2026-08-07T11:00:00",
+            project="/workspace/docs",
+            source="cli",
+            display="Update the docs",
+            tokens=200,
+            cost=0.20,
+        ),
+        _session(
+            "h-old",
+            timestamp="2026-08-07T10:00:00",
+            project="/workspace/app",
+            source="cli",
+            display="Review Hermes sessions",
+            tokens=100,
+            cost=0.10,
+        ),
+    ]
+
+    async def fake_sessions(fresh: bool = False):
+        return sessions
+
+    monkeypatch.setattr(main, "get_sessions_cached", fake_sessions)
+    return sessions
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_hermes_sessions_paginates_and_reports_metadata(hermes_sessions):
+    result = _run(main.hermes_sessions(page=2, page_size=2, sort="newest"))
+
+    assert [session["id"] for session in result["sessions"]] == ["h-old"]
+    assert result["pagination"] == {
+        "page": 2,
+        "page_size": 2,
+        "total": 3,
+        "total_pages": 2,
+    }
+
+
+def test_hermes_sessions_filters_search_project_source_and_model(hermes_sessions):
+    result = _run(
+        main.hermes_sessions(
+            search="replication",
+            project="/workspace/app",
+            source="gateway",
+            model="codex",
+            page=1,
+            page_size=50,
+        )
+    )
+
+    assert [session["id"] for session in result["sessions"]] == ["h-new"]
+    assert result["sessions"][0]["source"] == "gateway"
+    assert result["pagination"]["total"] == 1
+
+
+def test_hermes_sessions_supports_oldest_and_cost_ordering(hermes_sessions):
+    oldest = _run(main.hermes_sessions(sort="oldest", page=1, page_size=50))
+    by_cost = _run(main.hermes_sessions(sort="cost_desc", page=1, page_size=50))
+
+    assert [session["id"] for session in oldest["sessions"]] == [
+        "h-old", "h-middle", "h-new"
+    ]
+    assert [session["id"] for session in by_cost["sessions"]] == [
+        "h-new", "h-middle", "h-old"
+    ]
+
+
+def test_hermes_sessions_returns_empty_page_for_no_matches(hermes_sessions):
+    result = _run(main.hermes_sessions(search="does-not-exist", page=1, page_size=50))
+
+    assert result["sessions"] == []
+    assert result["pagination"] == {
+        "page": 1,
+        "page_size": 50,
+        "total": 0,
+        "total_pages": 0,
+    }

--- a/frontend/src/app/hermes/page.tsx
+++ b/frontend/src/app/hermes/page.tsx
@@ -22,6 +22,7 @@ import {
 import SourceBadge from "@/components/SourceBadge";
 import HermesIcon from "@/components/icons/HermesIcon";
 import { formatCost } from "@/lib/format";
+import { profileColor, profileTint } from "@/lib/profileColor";
 import { trackEvent } from "@/lib/telemetry";
 
 interface GatewayState {

--- a/frontend/src/app/hermes/page.tsx
+++ b/frontend/src/app/hermes/page.tsx
@@ -10,6 +10,7 @@ import {
   Kanban,
 } from "lucide-react";
 import { useResource } from "@/lib/api";
+import { useScrollState } from "@/lib/useScrollState";
 import {
   PageHeader, Card, CardHeader, CardTitle, StatTile, EmptyState, Section,
   Table, THead, TBody, TR, TH, TD, Badge,
@@ -164,7 +165,10 @@ export default function HermesPage() {
     });
   }, [hermesSessions]);
 
-  const loading = !sessionsRes.data;
+  const loading = sessionsRes.loading;
+
+  // Restore scroll position when data fetch is complete.
+  useScrollState("key_hermes_page", !loading);
 
   return (
     <div className="px-8 py-8 max-w-[1600px] mx-auto space-y-10 pb-20">

--- a/frontend/src/app/hermes/page.tsx
+++ b/frontend/src/app/hermes/page.tsx
@@ -21,8 +21,7 @@ import {
 } from "@/lib/hermesTelemetry";
 import SourceBadge from "@/components/SourceBadge";
 import HermesIcon from "@/components/icons/HermesIcon";
-import { formatTokens, formatCost } from "@/lib/format";
-import { profileColor, profileTint } from "@/lib/profileColor";
+import { formatCost } from "@/lib/format";
 import { trackEvent } from "@/lib/telemetry";
 
 interface GatewayState {
@@ -65,17 +64,6 @@ interface Session {
   hermes_profile?: string;
   project_inferred?: boolean;
   cost_anomaly?: boolean;
-}
-
-interface Group {
-  /** display label */
-  label: string;
-  /** "project" or "source" — drives the icon/badge shown next to the label */
-  kind: "project" | "source";
-  /** group key for stable sort */
-  key: string;
-  sessions: Session[];
-  totalCost: number;
 }
 
 export default function HermesPage() {
@@ -142,30 +130,14 @@ export default function HermesPage() {
     return [...m.entries()].sort((a, b) => b[1] - a[1]);
   }, [hermesSessions]);
 
-  const groups = useMemo<Group[]>(() => {
-    const byKey = new Map<string, Group>();
-    for (const s of hermesSessions) {
-      const hasProject = s.project && s.project !== "unknown";
-      const key = hasProject ? `p:${s.project}` : `s:${s.source_subtype || "unknown"}`;
-      const label = hasProject ? s.project : (s.source_subtype || "unknown");
-      const kind: "project" | "source" = hasProject ? "project" : "source";
-      let g = byKey.get(key);
-      if (!g) {
-        g = { label, kind, key, sessions: [], totalCost: 0 };
-        byKey.set(key, g);
-      }
-      g.sessions.push(s);
-      g.totalCost += s.cost || 0;
-    }
-    // sort: projects first (alphabetical), then sources (by session count desc)
-    return [...byKey.values()].sort((a, b) => {
-      if (a.kind !== b.kind) return a.kind === "project" ? -1 : 1;
-      if (a.kind === "project") return a.label.localeCompare(b.label);
-      return b.sessions.length - a.sessions.length;
-    });
-  }, [hermesSessions]);
-
   const loading = sessionsRes.loading;
+  const recentSessions = useMemo(
+    () => hermesSessions
+      .slice()
+      .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
+      .slice(0, 10),
+    [hermesSessions]
+  );
 
   // Restore scroll position when data fetch is complete.
   useScrollState("key_hermes_page", !loading);
@@ -464,114 +436,49 @@ export default function HermesPage() {
         </Card>
       )}
 
-      {/* Grouped sessions */}
-      {!loading && groups.map((g) => (
-        <Card key={g.key}>
-          <CardHeader>
-            <CardTitle>
-              {g.kind === "project" ? (
-                <span className="flex items-center gap-2">
-                  <span className="font-mono text-[var(--tt-fg)] truncate" title={g.label}>
-                    {g.label}
-                  </span>
-                  <Badge variant="neutral" size="xs">project</Badge>
-                </span>
-              ) : (
-                <span className="flex items-center gap-2">
-                  <SourceBadge source={g.label} size="sm" />
-                  <span className="text-[11px] text-[var(--tt-fg-dim)] font-normal">no project</span>
-                </span>
-              )}
-            </CardTitle>
-            <div className="ml-auto text-[11px] tabular text-[var(--tt-fg-muted)]">
-              {g.sessions.length} session{g.sessions.length === 1 ? "" : "s"}
-              {g.totalCost > 0 && ` · ${formatCost(g.totalCost)}`}
+      {/* Recent sessions — the full history lives in the dedicated explorer. */}
+      {!loading && hermesSessions.length > 0 && (
+        <Card padding="none" className="overflow-hidden">
+          <CardHeader className="px-5 pt-5">
+            <div>
+              <CardTitle>Recent Hermes sessions</CardTitle>
+              <div className="mt-1 text-[11px] text-[var(--tt-fg-muted)]">
+                Showing {recentSessions.length} of {hermesSessions.length.toLocaleString()} sessions
+              </div>
             </div>
+            <Link href="/hermes/sessions" className="inline-flex items-center gap-1.5 text-[12px] text-[var(--tt-brand)] hover:underline">
+              View all sessions <ArrowRight size={13} />
+            </Link>
           </CardHeader>
           <Table>
             <THead>
               <TR>
                 <TH className="pl-5">Source</TH>
-                <TH>Model</TH>
+                <TH>Project</TH>
                 <TH>Message</TH>
+                <TH>Model</TH>
                 <TH className="text-right">API equiv.</TH>
                 <TH className="text-right pr-5">Time</TH>
               </TR>
             </THead>
             <TBody>
-              {g.sessions
-                .slice()
-                .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
-                .map((s) => (
-                  <TR key={s.id} interactive>
-                    <TD className="pl-5">
-                      <Link href={`/sessions/${s.id}?agent=hermes&from=${encodeURIComponent(pathname)}`} className="block">
-                        <span className="inline-flex items-center gap-1.5">
-                          <SourceBadge source={s.source_subtype} size="xs" />
-                          {s.hermes_profile && profileScope === "all" && (
-                            <span
-                              className="inline-flex items-center gap-1 font-mono text-[9px] px-1.5 h-4 rounded-full border"
-                              style={{
-                                color: profileColor(s.hermes_profile) ?? undefined,
-                                borderColor: profileColor(s.hermes_profile) ?? undefined,
-                                background: profileTint(s.hermes_profile) ?? undefined,
-                              }}
-                              title={`Profile: ${s.hermes_profile}`}
-                            >
-                              {s.hermes_profile}
-                            </span>
-                          )}
-                        </span>
-                      </Link>
-                    </TD>
-                    <TD className="font-mono text-[11px] text-[var(--tt-fg-muted)] max-w-[180px] truncate" title={s.model}>
-                      <Link href={`/sessions/${s.id}?agent=hermes&from=${encodeURIComponent(pathname)}`} className="block truncate">
-                        {s.model || "—"}
-                      </Link>
-                    </TD>
-                    <TD className="text-[var(--tt-fg)] max-w-[480px] truncate">
-                      <Link href={`/sessions/${s.id}?agent=hermes&from=${encodeURIComponent(pathname)}`} className="block truncate">
-                        <span className="inline-flex items-center gap-1.5">
-                          {s.cost_anomaly && (
-                            <span
-                              title={`Reasoning tokens (${s.tokens?.reasoning?.toLocaleString() ?? 0}) dominate output (${s.tokens?.output?.toLocaleString() ?? 0}) — possible silent thinking-mode waste`}
-                              className="inline-flex items-center gap-0.5 text-[9px] text-[var(--tt-warn-fg)] font-mono uppercase tracking-wider"
-                            >
-                              <AlertTriangle size={9} /> reasoning
-                            </span>
-                          )}
-                          <span className="truncate">
-                            {s.display || s.text || (
-                              <span className="italic text-[var(--tt-fg-faint)]">No message content</span>
-                            )}
-                          </span>
-                        </span>
-                      </Link>
-                    </TD>
-                    <TD className="text-right tabular text-[11px] text-[var(--tt-fg-muted)]">
-                      <Link href={`/sessions/${s.id}?agent=hermes&from=${encodeURIComponent(pathname)}`} className="block">
-                        {s.cost && s.cost > 0 ? formatCost(s.cost) : "—"}
-                        {s.tokens?.reasoning && s.tokens.reasoning > 0 ? (
-                          <div className="text-[9px] text-[var(--tt-fg-faint)] uppercase tracking-wider">
-                            +{formatTokens(s.tokens.reasoning)} reasoning
-                          </div>
-                        ) : null}
-                      </Link>
-                    </TD>
-                    <TD className="text-right pr-5 tabular text-[11px] text-[var(--tt-fg-muted)]">
-                      <Link href={`/sessions/${s.id}?agent=hermes&from=${encodeURIComponent(pathname)}`} className="block">
-                        <div>{format(new Date(s.timestamp), "HH:mm:ss")}</div>
-                        <div className="text-[10px] text-[var(--tt-fg-faint)] uppercase tracking-wider">
-                          {format(new Date(s.timestamp), "MMM d")}
-                        </div>
-                      </Link>
-                    </TD>
-                  </TR>
-                ))}
+              {recentSessions.map((s) => (
+                <TR key={s.id} interactive>
+                  <TD className="pl-5"><Link href={`/sessions/${s.id}?agent=hermes&from=${encodeURIComponent(pathname)}`}><SourceBadge source={s.source_subtype} size="xs" /></Link></TD>
+                  <TD className="max-w-[180px] truncate" title={s.project}><Link href={`/sessions/${s.id}?agent=hermes&from=${encodeURIComponent(pathname)}`} className="block truncate text-[var(--tt-fg-muted)]">{s.project || "unknown"}</Link></TD>
+                  <TD className="max-w-[480px] truncate"><Link href={`/sessions/${s.id}?agent=hermes&from=${encodeURIComponent(pathname)}`} className="block truncate text-[var(--tt-fg)]">
+                    {s.cost_anomaly && <AlertTriangle size={10} className="inline mr-1 text-[var(--tt-warn-fg)]" aria-label="Reasoning cost anomaly" />}
+                    {s.display || s.text || <span className="italic text-[var(--tt-fg-faint)]">No message content</span>}
+                  </Link></TD>
+                  <TD className="font-mono text-[11px] text-[var(--tt-fg-muted)] max-w-[160px] truncate" title={s.model}><Link href={`/sessions/${s.id}?agent=hermes&from=${encodeURIComponent(pathname)}`} className="block truncate">{s.model || "—"}</Link></TD>
+                  <TD className="text-right tabular text-[11px] text-[var(--tt-fg-muted)]"><Link href={`/sessions/${s.id}?agent=hermes&from=${encodeURIComponent(pathname)}`} className="block">{s.cost && s.cost > 0 ? formatCost(s.cost) : "—"}</Link></TD>
+                  <TD className="text-right pr-5 tabular text-[11px] text-[var(--tt-fg-muted)]"><Link href={`/sessions/${s.id}?agent=hermes&from=${encodeURIComponent(pathname)}`} className="block"><div>{formatDistanceToNow(new Date(s.timestamp), { addSuffix: true })}</div><div className="text-[10px] text-[var(--tt-fg-faint)]">{format(new Date(s.timestamp), "MMM d")}</div></Link></TD>
+                </TR>
+              ))}
             </TBody>
           </Table>
         </Card>
-      ))}
+      )}
     </div>
   );
 }

--- a/frontend/src/app/hermes/sessions/page.tsx
+++ b/frontend/src/app/hermes/sessions/page.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { List } from "lucide-react";
+import { Suspense } from "react";
+import { PageHeader } from "@/components/ui";
+import HermesIcon from "@/components/icons/HermesIcon";
+import HermesSessionExplorer from "@/components/hermes/HermesSessionExplorer";
+
+export default function HermesSessionsPage() {
+  return (
+    <div className="px-8 py-8 max-w-[1600px] mx-auto space-y-8 pb-20">
+      <PageHeader
+        backHref="/hermes"
+        eyebrow="Hermes Agent"
+        title="Session explorer"
+        description="Search, filter, and inspect Hermes sessions without rendering the entire history at once."
+        icon={<HermesIcon size={20} />}
+        actions={<div className="flex items-center gap-2 text-[11px] text-[var(--tt-fg-dim)]"><List size={14} /> Newest first by default</div>}
+      />
+      <Suspense fallback={<div className="h-96 rounded-[var(--tt-radius-lg)] border border-[var(--tt-border)] bg-[var(--tt-panel)] animate-pulse" aria-label="Loading session explorer" />}>
+        <HermesSessionExplorer />
+      </Suspense>
+    </div>
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -9,6 +9,7 @@ import {
 } from "lucide-react";
 
 import { useResource } from "@/lib/api";
+import { useScrollState } from "@/lib/useScrollState";
 import { AGENTS, getAgent, type AgentKey } from "@/lib/agents";
 import SourceBadge from "@/components/SourceBadge";
 import CopilotSourceBadge from "@/components/CopilotSourceBadge";
@@ -74,6 +75,10 @@ export default function Home() {
   const totalModelSessions = modelRows.reduce((a, r) => a + r.session_count, 0) || 1;
 
   const loading = sessionsRes.loading;
+
+  // Restore scroll position when data fetch is complete
+  useScrollState("key_dashboard_page", !loading);
+  const { ref: recentActivityRef, onScroll: handleRecentActivityScroll } = useScrollState("key_dashboard_recent_activity", !loading && sessions.length > 0);
 
   const [showLocalPower, setShowLocalPower] = useState(false);
   useEffect(() => {
@@ -247,7 +252,7 @@ export default function Home() {
               description="TokenTelemetry watches local agent runtimes for activity. Run Claude Code, Cursor, Copilot, or another supported agent to populate this feed."
             />
           ) : (
-            <div className="max-h-[560px] overflow-y-auto">
+            <div ref={recentActivityRef} onScroll={handleRecentActivityScroll} className="max-h-[560px] overflow-y-auto">
               <Table>
                 <THead>
                   <TR>

--- a/frontend/src/app/projects/[path]/activity/page.tsx
+++ b/frontend/src/app/projects/[path]/activity/page.tsx
@@ -10,12 +10,17 @@ import {
   Table, THead, TBody, TR, TH, TD,
 } from "@/components/ui";
 import { useProject } from "../_lib/project-context";
+import { useScrollState } from "@/lib/useScrollState";
 import CopilotSourceBadge from "@/components/CopilotSourceBadge";
 import AntigravitySourceBadge from "@/components/AntigravitySourceBadge";
 
 export default function ActivityTab() {
   const pathname = usePathname();
   const { sessions, loading } = useProject();
+
+  // Restore scroll position when data fetch is complete
+  useScrollState(`key_project_activity_page`, !loading);
+  const { ref: sessionHistoryRef, onScroll: handleSessionHistoryScroll } = useScrollState(`key_project_activity_sessions`, !loading && sessions.length > 0);
 
   return (
     <Card padding="none">
@@ -35,7 +40,7 @@ export default function ActivityTab() {
           description="Once any agent runs in this workspace, sessions will appear here."
         />
       ) : (
-        <div className="max-h-[700px] overflow-y-auto">
+        <div ref={sessionHistoryRef} onScroll={handleSessionHistoryScroll} className="max-h-[700px] overflow-y-auto">
           <Table>
             <THead>
               <TR>

--- a/frontend/src/app/projects/page.tsx
+++ b/frontend/src/app/projects/page.tsx
@@ -3,17 +3,19 @@
 import { useMemo, useState } from "react";
 import Link from "next/link";
 import {
-  Folder, Search, ArrowRight, Wrench, Users, ClipboardList,
-  LayoutGrid, List as ListIcon, ArrowUpDown, FolderOpen,
+  Folder, Search, ArrowRight, Wrench,
+  LayoutGrid, List as ListIcon, ArrowUpDown,
   GitBranch, ChevronRight,
 } from "lucide-react";
 
 import { useResource } from "@/lib/api";
+import { useScrollState } from "@/lib/useScrollState";
+import { useSessionState } from "@/lib/useSessionState";
 import { getAgent } from "@/lib/agents";
 import { cn } from "@/lib/cn";
 import { formatTokens, formatCost } from "@/lib/format";
 import {
-  PageHeader, Section, Card, Badge, AgentBadge, Button, EmptyState, Skeleton,
+  PageHeader, Section, Card, Badge, AgentBadge, EmptyState, Skeleton,
   Table, THead, TBody, TR, TH, TD,
 } from "@/components/ui";
 
@@ -74,10 +76,16 @@ const SORTS: { key: SortKey; label: string }[] = [
 export default function ProjectsPage() {
   const { data: projects = [], loading } = useResource<Project[]>("/projects", { initial: [] });
 
-  const [search, setSearch] = useState("");
-  const [view, setView] = useState<ViewMode>("grid");
-  const [sortKey, setSortKey] = useState<SortKey>("sessions");
-  const [sortDesc, setSortDesc] = useState(true);
+  const [pageState, setPageState] = useSessionState("projects_page", {
+    search: "",
+    view: "grid" as ViewMode,
+    sortKey: "sessions" as SortKey,
+    sortDesc: true,
+  });
+  const { search, view, sortKey, sortDesc } = pageState;
+
+  // Restore scroll position when data fetch is complete
+  useScrollState("key_projects_page", !loading);
 
   const filtered = useMemo(() => {
     const q = search.toLowerCase().trim();
@@ -121,7 +129,7 @@ export default function ProjectsPage() {
             type="text"
             placeholder="Search by name or path…"
             value={search}
-            onChange={(e) => setSearch(e.target.value)}
+            onChange={(e) => setPageState({ search: e.target.value })}
             className="w-full h-9 pl-9 pr-3 rounded-[var(--tt-radius)] bg-[var(--tt-panel)] border border-[var(--tt-border)] text-[13px] text-[var(--tt-fg)] placeholder:text-[var(--tt-fg-faint)] hover:border-[var(--tt-border-strong)] focus:border-[color:var(--tt-brand)]/40 focus:outline-none focus:ring-1 focus:ring-[color:var(--tt-brand)]/30 transition-colors"
           />
         </div>
@@ -132,7 +140,7 @@ export default function ProjectsPage() {
           {SORTS.map((s) => (
             <button
               key={s.key}
-              onClick={() => (sortKey === s.key ? setSortDesc(!sortDesc) : setSortKey(s.key))}
+              onClick={() => (sortKey === s.key ? setPageState({ sortDesc: !sortDesc }) : setPageState({ sortKey: s.key }))}
               className={cn(
                 "h-9 px-2.5 text-[12px] font-medium transition-colors flex items-center gap-1",
                 sortKey === s.key ? "text-[var(--tt-fg)] tt-tint-1" : "text-[var(--tt-fg-muted)] hover:text-[var(--tt-fg)]",
@@ -154,7 +162,7 @@ export default function ProjectsPage() {
           ].map(({ v, icon: I, label }) => (
             <button
               key={v}
-              onClick={() => setView(v as ViewMode)}
+              onClick={() => setPageState({ view: v as ViewMode })}
               aria-label={label}
               className={cn(
                 "h-9 w-9 grid place-items-center transition-colors",

--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -169,6 +169,72 @@ function eventKind(evt: Event): StepKind {
   return "other";
 }
 
+function codexVisibleSignatures(event: any): string[] {
+  const payload = event?.payload;
+  if (!payload || typeof payload !== "object") return [];
+
+  const textSignature = (kind: string, value: unknown) => {
+    const text = String(value ?? "").trim();
+    return text ? `${kind}:${text}` : null;
+  };
+
+  if (event.type === "event_msg") {
+    if (payload.type === "user_message") return [textSignature("user", payload.message)].filter(Boolean) as string[];
+    if (payload.type === "agent_message") return [textSignature("assistant", payload.message)].filter(Boolean) as string[];
+    if (payload.type === "agent_reasoning") return [textSignature("reasoning", payload.text)].filter(Boolean) as string[];
+    return [];
+  }
+
+  if (event.type !== "response_item") return [];
+  if (payload.type === "reasoning") {
+    return (payload.summary || [])
+      .filter((item: any) => item && typeof item === "object")
+      .map((item: any) => textSignature("reasoning", item.text))
+      .filter(Boolean) as string[];
+  }
+  if (payload.type !== "message" || !["user", "assistant"].includes(payload.role)) return [];
+
+  const text = (payload.content || [])
+    .filter((item: any) => item && ["input_text", "output_text"].includes(item.type))
+    .map((item: any) => item.text || "")
+    .join("");
+  const signature = textSignature(payload.role, text);
+  return signature ? [signature] : [];
+}
+
+function codexEventTimestamp(event: any): number | undefined {
+  if (typeof event?.normalized_timestamp === "number") return event.normalized_timestamp;
+  if (event?.timestamp) {
+    const timestamp = Date.parse(event.timestamp);
+    return Number.isNaN(timestamp) ? undefined : timestamp;
+  }
+  return undefined;
+}
+
+function dedupeCodexMirrors(events: any[]): any[] {
+  const canonical = new Map<string, Array<{ index: number; timestamp?: number }>>();
+  events.forEach((event, index) => {
+    if (event.type !== "response_item") return;
+    for (const signature of codexVisibleSignatures(event)) {
+      const matches = canonical.get(signature) || [];
+      matches.push({ index, timestamp: codexEventTimestamp(event) });
+      canonical.set(signature, matches);
+    }
+  });
+
+  return events.filter((event, index) => {
+    if (event.type !== "event_msg") return true;
+    const timestamp = codexEventTimestamp(event);
+    const mirrored = codexVisibleSignatures(event).some((signature) =>
+      (canonical.get(signature) || []).some((match) =>
+        Math.abs(index - match.index) <= 4 &&
+        (timestamp === undefined || match.timestamp === undefined || Math.abs(timestamp - match.timestamp) <= 100)
+      )
+    );
+    return !mirrored;
+  });
+}
+
 /* Normalize a raw trace payload (session detail or subagent transcript) into
    renderable events — shared by the main trace fetch and the subagent
    drill-in viewer so both filter the same noise. */
@@ -199,6 +265,10 @@ function normalizeTraceEvents(agent: string | null, data: any): Event[] {
       lastKept = e;
       return true;
     });
+    // Codex writes a canonical response_item and an event_msg projection for
+    // the same visible turn. Keep the canonical event so the Step Index and
+    // conversation cards are driven by one shared timeline.
+    evts = dedupeCodexMirrors(evts);
   }
   if (agent === "claude" || agent === "cursor") {
     const NOISE_TYPES = new Set([

--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -235,6 +235,43 @@ function dedupeCodexMirrors(events: any[]): any[] {
   });
 }
 
+function collapseCodexReasoningSnapshots(events: any[]): any[] {
+  const collapsed: any[] = [];
+  for (const event of events) {
+    const isReasoning = event?.type === "response_item" && event?.payload?.type === "reasoning";
+    if (!isReasoning) {
+      collapsed.push(event);
+      continue;
+    }
+
+    const currentText = codexVisibleSignatures(event)
+      .filter((signature) => signature.startsWith("reasoning:"))
+      .map((signature) => signature.slice("reasoning:".length))
+      .join("\n\n");
+    if (!currentText) continue;
+
+    let previousIndex = collapsed.length - 1;
+    while (previousIndex >= 0 && collapsed[previousIndex]?.type === "event_msg" && collapsed[previousIndex]?.payload?.type === "token_count") {
+      previousIndex -= 1;
+    }
+
+    const previous = previousIndex >= 0 ? collapsed[previousIndex] : null;
+    if (previous?.type === "response_item" && previous?.payload?.type === "reasoning") {
+      const previousText = codexVisibleSignatures(previous)
+        .filter((signature) => signature.startsWith("reasoning:"))
+        .map((signature) => signature.slice("reasoning:".length))
+        .join("\n\n");
+      if (previousText === currentText || previousText.startsWith(currentText) || currentText.startsWith(previousText)) {
+        if (currentText.length >= previousText.length) collapsed[previousIndex] = event;
+        continue;
+      }
+    }
+
+    collapsed.push(event);
+  }
+  return collapsed;
+}
+
 /* Normalize a raw trace payload (session detail or subagent transcript) into
    renderable events — shared by the main trace fetch and the subagent
    drill-in viewer so both filter the same noise. */
@@ -268,7 +305,7 @@ function normalizeTraceEvents(agent: string | null, data: any): Event[] {
     // Codex writes a canonical response_item and an event_msg projection for
     // the same visible turn. Keep the canonical event so the Step Index and
     // conversation cards are driven by one shared timeline.
-    evts = dedupeCodexMirrors(evts);
+    evts = collapseCodexReasoningSnapshots(dedupeCodexMirrors(evts));
   }
   if (agent === "claude" || agent === "cursor") {
     const NOISE_TYPES = new Set([

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -9,6 +9,7 @@ import {
 import { useResource } from "@/lib/api";
 import { ALL_AGENT_KEYS, getAgent } from "@/lib/agents";
 import { cn } from "@/lib/cn";
+import { clearPageState } from "@/lib/pageState";
 import { ThemeToggle } from "./ThemeToggle";
 import NotificationBell from "./notifications/NotificationBell";
 import HermesIcon from "./icons/HermesIcon";
@@ -129,6 +130,7 @@ function NavLink({ link, pathname, isCollapsed }: {
     <Link
       href={link.href}
       title={isCollapsed ? link.name : undefined}
+      onClick={() => {clearPageState()}}
       className={cn(
         "relative flex items-center gap-3 rounded-[var(--tt-radius)] px-2.5 py-2 text-[13px] font-medium transition-colors",
         isActive

--- a/frontend/src/components/hermes/HermesSessionExplorer.tsx
+++ b/frontend/src/components/hermes/HermesSessionExplorer.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { format, formatDistanceToNow } from "date-fns";
+import {
+  AlertTriangle, ChevronLeft, ChevronRight, ExternalLink, RotateCcw,
+  Search, SlidersHorizontal, X,
+} from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { useResource } from "@/lib/api";
+import {
+  buildHermesSessionsPath, formatHermesProject, type HermesSessionPage,
+  type HermesSessionQuery, type HermesSessionSort,
+} from "@/lib/hermesSessions";
+import { formatCost, formatTokens } from "@/lib/format";
+import { Badge, Button, Card, EmptyState, Skeleton } from "@/components/ui";
+import SourceBadge from "@/components/SourceBadge";
+
+const PAGE_SIZE = 50;
+
+function readQuery(searchParams: { get(name: string): string | null }): HermesSessionQuery {
+  const rawSort = searchParams.get("sort");
+  const sort: HermesSessionSort = rawSort === "oldest" || rawSort === "cost" || rawSort === "tokens"
+    ? rawSort
+    : "newest";
+  return {
+    page: Math.max(1, Number(searchParams.get("page")) || 1),
+    pageSize: PAGE_SIZE,
+    search: searchParams.get("search") || "",
+    project: searchParams.get("project") || "",
+    source: searchParams.get("source") || "",
+    model: searchParams.get("model") || "",
+    sort,
+  };
+}
+
+export default function HermesSessionExplorer() {
+  const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const query = useMemo(() => readQuery(searchParams), [searchParams]);
+  const [searchInput, setSearchInput] = useState(query.search || "");
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => setSearchInput(query.search || ""), 0);
+    return () => window.clearTimeout(timer);
+  }, [query.search]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      if (searchInput.trim() === (query.search || "").trim()) return;
+      updateQuery({ search: searchInput.trim() || null, page: "1" });
+    }, 300);
+    return () => window.clearTimeout(timer);
+  }, [searchInput]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const path = useMemo(() => buildHermesSessionsPath(query), [query]);
+  const { data, loading, error, refetch } = useResource<HermesSessionPage>(path, {
+    pollMs: 15_000,
+    initial: { sessions: [], pagination: { page: 1, page_size: PAGE_SIZE, total: 0, total_pages: 0 } },
+  });
+
+  const activeFilterCount = [query.project, query.source, query.model, query.search].filter(Boolean).length;
+
+  function updateQuery(updates: Record<string, string | null>) {
+    const next = new URLSearchParams(searchParams.toString());
+    for (const [key, value] of Object.entries(updates)) {
+      if (value) next.set(key, value);
+      else next.delete(key);
+    }
+    const nextQuery = next.toString();
+    router.replace(nextQuery ? `${pathname}?${nextQuery}` : pathname, { scroll: false });
+  }
+
+  function clearFilters() {
+    setSearchInput("");
+    updateQuery({ search: null, project: null, source: null, model: null, sort: null, page: "1" });
+  }
+
+  const sessions = data?.sessions ?? [];
+  const totalPages = data?.pagination.total_pages ?? 0;
+  const returnPath = searchParams.toString() ? `${pathname}?${searchParams.toString()}` : pathname;
+
+  return (
+    <div className="space-y-4">
+      <Card padding="sm" tone="sunken">
+        <div className="flex flex-wrap items-center gap-2">
+          <label className="relative flex-1 min-w-[240px]">
+            <span className="sr-only">Search Hermes sessions</span>
+            <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--tt-fg-dim)]" />
+            <input
+              type="search"
+              value={searchInput}
+              onChange={(event) => setSearchInput(event.target.value)}
+              placeholder="Search messages, projects, models…"
+              className="w-full h-9 pl-9 pr-3 rounded-[var(--tt-radius)] bg-[var(--tt-panel)] border border-[var(--tt-border)] text-[13px] text-[var(--tt-fg)] placeholder:text-[var(--tt-fg-dim)] focus:outline-none focus:border-[var(--tt-border-strong)]"
+            />
+          </label>
+          <FilterInput label="Project" value={query.project || ""} onChange={(value) => updateQuery({ project: value || null, page: "1" })} />
+          <FilterInput label="Source" value={query.source || ""} onChange={(value) => updateQuery({ source: value || null, page: "1" })} />
+          <FilterInput label="Model" value={query.model || ""} onChange={(value) => updateQuery({ model: value || null, page: "1" })} />
+          <select
+            aria-label="Sort Hermes sessions"
+            value={query.sort || "newest"}
+            onChange={(event) => updateQuery({ sort: event.target.value === "newest" ? null : event.target.value, page: "1" })}
+            className="h-9 rounded-[var(--tt-radius)] bg-[var(--tt-panel)] border border-[var(--tt-border)] px-2.5 text-[12px] text-[var(--tt-fg-muted)] focus:outline-none focus:border-[var(--tt-border-strong)]"
+          >
+            <option value="newest">Newest first</option>
+            <option value="oldest">Oldest first</option>
+            <option value="cost">Highest cost</option>
+            <option value="tokens">Most tokens</option>
+          </select>
+          {activeFilterCount > 0 && (
+            <Button variant="ghost" size="sm" onClick={clearFilters} title="Clear filters">
+              <X size={13} /> Clear
+            </Button>
+          )}
+        </div>
+        <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] text-[var(--tt-fg-dim)]">
+          <SlidersHorizontal size={12} />
+          <span>{data ? `${data.pagination.total.toLocaleString()} sessions` : "Loading sessions…"}</span>
+          {activeFilterCount > 0 && <Badge variant="brand" size="xs">{activeFilterCount} filters active</Badge>}
+          <span className="ml-auto">Updated automatically</span>
+        </div>
+      </Card>
+
+      {loading && sessions.length === 0 ? (
+        <Card padding="none">
+          <div className="p-5 space-y-3" aria-busy="true" aria-label="Loading Hermes sessions">
+            {Array.from({ length: 8 }).map((_, index) => <Skeleton key={index} className="h-12 w-full" />)}
+          </div>
+        </Card>
+      ) : error ? (
+        <Card>
+          <EmptyState
+            icon={<AlertTriangle size={20} />}
+            title="Could not load Hermes sessions"
+            description={error.message}
+            action={<Button onClick={refetch}><RotateCcw size={13} /> Try again</Button>}
+          />
+        </Card>
+      ) : sessions.length === 0 ? (
+        <Card><EmptyState title="No Hermes sessions match" description="Try clearing a filter or broadening your search." action={activeFilterCount > 0 ? <Button onClick={clearFilters}>Clear filters</Button> : undefined} /></Card>
+      ) : (
+        <Card padding="none" className="overflow-hidden">
+          <div className="hidden md:grid grid-cols-[120px_minmax(140px,1fr)_minmax(140px,1.5fr)_minmax(100px,0.8fr)_110px_112px] gap-3 px-5 py-3 border-b border-[var(--tt-border)] text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--tt-fg-dim)]">
+            <div>Source</div><div>Project</div><div>Message</div><div>Model</div><div className="text-right">Cost</div><div className="text-right">Time</div>
+          </div>
+          <div className="divide-y divide-[var(--tt-border)]">
+            {sessions.map((session) => <HermesSessionRow key={session.id} session={session} returnPath={returnPath} />)}
+          </div>
+          <div className="flex flex-wrap items-center justify-between gap-3 px-5 py-3 border-t border-[var(--tt-border)] text-[11px] text-[var(--tt-fg-muted)]">
+            <span>Page {data?.pagination.page ?? query.page} of {totalPages || 1}</span>
+            <div className="flex items-center gap-1">
+              <Button aria-label="Previous page" variant="ghost" size="sm" disabled={(data?.pagination.page ?? query.page ?? 1) <= 1} onClick={() => updateQuery({ page: String(Math.max(1, (data?.pagination.page ?? query.page ?? 1) - 1)) })}><ChevronLeft size={14} /></Button>
+              <Button aria-label="Next page" variant="ghost" size="sm" disabled={totalPages === 0 || (data?.pagination.page ?? query.page ?? 1) >= totalPages} onClick={() => updateQuery({ page: String((data?.pagination.page ?? query.page ?? 1) + 1) })}><ChevronRight size={14} /></Button>
+            </div>
+          </div>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+function FilterInput({ label, value, onChange }: { label: string; value: string; onChange: (value: string) => void }) {
+  return (
+    <label className="relative w-[132px]">
+      <span className="sr-only">Filter by {label}</span>
+      <input
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={label}
+        className="w-full h-9 rounded-[var(--tt-radius)] bg-[var(--tt-panel)] border border-[var(--tt-border)] px-2.5 text-[12px] text-[var(--tt-fg-muted)] placeholder:text-[var(--tt-fg-dim)] focus:outline-none focus:border-[var(--tt-border-strong)]"
+      />
+    </label>
+  );
+}
+
+function HermesSessionRow({ session, returnPath }: { session: HermesSessionPage["sessions"][number]; returnPath: string }) {
+  const href = `/sessions/${session.id}?agent=hermes&from=${encodeURIComponent(returnPath)}`;
+  const message = session.display || session.text || "No message content";
+  return (
+    <Link href={href} className="group block px-5 py-3 hover:bg-[var(--tt-sunken)] transition-colors focus:outline-none focus:bg-[var(--tt-sunken)]">
+      <div className="grid grid-cols-1 md:grid-cols-[120px_minmax(140px,1fr)_minmax(140px,1.5fr)_minmax(100px,0.8fr)_110px_112px] gap-2 md:gap-3 items-center text-[12px]">
+        <div><SourceBadge source={session.source_subtype} size="xs" /></div>
+        <div className="min-w-0">
+          <div className="text-[var(--tt-fg)] truncate" title={session.project}>{formatHermesProject(session.project)}</div>
+          <div className="text-[10px] text-[var(--tt-fg-dim)] truncate" title={session.project}>{session.project || "unknown"}</div>
+        </div>
+        <div className="min-w-0 text-[var(--tt-fg)] truncate" title={message}>
+          {session.cost_anomaly && <AlertTriangle size={11} className="inline mr-1 text-[var(--tt-warn-fg)]" aria-label="Reasoning cost anomaly" />}
+          {message}
+        </div>
+        <div className="font-mono text-[11px] text-[var(--tt-fg-muted)] truncate" title={session.model}>{session.model || "—"}</div>
+        <div className="md:text-right tabular text-[var(--tt-fg-muted)]">
+          {session.cost && session.cost > 0 ? formatCost(session.cost) : "—"}
+          {session.tokens?.total ? <div className="text-[10px] text-[var(--tt-fg-dim)]">{formatTokens(session.tokens.total)} tok</div> : null}
+        </div>
+        <div className="md:text-right text-[11px] text-[var(--tt-fg-muted)]">
+          <div>{formatDistanceToNow(new Date(session.timestamp), { addSuffix: true })}</div>
+          <div className="text-[10px] text-[var(--tt-fg-dim)]">{format(new Date(session.timestamp), "MMM d, HH:mm")}</div>
+        </div>
+      </div>
+      <div className="mt-1 flex items-center justify-end gap-1 text-[10px] text-[var(--tt-fg-dim)] opacity-0 group-hover:opacity-100 group-focus:opacity-100 transition-opacity">
+        Open trace <ExternalLink size={10} />
+      </div>
+    </Link>
+  );
+}

--- a/frontend/src/lib/hermesSessions.ts
+++ b/frontend/src/lib/hermesSessions.ts
@@ -1,0 +1,65 @@
+export interface HermesSession {
+  id: string;
+  agent: "hermes";
+  project: string;
+  timestamp: string;
+  display?: string;
+  text?: string;
+  model?: string;
+  source_subtype?: string;
+  cost?: number;
+  cost_anomaly?: boolean;
+  tokens?: {
+    input: number;
+    output: number;
+    cached: number;
+    reasoning?: number;
+    total: number;
+  };
+}
+
+export type HermesSessionSort = "newest" | "oldest" | "cost" | "tokens";
+
+export interface HermesSessionPage {
+  sessions: HermesSession[];
+  pagination: {
+    page: number;
+    page_size: number;
+    total: number;
+    total_pages: number;
+  };
+}
+
+export interface HermesSessionQuery {
+  page?: number;
+  pageSize?: number;
+  search?: string;
+  project?: string;
+  source?: string;
+  model?: string;
+  sort?: HermesSessionSort;
+}
+
+export function buildHermesSessionsPath(query: HermesSessionQuery): string {
+  const params = new URLSearchParams();
+  const page = query.page ?? 1;
+  const pageSize = query.pageSize ?? 50;
+
+  params.set("page", String(page));
+  params.set("page_size", String(pageSize));
+  if (query.search?.trim()) params.set("search", query.search.trim());
+  if (query.project) params.set("project", query.project);
+  if (query.source) params.set("source", query.source);
+  if (query.model) params.set("model", query.model);
+  if (query.sort && query.sort !== "newest") {
+    params.set("sort", query.sort === "cost" ? "cost_desc" : query.sort === "tokens" ? "tokens_desc" : query.sort);
+  }
+
+  return `/hermes/sessions?${params.toString()}`;
+}
+
+export function formatHermesProject(project: string): string {
+  if (!project || project === "unknown") return "No project";
+  const parts = project.split(/[\\/]/).filter(Boolean);
+  return parts.at(-1) || project;
+}

--- a/frontend/src/lib/pageState.ts
+++ b/frontend/src/lib/pageState.ts
@@ -1,0 +1,19 @@
+"use client";
+
+/**
+ * Registry of sessionStorage keys used for persisted page state (UI + scroll).
+ */
+const registeredKeys = new Set<string>();
+
+/** Tracks a sessionStorage key so it can be purged on menu navigation. */
+export function registerStateKey(key: string): void {
+  registeredKeys.add(key);
+}
+
+/** Removes every tracked page-state and scroll-restoration key. */
+export function clearPageState(): void {
+  registeredKeys.forEach((key) => {
+    try { sessionStorage.removeItem(key); } catch {}
+  });
+  registeredKeys.clear();
+}

--- a/frontend/src/lib/useScrollState.ts
+++ b/frontend/src/lib/useScrollState.ts
@@ -1,0 +1,98 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+import { registerStateKey } from "@/lib/pageState";
+
+type ScrollTarget = HTMLElement | Window | null;
+
+function getPageContainer(): ScrollTarget {
+  if (typeof document === "undefined") return null;
+  return document.querySelector("main") ?? window;
+}
+
+function getScrollTop(target: ScrollTarget): number {
+  if (!target) return 0;
+  return "scrollTop" in target ? target.scrollTop : target.scrollY;
+}
+
+function scrollToY(target: ScrollTarget, y: number): void {
+  if (!target) return;
+  if ("scrollTop" in target) {
+    target.scrollTop = y;
+  } else {
+    target.scrollTo({ top: y, behavior: "instant" });
+  }
+}
+
+/**
+ * Persists and restores scroll position for a page or scrollable element.
+ *
+ * - Targets the page <main> container by default, or an element bound via the returned `ref` + `onScroll`.
+ * - Positions are stored in sessionStorage under `scroll_<key>` and restored once `isReady` becomes true.
+ */
+export function useScrollState(key: string, isReady: boolean = true) {
+  const nodeRef = useRef<HTMLElement | null>(null);
+  const isRestoringRef = useRef(false);
+  const restoredRef = useRef(false);
+
+  useEffect(() => {
+    registerStateKey(`scroll_${key}`);
+  }, [key]);
+
+  const saveScrollPosition = useCallback((top: number) => {
+    if (isRestoringRef.current) return;
+    sessionStorage.setItem(`scroll_${key}`, String(top));
+  },[key]);
+
+  const ref = useCallback((node: HTMLElement | null) => {
+    nodeRef.current = node;
+  }, []);
+
+  const onScroll = useCallback((e: React.UIEvent<HTMLElement>) => {
+    saveScrollPosition(e.currentTarget.scrollTop);
+  },[saveScrollPosition]);
+
+  useEffect(() => {
+    const target = nodeRef.current ?? getPageContainer();
+    if (!target) return;
+
+    if ("scrollRestoration" in window.history) {
+      window.history.scrollRestoration = "manual";
+    }
+
+    // Restore the saved position once, when the page is ready to paint.
+    if (isReady && !restoredRef.current) {
+      const savedStr = sessionStorage.getItem(`scroll_${key}`);
+      const savedY = savedStr ? parseInt(savedStr, 10) : 0;
+
+      if (!isNaN(savedY) && savedY > 0) {
+        isRestoringRef.current = true;
+        requestAnimationFrame(() => {
+          scrollToY(target, savedY);
+          isRestoringRef.current = false;
+          restoredRef.current = true;
+        });
+      } else {
+        restoredRef.current = true;
+      }
+    }
+
+    // Persist the position, debounced, while the user scrolls.
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const handleScrollPosition = () => {
+      if (isRestoringRef.current) return;
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => saveScrollPosition(getScrollTop(target)), 50);
+    };
+
+    target.addEventListener("scroll", handleScrollPosition, { passive: true });
+
+    return () => {
+      if (timer) clearTimeout(timer);
+      target.removeEventListener("scroll", handleScrollPosition);
+    };
+  }, [key, isReady, saveScrollPosition]);
+
+  return { ref, onScroll };
+}

--- a/frontend/src/lib/useSessionState.ts
+++ b/frontend/src/lib/useSessionState.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { registerStateKey } from "@/lib/pageState";
+
+export type StateSetter<T> = Partial<T> | ((prev: T) => T);
+
+function readStorage<T>(key: string): T | null {
+  try {
+    const item = sessionStorage.getItem(key);
+    return item !== null ? (JSON.parse(item) as T) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Custom hook that persists React state to sessionStorage under a single key.
+ *
+ * - Automatically saves state to sessionStorage and restores it on page remount.
+ * - Merges saved state with default values so missing fields are safely filled.
+ * - Supports partial state updates (patching).
+ */
+export function useSessionState<T extends object>(key: string, defaults: T): [T, (patch: StateSetter<T>) => void] {
+  const [state, setState] = useState<T>(() => {
+    if (typeof window === "undefined") return defaults;
+    const stored = readStorage<Partial<T>>(key);
+    return stored ? { ...defaults, ...stored } : defaults;
+  });
+
+  useEffect(() => {
+    registerStateKey(key);
+  }, [key]);
+
+  useEffect(() => {
+    try { sessionStorage.setItem(key, JSON.stringify(state)); } catch {}
+  }, [key, state]);
+
+  const set = useCallback((patch: StateSetter<T>) => {
+    setState((prev) =>
+      typeof patch === "function" ? patch(prev) : { ...prev, ...patch }
+    );
+  }, []);
+
+  return [state, set];
+}


### PR DESCRIPTION
## Summary
- add a paginated, searchable Hermes session explorer at `/hermes/sessions` and keep `/hermes` focused on recent sessions
- remove duplicate/mirrored Codex trace cards while keeping legacy event-only records intact
- apply session scroll-state restoration from PR #245

## Verification
- `python3.11 -m pytest backend/test_hermes_sessions_api.py backend/test_codex_trace.py -q`
- `npm run build` (from `frontend/`)
- live API check: `GET /hermes/sessions?page=1&page_size=1`