### PR TITLE
fix(frontend): fix aside height mismatch when viewing Hermes agent sessions

### DIFF
--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -1028,7 +1028,7 @@ export default function SessionDetailPage() {
       ) : (
         <main className={`flex-1 w-full max-w-[1800px] mx-auto grid min-h-0 ${sidebarOpen ? "grid-cols-[240px_1fr_380px]" : "grid-cols-[240px_1fr_40px]"}`}>
           {/* LEFT: Step Index */}
-          <aside className="border-r border-[var(--tt-border)] bg-[var(--tt-sunken)]/60 overflow-y-auto max-h-[calc(100vh-200px)] sticky top-[200px]">
+          <aside className="border-r border-[var(--tt-border)] bg-[var(--tt-sunken)]/60 overflow-y-auto max-h-[calc(100vh-200px)]">
              <div className="px-3 py-2 border-b border-[var(--tt-border)] flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--tt-fg-dim)]">
                 <ListMusic size={12} /> Step Index
              </div>
@@ -1116,7 +1116,7 @@ export default function SessionDetailPage() {
           </section>
 
           {/* RIGHT: Sidebar */}
-          <aside className="border-l border-[var(--tt-border)] bg-[var(--tt-sunken)]/60 overflow-y-auto max-h-[calc(100vh-200px)] sticky top-[200px]">
+          <aside className="border-l border-[var(--tt-border)] bg-[var(--tt-sunken)]/60 overflow-y-auto max-h-[calc(100vh-200px)]">
              {!sidebarOpen ? (
                 <button
                    onClick={() => setSidebarOpen(true)}


### PR DESCRIPTION

## Summary
This PR resolves a layout height inconsistency in `/frontend/src/app/sessions/[id]/page.tsx` where the left (`Step Index`) and right (`Inspector`) `<aside>` panels exhibited mismatched heights compared to the center `<section>` on wider viewports.

Testing revealed that this bug is directly influenced by the presence or absence of the bottom **Execution Timeline Footer** (`!loading && waterfallData.length > 0`). For agents like **Hermes**, where no waterfall timeline data is rendered, theabsent Footer combined with `sticky top-[200px]` causes a severe vertical height mismatch across the sidebars.

Removing `sticky top-[200px]` guarantees matching panel heights across all screen widths, completely independent of whether the Execution Timeline Footer is rendered.

1. **Footer Dependency**: The bottom Footer (Execution Timeline) renders conditionally based on `waterfallData.length > 0`. For specific agents (such as **Hermes**), waterfall data is absent, so the Footer does **not** appear.
2. **Viewport & Offset Reaction**: When the Footer is missing, the available vertical viewport space shifts. The `sticky top-[200px]` rule on the outer `<aside>` elements forces an unwanted 200px top offset, pushing the sidebars down and makingthem significantly shorter/misaligned relative to the center `<section>` on wide viewports.
3. **Screen Width Interaction**: On wider viewports, grid height expands and exposes this vertical offset mismatch. On narrower viewports, grid reflow compresses elements and conceals the defect.

Both `<aside>` elements were declared with:
`className="... overflow-y-auto max-h-[calc(100vh-150px)] sticky top-[200px]"`

Combining `sticky top-[200px]` with bounded overflow scrolling (`max-h-[calc(100vh-150px)]`) broke flex/grid height inheritance whenever bottom page constraints (like the Execution Timeline Footer) varied.


## Type of change
- [x] Bug fix
- [ ] New feature (new agent support, new dashboard view, etc.)
- [ ] Improvement / refactor
- [ ] Docs / chore

## How to test
1. Run `./start.sh`
2. Navigate to a **Hermes** session trace page (`/sessions/[id]?agent=hermes`) where the bottom Execution Timeline Footer is absent (`waterfallData.length === 0`).
3. Expand the browser window width.
4. Observe the height difference between the center section and the left/right sidebars.
5. Compare with sessions that include a Footer vs. Hermes sessions without a Footer.

## Checklist
- [x] I tested this locally with `./start.sh`
- [x] No secrets or API keys are included
- [x] PR is focused on one change
- [x] README or CHANGELOG updated if needed

<img width="1843" height="729" alt="image" src="https://github.com/user-attachments/assets/36e7db0a-98c8-4c55-abbb-d4211682bcc9" />

## Related issue
Closes #265
