### PR TITLE
feat(frontend): add copied feedback to context panel session id copy button

### DIFF
--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -938,7 +938,7 @@ export default function SessionDetailPage() {
                   )}
                   <button
                     onClick={() => {navigator.clipboard?.writeText(id)
-                        .then(() => { setCopiedId(true); setTimeout(() => setCopiedId(false), 1500); })
+                        .then(() => { setCopiedId(true); setTimeout(() => setCopiedId(false), 1000); })
                         .catch(() => {});
                     }}
                     title="Copy session id"
@@ -1692,6 +1692,7 @@ function StepRow({ step, active, beyond, onClick }: { step: Step; active: boolea
 }
 
 function ContextPanel({ ctx }: { ctx: any }) {
+  const [copiedId, setCopiedId] = useState(false);
   const Row = ({ k, v, mono = true }: { k: string; v?: any; mono?: boolean }) =>
     v ? (
       <div className="space-y-0.5">
@@ -1708,13 +1709,27 @@ function ContextPanel({ ctx }: { ctx: any }) {
       {ctx.sessionId && (
         <div className="space-y-1">
           <div className="text-[9px] font-semibold uppercase tracking-[0.16em] text-[var(--tt-fg-dim)]">Session ID</div>
-          <div className="flex items-center gap-1.5 bg-[var(--tt-sunken)] border border-[var(--tt-border)] rounded px-2 py-1.5">
-            <span className="text-[10px] font-mono text-[var(--tt-fg)] break-all flex-1" title={ctx.sessionId}>{ctx.sessionId}</span>
+          <div className={`flex items-center gap-1.5 bg-[var(--tt-sunken)] border rounded px-2 py-1.5 transition-colors ${
+            copiedId
+              ? "text-[var(--tt-success-fg)] border-[color:var(--tt-success)]/50"
+              : "border-[var(--tt-border)]"
+          }`}>
+            <span className={`text-[10px] font-mono break-all flex-1 ${copiedId ? "text-[var(--tt-success-fg)]" : "text-[var(--tt-fg)]"}`} title={ctx.sessionId}>
+              {copiedId ? "Copied" : ctx.sessionId}
+            </span>
             <button
-              onClick={() => { navigator.clipboard?.writeText(ctx.sessionId); }}
-              className="text-[9px] font-black uppercase text-[var(--tt-fg-dim)] hover:text-[var(--tt-brand)] transition-colors px-1"
-              title="Copy">
-              copy
+              onClick={() => {navigator.clipboard?.writeText(ctx.sessionId)
+                  .then(() => { setCopiedId(true); setTimeout(() => setCopiedId(false), 1000); })
+                  .catch(() => {});
+              }}
+              title="Copy session id"
+              className={`p-1 rounded transition-colors ${
+                copiedId
+                  ? "text-[var(--tt-success-fg)]"
+                  : "text-[var(--tt-fg-muted)] hover:text-[var(--tt-fg)]"
+              }`}
+            >
+              {copiedId ? (<Check size={11} strokeWidth={3} className="text-[var(--tt-success-fg)]" />) : (<Copy size={11} className="opacity-60" />)}
             </button>
           </div>
           {ctx.agent && <div className="text-[9px] font-mono text-[var(--tt-fg-faint)] uppercase">agent: {ctx.agent}</div>}


### PR DESCRIPTION

## Summary
This PR improves the copy experience for the Session ID in the right-side Context Panel (`Session Context`) on the session detail page (`/sessions/[id]`).

Previously, the panel used a plain "copy" text button with no visual feedback on click. This change replaces it with a `Copy` icon button and adds in-place visual feedback ("Copied" label, `Check` icon, and success border tint for 1s) consistent with the header's copy button, while keeping the full session ID text directly selectable.

Reduced the "Copied" feedback timeout from 1.5s to 1s across the page (header and context panel) to make the interaction feel more responsive.

## Type of change
- [ ] Bug fix
- [ ] New feature (new agent support, new dashboard view, etc.)
- [x] Improvement / refactor
- [ ] Docs / chore

## How to test
1. Run `./start.sh`
2. Open any session trace at `/sessions/[id]`
3. In the right sidebar, ensure the `Context` tab is active
4. Click the copy icon next to the Session ID
5. Verify that:
   - The text temporarily flips to "Copied" with success styling.
   - The icon changes to a checkmark.
   - The container border tints green for 1 second before reverting.
   - Manual text dragging/selection on the session ID text still works properly.
<img width="374" height="217" alt="image" src="https://github.com/user-attachments/assets/662b90cd-b565-4540-a003-f6a0c1a39e50" />


## Checklist
- [x] I tested this locally with `./start.sh`
- [x] No secrets or API keys are included
- [x] PR is focused on one change
- [x] README or CHANGELOG updated if needed

## Related issue
Closes #283 
