### PR TITLE
fix(billing): price cached reads cumulatively

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -3961,17 +3961,19 @@ def _rollup_agent_transcript(f: Path, agent_type: Optional[str] = None,
 
     Each transcript runs its own context and often a DIFFERENT model than the
     parent (e.g. Explore on Haiku under an Opus session), so cost is computed
-    per file with that file's model. Cache semantics match the main scanner:
-    cached = high-water-mark of cache_read per transcript, cache writes are
-    billed per event and accumulate. Returns None if the file can't be read.
+    per file with that file's model. ``cached`` remains the per-transcript
+    high-water mark for display, while ``_cached_sum`` is the cumulative billed
+    cache-read volume. Cache writes are billed per event and accumulate.
+    Returns None if the file can't be read.
 
     Shared by _claude_subagent_usage (flat Task/Agent transcripts) and
     _claude_workflow_entries (dynamic-workflow agents) so the token/cost math
     can't drift between the two.
     """
-    tokens = {"input": 0, "output": 0, "cached": 0, "cache_creation": 0,
+    tokens = {"input": 0, "output": 0, "cached": 0, "_cached_sum": 0, "cache_creation": 0,
               "cache_creation_1h": 0, "total": 0}
     model = None
+    seen_message_ids: set = set()
     try:
         with open(f, "r", encoding="utf-8", errors="replace") as fh:
             for line in fh:
@@ -3991,18 +3993,24 @@ def _rollup_agent_transcript(f: Path, agent_type: Optional[str] = None,
                 usage = msg.get("usage", {}) if isinstance(msg.get("usage"), dict) else {}
                 if not usage:
                     continue
+                message_id = msg.get("id")
+                if message_id:
+                    if message_id in seen_message_ids:
+                        continue
+                    seen_message_ids.add(message_id)
                 cr = usage.get("cache_read_input_tokens", 0) or 0
                 cc = usage.get("cache_creation_input_tokens", 0) or 0
                 cc_1h = (usage.get("cache_creation", {}) or {}).get("ephemeral_1h_input_tokens", 0) or 0
                 tokens["input"] += usage.get("input_tokens", 0) or 0
                 tokens["output"] += usage.get("output_tokens", 0) or 0
                 tokens["cached"] = max(tokens["cached"], cr)
+                tokens["_cached_sum"] += cr
                 tokens["cache_creation"] += cc
                 tokens["cache_creation_1h"] += cc_1h
     except Exception:
         return None
     tokens["total"] = tokens["input"] + tokens["output"] + tokens["cached"]
-    cost = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"],
+    cost = calculate_cost(model, tokens["input"], tokens["output"], tokens["_cached_sum"],
                           cache_creation_tokens=tokens["cache_creation"],
                           cache_creation_1h_tokens=tokens["cache_creation_1h"])
     entry = {
@@ -4129,7 +4137,7 @@ def _claude_subagent_usage(session_file: Path, sid: str) -> Optional[Dict[str, A
     entries.extend(_claude_workflow_entries(sub_dir))
     if not entries:
         return None
-    totals = {"input": 0, "output": 0, "cached": 0, "cache_creation": 0,
+    totals = {"input": 0, "output": 0, "cached": 0, "_cached_sum": 0, "cache_creation": 0,
               "cache_creation_1h": 0, "total": 0}
     by_type: Dict[str, Dict[str, Any]] = {}
     for e in entries:
@@ -4393,7 +4401,7 @@ def _claude_build_goals(arms: List[Dict[str, Any]],
             # incremental, unlike Codex's whole-goal native count.
             "cost_basis": "attributed_turns",
             "cost": (calculate_cost(model, u.get("input", 0), u.get("output", 0),
-                                    u.get("cached", 0),
+                                    u.get("_cached_sum", u.get("cached", 0)),
                                     cache_creation_tokens=u.get("cache_creation", 0),
                                     cache_creation_1h_tokens=u.get("cache_creation_1h", 0))
                      if tokens else None),
@@ -4411,7 +4419,7 @@ def _claude_build_goals(arms: List[Dict[str, Any]],
 _CLAUDE_CACHE_FIELDS = (
     "tokens", "model", "cost", "mcp_tools", "has_plan", "plans",
     "delegation", "delegated_cost", "tool_counts", "mcp_usage", "skills_used",
-    "loop", "published_artifacts", "goals",
+    "loop", "published_artifacts", "goals", "untracked_background",
 )
 
 
@@ -4644,7 +4652,7 @@ def _scan_sessions_sync():
                     loop_prompts: set = set()                # loop prompt text, to count re-injected fires
                     loop_fires: List[str] = []               # ts of each re-injected fire
                     in_loop_span = False                     # inside a loop-fire response turn right now
-                    loop_usage = {"input": 0, "output": 0, "cached": 0,
+                    loop_usage = {"input": 0, "output": 0, "cached": 0, "_cached_sum": 0,
                                   "cache_creation": 0, "cache_creation_1h": 0}  # loop's OWN footprint
                     artifact_calls: Dict[str, Dict[str, Any]] = {}  # Artifact tool_use_id -> input meta
                     published_arts: Dict[str, Dict[str, Any]] = {}  # hosted url -> published-artifact record
@@ -4653,12 +4661,21 @@ def _scan_sessions_sync():
                     goal_blocks: List[Dict[str, Any]] = []   # each blocked stop, tagged with its arm
                     goal_span_arm: Optional[int] = None      # arm index owning the current post-block span
                     goal_usage_by_arm: Dict[int, Dict[str, int]] = {}  # arm idx -> attributed footprint
+                    seen_assistant_message_ids: set = set()
+                    untracked_background = {"recaps": 0, "titles": 0, "compactions": 0}
                     try:
                         with open(session_file, "r", encoding="utf-8", errors="replace") as f:
                             for line in f:
                                 try:
                                     data = json.loads(line)
                                 except Exception: continue
+                                if data.get("type") == "ai-title":
+                                    untracked_background["titles"] += 1
+                                elif data.get("type") == "system":
+                                    if data.get("subtype") == "away_summary":
+                                        untracked_background["recaps"] += 1
+                                    elif data.get("subtype") == "compact_boundary":
+                                        untracked_background["compactions"] += 1
                                 if data.get("type") in ("user", "assistant") and data.get("timestamp"):
                                     last_real_ts = data["timestamp"]
                                 if data.get("type") == "assistant":
@@ -4668,6 +4685,11 @@ def _scan_sessions_sync():
                                         sess["model"] = m
                                     usage = msg.get("usage", {})
                                     if usage:
+                                        message_id = msg.get("id")
+                                        if message_id:
+                                            if message_id in seen_assistant_message_ids:
+                                                continue
+                                            seen_assistant_message_ids.add(message_id)
                                         cr = usage.get("cache_read_input_tokens", 0) or 0
                                         cc = usage.get("cache_creation_input_tokens", 0) or 0
                                         cc_1h = (usage.get("cache_creation", {}) or {}).get("ephemeral_1h_input_tokens", 0) or 0
@@ -4683,6 +4705,7 @@ def _scan_sessions_sync():
                                             loop_usage["input"] += usage.get("input_tokens", 0) or 0
                                             loop_usage["output"] += usage.get("output_tokens", 0) or 0
                                             loop_usage["cached"] = max(loop_usage["cached"], cr)
+                                            loop_usage["_cached_sum"] += cr
                                             loop_usage["cache_creation"] += cc
                                             loop_usage["cache_creation_1h"] += cc_1h
                                         if goal_span_arm is not None:
@@ -4690,15 +4713,16 @@ def _scan_sessions_sync():
                                             # it is the goal's incremental cost. Same span technique
                                             # as the loop footprint above.
                                             gu = goal_usage_by_arm.setdefault(goal_span_arm, {
-                                                "input": 0, "output": 0, "cached": 0,
+                                                "input": 0, "output": 0, "cached": 0, "_cached_sum": 0,
                                                 "cache_creation": 0, "cache_creation_1h": 0})
                                             gu["input"] += usage.get("input_tokens", 0) or 0
                                             gu["output"] += usage.get("output_tokens", 0) or 0
                                             gu["cached"] = max(gu["cached"], cr)
+                                            gu["_cached_sum"] += cr
                                             gu["cache_creation"] += cc
                                             gu["cache_creation_1h"] += cc_1h
                                     sess["tokens"]["total"] = sess["tokens"]["input"] + sess["tokens"]["output"] + sess["tokens"]["cached"]
-                                    sess["cost"] = calculate_cost(sess.get("model"), sess["tokens"]["input"], sess["tokens"]["output"], sess["tokens"]["cached"], cache_creation_tokens=sess["tokens"].get("cache_creation", 0), cache_creation_1h_tokens=sess["tokens"].get("cache_creation_1h", 0))
+                                    sess["cost"] = calculate_cost(sess.get("model"), sess["tokens"]["input"], sess["tokens"]["output"], sess["tokens"].get("_cached_sum", sess["tokens"]["cached"]), cache_creation_tokens=sess["tokens"].get("cache_creation", 0), cache_creation_1h_tokens=sess["tokens"].get("cache_creation_1h", 0))
                                     for item in msg.get("content", []):
                                         if item.get("type") == "tool_use":
                                             tool = item.get("name")
@@ -4861,6 +4885,9 @@ def _scan_sessions_sync():
                             sess["timestamp"] = datetime.fromisoformat(last_real_ts.replace("Z", "+00:00"))
                         except ValueError:
                             pass
+                    untracked_total = sum(untracked_background.values())
+                    if untracked_total:
+                        sess["untracked_background"] = {**untracked_background, "total": untracked_total}
                     if published_arts:
                         sess["published_artifacts"] = sorted(
                             published_arts.values(),
@@ -4886,10 +4913,10 @@ def _scan_sessions_sync():
                         # Loop's OWN footprint: usage from the fire-response turns only, NOT
                         # the whole session (a session may do lots of non-loop work).
                         lu = loop_usage
-                        # Cost uses the same basis as the session (cached=high-water-mark), so
-                        # footprint_cost is guaranteed <= the session's own cost.
+                        # Cost uses cumulative cache reads, while the visible cached count
+                        # remains the context high-water mark used by the session header.
                         footprint_cost = calculate_cost(sess.get("model"), lu["input"], lu["output"],
-                            lu["cached"], cache_creation_tokens=lu["cache_creation"],
+                            lu.get("_cached_sum", lu["cached"]), cache_creation_tokens=lu["cache_creation"],
                             cache_creation_1h_tokens=lu["cache_creation_1h"])
                         # Billed tokens the loop's own turns produced/processed (input+output).
                         # Cache read/write is session context overhead, excluded — so this is the

--- a/backend/main.py
+++ b/backend/main.py
@@ -5559,7 +5559,7 @@ def _scan_sessions_sync():
                                                     plans.append({"session_id": sid, "agent": "qwen", "timestamp": last_ts, "content": t_text})
                                 except Exception: continue
                         tokens["total"] = tokens["input"] + tokens["output"] + tokens["cached"]
-                        tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"], cache_creation_tokens=tokens.get("cache_creation", 0), cache_creation_1h_tokens=tokens.get("cache_creation_1h", 0))
+                        tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens.get("_cached_sum", tokens["cached"]), cache_creation_tokens=tokens.get("cache_creation", 0), cache_creation_1h_tokens=tokens.get("cache_creation_1h", 0))
                         _q_sess = {"id": sid, "agent": "qwen", "project": project_path, "timestamp": last_ts, "display": first_msg[:100], "tokens": tokens, "mcp_tools": mcp_tools, "has_plan": has_plan, "plans": plans, "model": model, "artifacts": artifacts, "cost": tokens["cost"]}
                         _attach_tool_usage(_q_sess, tool_counts, q_skill_counts)
                         sessions.append(_q_sess)
@@ -5675,7 +5675,7 @@ def _scan_sessions_sync():
                                                         has_plan = True
                                                         plans.append({"session_id": sid, "agent": "cursor", "timestamp": mtime, "content": t_text})
                                 tokens["total"] = tokens["input"] + tokens["output"] + tokens["cached"]
-                                tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"], cache_creation_tokens=tokens.get("cache_creation", 0), cache_creation_1h_tokens=tokens.get("cache_creation_1h", 0))
+                                tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens.get("_cached_sum", tokens["cached"]), cache_creation_tokens=tokens.get("cache_creation", 0), cache_creation_1h_tokens=tokens.get("cache_creation_1h", 0))
                                 # Cursor writes subagent transcripts to <sid>/subagents/
                                 # but they carry NO usage fields (verified), so we can
                                 # only count spawns — never estimate their tokens.

--- a/backend/scan_cache.py
+++ b/backend/scan_cache.py
@@ -34,7 +34,7 @@ logger = logging.getLogger("tokentelemetry.scan_cache")
 # update that affects cached costs. `_mtime` only detects source-transcript
 # changes; this detects code changes. A mismatch is a miss, so stale entries
 # are transparently reparsed and rewritten — never migrated in place.
-CACHE_VERSION = 6  # v2: added "loop" field; v3: added loop footprint_tokens/footprint_cost; v4: added published_artifacts; v5: page artifacts carry source path; v6: added "goals" (/goal)
+CACHE_VERSION = 7  # v2: added "loop" field; v3: added loop footprint_tokens/footprint_cost; v4: added published_artifacts; v5: page artifacts carry source path; v6: added "goals" (/goal); v7: Claude cached-read costs use cumulative usage and record untracked background activity
 
 
 def _require_safe_component(candidate: str) -> str:

--- a/backend/test_delegation.py
+++ b/backend/test_delegation.py
@@ -35,7 +35,7 @@ def _jl(**kw) -> str:
 
 def _assistant_line(model="claude-opus-4-8", inp=0, out=0, cache_read=0,
                     cache_creation=0, cache_creation_1h=0, attribution=None,
-                    content=None):
+                    content=None, message_id=None):
     usage = {
         "input_tokens": inp, "output_tokens": out,
         "cache_read_input_tokens": cache_read,
@@ -43,6 +43,8 @@ def _assistant_line(model="claude-opus-4-8", inp=0, out=0, cache_read=0,
         "cache_creation": {"ephemeral_1h_input_tokens": cache_creation_1h},
     }
     line = {"type": "assistant", "message": {"model": model, "usage": usage, "content": content or []}}
+    if message_id:
+        line["message"]["id"] = message_id
     if attribution:
         line["attributionAgent"] = attribution
     return json.dumps(line) + "\n"
@@ -209,13 +211,16 @@ def test_helper_rollup(tmp_path):
     assert one["description"] == "look around"
     assert one["tool_use_id"] == "toolu_1"
     assert one["model"] == "claude-haiku-4-5-20251001"
-    # input/output cumulative; cached = high-water-mark (NOT 100+300);
-    # cache_creation cumulative. Synthetic + truncated lines ignored.
+    # input/output cumulative; cached = high-water-mark (NOT 100+300), while
+    # _cached_sum tracks the billed per-turn reads. Cache creation is cumulative.
     assert one["tokens"]["input"] == 30
     assert one["tokens"]["output"] == 10
     assert one["tokens"]["cached"] == 300
+    assert one["tokens"]["_cached_sum"] == 400
     assert one["tokens"]["cache_creation"] == 100
     assert one["tokens"]["total"] == 30 + 10 + 300
+    assert one["cost"] == pytest.approx(main.calculate_cost(
+        "claude-haiku-4-5-20251001", 30, 10, 400, cache_creation_tokens=100))
     # meta fallbacks
     assert by_id["two"]["agent_type"] == "general-purpose"
     assert by_id["three"]["agent_type"] == "unknown"
@@ -223,6 +228,7 @@ def test_helper_rollup(tmp_path):
     assert deleg["totals"]["input"] == 30 + 7 + 1
     assert deleg["totals"]["output"] == 10 + 3 + 2
     assert deleg["totals"]["cached"] == 300 + 40 + 0
+    assert deleg["totals"]["_cached_sum"] == 400 + 40 + 0
     assert deleg["cost"] >= 0
 
 
@@ -297,6 +303,45 @@ def test_scan_claude_without_spawns(scan_env):
     assert s["delegation"]["spawn_count"] == 0
     assert "delegated_input" not in s["tokens"]
     assert "delegated_cost" not in s
+
+
+def test_claude_scan_dedupes_usage_and_records_unpriced_background_activity(scan_env):
+    """Repeated assistant records must not inflate cost, while usage-free
+    Claude background records remain visible as unpriced activity."""
+    sid = "sid-background-activity"
+    session_file = make_claude_tree(scan_env / ".claude", sid, with_subagents=False)
+    session_file.write_text(
+        _jl(type="user", cwd="/tmp/proj", message={"role": "user", "content": "hi"})
+        + _assistant_line(model="claude-sonnet-4-6", inp=100, out=10, cache_read=20,
+                          message_id="message-1")
+        + _assistant_line(model="claude-sonnet-4-6", inp=100, out=10, cache_read=20,
+                          message_id="message-1")
+        + _assistant_line(model="claude-sonnet-4-6", inp=50, out=5, cache_read=30,
+                          message_id="message-2")
+        + _jl(type="system", subtype="away_summary", content="summary")
+        + _jl(type="ai-title", aiTitle="A title", sessionId=sid)
+        + _jl(type="system", subtype="compact_boundary", compactMetadata={
+            "preTokens": 1000, "postTokens": 100,
+        })
+        + _jl(type="user", message={"role": "user", "content": "compact summary"}),
+        encoding="utf-8",
+    )
+
+    first = next(s for s in main._scan_sessions_sync() if s["agent"] == "claude" and s["id"] == sid)
+
+    assert first["tokens"] == {
+        "input": 150, "output": 15, "cached": 30, "_cached_sum": 50, "total": 195,
+        "cache_creation": 0, "cache_creation_1h": 0,
+    }
+    assert first["cost"] == pytest.approx(main.calculate_cost("claude-sonnet-4-6", 150, 15, 50))
+    assert first["untracked_background"] == {
+        "recaps": 1, "titles": 1, "compactions": 1, "total": 3,
+    }
+
+    # The sidecar cache must preserve the disclosure as well as the corrected cost.
+    second = next(s for s in main._scan_sessions_sync() if s["agent"] == "claude" and s["id"] == sid)
+    assert second["cost"] == first["cost"]
+    assert second["untracked_background"] == first["untracked_background"]
 
 
 def test_scan_cursor_spawn_count_only(scan_env):

--- a/backend/test_delegation.py
+++ b/backend/test_delegation.py
@@ -370,6 +370,44 @@ def test_scan_cursor_spawn_count_only(scan_env):
     assert "delegated_input" not in s["tokens"]
 
 
+def test_qwen_and_cursor_price_cumulative_cache_reads(scan_env, monkeypatch):
+    """Cache reads are per-turn usage, while the display bucket stays HWM."""
+    model = "claude-sonnet-4-6"
+    usages = [
+        {"input_tokens": 100, "output_tokens": 20, "cache_read_input_tokens": 100,
+         "cache_creation_input_tokens": 5},
+        {"input_tokens": 200, "output_tokens": 30, "cache_read_input_tokens": 300,
+         "cache_creation_input_tokens": 7},
+    ]
+
+    qwen_dir = scan_env / ".qwen"
+    monkeypatch.setattr(main, "QWEN_DIR", qwen_dir)
+    qwen_chat = qwen_dir / "projects" / "proj" / "chats" / "qwen-cache.jsonl"
+    qwen_chat.parent.mkdir(parents=True)
+    qwen_chat.write_text("".join(
+        _jl(type="assistant", message={"model": model, "usage": usage, "content": []})
+        for usage in usages
+    ), encoding="utf-8")
+
+    cursor_sid = "cursor-cache"
+    cursor_chat = (scan_env / ".cursor" / "projects" / "proj" / "agent-transcripts"
+                   / cursor_sid / f"{cursor_sid}.jsonl")
+    cursor_chat.parent.mkdir(parents=True)
+    cursor_chat.write_text("".join(
+        _jl(role="assistant", message={"model": model, "usage": usage, "content": []})
+        for usage in usages
+    ), encoding="utf-8")
+
+    sessions = main._scan_sessions_sync()
+    expected_cost = main.calculate_cost(model, 300, 50, 400, cache_creation_tokens=12)
+    for agent, sid in (("qwen", "qwen-cache"), ("cursor", cursor_sid)):
+        session = next(s for s in sessions if s["agent"] == agent and s["id"] == sid)
+        assert session["tokens"]["cached"] == 300
+        assert session["tokens"]["_cached_sum"] == 400
+        assert session["tokens"]["cache_creation"] == 12
+        assert session["cost"] == pytest.approx(expected_cost)
+
+
 def _make_opencode_db(path: Path):
     con = sqlite3.connect(path)
     con.execute("CREATE TABLE session (id TEXT, project_id TEXT, parent_id TEXT, "

--- a/frontend/src/app/analytics/page.tsx
+++ b/frontend/src/app/analytics/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { cn } from "@/lib/cn";
 import {
   BarChart3, TrendingUp, ArrowDownToLine, ArrowUpFromLine,
-  Zap, DollarSign, Cpu, GitBranch, Repeat,
+  Zap, DollarSign, Cpu, GitBranch, Repeat, Info,
 } from "lucide-react";
 import {
   AreaChart, Area, BarChart, Bar, PieChart as RePieChart, Pie, Cell,
@@ -214,6 +214,7 @@ export default function AnalyticsPage() {
   }
 
   const cacheEff = ((data.total.cached / Math.max(1, data.total.input + data.total.cached)) * 100);
+  const hasClaudeSessions = (data.by_agent.claude?.session_count ?? 0) > 0;
 
   return (
     <div className="px-8 py-8 max-w-[1600px] mx-auto space-y-10 pb-20">
@@ -230,6 +231,19 @@ export default function AnalyticsPage() {
           )
         }
       />
+
+      {hasClaudeSessions && (
+        <div
+          role="note"
+          className="flex items-start gap-3 rounded-[var(--tt-radius)] border border-amber-400/30 bg-amber-400/[0.06] px-4 py-3 text-[12px] text-[var(--tt-fg-muted)]"
+        >
+          <Info size={15} className="mt-0.5 shrink-0 text-amber-300" aria-hidden="true" />
+          <div>
+            <p className="font-semibold text-[var(--tt-fg)]">Claude Code totals reflect recorded usage.</p>
+            <p className="mt-0.5">Recap, title, and compaction records can lack local token usage, so their activity cannot be priced or included in these totals.</p>
+          </div>
+        </div>
+      )}
 
       {/* Filter toolbar: granularity + custom range + agent/model selection.
           The date-range presets live on the consumption chart header. */}

--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -78,6 +78,8 @@ interface Session {
   loop?: any;
   /** Goal Mode (`/goal`); a session can set several, so this is a list */
   goals?: any[];
+  /** Claude Code records that lack local usage and therefore cannot be priced. */
+  untracked_background?: { recaps: number; titles: number; compactions: number; total: number };
 }
 
 interface Event {
@@ -685,6 +687,8 @@ export default function SessionDetailPage() {
      return tools;
   }, [events, toolResultByUseId]);
 
+  const untrackedBackground = agent === "claude" ? sessionInfo?.untracked_background : undefined;
+
   return (
     <div className="min-h-screen bg-[var(--tt-canvas)] text-[var(--tt-fg)] font-sans flex flex-col">
       <header className="bg-[var(--tt-canvas)]/85 border-b border-[var(--tt-border)] px-6 py-4 sticky top-0 z-50 backdrop-blur supports-[backdrop-filter]:bg-[var(--tt-canvas)]/65">
@@ -818,6 +822,19 @@ export default function SessionDetailPage() {
               </Button>
             </div>
           </div>
+
+          {untrackedBackground && untrackedBackground.total > 0 && (
+            <div
+              role="note"
+              className="flex items-start gap-2 rounded-[var(--tt-radius)] border border-amber-400/30 bg-amber-400/[0.06] px-3 py-2 text-[11px] text-[var(--tt-fg-muted)]"
+            >
+              <Info size={14} className="mt-0.5 shrink-0 text-amber-300" aria-hidden="true" />
+              <span>
+                {untrackedBackground.total} Claude Code background record{untrackedBackground.total === 1 ? "" : "s"} without local usage data
+                {" "}(recaps {untrackedBackground.recaps}, titles {untrackedBackground.titles}, compactions {untrackedBackground.compactions}); not included in the recorded cost.
+              </span>
+            </div>
+          )}
 
           {/* Timeline scrubber */}
           {!loading && events.length > 0 && (


### PR DESCRIPTION
## Summary
- price Claude, Qwen, and Cursor cache reads from their cumulative per-session total
- retain the existing cache high-water mark for display purposes
- disclose Claude usage that cannot be priced and add Qwen/Cursor regression coverage

## Validation
- backend delegation, Cline, and goals: 120 passed, 1 deselected
- Antigravity CLI: 12/12 passed

## Scope
Antigravity regular chat traces already sum cache reads cumulatively. Cline reads cumulative session aggregates and provider-reported cost, so neither has the high-water-mark billing defect.

Closes #224