### PR TITLE
feat(hermes): persist session explorer filter state, simplify compone…

### DIFF
--- a/frontend/src/components/hermes/HermesSessionExplorer.tsx
+++ b/frontend/src/components/hermes/HermesSessionExplorer.tsx
@@ -16,6 +16,7 @@ import {
 import { formatCost, formatTokens } from "@/lib/format";
 import { Badge, Button, Card, EmptyState, Skeleton } from "@/components/ui";
 import SourceBadge from "@/components/SourceBadge";
+import { useScrollState } from "@/lib/useScrollState";
 
 const PAGE_SIZE = 50;
 
@@ -60,6 +61,9 @@ export default function HermesSessionExplorer() {
     pollMs: 15_000,
     initial: { sessions: [], pagination: { page: 1, page_size: PAGE_SIZE, total: 0, total_pages: 0 } },
   });
+
+  // Restore scroll position once session data is loaded.
+  useScrollState("key_hermes_sessions_page", !loading);
 
   const activeFilterCount = [query.project, query.source, query.model, query.search].filter(Boolean).length;
 

--- a/frontend/src/lib/useScrollState.ts
+++ b/frontend/src/lib/useScrollState.ts
@@ -41,6 +41,8 @@ export function useScrollState(key: string, isReady: boolean = true) {
 
   const saveScrollPosition = useCallback((top: number) => {
     if (isRestoringRef.current) return;
+    // Ignore programmatic scrolls that fire before the initial restore runs
+    if (!restoredRef.current) return;
     sessionStorage.setItem(`scroll_${key}`, String(top));
   },[key]);
 


### PR DESCRIPTION
## Summary
This PR addresses state persistence and scroll restoration issues on the Hermes Session Explorer (/hermes/sessions) page, bringing its user experience in line with the Projects page while streamlining component architecture.

**Key Changes:**
1. Persist Filter State (useSessionState): 
- **Before**: The explorer derived filter states (search, project, source, model, sort, page) from URL query parameters on every render, causing filter and page selections to reset during navigation.
- **After**: Implemented useSessionState("hermes_sessions_page", DEFAULT_QUERY) so filters seamlessly persist in sessionStorage across navigations, matching the pattern used in /projects. Directly bound input elements to query.search and setQuery, removing redundant local state and timer boilerplate.

2. Fix Scroll Restoration & Race Condition (useScrollState):
- Added useScrollState to the Session Explorer to preserve scroll positions upon back-navigation.
- Fixed a race condition in useScrollState where a pre-restore programmatic scroll clamp of <main> to 0 (occurring while initial page data was fetching) would overwrite stored scroll offsets, causing /hermes to reset to the top when navigating back.

## Type of change
- [ ] Bug fix
- [ ] New feature (new agent support, new dashboard view, etc.)
- [x] Improvement / refactor
- [ ] Docs / chore

## How to test
1. Run `./start.sh`
2. Open /hermes, scroll down, click View all sessions.
3. Apply filters / navigate pages, open a session, then press Back — the explorer keeps its filters and scroll.
4. Press Back again — /hermes now restores its previous scroll position instead of jumping to the top.

## Checklist
- [x] I tested this locally with `./start.sh`
- [x] No secrets or API keys are included
- [x] PR is focused on one change
- [ ] README or CHANGELOG updated if needed

## Related issue
Closes #251
