### PR TITLE
fix(grok): read billed usage from the unified inference log

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -435,6 +435,9 @@ HERMES_PROFILES_DIR = HERMES_DIR / "profiles"
 # Stores rich per-session data under ~/.grok/sessions/<encoded-cwd>/<uuid>/
 GROK_DIR = HOME / ".grok"
 GROK_SESSIONS_DIR = GROK_DIR / "sessions"
+# Per-turn billed usage (prompt / cached / completion) lives here, not in the
+# session dir. Session files only expose a context-window footprint.
+GROK_UNIFIED_LOG = GROK_DIR / "logs" / "unified.jsonl"
 
 # Grok Build session file names (per <cwd-uuid> directory)
 GROK_SUMMARY = "summary.json"
@@ -3079,13 +3082,99 @@ def _grok_loop_detect(
     }
 
 
+# Cached parse of ~/.grok/logs/unified.jsonl. Keyed by (resolved path, mtime, size)
+# so a dashboard refresh does not re-read a multi-MB JSONL unless it changed.
+_GROK_LOG_CACHE: Dict[str, Any] = {"key": None, "data": {}}
+
+
+def _grok_usage_from_unified_log(path: Optional[Path] = None) -> Dict[str, Dict[str, Any]]:
+    """Aggregate billed usage from Grok's unified inference log.
+
+    Each ``shell.turn.inference_done`` row is one request:
+      input  = prompt_tokens − cached_prompt_tokens
+      cached = cached_prompt_tokens
+      output = completion_tokens
+    Turns are kept so cost can apply xAI's per-request 200k long-context 2×.
+    Missing / unreadable log → {}.
+    """
+    log_path = path if path is not None else GROK_UNIFIED_LOG
+    if not log_path.exists() or not log_path.is_file():
+        return {}
+    try:
+        st = log_path.stat()
+        cache_key = (str(log_path.resolve()), st.st_mtime_ns, st.st_size)
+    except OSError:
+        return {}
+    if _GROK_LOG_CACHE.get("key") == cache_key:
+        return _GROK_LOG_CACHE["data"]
+
+    by_sid: Dict[str, Dict[str, Any]] = {}
+    try:
+        with open(log_path, "r", encoding="utf-8", errors="ignore") as f:
+            for line in f:
+                if "inference_done" not in line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except Exception:
+                    continue
+                if rec.get("msg") != "shell.turn.inference_done":
+                    continue
+                sid = rec.get("sid")
+                if not sid:
+                    continue
+                ctx = rec.get("ctx") or {}
+                try:
+                    prompt = int(ctx.get("prompt_tokens") or 0)
+                    cached = int(ctx.get("cached_prompt_tokens") or 0)
+                    completion = int(ctx.get("completion_tokens") or 0)
+                    reasoning = int(ctx.get("reasoning_tokens") or 0)
+                except (TypeError, ValueError):
+                    continue
+                if prompt < 0 or cached < 0 or completion < 0:
+                    continue
+                cached = min(cached, prompt)
+                row = by_sid.get(sid)
+                if row is None:
+                    row = {
+                        "input": 0,
+                        "output": 0,
+                        "cached": 0,
+                        "reasoning": 0,
+                        "turns": [],
+                    }
+                    by_sid[sid] = row
+                row["input"] += prompt - cached
+                row["output"] += completion
+                row["cached"] += cached
+                row["reasoning"] += max(reasoning, 0)
+                row["turns"].append((prompt, cached, completion))
+    except OSError:
+        return {}
+
+    _GROK_LOG_CACHE["key"] = cache_key
+    _GROK_LOG_CACHE["data"] = by_sid
+    return by_sid
+
+
+def _grok_price_turns(model: str, turns: List[Tuple[int, int, int]]) -> float:
+    """Sum per-request xAI cost (applies the 200k-prompt 2× cliff per turn)."""
+    from pricing import calculate_xai_turn_cost
+    return sum(calculate_xai_turn_cost(model, prompt, completion, cached)
+               for prompt, cached, completion in turns)
+
+
 def _scan_grok_sessions() -> List[Dict[str, Any]]:
     """Scan Grok Build sessions under ~/.grok/sessions/.
 
     Produces the standard TokenTelemetry session record with rich Grok-specific forensics.
+    Prefers billed usage from ``unified.jsonl`` when the session appears there;
+    otherwise falls back to the context-window footprint (output/cached n/a).
     """
     if not GROK_SESSIONS_DIR.exists():
         return []
