### PR TITLE
feat(frontend): add step index category filter in session detail view

### DIFF
--- a/UPDATE.json
+++ b/UPDATE.json
@@ -1,6 +1,16 @@
 {
   "releases": [
     {
+      "tag": "2026-08-15",
+      "title": "Filter the step index on a session trace",
+      "highlights": [
+        {
+          "title": "Narrow a long trace to the steps you care about",
+          "description": "The Step Index on a session trace now has a filter next to its heading, listing every event category in the session with a count: user prompts, responses, reasoning, and each tool by name. Tick the ones you want and both the index and the trace beside it drop to just those steps, which makes a run with several thousand steps navigable. Thanks to hwantage for building and contributing this (PR #269)."
+        }
+      ]
+    },
+    {
       "tag": "2026-08-10",
       "title": "Hermes session explorer keeps your place",
       "highlights": [

--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -463,6 +463,36 @@ export default function SessionDetailPage() {
 
   const [filterOpen, setFilterOpen] = useState(false);
   const [selectedFilters, setSelectedFilters] = useState<Set<string>>(new Set());
+  const filterBtnRef = useRef<HTMLButtonElement | null>(null);
+  const [filterAnchor, setFilterAnchor] = useState<{ top: number; right: number; listMaxH: number } | null>(null);
+
+  // The filter panel is portalled to <body>: the session layout's backdrop-blur
+  // ancestors break `position: fixed` inside the aside, and the aside's own
+  // overflow-y-auto would clip the panel. Anchor it to the button and size the
+  // category list to the room actually left below it, so short viewports don't
+  // push rows past the fold on a page that never scrolls.
+  useEffect(() => {
+    if (!filterOpen) { setFilterAnchor(null); return; }
+    const place = () => {
+      const el = filterBtnRef.current;
+      if (!el) return;
+      const r = el.getBoundingClientRect();
+      const top = r.bottom + 4;
+      setFilterAnchor({
+        top,
+        right: Math.max(8, window.innerWidth - r.right),
+        listMaxH: Math.max(120, Math.min(300, window.innerHeight - top - 76)),
+      });
+    };
+    place();
+    window.addEventListener("resize", place);
+    // capture: the aside scrolls, not the window, so the panel follows the button
+    window.addEventListener("scroll", place, true);
+    return () => {
+      window.removeEventListener("resize", place);
+      window.removeEventListener("scroll", place, true);
+    };
+  }, [filterOpen]);
 
   useEffect(() => {
     if (id && agent) {
@@ -1063,20 +1093,24 @@ export default function SessionDetailPage() {
         <main className={`flex-1 w-full max-w-[1800px] mx-auto grid min-h-0 ${sidebarOpen ? "grid-cols-[240px_1fr_380px]" : "grid-cols-[240px_1fr_40px]"}`}>
           {/* LEFT: Step Index */}
           <aside className="border-r border-[var(--tt-border)] bg-[var(--tt-sunken)]/60 overflow-y-auto max-h-[calc(100vh-200px)]">
-             <div className="px-3 py-2 border-b border-[var(--tt-border)] flex items-center justify-between">
+             <div className="sticky top-0 z-30 px-3 py-2 border-b border-[var(--tt-border)] flex items-center justify-between bg-[var(--tt-sunken)] backdrop-blur supports-[backdrop-filter]:bg-[var(--tt-sunken)]/85">
                 <div className="flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--tt-fg-dim)]">
                    <ListMusic size={12} /> Step Index
                 </div>
                 <div className="relative">
                    <button
+                     ref={filterBtnRef}
                      onClick={() => setFilterOpen(!filterOpen)}
                      className={`p-1 rounded cursor-pointer transition-colors ${selectedFilters.size > 0 ? "bg-[var(--tt-brand-bg)] text-[var(--tt-brand)]" : "text-[var(--tt-fg-muted)] hover:bg-[var(--tt-panel-hover)]"}`}
                      title="Filter steps"
                    >
                      <Filter size={14} />
                    </button>
-                   {filterOpen && (
-                     <div className="absolute right-0 top-full mt-1 w-52 bg-[var(--tt-panel)] border border-[var(--tt-border)] rounded shadow-xl z-50 p-2 flex flex-col gap-2">
+                   {filterOpen && filterAnchor && typeof document !== "undefined" && createPortal(
+                     <div
+                       className="fixed w-52 bg-[var(--tt-panel)] border border-[var(--tt-border)] rounded shadow-xl z-[60] p-2 flex flex-col gap-2"
+                       style={{ top: filterAnchor.top, right: filterAnchor.right }}
+                     >
                        <div className="flex items-center justify-between pb-1 border-b border-[var(--tt-border)]">
                          <button 
                            className="text-[11px] font-medium text-[var(--tt-fg-muted)] hover:text-[var(--tt-brand)] cursor-pointer"
@@ -1092,7 +1126,7 @@ export default function SessionDetailPage() {
                            <X size={14} />
                          </button>
                        </div>
-                       <div className="max-h-[300px] overflow-y-auto space-y-1">
+                       <div className="overflow-y-auto space-y-1" style={{ maxHeight: filterAnchor.listMaxH }}>
                          {stepCategoryCounts.map(([label, { count, kind }]) => {
                            const icon = STEP_ICONS[kind] || STEP_ICONS.other;
                            
@@ -1116,7 +1150,8 @@ export default function SessionDetailPage() {
                            );
                          })}
                        </div>
-                     </div>
+                     </div>,
+                     document.body
                    )}
                 </div>
              </div>

--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -5,7 +5,7 @@ import { createPortal } from "react-dom";
 import { useParams, useSearchParams, useRouter } from "next/navigation";
 import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { ArrowLeft, Brain, Code, MessageSquare, Terminal, User, Users, FileText, Activity, Zap, Info, Sparkles, GitBranch, LayoutPanelLeft, ListMusic, ChevronRight, ChevronLeft, Play, Pause, Wrench, Cpu, Folder, AlertTriangle, Hash, Clock, FileCode, Settings2, ChevronDown, ChevronUp, Copy, Check, Maximize2, X, Repeat, Globe, ExternalLink, Target, DollarSign } from "lucide-react";
+import { ArrowLeft, Brain, Code, MessageSquare, Terminal, User, Users, FileText, Activity, Zap, Info, Sparkles, GitBranch, LayoutPanelLeft, ListMusic, ChevronRight, ChevronLeft, Play, Pause, Wrench, Cpu, Folder, AlertTriangle, Hash, Clock, FileCode, Settings2, ChevronDown, ChevronUp, Copy, Check, Maximize2, X, Repeat, Globe, ExternalLink, Target, DollarSign, Filter } from "lucide-react";
 import Link from "next/link";
 import { format } from "date-fns";
 import { AgentBadge, Badge, Button, Skeleton } from "@/components/ui";
@@ -377,6 +377,16 @@ function normalizeTs(evt: Event): number | undefined {
   return undefined;
 }
 
+const STEP_ICONS: Record<StepKind, React.ReactNode> = {
+  user: <User size={11} className="text-[var(--tt-brand)]" />,
+  assistant: <MessageSquare size={11} className="text-[var(--tt-success-fg)]" />,
+  reasoning: <Brain size={11} className="text-[var(--tt-warn-fg)]" />,
+  tool: <Wrench size={11} className="text-sky-400" />,
+  tool_result: <Terminal size={11} className="text-[var(--tt-fg-dim)]" />,
+  meta: <Info size={11} className="text-[var(--tt-fg-faint)]" />,
+  other: <Zap size={11} className="text-[var(--tt-fg-faint)]" />,
+};
+
 const stepRingClass: Record<StepKind, string> = {
   user: "ring-2 ring-blue-500/70",
   assistant: "ring-2 ring-emerald-500/70",
@@ -450,6 +460,9 @@ export default function SessionDetailPage() {
   const [projectConfig, setProjectConfig] = useState<any>(null);
   const stepRefs = useRef<Record<number, HTMLDivElement | null>>({});
   const stepIndexRefs = useRef<Record<number, HTMLDivElement | null>>({});
+
+  const [filterOpen, setFilterOpen] = useState(false);
+  const [selectedFilters, setSelectedFilters] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     if (id && agent) {
@@ -593,6 +606,27 @@ export default function SessionDetailPage() {
       }),
     [events, stepTokens]
   );
+
+  const stepCategoryCounts = useMemo(() => {
+    const map: Record<string, { count: number, kind: StepKind }> = {};
+    steps.forEach((s) => {
+      const key = s.kind === "user" ? "User Prompt" : (s.label || s.kind);
+      if (!map[key]) {
+        map[key] = { count: 0, kind: s.kind };
+      }
+      map[key].count += 1;
+    });
+    const priority: Record<string, number> = {
+      "User Prompt": 1,
+      "Response": 2,
+    };
+    return Object.entries(map).sort((a, b) => {
+      const pA = priority[a[0]] || 99;
+      const pB = priority[b[0]] || 99;
+      if (pA !== pB) return pA - pB;
+      return b[1].count - a[1].count;
+    });
+  }, [steps]);
 
   // Stats
   const stats = useMemo(() => {
@@ -1029,15 +1063,73 @@ export default function SessionDetailPage() {
         <main className={`flex-1 w-full max-w-[1800px] mx-auto grid min-h-0 ${sidebarOpen ? "grid-cols-[240px_1fr_380px]" : "grid-cols-[240px_1fr_40px]"}`}>
           {/* LEFT: Step Index */}
           <aside className="border-r border-[var(--tt-border)] bg-[var(--tt-sunken)]/60 overflow-y-auto max-h-[calc(100vh-200px)] sticky top-[200px]">
-             <div className="px-3 py-2 border-b border-[var(--tt-border)] flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--tt-fg-dim)]">
-                <ListMusic size={12} /> Step Index
+             <div className="px-3 py-2 border-b border-[var(--tt-border)] flex items-center justify-between">
+                <div className="flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--tt-fg-dim)]">
+                   <ListMusic size={12} /> Step Index
+                </div>
+                <div className="relative">
+                   <button
+                     onClick={() => setFilterOpen(!filterOpen)}
+                     className={`p-1 rounded cursor-pointer transition-colors ${selectedFilters.size > 0 ? "bg-[var(--tt-brand-bg)] text-[var(--tt-brand)]" : "text-[var(--tt-fg-muted)] hover:bg-[var(--tt-panel-hover)]"}`}
+                     title="Filter steps"
+                   >
+                     <Filter size={14} />
+                   </button>
+                   {filterOpen && (
+                     <div className="absolute right-0 top-full mt-1 w-52 bg-[var(--tt-panel)] border border-[var(--tt-border)] rounded shadow-xl z-50 p-2 flex flex-col gap-2">
+                       <div className="flex items-center justify-between pb-1 border-b border-[var(--tt-border)]">
+                         <button 
+                           className="text-[11px] font-medium text-[var(--tt-fg-muted)] hover:text-[var(--tt-brand)] cursor-pointer"
+                           onClick={() => setSelectedFilters(new Set())}
+                         >
+                           Reset
+                         </button>
+                         <button 
+                           className="text-[var(--tt-fg-muted)] hover:text-[var(--tt-fg)] p-0.5 rounded cursor-pointer"
+                           onClick={() => setFilterOpen(false)}
+                           title="Close"
+                         >
+                           <X size={14} />
+                         </button>
+                       </div>
+                       <div className="max-h-[300px] overflow-y-auto space-y-1">
+                         {stepCategoryCounts.map(([label, { count, kind }]) => {
+                           const icon = STEP_ICONS[kind] || STEP_ICONS.other;
+                           
+                           return (
+                             <label key={label} className="flex items-center gap-2 px-1 py-1 hover:bg-[var(--tt-panel-hover)] rounded cursor-pointer">
+                               <input 
+                                 type="checkbox" 
+                                 className="accent-[var(--tt-brand)] cursor-pointer"
+                                 checked={selectedFilters.has(label)}
+                                 onChange={(e) => {
+                                   const next = new Set(selectedFilters);
+                                   if (e.target.checked) next.add(label);
+                                   else next.delete(label);
+                                   setSelectedFilters(next);
+                                 }}
+                               />
+                               <div>{icon}</div>
+                               <span className="text-[12px] text-[var(--tt-fg)] flex-1 truncate" title={label}>{label}</span>
+                               <span className="text-[10px] text-[var(--tt-fg-dim)]">({count})</span>
+                             </label>
+                           );
+                         })}
+                       </div>
+                     </div>
+                   )}
+                </div>
              </div>
              <div className="py-1">
-                {steps.map((s) => (
-                   <div key={s.idx} ref={(el) => { stepIndexRefs.current[s.idx] = el; }}>
-                      <StepRow step={s} active={activeStep === s.idx} beyond={s.idx >= playbackIndex} onClick={() => jumpTo(s.idx)} />
-                   </div>
-                ))}
+                {steps.map((s) => {
+                   const filterKey = s.kind === "user" ? "User Prompt" : (s.label || s.kind);
+                   if (selectedFilters.size > 0 && !selectedFilters.has(filterKey)) return null;
+                   return (
+                     <div key={s.idx} ref={(el) => { stepIndexRefs.current[s.idx] = el; }}>
+                        <StepRow step={s} active={activeStep === s.idx} beyond={s.idx >= playbackIndex} onClick={() => jumpTo(s.idx)} />
+                     </div>
+                   );
+                })}
              </div>
           </aside>
 
@@ -1085,6 +1177,9 @@ export default function SessionDetailPage() {
                       
                       if (splitView && ((isReasoning || hasThinkingPart) && !hasText)) return null;
                       const kind = eventKind(event);
+                      const baseLabel = stepLabel(event, kind);
+                      const filterKey = kind === "user" ? "User Prompt" : baseLabel;
+                      if (selectedFilters.size > 0 && !selectedFilters.has(filterKey)) return null;
 
                       return (
                          <div key={idx} ref={(el) => { stepRefs.current[idx] = el; }} onClick={(e) => handleStepCardClick(e, idx)} className={activeStep === idx ? `${stepRingClass[kind]} rounded-[var(--tt-radius-lg)]` : ""}>
@@ -1104,6 +1199,9 @@ export default function SessionDetailPage() {
 
                          if (!isReasoning && !isTool && !hasThinkingPart) return null;
                          const kind = eventKind(event);
+                         const baseLabel = stepLabel(event, kind);
+                         const filterKey = kind === "user" ? "User Prompt" : baseLabel;
+                         if (selectedFilters.size > 0 && !selectedFilters.has(filterKey)) return null;
                          return (
                             <div key={idx} ref={(el) => { stepRefs.current[idx] = el; }} onClick={(e) => handleStepCardClick(e, idx)} className={activeStep === idx ? `${stepRingClass[kind]} rounded-[var(--tt-radius-lg)]` : ""}>
                                <EventCard event={event} mode="brain" agent={agent} />
@@ -1472,31 +1570,13 @@ function TabBtn({ active, onClick, icon, children }: { active: boolean; onClick:
 }
 
 function StepRow({ step, active, beyond, onClick }: { step: Step; active: boolean; beyond: boolean; onClick: () => void }) {
-  const icon: Record<StepKind, React.ReactNode> = {
-    user: <User size={11} />,
-    assistant: <MessageSquare size={11} />,
-    reasoning: <Brain size={11} />,
-    tool: <Wrench size={11} />,
-    tool_result: <Terminal size={11} />,
-    meta: <Info size={11} />,
-    other: <Zap size={11} />,
-  };
-  const color: Record<StepKind, string> = {
-    user: "text-[var(--tt-brand)]",
-    assistant: "text-[var(--tt-success-fg)]",
-    reasoning: "text-[var(--tt-warn-fg)]",
-    tool: "text-sky-400",
-    tool_result: "text-[var(--tt-fg-dim)]",
-    meta: "text-[var(--tt-fg-faint)]",
-    other: "text-[var(--tt-fg-faint)]",
-  };
   return (
     <button
       onClick={onClick}
       className={`w-full text-left flex items-center gap-2 px-3 py-1.5 text-[10px] font-mono border-l-2 transition-colors ${active ? "bg-blue-500/10 border-blue-500" : "border-transparent hover:bg-[var(--tt-panel)]/70"} ${beyond ? "opacity-30" : ""}`}
     >
       <span className="text-[var(--tt-fg-faint)] w-7 tabular-nums">{step.idx.toString().padStart(3, "0")}</span>
-      <span className={color[step.kind]}>{icon[step.kind]}</span>
+      <span>{STEP_ICONS[step.kind] || STEP_ICONS.other}</span>
       <span className="text-[var(--tt-fg)] truncate flex-1">{step.label}</span>
       {step.tokens && (
         <span

--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -1062,7 +1062,7 @@ export default function SessionDetailPage() {
       ) : (
         <main className={`flex-1 w-full max-w-[1800px] mx-auto grid min-h-0 ${sidebarOpen ? "grid-cols-[240px_1fr_380px]" : "grid-cols-[240px_1fr_40px]"}`}>
           {/* LEFT: Step Index */}
-          <aside className="border-r border-[var(--tt-border)] bg-[var(--tt-sunken)]/60 overflow-y-auto max-h-[calc(100vh-200px)] sticky top-[200px]">
+          <aside className="border-r border-[var(--tt-border)] bg-[var(--tt-sunken)]/60 overflow-y-auto max-h-[calc(100vh-200px)]">
              <div className="px-3 py-2 border-b border-[var(--tt-border)] flex items-center justify-between">
                 <div className="flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--tt-fg-dim)]">
                    <ListMusic size={12} /> Step Index


### PR DESCRIPTION
## Summary
This PR adds an in-memory event and step category filter to the **Step Index** sidebar on the session detail page (`/sessions/[id]`). Users can now filter long session traces by specific event categories (such as `User Prompt`, `Response`, `Reasoning`, or specific tool names) to quickly navigate complex agent workflows.

### 1. Continuity with Existing Event System & Icons
- Extracted step icons into a shared `STEP_ICONS` map so the Step Index rows and filter category menu use the exact same visual cues and color tokens.
- Directly reuses existing classification functions (`eventKind`, `stepLabel`) to group steps naturally into `User Prompt`, `Response`, `Reasoning`, and specific tool call names.

### 2. In-Memory Performance (Zero Extra API Overhead)
- Category counts and step lists are aggregated in-memory via `useMemo` from the already loaded `events` array.
- Incurs zero network roundtrips, no backend API changes, and no external dependencies. Filtering reaction is immediate.

## Type of change
- [ ] Bug fix
- [ ] New feature (new agent support, new dashboard view, etc.)
- [x] Improvement / refactor
- [ ] Docs / chore

## How to test
1. Run `./start.sh`
2. Open any session detail trace at `/sessions/[id]`
3. Click the filter icon next to the **Step Index** header on the left sidebar.
4. Select one or more filter categories (e.g., check `User Prompt` and a specific tool like `read_file`).
5. Verify that:
   - The Step Index list updates immediately to show only matching steps.
   - Original step index numbers (`000`, `005`, etc.) remain intact.
   - Clicking a filtered step smoothly scrolls the center section to that card and updates the Inspector panel.
6. Click `Reset` to clear all filters and verify the full step list returns.

<img width="725" height="634" alt="image" src="https://github.com/user-attachments/assets/b61f2a8c-32ad-4cac-b81f-c36e1760cd96" />


## Checklist
- [x] I tested this locally with `./start.sh`
- [x] No secrets or API keys are included
- [x] PR is focused on one change
- [x] README or CHANGELOG updated if needed

## Related issue
Closes #268