### PR TITLE
fix(cli): repair a pip-less venv, and bootstrap with uv when it's installed

### DIFF
--- a/UPDATE.json
+++ b/UPDATE.json
@@ -2,6 +2,20 @@
   "releases": [
     {
       "tag": "2026-08-15",
+      "title": "Install fixes for Linux, faster setup with uv",
+      "highlights": [
+        {
+          "title": "Installs no longer stop at \"No module named pip\"",
+          "description": "On Debian and Ubuntu, Python creates the virtual environment but leaves pip out of it unless the separate python3-venv package is installed, so the first launch failed on the backend dependencies. The launcher now bootstraps pip itself, and if that isn't possible it names the package to install instead of showing a pip traceback. Thanks to yannschepens for reporting this (issue #267)."
+        },
+        {
+          "title": "Setup uses uv when you already have it",
+          "description": "If uv is on your PATH, first-run setup uses it for the virtual environment and the dependency install: about 0.4 seconds instead of 2.8 on a warm cache, with the same Python and the same hash-checked packages. Nothing to install and nothing to configure; without uv the setup works exactly as before."
+        }
+      ]
+    },
+    {
+      "tag": "2026-08-15",
       "title": "Filter the step index on a session trace",
       "highlights": [
         {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -270,6 +270,17 @@ function pipBootstrapHint() {
   ].join('\n');
 }
 
+function findUv() {
+  // Opportunistic only: uv builds the venv itself instead of going through the
+  // stdlib venv module, so it never touches ensurepip, and it installs an order
+  // of magnitude faster. We never install it — if it isn't already on PATH we
+  // use python/pip exactly as before, so uv is a speed-up, not a prerequisite.
+  // TT_NO_UV=1 forces the pip path.
+  if (process.env.TT_NO_UV === '1') return null;
+  if (!which('uv')) return null;
+  return runSoft('uv', ['--version'], { stdio: 'ignore' }) === 0 ? 'uv' : null;
+}
+
 function venvPipWorks() {
   if (!fs.existsSync(venvPython)) return false;
   return runSoft(venvPython, ['-m', 'pip', '--version'], { stdio: 'ignore' }) === 0;
@@ -290,15 +301,28 @@ function ensureVenvPip() {
 }
 
 function ensureBackend() {
+  const uv = findUv();
   // Check for the interpreter rather than the directory: an interrupted or
   // failed `python -m venv` leaves a directory behind with nothing runnable in
   // it. Re-running venv creation over an existing directory fills in what's
   // missing, so there's nothing to delete here.
   if (!fs.existsSync(venvPython)) {
     const py = findPython();
-    console.log('→ creating Python venv…');
-    if (runSoft(py, ['-m', 'venv', 'venv'], { cwd: backendDir }) !== 0 || !fs.existsSync(venvPython)) {
-      die('could not create the Python venv at backend/venv.\n' + pipBootstrapHint());
+    console.log(uv ? '→ creating Python venv (uv)…' : '→ creating Python venv…');
+    // Pin uv to the same interpreter the pip path would have used, and forbid
+    // Python downloads, so `uv` on PATH changes the speed of the bootstrap and
+    // nothing else. The resolved path matters: given the bare name `python3`,
+    // uv prefers its own managed CPython over the one on PATH, which would
+    // quietly build the venv on a different Python than every previous release.
+    // --seed puts pip inside the venv: uv leaves it out by default, and without
+    // it a user who later drops uv gets a venv this script can't install into.
+    const created = uv
+      ? runSoft(uv, ['venv', 'venv', '--seed', '--no-python-downloads', '--python', which(py) || py], { cwd: backendDir })
+      : runSoft(py, ['-m', 'venv', 'venv'], { cwd: backendDir });
+    if (created !== 0 || !fs.existsSync(venvPython)) {
+      die('could not create the Python venv at backend/venv.\n' + (uv
+        ? 'Delete backend/venv and retry, or set TT_NO_UV=1 to bootstrap with python -m venv.'
+        : pipBootstrapHint()));
     }
   }
   // Skip pip install when requirements haven't changed since last install.
@@ -319,15 +343,20 @@ function ensureBackend() {
   try { cachedSha = fs.readFileSync(stampPath, 'utf8').trim(); } catch {}
   const currentSha = require('crypto').createHash('sha1').update(fs.readFileSync(installFrom)).digest('hex');
   if (cachedSha === currentSha) return;
-  // Only probe pip on the install path. The stamp lives inside the venv, so a
-  // matching stamp means this venv already completed an install with a working
-  // pip — no need to pay a Python startup on every launch.
-  ensureVenvPip();
-  console.log('→ installing backend dependencies…');
-  if (useLock) {
-    run(venvPython, ['-m', 'pip', 'install', '--quiet', '--require-hashes', '-r', 'requirements.lock'], { cwd: backendDir });
+  const reqFile = useLock ? 'requirements.lock' : 'requirements.txt';
+  const hashFlags = useLock ? ['--require-hashes'] : [];
+  if (uv) {
+    // uv reads the same pip-style lock and enforces the same hashes. --python
+    // targets our venv explicitly rather than whatever VIRTUAL_ENV points at.
+    console.log('→ installing backend dependencies (uv)…');
+    run(uv, ['pip', 'install', '--quiet', '--python', venvPython, ...hashFlags, '-r', reqFile], { cwd: backendDir });
   } else {
-    run(venvPython, ['-m', 'pip', 'install', '--quiet', '-r', 'requirements.txt'], { cwd: backendDir });
+    // Only probe pip on the install path. The stamp lives inside the venv, so a
+    // matching stamp means this venv already completed an install with a working
+    // pip — no need to pay a Python startup on every launch.
+    ensureVenvPip();
+    console.log('→ installing backend dependencies…');
+    run(venvPython, ['-m', 'pip', 'install', '--quiet', ...hashFlags, '-r', reqFile], { cwd: backendDir });
   }
   try { fs.writeFileSync(stampPath, currentSha); } catch {}
 }

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -309,20 +309,26 @@ function ensureBackend() {
   if (!fs.existsSync(venvPython)) {
     const py = findPython();
     console.log(uv ? '→ creating Python venv (uv)…' : '→ creating Python venv…');
-    // Pin uv to the same interpreter the pip path would have used, and forbid
-    // Python downloads, so `uv` on PATH changes the speed of the bootstrap and
-    // nothing else. The resolved path matters: given the bare name `python3`,
-    // uv prefers its own managed CPython over the one on PATH, which would
-    // quietly build the venv on a different Python than every previous release.
-    // --seed puts pip inside the venv: uv leaves it out by default, and without
-    // it a user who later drops uv gets a venv this script can't install into.
-    const created = uv
-      ? runSoft(uv, ['venv', 'venv', '--seed', '--no-python-downloads', '--python', which(py) || py], { cwd: backendDir })
+    // Pin uv to the same interpreter the pip path would have used, so `uv` on
+    // PATH changes the speed of the bootstrap and nothing else. The resolved
+    // path matters: given the bare name `python3`, uv prefers its own managed
+    // CPython over the one on PATH, which would quietly build the venv on a
+    // different Python than every previous release. An absolute path also means
+    // uv has nothing to go and download. --seed puts pip inside the venv: uv
+    // leaves it out by default, and without it a user who later drops uv gets a
+    // venv this script can't install into.
+    let created = uv
+      ? runSoft(uv, ['venv', 'venv', '--seed', '--python', which(py) || py], { cwd: backendDir })
       : runSoft(py, ['-m', 'venv', 'venv'], { cwd: backendDir });
+    if (uv && created !== 0) {
+      // A uv old enough not to know one of these flags shouldn't cost anyone
+      // their install. Unlike a retry of the same command this is a different
+      // tool, which can genuinely succeed where the first one didn't.
+      console.log('→ uv could not create the venv, falling back to python -m venv…');
+      created = runSoft(py, ['-m', 'venv', 'venv'], { cwd: backendDir });
+    }
     if (created !== 0 || !fs.existsSync(venvPython)) {
-      die('could not create the Python venv at backend/venv.\n' + (uv
-        ? 'Delete backend/venv and retry, or set TT_NO_UV=1 to bootstrap with python -m venv.'
-        : pipBootstrapHint()));
+      die('could not create the Python venv at backend/venv.\n' + pipBootstrapHint());
     }
   }
   // Skip pip install when requirements haven't changed since last install.
@@ -349,7 +355,9 @@ function ensureBackend() {
     // uv reads the same pip-style lock and enforces the same hashes. --python
     // targets our venv explicitly rather than whatever VIRTUAL_ENV points at.
     console.log('→ installing backend dependencies (uv)…');
-    run(uv, ['pip', 'install', '--quiet', '--python', venvPython, ...hashFlags, '-r', reqFile], { cwd: backendDir });
+    if (runSoft(uv, ['pip', 'install', '--quiet', '--python', venvPython, ...hashFlags, '-r', reqFile], { cwd: backendDir }) !== 0) {
+      die(`installing backend dependencies with uv failed (see above).\nRe-run with TT_NO_UV=1 to install ${reqFile} with pip instead.`);
+    }
   } else {
     // Only probe pip on the install path. The stamp lives inside the venv, so a
     // matching stamp means this venv already completed an install with a working

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -122,7 +122,10 @@ function printHelp() {
   ].join('\n'));
 }
 
-function run(cmd, args, opts = {}) {
+function runSoft(cmd, args, opts = {}) {
+  // Returns the exit status instead of dying, for commands we want to attempt
+  // and recover from (pip probes, the ensurepip repair).
+  //
   // On Windows we spawn through the shell so PATH-resolved commands (`py`, the
   // python launcher, etc.) work — but cmd.exe re-parses the line and does NOT
   // quote for us. When the repo lives in a path with spaces (e.g.
@@ -140,7 +143,12 @@ function run(cmd, args, opts = {}) {
     useShell ? args.map(quote) : args,
     { stdio: 'inherit', shell: useShell, ...opts },
   );
-  if (res.status !== 0) die(`"${cmd} ${args.join(' ')}" exited with ${res.status}`);
+  return res.status;
+}
+
+function run(cmd, args, opts = {}) {
+  const status = runSoft(cmd, args, opts);
+  if (status !== 0) die(`"${cmd} ${args.join(' ')}" exited with ${status}`);
 }
 
 function canConnect(host, port, timeoutMs = 300) {
@@ -236,11 +244,62 @@ function findPython() {
   die('Python 3.9+ is required. Install from https://www.python.org/downloads/ and retry.');
 }
 
+function pythonSeries() {
+  // "3.10" for the venv interpreter (or the system one, if there's no venv yet).
+  // Used to name the right distro package in the pip-bootstrap hint. No shell,
+  // so paths with spaces are safe on every platform.
+  const cmd = fs.existsSync(venvPython) ? venvPython : 'python3';
+  const probe = spawnSync(cmd, ['-c', 'import sys; print("%d.%d" % sys.version_info[:2])'], { encoding: 'utf8' });
+  return probe.status === 0 ? probe.stdout.trim() : '';
+}
+
+function pipBootstrapHint() {
+  if (isWindows) {
+    return 'Reinstall Python from https://www.python.org/downloads/ with the "pip" component\nselected, then delete backend\\venv and run this again.';
+  }
+  if (process.platform === 'darwin') {
+    return 'Install a Python that bundles pip (e.g. `brew install python`), then delete\nbackend/venv and run this again.';
+  }
+  const series = pythonSeries();
+  return [
+    "Python couldn't bootstrap pip into the venv. On Debian/Ubuntu that step ships",
+    'in a separate package:',
+    `  sudo apt install python${series || '3'}-venv`,
+    '  sudo dnf install python3-pip        # Fedora/RHEL',
+    'Then delete backend/venv and run this again.',
+  ].join('\n');
+}
+
+function venvPipWorks() {
+  if (!fs.existsSync(venvPython)) return false;
+  return runSoft(venvPython, ['-m', 'pip', '--version'], { stdio: 'ignore' }) === 0;
+}
+
+function ensureVenvPip() {
+  if (venvPipWorks()) return;
+  // The venv directory and its interpreter can both exist while pip does not:
+  // `python -m venv` bootstraps pip through ensurepip as its final step, and on
+  // Debian/Ubuntu that step is what fails when python3-venv isn't installed.
+  // The half-built tree is left behind, so the next launch skips creation and
+  // dies with "No module named pip" (issue #267). Repair it from the wheels
+  // bundled with the stdlib — offline, no PyPI round-trip.
+  console.log('→ venv has no pip, bootstrapping it…');
+  runSoft(venvPython, ['-m', 'ensurepip', '--upgrade']);
+  if (venvPipWorks()) return;
+  die('the Python venv at backend/venv has no working pip.\n' + pipBootstrapHint());
+}
+
 function ensureBackend() {
-  if (!fs.existsSync(venvDir)) {
+  // Check for the interpreter rather than the directory: an interrupted or
+  // failed `python -m venv` leaves a directory behind with nothing runnable in
+  // it. Re-running venv creation over an existing directory fills in what's
+  // missing, so there's nothing to delete here.
+  if (!fs.existsSync(venvPython)) {
     const py = findPython();
     console.log('→ creating Python venv…');
-    run(py, ['-m', 'venv', 'venv'], { cwd: backendDir });
+    if (runSoft(py, ['-m', 'venv', 'venv'], { cwd: backendDir }) !== 0 || !fs.existsSync(venvPython)) {
+      die('could not create the Python venv at backend/venv.\n' + pipBootstrapHint());
+    }
   }
   // Skip pip install when requirements haven't changed since last install.
   // Previously this ran every launch (hitting PyPI ~6× per hour for someone
@@ -260,6 +319,10 @@ function ensureBackend() {
   try { cachedSha = fs.readFileSync(stampPath, 'utf8').trim(); } catch {}
   const currentSha = require('crypto').createHash('sha1').update(fs.readFileSync(installFrom)).digest('hex');
   if (cachedSha === currentSha) return;
+  // Only probe pip on the install path. The stamp lives inside the venv, so a
+  // matching stamp means this venv already completed an install with a working
+  // pip — no need to pay a Python startup on every launch.
+  ensureVenvPip();
   console.log('→ installing backend dependencies…');
   if (useLock) {
     run(venvPython, ['-m', 'pip', 'install', '--quiet', '--require-hashes', '-r', 'requirements.lock'], { cwd: backendDir });

--- a/website/content/docs/installation.mdx
+++ b/website/content/docs/installation.mdx
@@ -71,6 +71,8 @@ node bin/cli.js
 
 The launcher creates a Python virtual environment and installs dependencies on first run. Subsequent starts skip the setup step if nothing has changed.
 
+If [uv](https://docs.astral.sh/uv/) is already on your PATH the launcher uses it for both steps, which is a good deal faster; otherwise it uses `python -m venv` and pip. You don't need to install uv, and either way you get the same interpreter and the same hash-checked packages. Set `TT_NO_UV=1` to force the pip path.
+
 ## What gets installed
 
 TokenTelemetry does **not** add any global npm package or modify your agent's config. It installs:

--- a/website/content/docs/installation.mdx
+++ b/website/content/docs/installation.mdx
@@ -10,7 +10,7 @@ import { Callout } from 'fumadocs-ui/components/callout';
 Before installing, make sure you have:
 
 - **Node.js 18+** — [nodejs.org](https://nodejs.org)
-- **Python 3.9+** — [python.org](https://www.python.org/downloads/)
+- **Python 3.9+** — [python.org](https://www.python.org/downloads/). On Debian/Ubuntu, also `sudo apt install python3-venv`: Python there ships without the venv/pip bootstrap, so the first launch can't install the backend dependencies.
 - **npm** (comes with Node.js)
 - At least one supported AI coding agent already installed (Claude Code, Gemini CLI, Codex, etc.)
 

--- a/website/content/docs/reference/cli.mdx
+++ b/website/content/docs/reference/cli.mdx
@@ -58,6 +58,7 @@ node bin/cli.js [options]     # cross-platform
 | `TOKENTELEMETRY_DATA_DIR` | Sets the data directory (used verbatim, no `.tokentelemetry` suffix). `--data-dir` flag wins. |
 | `TT_AUTH_TOKEN` | Access token for remote requests. `--auth-token` flag wins. |
 | `AGENT_HARNESS_NO_OPEN` | Set to any non-empty value to skip auto-opening the browser on startup. |
+| `TT_NO_UV` | Set to `1` to bootstrap the backend venv with `python -m venv` and pip even when [uv](https://docs.astral.sh/uv/) is on PATH. |
 | `NEXT_PUBLIC_API_PORT` | Passed to the Next.js dev server to tell the frontend which port the backend is on. Set automatically by the launcher from `--api-port`. |
 | `NEXT_PUBLIC_API_BASE` | Full backend URL override (e.g. `http://localhost:8000`). Overrides the runtime auto-detection from `window.location`. Useful in SSH-tunnel setups. |
 

--- a/website/content/docs/reference/troubleshooting.mdx
+++ b/website/content/docs/reference/troubleshooting.mdx
@@ -188,6 +188,26 @@ python3 --version   # should show 3.9+
 
 ---
 
+## `No module named pip` during install
+
+**Symptom:** On Linux, the first launch stops at:
+
+```
+→ installing backend dependencies…
+backend/venv/bin/python3: No module named pip
+```
+
+**Cause:** `python3 -m venv` bootstraps pip as its last step, and on Debian/Ubuntu that step ships in a separate package. Without it the venv is left half-built.
+
+**Fix:** Update to the current version, which repairs this automatically. On older versions, install the package and delete the broken venv:
+
+```bash
+sudo apt install python3-venv     # Debian/Ubuntu
+rm -rf backend/venv && ./start.sh
+```
+
+---
+
 ## No sessions showing after first install
 
 **Symptom:** The dashboard shows zero sessions immediately after installing.


### PR DESCRIPTION
Fixes #267, and takes the bootstrap through uv when the user already has it.

## What broke

On Ubuntu 22.04 the first launch died with:

```
→ installing backend dependencies…
/<install_path>/backend/venv/bin/python3: No module named pip

ERROR: "…/venv/bin/python3 -m pip install --quiet --require-hashes -r requirements.lock" exited with 1
```

`python3 -m venv` bootstraps pip through `ensurepip` as its final step. On Debian/Ubuntu that step ships in a separate `python3-venv` package, so without it the command fails *after* creating the directory, `pyvenv.cfg` and a working `bin/python3`. `ensureBackend()` checked `existsSync(venvDir)`, saw the tree, skipped creation, and went straight to a pip that isn't there. The reporter's own fix was `venv/bin/python3 -m ensurepip --upgrade`.

## The fix (commit 1)

- Probe pip before installing, and repair a pip-less venv with `python -m ensurepip --upgrade` — the wheels are bundled with the stdlib, so no PyPI round-trip.
- If pip is still missing, exit with the package to install (`sudo apt install python3.X-venv`, `sudo dnf install python3-pip`) instead of a raw pip traceback.
- Key the venv check on the interpreter rather than the directory, so a half-created venv is filled in on the next run. Nothing is deleted: `python -m venv` is idempotent over an existing directory.
- Split `run()` into `runSoft()` (returns status) + `run()` (dies), so the new probes keep the Windows quoting that paths with spaces depend on.

The probe runs only on the install path. `.requirements.sha` lives inside the venv, so a matching stamp already implies a venv that completed an install with a working pip, and normal launches don't pay an extra Python startup.

## uv, opportunistically (commit 2)

uv builds the venv itself rather than going through the stdlib venv module, so it never touches ensurepip, and it installs the same hash-pinned lock much faster. Both steps use uv when `uv` is on PATH, and fall back to `python -m venv` + pip otherwise. We never install uv — it stays a speed-up, not a fourth prerequisite alongside node, npm and python. `TT_NO_UV=1` forces the pip path.

Two details keep the paths interchangeable:

- `--python` gets the **resolved interpreter path**, not the bare name. Given `python3`, uv prefers its own managed CPython over the one on PATH, which would quietly build the venv on a different Python than every previous release did. An absolute path also leaves uv nothing to download.
- `--seed` installs pip inside the venv. uv omits it by default, and a user who later drops uv would be left with a venv this script can't install into.

If `uv venv` fails anyway (an old uv, an unknown flag), creation retries with `python -m venv` rather than ending the install, and a failed uv install names `TT_NO_UV=1` in its error.

Measured on this repo's lock (29 packages, warm caches), empty `backend/venv` to working imports: **0.39s with uv, 2.78s with pip.**

## Verification

Reproduced the exact #267 state with `python3 -m venv --without-pip backend/venv` (directory, `pyvenv.cfg`, working interpreter, no pip) and drove `ensureBackend()` directly on both paths:

| case | before | after |
| --- | --- | --- |
| pip-less venv, no uv | reporter's error, exit 1 | bootstraps pip via ensurepip, installs deps, imports work |
| pip-less venv, uv on PATH | reporter's error, exit 1 | uv installs straight into it, no ensurepip involved |
| clean bootstrap, both paths | — | same interpreter (3.14.6), same packages |
| pip install into a uv-created venv | — | works, thanks to `--seed` |
| healthy venv, unchanged lock | early return | early return, no extra spawn |
| venv dir with no interpreter | pip failure | recreated in place |
| `ensurepip` forced to fail | — | exits with the apt/dnf hint |
| every hash for one package corrupted | pip fails | uv fails too, computed-vs-expected mismatch |
| stub uv that rejects `uv venv` | — | falls back to `python -m venv`, install still via uv |

`node --check bin/cli.js` passes. Docs: installation page, `TT_NO_UV` in the CLI env-var reference, and a troubleshooting entry for the error message people will search for.

Reported by @yannschepens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
