### PR TITLE
fix(frontend): prevent aside layer shift and fix sticky header overlap in session detail

### DIFF
--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -862,8 +862,8 @@ export default function SessionDetailPage() {
   const untrackedBackground = agent === "claude" ? sessionInfo?.untracked_background : undefined;
 
   return (
-    <div className="min-h-screen bg-[var(--tt-canvas)] text-[var(--tt-fg)] font-sans flex flex-col">
-      <header className="bg-[var(--tt-canvas)]/85 border-b border-[var(--tt-border)] px-6 py-4 sticky top-0 z-50 backdrop-blur supports-[backdrop-filter]:bg-[var(--tt-canvas)]/65">
+    <div className="h-screen bg-[var(--tt-canvas)] text-[var(--tt-fg)] font-sans flex flex-col overflow-hidden">
+      <header className="bg-[var(--tt-canvas)]/85 border-b border-[var(--tt-border)] px-6 py-4 shrink-0 z-50 backdrop-blur supports-[backdrop-filter]:bg-[var(--tt-canvas)]/65">
         <div className="max-w-[1600px] mx-auto flex flex-col gap-4">
           <div className="flex items-start justify-between gap-4 flex-wrap">
             <div className="flex items-start gap-3 min-w-0">
@@ -1092,7 +1092,7 @@ export default function SessionDetailPage() {
       ) : (
         <main className={`flex-1 w-full max-w-[1800px] mx-auto grid min-h-0 ${sidebarOpen ? "grid-cols-[240px_1fr_380px]" : "grid-cols-[240px_1fr_40px]"}`}>
           {/* LEFT: Step Index */}
-          <aside className="border-r border-[var(--tt-border)] bg-[var(--tt-sunken)]/60 overflow-y-auto max-h-[calc(100vh-200px)]">
+          <aside className="border-r border-[var(--tt-border)] bg-[var(--tt-sunken)]/60 overflow-y-auto h-full scroll-pt-10">
              <div className="sticky top-0 z-30 px-3 py-2 border-b border-[var(--tt-border)] flex items-center justify-between bg-[var(--tt-sunken)] backdrop-blur supports-[backdrop-filter]:bg-[var(--tt-sunken)]/85">
                 <div className="flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--tt-fg-dim)]">
                    <ListMusic size={12} /> Step Index
@@ -1160,7 +1160,7 @@ export default function SessionDetailPage() {
                    const filterKey = s.kind === "user" ? "User Prompt" : (s.label || s.kind);
                    if (selectedFilters.size > 0 && !selectedFilters.has(filterKey)) return null;
                    return (
-                     <div key={s.idx} ref={(el) => { stepIndexRefs.current[s.idx] = el; }}>
+                     <div key={s.idx} ref={(el) => { stepIndexRefs.current[s.idx] = el; }} className="scroll-mt-2">
                         <StepRow step={s} active={activeStep === s.idx} beyond={s.idx >= playbackIndex} onClick={() => jumpTo(s.idx)} />
                      </div>
                    );
@@ -1169,7 +1169,7 @@ export default function SessionDetailPage() {
           </aside>
 
           {/* CENTER: Conversation */}
-          <section className="overflow-y-auto max-h-[calc(100vh-200px)] p-8">
+          <section className="overflow-y-auto h-full p-8">
              {/* Trace summary — narrative + deterministic brief, near the top of the trace */}
              {agent && (
                <div className="mb-8">
@@ -1249,7 +1249,7 @@ export default function SessionDetailPage() {
           </section>
 
           {/* RIGHT: Sidebar */}
-          <aside className="border-l border-[var(--tt-border)] bg-[var(--tt-sunken)]/60 overflow-y-auto max-h-[calc(100vh-200px)]">
+          <aside className="border-l border-[var(--tt-border)] bg-[var(--tt-sunken)]/60 overflow-y-auto h-full">
              {!sidebarOpen ? (
                 <button
                    onClick={() => setSidebarOpen(true)}
@@ -1306,7 +1306,7 @@ export default function SessionDetailPage() {
 
       {/* RESTORED: Waterfall Footer */}
       {!loading && waterfallData.length > 0 && (
-         <footer className="bg-[var(--tt-panel)] border-t border-[var(--tt-border)] sticky bottom-0 z-40 backdrop-blur-xl bg-opacity-80">
+         <footer className="bg-[var(--tt-panel)] border-t border-[var(--tt-border)] shrink-0 z-40 backdrop-blur-xl bg-opacity-80">
             <div className={`max-w-[1600px] mx-auto ${timelineOpen ? "p-6" : "px-6 py-2"}`}>
                <div className={`flex items-center justify-between ${timelineOpen ? "mb-6" : ""}`}>
                   <button


### PR DESCRIPTION

## Summary
This PR fixes a layout shift and header overlap bug on the session detail page (`/frontend/src/app/sessions/[id]/page.tsx`):
1. **Prevents Aside Layer Shift**: Clicking lower items in the **Step Index** on sessions with the bottom Execution Timeline Footer no longer causes the outer window to scroll or push the sidebar panels behind the top header.
2. **Keeps Step Index Header Always Accessible**: The Step Index title bar and filter button remain fixed and reachable at all times regardless of step list length or footer visibility.
3. **Fixes Sticky Header Overlap on Reverse Navigation**: When navigating upward from the center dialogue stream, target step items stop cleanly below the sticky Step Index title bar instead of hiding underneath it.
4. **Guarantees Viewport Isolation Above Footer**: Long step lists now scroll strictly within the main panel height above the Execution Timeline footer.

## Root Cause Analysis

1. **Outer Scroll from Height Overflow**:
   - The page combined `header` (~160px), `main` (`max-h-[calc(100vh-200px)]`), and `footer` (~250px) inside `min-h-screen`, causing the total height to exceed the viewport (`100vh`) whenever the Execution Timeline Footer was rendered.
   - When `scrollIntoView()` was triggered on a step item, the browser scrolled the outer container down to center the element, which pushed the `<main>` grid upward and hid the Step Index header beneath the top navigation bar.
2. **Sticky Header Overlap with `block: 'nearest'`**:
   - When clicking an upper dialogue card in the center section, `scrollIntoView({ block: 'nearest' })` scrolled the Step Index upward until the target item's top reached `0px`. Because the Step Index title bar is pinned with `sticky top-0`, the item was positioned directly behind the title bar.

---

## Key Changes (Pure CSS Minimal Diff)

- **Strict Viewport Flexbox Layout**:
  - Replaced `min-h-screen` on the root container with `h-screen overflow-hidden`.
  - Changed `header` and `footer` positioning to `shrink-0` to lock their heights predictably.
  - Replaced hardcoded `max-h-[calc(100vh-200px)]` on the three panels (`aside`, `section`, `aside`) with `h-full overflow-y-auto` so they naturally occupy the exact remaining height (`flex-1 min-h-0`).
- **CSS Scroll Offsets for Sticky Header**:
  - Added `scroll-pt-10` (`scroll-padding-top: 40px`) to the Step Index `<aside>` scroll container.
  - Added `scroll-mt-2` to each `StepRow` wrapper.
  - This informs the browser's `scrollIntoView()` calculation of the 40px sticky header zone, ensuring items stop immediately below the title bar with appropriate breathing room.

## Type of change
- [x] Bug fix
- [ ] New feature (new agent support, new dashboard view, etc.)
- [ ] Improvement / refactor
- [ ] Docs / chore

## How to test
<!-- Steps to verify this PR works correctly -->
1. Run `./start.sh`
2. Open any session trace that has an Execution Timeline footer (e.g., Claude Code or Codex) at `/sessions/[id]`.
3. In the left **Step Index**, scroll down and click one of the bottommost step items:
   - Verify that the center conversation scrolls to the target card smoothly.
   - Verify that the Step Index header and filter button stay pinned in place and do **not** shift upward or hide behind the top header.
4. In the center conversation, scroll up and click an earlier dialogue card:
   - Verify that the Step Index smoothly scrolls up and highlights the corresponding step item.
   - Verify that the step item stops cleanly below the sticky "Step Index" title bar and is **not** obscured behind it.
5. Test with sessions where the footer is absent (e.g., Hermes) and verify consistent layout behavior.

## Checklist
- [x] I tested this locally with `./start.sh`
- [x] No secrets or API keys are included
- [x] PR is focused on one change
- [x] README or CHANGELOG updated if needed

## Related issue
Closes #270 
