### PR TITLE
feat(hermes): load-more session list, filters that survive navigation

### DIFF
--- a/UPDATE.json
+++ b/UPDATE.json
@@ -2,11 +2,11 @@
   "releases": [
     {
       "tag": "2026-08-10",
-      "title": "Hermes session list loads on demand",
+      "title": "Hermes session explorer keeps your place",
       "highlights": [
         {
-          "title": "Load more replaces page numbers",
-          "description": "The Hermes session explorer grows the list in place instead of walking page by page. The footer tells you how many of the matching sessions are on screen, and the filters stay the way to narrow a long history.",
+          "title": "Load more, and filters that stay put",
+          "description": "The Hermes session explorer grows the list with a Load more button instead of walking page by page, and the footer says how many of the matching sessions are on screen. Filtering, moving to another page and coming back now returns you to the same filtered list, and the filters stay in the address bar so a filtered view is still something you can bookmark or share.",
           "href": "/hermes/sessions"
         }
       ]

--- a/UPDATE.json
+++ b/UPDATE.json
@@ -1,6 +1,17 @@
 {
   "releases": [
     {
+      "tag": "2026-08-10",
+      "title": "Hermes session list loads on demand",
+      "highlights": [
+        {
+          "title": "Load more replaces page numbers",
+          "description": "The Hermes session explorer grows the list in place instead of walking page by page. The footer tells you how many of the matching sessions are on screen, and the filters stay the way to narrow a long history.",
+          "href": "/hermes/sessions"
+        }
+      ]
+    },
+    {
       "tag": "2026-08-08",
       "title": "Muse Code and Prime Agent support",
       "highlights": [

--- a/frontend/src/components/hermes/HermesSessionExplorer.tsx
+++ b/frontend/src/components/hermes/HermesSessionExplorer.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { format, formatDistanceToNow } from "date-fns";
 import {
-  AlertTriangle, ChevronLeft, ChevronRight, ExternalLink, RotateCcw,
+  AlertTriangle, ChevronDown, ExternalLink, RotateCcw,
   Search, SlidersHorizontal, X,
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
@@ -18,6 +18,10 @@ import { Badge, Button, Card, EmptyState, Skeleton } from "@/components/ui";
 import SourceBadge from "@/components/SourceBadge";
 
 const PAGE_SIZE = 50;
+// The backend rejects page_size above 200, so that is the most rows this view can
+// hold at once. Past it the filters are the way to narrow things down, which is
+// why there is no page-by-page walk any more.
+const MAX_ROWS = 200;
 
 function readQuery(searchParams: { get(name: string): string | null }): HermesSessionQuery {
   const rawSort = searchParams.get("sort");
@@ -25,8 +29,6 @@ function readQuery(searchParams: { get(name: string): string | null }): HermesSe
     ? rawSort
     : "newest";
   return {
-    page: Math.max(1, Number(searchParams.get("page")) || 1),
-    pageSize: PAGE_SIZE,
     search: searchParams.get("search") || "",
     project: searchParams.get("project") || "",
     source: searchParams.get("source") || "",
@@ -50,12 +52,20 @@ export default function HermesSessionExplorer() {
   useEffect(() => {
     const timer = window.setTimeout(() => {
       if (searchInput.trim() === (query.search || "").trim()) return;
-      updateQuery({ search: searchInput.trim() || null, page: "1" });
+      updateQuery({ search: searchInput.trim() || null });
     }, 300);
     return () => window.clearTimeout(timer);
   }, [searchInput]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const path = useMemo(() => buildHermesSessionsPath(query), [query]);
+  // How many rows to ask for. "Load more" grows this rather than walking pages,
+  // so one request always returns the whole visible list and there is no page
+  // number to fall out of sync with the results.
+  const [rowLimit, setRowLimit] = useState(PAGE_SIZE);
+
+  const path = useMemo(
+    () => buildHermesSessionsPath({ ...query, page: 1, pageSize: rowLimit }),
+    [query, rowLimit],
+  );
   const { data, loading, error, refetch } = useResource<HermesSessionPage>(path, {
     pollMs: 15_000,
     initial: { sessions: [], pagination: { page: 1, page_size: PAGE_SIZE, total: 0, total_pages: 0 } },
@@ -69,17 +79,26 @@ export default function HermesSessionExplorer() {
       if (value) next.set(key, value);
       else next.delete(key);
     }
+    // Left over from the old paginated view; harmless in the URL but misleading.
+    next.delete("page");
+    // Any filter change re-scopes the list, so start from one screenful again.
+    setRowLimit(PAGE_SIZE);
     const nextQuery = next.toString();
     router.replace(nextQuery ? `${pathname}?${nextQuery}` : pathname, { scroll: false });
   }
 
   function clearFilters() {
     setSearchInput("");
-    updateQuery({ search: null, project: null, source: null, model: null, sort: null, page: "1" });
+    updateQuery({ search: null, project: null, source: null, model: null, sort: null });
   }
 
   const sessions = data?.sessions ?? [];
-  const totalPages = data?.pagination.total_pages ?? 0;
+  const total = data?.pagination.total ?? 0;
+  // A larger limit than we have rows for means the wider request is still in
+  // flight — useResource keeps serving the previous response until it lands.
+  const loadingMore = rowLimit > sessions.length && sessions.length < total;
+  const canLoadMore = sessions.length < total && rowLimit < MAX_ROWS;
+  const cappedOut = rowLimit >= MAX_ROWS && total > sessions.length;
   const returnPath = searchParams.toString() ? `${pathname}?${searchParams.toString()}` : pathname;
 
   return (
@@ -97,13 +116,13 @@ export default function HermesSessionExplorer() {
               className="w-full h-9 pl-9 pr-3 rounded-[var(--tt-radius)] bg-[var(--tt-panel)] border border-[var(--tt-border)] text-[13px] text-[var(--tt-fg)] placeholder:text-[var(--tt-fg-dim)] focus:outline-none focus:border-[var(--tt-border-strong)]"
             />
           </label>
-          <FilterInput label="Project" value={query.project || ""} onChange={(value) => updateQuery({ project: value || null, page: "1" })} />
-          <FilterInput label="Source" value={query.source || ""} onChange={(value) => updateQuery({ source: value || null, page: "1" })} />
-          <FilterInput label="Model" value={query.model || ""} onChange={(value) => updateQuery({ model: value || null, page: "1" })} />
+          <FilterInput label="Project" value={query.project || ""} onChange={(value) => updateQuery({ project: value || null })} />
+          <FilterInput label="Source" value={query.source || ""} onChange={(value) => updateQuery({ source: value || null })} />
+          <FilterInput label="Model" value={query.model || ""} onChange={(value) => updateQuery({ model: value || null })} />
           <select
             aria-label="Sort Hermes sessions"
             value={query.sort || "newest"}
-            onChange={(event) => updateQuery({ sort: event.target.value === "newest" ? null : event.target.value, page: "1" })}
+            onChange={(event) => updateQuery({ sort: event.target.value === "newest" ? null : event.target.value })}
             className="h-9 rounded-[var(--tt-radius)] bg-[var(--tt-panel)] border border-[var(--tt-border)] px-2.5 text-[12px] text-[var(--tt-fg-muted)] focus:outline-none focus:border-[var(--tt-border-strong)]"
           >
             <option value="newest">Newest first</option>
@@ -151,11 +170,19 @@ export default function HermesSessionExplorer() {
             {sessions.map((session) => <HermesSessionRow key={session.id} session={session} returnPath={returnPath} />)}
           </div>
           <div className="flex flex-wrap items-center justify-between gap-3 px-5 py-3 border-t border-[var(--tt-border)] text-[11px] text-[var(--tt-fg-muted)]">
-            <span>Page {data?.pagination.page ?? query.page} of {totalPages || 1}</span>
-            <div className="flex items-center gap-1">
-              <Button aria-label="Previous page" variant="ghost" size="sm" disabled={(data?.pagination.page ?? query.page ?? 1) <= 1} onClick={() => updateQuery({ page: String(Math.max(1, (data?.pagination.page ?? query.page ?? 1) - 1)) })}><ChevronLeft size={14} /></Button>
-              <Button aria-label="Next page" variant="ghost" size="sm" disabled={totalPages === 0 || (data?.pagination.page ?? query.page ?? 1) >= totalPages} onClick={() => updateQuery({ page: String((data?.pagination.page ?? query.page ?? 1) + 1) })}><ChevronRight size={14} /></Button>
-            </div>
+            <span>Showing {sessions.length.toLocaleString()} of {total.toLocaleString()}</span>
+            {canLoadMore ? (
+              <Button
+                variant="ghost"
+                size="sm"
+                disabled={loadingMore}
+                onClick={() => setRowLimit((limit) => Math.min(MAX_ROWS, limit + PAGE_SIZE))}
+              >
+                {loadingMore ? "Loading…" : <>Load more <ChevronDown size={14} /></>}
+              </Button>
+            ) : cappedOut ? (
+              <span>Showing the first {MAX_ROWS} — narrow with filters to reach the rest</span>
+            ) : null}
           </div>
         </Card>
       )}

--- a/frontend/src/components/hermes/HermesSessionExplorer.tsx
+++ b/frontend/src/components/hermes/HermesSessionExplorer.tsx
@@ -7,7 +7,7 @@ import {
   AlertTriangle, ChevronDown, ExternalLink, RotateCcw,
   Search, SlidersHorizontal, X,
 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useResource } from "@/lib/api";
 import {
   buildHermesSessionsPath, formatHermesProject, type HermesSessionPage,
@@ -22,6 +22,13 @@ const PAGE_SIZE = 50;
 // hold at once. Past it the filters are the way to narrow things down, which is
 // why there is no page-by-page walk any more.
 const MAX_ROWS = 200;
+
+// The last filter set, so leaving the page and coming back through the sidebar
+// does not silently drop it. Deliberately NOT passed to registerStateKey: every
+// sidebar link calls clearPageState(), which is the exact trip this has to
+// survive. The URL stays the source of truth — this is only consulted when the
+// explorer is opened with no query of its own, so shared links still win.
+const FILTER_MEMORY_KEY = "hermes_explorer_filters";
 
 function readQuery(searchParams: { get(name: string): string | null }): HermesSessionQuery {
   const rawSort = searchParams.get("sort");
@@ -57,6 +64,17 @@ export default function HermesSessionExplorer() {
     return () => window.clearTimeout(timer);
   }, [searchInput]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Re-apply the remembered filters when the explorer is opened cold, e.g. via
+  // the "View all sessions" link, which carries no query of its own.
+  const filtersRestored = useRef(false);
+  useEffect(() => {
+    if (filtersRestored.current) return;
+    filtersRestored.current = true;
+    if (searchParams.toString()) return;
+    const remembered = sessionStorage.getItem(FILTER_MEMORY_KEY);
+    if (remembered) router.replace(`${pathname}?${remembered}`, { scroll: false });
+  }, [pathname, router, searchParams]);
+
   // How many rows to ask for. "Load more" grows this rather than walking pages,
   // so one request always returns the whole visible list and there is no page
   // number to fall out of sync with the results.
@@ -84,6 +102,8 @@ export default function HermesSessionExplorer() {
     // Any filter change re-scopes the list, so start from one screenful again.
     setRowLimit(PAGE_SIZE);
     const nextQuery = next.toString();
+    // Clearing writes an empty string, so a cleared list stays cleared.
+    sessionStorage.setItem(FILTER_MEMORY_KEY, nextQuery);
     router.replace(nextQuery ? `${pathname}?${nextQuery}` : pathname, { scroll: false });
   }
 


### PR DESCRIPTION
Addresses the filter-persistence half of #251, by a different route than #252.

## What changed

**Pagination → "Load more".** The explorer walked pages with a `Page X of Y` footer. With a page size of 50 that is dead UI for most histories, and it put a page number into the URL that could outlive the result set it referred to — landing on an empty screen with no control to get back, because `activeFilterCount` ignores `page` and so the Clear button stays hidden.

"Load more" grows the requested page size instead of stepping through pages, so one request always returns the whole visible list. There is no page number to fall out of sync, filter changes reset to one screenful, and the footer states how many of the matching sessions are on screen. The backend rejects `page_size` above 200, so the view stops there and says so rather than silently truncating.

**Filters survive leaving the page.** Filtering the explorer, navigating away via the sidebar and coming back through "View all sessions" dropped the filters: that link carries no query of its own, and every sidebar link calls `clearPageState()`.

The last filter set is now remembered and re-applied when the explorer opens with no query. The URL stays the source of truth — a query in the address bar always wins, so shared and bookmarked links are unaffected — and clearing records the empty set so a cleared list stays cleared. The memory is deliberately not registered with `registerStateKey`, because that registry is purged by `clearPageState()` on every sidebar link, which is precisely the navigation it needs to survive.

## Why not #252's approach

#252 moves the filters out of the URL into `sessionStorage` via `useSessionState`. That state is registered with `registerStateKey`, so `clearPageState()` deletes it on any sidebar click — the exact journey it is meant to fix. Verified against its merge-base: `hermes_sessions_page` goes from `search: "marketing"` to `null` on one sidebar click. It also removes the 300ms search debounce (9 backend requests for a 9-character search, versus 1) and drops the `page` clamp and `sort` whitelist that `readQuery` provided.

## Testing

Run against a local backend with Hermes sessions.

- Filter the explorer, click any sidebar item, return via "View all sessions" — the filtered list comes back, with the query in the address bar.
- Clear the filters and repeat — the list stays cleared.
- Copy the filtered URL into a new tab — it still resolves to that view.
- With more sessions than the page size, "Load more" appends and the footer count tracks; changing a filter resets to one screenful.

Verified locally: `tsc --noEmit` clean, `eslint` clean on the changed file, and the above flows checked in the browser against a live backend.

## Not covered

The scroll-restoration half of #251 is not in this PR — `/hermes/sessions` still has no `useScrollState`. That remains a genuine gap and is better landed as a focused change with a repro.