+
+    usage_by_sid = _grok_usage_from_unified_log()
 
     # Load aliases locally so this top-level function doesn't depend on closures inside _scan_sessions_sync
     aliases = _load_project_aliases()
@@ -3143,47 +3232,56 @@ def _scan_grok_sessions() -> List[Dict[str, Any]]:
                 except Exception:
                     signals = {}
 
-            # Token forensics. Grok exposes no prompt/completion split anywhere, so we
-            # use signals.contextTokensUsed (the measured context footprint) when present,
-            # falling back to the max cumulative totalTokens scanned from updates.jsonl.
-            tokens = {"input": 0, "output": 0, "cached": 0, "total": 0}
-            ctx_used = signals.get("contextTokensUsed")
-            if isinstance(ctx_used, (int, float)) and ctx_used > 0:
-                total = int(ctx_used)
+            # Token forensics. Prefer billed per-turn usage from unified.jsonl.
+            # Session files only record contextTokensUsed (current window
+            # footprint) — that is not a prompt/completion split and must not
+            # be shown as billed Input when the log has the real numbers.
+            tokens = {"input": 0, "output": 0, "cached": 0, "total": 0, "source": "context"}
+            usage = usage_by_sid.get(sid)
+            if usage and usage.get("turns"):
+                tokens["input"] = usage["input"]
+                tokens["output"] = usage["output"]
+                tokens["cached"] = usage["cached"]
+                tokens["total"] = usage["input"] + usage["output"] + usage["cached"]
+                tokens["source"] = "usage"
+                tokens["cost"] = _grok_price_turns(model, usage["turns"])
             else:
-                # Fallback only when signals lacks a usable figure: scan the (large)
-                # updates.jsonl for the max cumulative totalTokens. Skipped entirely
-                # in the common case so the list scan stays cheap.
-                max_total = 0
-                updates_path = sess_id_dir / GROK_UPDATES
-                if updates_path.exists():
-                    try:
-                        with open(updates_path, "r", encoding="utf-8", errors="ignore") as f:
-                            for line in f:
-                                if "totalTokens" not in line:
-                                    continue
-                                try:
-                                    u = json.loads(line)
-                                    meta = (u.get("params") or {}).get("_meta") or {}
-                                    val = meta.get("totalTokens")
-                                    if isinstance(val, (int, float)) and val > max_total:
-                                        max_total = int(val)
-                                except Exception:
-                                    continue
-                    except Exception:
-                        pass
-                total = max_total
+                ctx_used = signals.get("contextTokensUsed")
+                if isinstance(ctx_used, (int, float)) and ctx_used > 0:
+                    total = int(ctx_used)
+                else:
+                    # Fallback only when signals lacks a usable figure: scan the (large)
+                    # updates.jsonl for the max cumulative totalTokens. Skipped entirely
+                    # in the common case so the list scan stays cheap.
+                    max_total = 0
+                    updates_path = sess_id_dir / GROK_UPDATES
+                    if updates_path.exists():
+                        try:
+                            with open(updates_path, "r", encoding="utf-8", errors="ignore") as f:
+                                for line in f:
+                                    if "totalTokens" not in line:
+                                        continue
+                                    try:
+                                        u = json.loads(line)
+                                        meta = (u.get("params") or {}).get("_meta") or {}
+                                        val = meta.get("totalTokens")
+                                        if isinstance(val, (int, float)) and val > max_total:
+                                            max_total = int(val)
+                                    except Exception:
+                                        continue
+                        except Exception:
+                            pass
+                    total = max_total
 
-            # Grok exposes no prompt/completion split; the agentic context is overwhelmingly
-            # fed-in tool/file content, so we attribute the measured context footprint to input
-            # rather than fabricating a 50/50 guess. Cost is therefore a lower-bound estimate.
-            tokens["total"] = total
-            tokens["input"] = total
-            tokens["output"] = 0
-            tokens["cached"] = 0
-
-            # Grok Build exposes only a single context-footprint total (no cache-write field); nothing to pass.
-            tokens["cost"] = calculate_cost(model, tokens.get("input", 0), tokens.get("output", 0), tokens.get("cached", 0))
+                # No billed split on disk: attribute the window footprint to
+                # input and leave output/cached at 0. Frontend renders those
+                # as "—" when source == "context". Cost is a lower bound.
+                tokens["total"] = total
+                tokens["input"] = total
+                tokens["output"] = 0
+                tokens["cached"] = 0
+                tokens["source"] = "context"
+                tokens["cost"] = calculate_cost(model, tokens.get("input", 0), tokens.get("output", 0), tokens.get("cached", 0))
 
             # Prefer signals.modelsUsed for the model when available.
             models_used = signals.get("modelsUsed")

--- a/backend/pricing.py
+++ b/backend/pricing.py
@@ -90,8 +90,14 @@ PRICING = {
     "deepseek-v4-pro":              {"in": 1.74,  "out": 3.48,  "cached_read": 0.0145},
 
     # --- xAI (Grok) ---
-    "grok-4.3":                     {"in": 1.25,  "out": 2.50,  "cached_read": None},
-    "grok-4.3-latest":              {"in": 1.25,  "out": 2.50,  "cached_read": None},
+    # List prices are the <200k-prompt band. Requests whose prompt reaches
+    # 200k tokens are billed at 2x all three rates for that request — see
+    # calculate_xai_turn_cost. https://docs.x.ai/developers/models/grok-4.6
+    "grok-4.6":                     {"in": 2.00,  "out": 6.00,  "cached_read": 0.50},
+    "grok-4.6-latest":              {"in": 2.00,  "out": 6.00,  "cached_read": 0.50},
+    "grok-4.5":                     {"in": 2.00,  "out": 6.00,  "cached_read": 0.30},
+    "grok-4.3":                     {"in": 1.25,  "out": 2.50,  "cached_read": 0.20},
+    "grok-4.3-latest":              {"in": 1.25,  "out": 2.50,  "cached_read": 0.20},
     # Grok Build — xAI's agentic coding CLI. Sessions record the model id as the
     # generic "grok-build"; the underlying model is grok-build-0.1 (256K context;
     # grok-code-fast-1 requests route here after 2026-05-15). API rates below.
@@ -270,6 +276,27 @@ def _load_bundled_pricing() -> None:
 _load_bundled_pricing()
 
 
+# xAI long-context cliff: a request whose prompt reaches this many tokens is
+# billed at 2x the <200k list rates for every token in that request (input,
+# cached input, and output). Applies per request, not per session.
+XAI_LONG_PROMPT_THRESHOLD = 200_000
+
+
+def _fuzzy_key_matches(key: str, model: str) -> bool:
+    """Substring match that refuses a shorter dotted version prefix.
+
+    ``grok-4`` must not win for ``grok-4.6`` (that used to silently bill at
+    grok-4's $3/$15). ``grok-4`` may still match ``grok-4-fast-reasoning``.
+    """
+    idx = model.find(key)
+    if idx < 0:
+        return False
+    after = model[idx + len(key):]
+    if after[:1] == "." and after[1:2].isdigit():
+        return False
+    return True
+
+
 def _normalize_model_id(model: str) -> str:
     """Lowercase and strip common aggregator namespace prefixes."""
     m = model.lower().strip()
@@ -364,7 +391,7 @@ def calculate_cost(
             # Fuzzy prefix match against the flat table (longer keys first)
             sorted_keys = sorted([k for k in PRICING.keys() if k != "_default"], key=len, reverse=True)
             for k in sorted_keys:
-                if k in m_norm:
+                if _fuzzy_key_matches(k, m_norm):
                     config = PRICING[k]
                     break
         if not config:
@@ -406,3 +433,25 @@ def calculate_cost(
 
     cache_write_cost = (cc_5m / 1_000_000) * cache_write_rate + (cc_1h / 1_000_000) * cache_write_1h_rate
     return in_cost + out_cost + cached_cost + cache_write_cost
+
+
+def calculate_xai_turn_cost(
+    model_name: Optional[str],
+    prompt_tokens: int,
+    completion_tokens: int,
+    cached_tokens: int = 0,
+) -> float:
+    """Price one xAI request, applying the 200k-prompt 2x cliff.
+
+    ``prompt_tokens`` is the full prompt (cached + uncached). Uncached input is
+    ``prompt − cached``. The 2x multiplier applies to the whole request when
+    the prompt reaches ``XAI_LONG_PROMPT_THRESHOLD``.
+    """
+    prompt = max(int(prompt_tokens or 0), 0)
+    cached = min(max(int(cached_tokens or 0), 0), prompt)
+    uncached = prompt - cached
+    completion = max(int(completion_tokens or 0), 0)
+    cost = calculate_cost(model_name, uncached, completion, cached)
+    if prompt >= XAI_LONG_PROMPT_THRESHOLD:
+        return cost * 2.0
+    return cost

--- a/backend/test_cline_smallcode.py
+++ b/backend/test_cline_smallcode.py
@@ -88,7 +88,7 @@ def scan_env(tmp_path, monkeypatch):
     scan_env — this module doesn't import it since it's private there)."""
     missing = tmp_path / "missing"
     for attr in ("CODEX_DIR", "GEMINI_DIR", "QWEN_DIR", "VIBE_DIR", "OLLAMA_DIR",
-                 "GROK_SESSIONS_DIR", "VSCODE_STORAGE", "CURSOR_STORAGE",
+                 "GROK_SESSIONS_DIR", "GROK_UNIFIED_LOG", "VSCODE_STORAGE", "CURSOR_STORAGE",
                  "COPILOT_CLI_DIR", "ANTIGRAVITY_BRAIN_DIR", "ANTIGRAVITY_CLI_DIR",
                  "HERMES_DIR", "PI_SESSIONS_DIR"):
         monkeypatch.setattr(main, attr, missing / attr.lower())

--- a/backend/test_copilot_vscode_scan.py
+++ b/backend/test_copilot_vscode_scan.py
@@ -24,7 +24,7 @@ def scan_env(tmp_path, monkeypatch):
     _scan_sessions_sync() run is hermetic (mirrors test_cline_smallcode.py)."""
     missing = tmp_path / "missing"
     for attr in ("CODEX_DIR", "GEMINI_DIR", "QWEN_DIR", "VIBE_DIR", "OLLAMA_DIR",
-                 "GROK_SESSIONS_DIR", "VSCODE_STORAGE", "CURSOR_STORAGE",
+                 "GROK_SESSIONS_DIR", "GROK_UNIFIED_LOG", "VSCODE_STORAGE", "CURSOR_STORAGE",
                  "COPILOT_CLI_DIR", "ANTIGRAVITY_BRAIN_DIR", "ANTIGRAVITY_CLI_DIR",
                  "HERMES_DIR", "PI_SESSIONS_DIR"):
         monkeypatch.setattr(main, attr, missing / attr.lower())

--- a/backend/test_delegation.py
+++ b/backend/test_delegation.py
@@ -254,7 +254,7 @@ def scan_env(tmp_path, monkeypatch):
     """Point every agent store at tmp_path so the scan is hermetic."""
     missing = tmp_path / "missing"
     for attr in ("CODEX_DIR", "GEMINI_DIR", "QWEN_DIR", "VIBE_DIR", "OLLAMA_DIR",
-                 "GROK_SESSIONS_DIR", "VSCODE_STORAGE", "CURSOR_STORAGE",
+                 "GROK_SESSIONS_DIR", "GROK_UNIFIED_LOG", "VSCODE_STORAGE", "CURSOR_STORAGE",
                  "COPILOT_CLI_DIR", "ANTIGRAVITY_BRAIN_DIR", "ANTIGRAVITY_CLI_DIR",
                  "HERMES_DIR", "PI_SESSIONS_DIR"):
         monkeypatch.setattr(main, attr, missing / attr.lower())

--- a/backend/test_goals.py
+++ b/backend/test_goals.py
@@ -234,7 +234,7 @@ def scan_env(tmp_path, monkeypatch):
     Claude tree we build is discovered."""
     missing = tmp_path / "missing"
     for attr in ("CODEX_DIR", "GEMINI_DIR", "QWEN_DIR", "VIBE_DIR", "OLLAMA_DIR",
-                 "GROK_SESSIONS_DIR", "VSCODE_STORAGE", "CURSOR_STORAGE",
+                 "GROK_SESSIONS_DIR", "GROK_UNIFIED_LOG", "VSCODE_STORAGE", "CURSOR_STORAGE",
                  "COPILOT_CLI_DIR", "ANTIGRAVITY_BRAIN_DIR", "ANTIGRAVITY_CLI_DIR",
                  "HERMES_DIR", "PI_SESSIONS_DIR"):
         monkeypatch.setattr(main, attr, missing / attr.lower())

--- a/backend/test_grok_usage.py
+++ b/backend/test_grok_usage.py
@@ -1,0 +1,140 @@
+"""Grok billed usage: unified.jsonl beats the context-window footprint."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+import main
+from pricing import calculate_cost, calculate_xai_turn_cost, PRICING
+
+
+SID = "01a0test-0000-0000-0000-000000000001"
+SID_NO_LOG = "01a0test-0000-0000-0000-000000000002"
+
+
+def _inference(sid, prompt, cached, completion, reasoning=0):
+    return {
+        "msg": "shell.turn.inference_done",
+        "sid": sid,
+        "ctx": {
+            "prompt_tokens": prompt,
+            "cached_prompt_tokens": cached,
+            "completion_tokens": completion,
+            "reasoning_tokens": reasoning,
+        },
+    }
+
+
+def _write_log(path: Path, rows):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(json.dumps(r) + "\n" for r in rows), encoding="utf-8")
+
+
+def _make_session(root: Path, sid: str, ctx: int, model="grok-4.6"):
+    bucket = root / "%2Ftmp%2Fx"
+    d = bucket / sid
+    d.mkdir(parents=True)
+    (d / "summary.json").write_text(json.dumps({
+        "created_at": "2026-08-21T00:00:00Z",
+        "updated_at": "2026-08-21T00:01:00Z",
+        "generated_title": f"sess {sid[:8]}",
+        "current_model_id": model,
+        "info": {"cwd": "/tmp/x"},
+    }), encoding="utf-8")
+    (d / "signals.json").write_text(json.dumps({
+        "contextTokensUsed": ctx,
+        "toolsUsed": ["read_file"],
+        "modelsUsed": [model],
+    }), encoding="utf-8")
+    return d
+
+
+def test_parse_unified_log_aggregates_turns(tmp_path):
+    log = tmp_path / "unified.jsonl"
+    _write_log(log, [
+        {"msg": "noise", "sid": SID},
+        _inference(SID, 100, 20, 10, reasoning=7),
+        _inference(SID, 250_000, 200_000, 50, reasoning=40),
+        _inference("other", 10, 0, 1),
+    ])
+    by_sid = main._grok_usage_from_unified_log(log)
+    row = by_sid[SID]
+    assert row["input"] == 80 + 50_000
+    assert row["cached"] == 20 + 200_000
+    assert row["output"] == 10 + 50
+    assert row["reasoning"] == 47
+    assert row["turns"] == [(100, 20, 10), (250_000, 200_000, 50)]
+    assert "other" in by_sid
+
+
+def test_scan_uses_log_usage_not_context(tmp_path, monkeypatch):
+    sessions = tmp_path / "sessions"
+    log = tmp_path / "unified.jsonl"
+    _make_session(sessions, SID, ctx=9_999)
+    _write_log(log, [
+        _inference(SID, 100, 20, 10),
+        _inference(SID, 250_000, 200_000, 50),
+    ])
+    monkeypatch.setattr(main, "GROK_SESSIONS_DIR", sessions)
+    monkeypatch.setattr(main, "GROK_UNIFIED_LOG", log)
+    monkeypatch.setattr(main, "PROJECT_ALIASES_FILE", tmp_path / "aliases.json")
+
+    out = {s["id"]: s for s in main._scan_grok_sessions()}
+    tok = out[SID]["tokens"]
+    assert tok["source"] == "usage"
+    assert tok["input"] == 50_080
+    assert tok["cached"] == 200_020
+    assert tok["output"] == 60
+    assert tok["total"] == 50_080 + 60 + 200_020
+    expected = (
+        calculate_xai_turn_cost("grok-4.6", 100, 10, 20)
+        + calculate_xai_turn_cost("grok-4.6", 250_000, 50, 200_000)
+    )
+    assert tok["cost"] == pytest.approx(expected)
+    # Must not keep using the window footprint as Input.
+    assert tok["input"] != 9_999
+
+
+def test_scan_falls_back_to_context_without_log(tmp_path, monkeypatch):
+    sessions = tmp_path / "sessions"
+    _make_session(sessions, SID_NO_LOG, ctx=1_500)
+    monkeypatch.setattr(main, "GROK_SESSIONS_DIR", sessions)
+    monkeypatch.setattr(main, "GROK_UNIFIED_LOG", tmp_path / "missing.jsonl")
+    monkeypatch.setattr(main, "PROJECT_ALIASES_FILE", tmp_path / "aliases.json")
+
+    out = {s["id"]: s for s in main._scan_grok_sessions()}
+    tok = out[SID_NO_LOG]["tokens"]
+    assert tok["source"] == "context"
+    assert tok["input"] == 1_500
+    assert tok["output"] == 0
+    assert tok["cached"] == 0
+    assert tok["cost"] == pytest.approx(calculate_cost("grok-4.6", 1_500, 0, 0))
+
+
+def test_grok_4_6_list_rates():
+    rates = PRICING["grok-4.6"]
+    assert rates["in"] == 2.00
+    assert rates["out"] == 6.00
+    assert rates["cached_read"] == 0.50
+    # Exact lookup — must not fall through to grok-4 ($3/$15).
+    assert calculate_cost("grok-4.6", 1_000_000, 0, 0) == pytest.approx(2.00)
+    assert calculate_cost("grok-4.6", 0, 1_000_000, 0) == pytest.approx(6.00)
+    assert calculate_cost("grok-4.6", 0, 0, 1_000_000) == pytest.approx(0.50)
+
+
+def test_grok_4_6_not_fuzzy_matched_to_grok_4():
+    # A model we have no exact row for, whose name starts with grok-4.X, must
+    # not inherit grok-4's $3/$15 just because "grok-4" is a substring.
+    assert calculate_cost("grok-4.9-hypothetical", 1_000_000, 0, 0) != 3.00
+
+
+def test_xai_turn_cost_short_vs_long():
+    short = calculate_xai_turn_cost("grok-4.6", 100_000, 1_000, 10_000)
+    # 90k uncached * $2 + 1k * $6 + 10k * $0.50 = 0.18 + 0.006 + 0.005 = 0.191
+    assert short == pytest.approx(0.191)
+    long = calculate_xai_turn_cost("grok-4.6", 200_000, 1_000, 10_000)
+    # Same cached/output, more uncached, and 2x rates because prompt hit the cliff.
+    base = calculate_cost("grok-4.6", 190_000, 1_000, 10_000)
+    assert long == pytest.approx(base * 2)
+    assert long > short * 2

--- a/backend/test_hermes_profiles.py
+++ b/backend/test_hermes_profiles.py
@@ -51,7 +51,7 @@ def _isolate_other_agents(tmp_path, monkeypatch):
     """Point every non-Hermes source at empty paths so a scan sees Hermes only."""
     missing = tmp_path / "missing"
     for attr in ("CODEX_DIR", "GEMINI_DIR", "QWEN_DIR", "VIBE_DIR", "OLLAMA_DIR",
-                 "GROK_SESSIONS_DIR", "VSCODE_STORAGE", "CURSOR_STORAGE",
+                 "GROK_SESSIONS_DIR", "GROK_UNIFIED_LOG", "VSCODE_STORAGE", "CURSOR_STORAGE",
                  "COPILOT_CLI_DIR", "ANTIGRAVITY_BRAIN_DIR", "ANTIGRAVITY_CLI_DIR",
                  "PI_SESSIONS_DIR"):
         monkeypatch.setattr(main, attr, missing / attr.lower())

--- a/backend/test_hermes_telemetry.py
+++ b/backend/test_hermes_telemetry.py
@@ -72,7 +72,7 @@ def _isolate_other_agents(tmp_path, monkeypatch):
     """Point every non-Hermes source at empty paths so a scan sees Hermes only."""
     missing = tmp_path / "missing"
     for attr in ("CODEX_DIR", "GEMINI_DIR", "QWEN_DIR", "VIBE_DIR", "OLLAMA_DIR",
-                 "GROK_SESSIONS_DIR", "VSCODE_STORAGE", "CURSOR_STORAGE",
+                 "GROK_SESSIONS_DIR", "GROK_UNIFIED_LOG", "VSCODE_STORAGE", "CURSOR_STORAGE",
                  "COPILOT_CLI_DIR", "ANTIGRAVITY_BRAIN_DIR", "ANTIGRAVITY_CLI_DIR",
                  "PI_SESSIONS_DIR"):
         monkeypatch.setattr(main, attr, missing / attr.lower())

--- a/backend/test_loops.py
+++ b/backend/test_loops.py
@@ -150,7 +150,7 @@ def scan_env(tmp_path, monkeypatch):
     only the Claude tree we build under tmp_path/.claude is discovered."""
     missing = tmp_path / "missing"
     for attr in ("CODEX_DIR", "GEMINI_DIR", "QWEN_DIR", "VIBE_DIR", "OLLAMA_DIR",
-                 "GROK_SESSIONS_DIR", "VSCODE_STORAGE", "CURSOR_STORAGE",
+                 "GROK_SESSIONS_DIR", "GROK_UNIFIED_LOG", "VSCODE_STORAGE", "CURSOR_STORAGE",
                  "COPILOT_CLI_DIR", "ANTIGRAVITY_BRAIN_DIR", "ANTIGRAVITY_CLI_DIR",
                  "HERMES_DIR", "PI_SESSIONS_DIR"):
         monkeypatch.setattr(main, attr, missing / attr.lower())

--- a/backend/test_published_artifacts.py
+++ b/backend/test_published_artifacts.py
@@ -56,7 +56,7 @@ def scan_env(tmp_path, monkeypatch):
     """Point every agent store at tmp_path so the scan is hermetic."""
     missing = tmp_path / "missing"
     for attr in ("CODEX_DIR", "GEMINI_DIR", "QWEN_DIR", "VIBE_DIR", "OLLAMA_DIR",
-                 "GROK_SESSIONS_DIR", "VSCODE_STORAGE", "CURSOR_STORAGE",
+                 "GROK_SESSIONS_DIR", "GROK_UNIFIED_LOG", "VSCODE_STORAGE", "CURSOR_STORAGE",
                  "COPILOT_CLI_DIR", "ANTIGRAVITY_BRAIN_DIR", "ANTIGRAVITY_CLI_DIR",
                  "HERMES_DIR", "PI_SESSIONS_DIR"):
         monkeypatch.setattr(main, attr, missing / attr.lower())

--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -54,7 +54,7 @@ interface Session {
   plans: any[];
   model?: string;
   models_used?: string[];
-  tokens?: { input: number; output: number; cached: number; total: number; cost?: number };
+  tokens?: { input: number; output: number; cached: number; total: number; cost?: number; source?: "usage" | "context" };
   cost?: number;
   cost_source?: "reported" | "estimated";
   artifacts?: Artifact[];
@@ -1009,11 +1009,10 @@ export default function SessionDetailPage() {
               </div>
               {sessionInfo?.tokens && (
                 <div className="hidden lg:flex items-center gap-3 bg-[var(--tt-sunken)] px-3 h-9 rounded-[var(--tt-radius)] border border-[var(--tt-border)]">
-                  {agent === "grok" ? (
-                    // Grok Build only reports cumulative context (input-side) usage —
-                    // it never logs generated-output or cache-read tokens, so we label
-                    // the figure "Context" and show "—" (not reported) rather than a
-                    // misleading 0. See GrokForensicsCard for the context-window meter.
+                  {agent === "grok" && sessionInfo.tokens.source !== "usage" ? (
+                    // Session files only record a context-window footprint.
+                    // When unified.jsonl has billed usage, source === "usage"
+                    // and we fall through to the Input/Output/Cached row.
                     <>
                       <TokenStat label="Context" value={sessionInfo.tokens.input.toLocaleString()} />
                       <span className="w-px h-5 bg-[var(--tt-border)]" />


### PR DESCRIPTION
## Summary
- Grok session directories only store a context-window footprint (`contextTokensUsed`), so the dashboard treated that number as Input and left Output, Cached, and cost empty or near zero.
- The Grok CLI already writes per-request `prompt_tokens` / `cached_prompt_tokens` / `completion_tokens` on `shell.turn.inference_done` rows in `~/.grok/logs/unified.jsonl`. The scanner now aggregates those by session id.
- Pricing adds `grok-4.6` at the published list rates and applies xAI's per-request 200k-prompt 2× cliff. Fuzzy lookup no longer maps `grok-4.6` onto `grok-4`.
- The session header shows Input / Output / Cached when billed usage is present (`tokens.source === "usage"`). Sessions with no log rows still show Context and em-dashes.

## Type of change
- [x] Bug fix
- [ ] New feature (new agent support, new dashboard view, etc.)
- [ ] Improvement / refactor
- [ ] Docs / chore

## How to test
1. Run `./start.sh` on a machine that has used Grok Build.
2. Open a Grok session that appears in `~/.grok/logs/unified.jsonl`.
3. Confirm the header shows Input, Output, and Cached (not Context / —) and a non-trivial API-equivalent cost.
4. Open a Grok session with no matching log rows — it should still show Context and em-dashes.
5. `pytest backend/test_grok_usage.py`

## Checklist
- [x] I tested this locally with `./start.sh`
- [x] No secrets or API keys are included
- [x] PR is focused on one change
- [ ] README or CHANGELOG updated if needed

## Related issue
N/A

Made with [Cursor](https://cursor.com)