### PR TITLE
fix(hooks): judge the branch the push actually comes from

### DIFF
--- a/.claude/hooks/enforce-update-json.py
+++ b/.claude/hooks/enforce-update-json.py
@@ -165,6 +165,101 @@ def _split_on_chain_operators(s: str) -> List[str]:
     return fragments
 
 
+def _cd_target(tokens: List[str]) -> Optional[str]:
+    """If a command fragment is a bare `cd <dir>`, return <dir>, else None.
+
+    `cd` with no argument, `cd -`, and `cd ~...` are treated as unknown so the
+    caller falls back rather than guessing at a directory.
+    """
+    i = 0
+    while i < len(tokens) and re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", tokens[i]):
+        i += 1
+    if i >= len(tokens) or tokens[i] != "cd":
+        return None
+    rest = [t for t in tokens[i + 1:] if not t.startswith("-")]
+    if len(rest) != 1:
+        return None
+    target = rest[0]
+    if target.startswith("~"):
+        return None
+    return target
+
+
+def _git_dash_c_target(tokens: List[str]) -> Optional[str]:
+    """Return the argument of `git -C <dir>` / `--work-tree=<dir>` if present."""
+    i = 0
+    while i < len(tokens) and re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", tokens[i]):
+        i += 1
+    if i >= len(tokens) or tokens[i] != "git":
+        return None
+    j = i + 1
+    while j < len(tokens):
+        tok = tokens[j]
+        if tok in ("-C", "--work-tree"):
+            return tokens[j + 1] if j + 1 < len(tokens) else None
+        if tok.startswith("--work-tree="):
+            return tok.split("=", 1)[1]
+        if tok in ("--git-dir", "--namespace"):
+            j += 2
+        elif tok.startswith(("--git-dir=", "--namespace=")):
+            j += 1
+        elif tok.startswith("-"):
+            j += 1
+        else:
+            break
+    return None
+
+
+def resolve_push_cwd(command_str: str, payload_cwd: Optional[str] = None) -> Optional[str]:
+    """Directory the push in `command_str` will actually run in.
+
+    Hooks are a separate process whose own cwd is the session's project root,
+    which is NOT where the command runs once Claude is in a worktree or the
+    command starts with `cd <dir> && ...`. Resolving the wrong directory made
+    both hooks judge an unrelated branch: a worktree push carrying only `fix:`
+    commits was denied because the *project root's* branch had a `feat:`
+    commit and no UPDATE.json.
+
+    Precedence, most explicit first:
+      1. `git -C <dir> push` in the push fragment itself
+      2. the accumulated `cd <dir>` prefix of the same command chain
+      3. the `cwd` field of the hook payload (worktree root / after `cd`)
+      4. None, i.e. let the caller inherit the hook process's own cwd
+
+    Relative paths compose against whatever is current at that point.
+    """
+    base = payload_cwd or None
+    try:
+        fragments = _split_on_chain_operators(command_str)
+    except Exception:
+        return base
+
+    def _resolve(path: str, against: Optional[str]) -> str:
+        if os.path.isabs(path):
+            return os.path.normpath(path)
+        return os.path.normpath(os.path.join(against or os.getcwd(), path))
+
+    for frag in fragments:
+        frag = frag.strip()
+        if not frag:
+            continue
+        try:
+            tokens = shlex.split(frag)
+        except ValueError:
+            continue
+        if not tokens:
+            continue
+        if _is_push_subcommand(tokens):
+            dash_c = _git_dash_c_target(tokens)
+            if dash_c:
+                return _resolve(dash_c, base)
+            return base
+        cd_to = _cd_target(tokens)
+        if cd_to:
+            base = _resolve(cd_to, base)
+    return base
+
+
 def _git(*args: str, cwd: Optional[str] = None, timeout: int = 10) -> Optional[str]:
     try:
         out = subprocess.check_output(
@@ -194,8 +289,11 @@ def main() -> None:
         _allow()
         return
 
-    # It IS a push / PR-create. Now check the branch state.
-    repo_root = _git("rev-parse", "--show-toplevel")
+    # It IS a push / PR-create. Resolve the directory the push runs in before
+    # asking git anything — the hook's own cwd is the project root, which is
+    # the wrong branch whenever the push comes from a worktree.
+    push_cwd = resolve_push_cwd(command, payload.get("cwd"))
+    repo_root = _git("rev-parse", "--show-toplevel", cwd=push_cwd)
     if not repo_root:
         _allow()
         return

--- a/.claude/hooks/prepush-claude-review.py
+++ b/.claude/hooks/prepush-claude-review.py
@@ -177,7 +177,11 @@ def main() -> None:
     if os.environ.get("TT_PREPUSH_REVIEW_RUNNING"):
         _allow()
 
-    repo_root = _git("rev-parse", "--show-toplevel")
+    # Same worktree caveat as the sibling hook: resolve where the push actually
+    # runs before asking git anything.
+    _resolve_cwd = getattr(_SIB, "resolve_push_cwd", None)
+    push_cwd = _resolve_cwd(command, payload.get("cwd")) if _resolve_cwd else payload.get("cwd")
+    repo_root = _git("rev-parse", "--show-toplevel", cwd=push_cwd)
     if not repo_root:
         _allow()
 

--- a/backend/test_hooks.py
+++ b/backend/test_hooks.py
@@ -1,0 +1,162 @@
+"""Pre-push hook tests.
+
+Focus: the hooks must judge the branch the push actually comes from. Both
+resolved the repo from their own process cwd (the session's project root),
+so any push out of a git worktree was evaluated against an unrelated branch.
+"""
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_HOOKS = Path(__file__).resolve().parents[1] / ".claude" / "hooks"
+_ENFORCE = _HOOKS / "enforce-update-json.py"
+
+
+def _load(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+hook = _load("enforce_update_json", _ENFORCE)
+
+
+# --- resolve_push_cwd ---------------------------------------------------------
+
+def test_plain_push_uses_payload_cwd():
+    assert hook.resolve_push_cwd("git push", "/repo/wt") == "/repo/wt"
+
+
+def test_cd_prefix_wins_over_payload_cwd():
+    assert hook.resolve_push_cwd("cd /repo/wt && git push", "/repo") == "/repo/wt"
+
+
+def test_relative_cd_composes_against_payload_cwd():
+    assert hook.resolve_push_cwd("cd sub && git push", "/repo") == "/repo/sub"
+
+
+def test_chained_relative_cds_compose():
+    assert hook.resolve_push_cwd("cd a && cd b && git push", "/repo") == "/repo/a/b"
+
+
+def test_git_dash_c_beats_cd():
+    assert hook.resolve_push_cwd("cd /elsewhere && git -C /repo/wt push", "/repo") == "/repo/wt"
+
+
+def test_git_dash_c_relative_resolves_against_current():
+    assert hook.resolve_push_cwd("cd /repo && git -C wt push", "/other") == "/repo/wt"
+
+
+def test_cd_after_the_push_is_ignored():
+    assert hook.resolve_push_cwd("git push && cd /elsewhere", "/repo") == "/repo"
+
+
+def test_unknown_cd_forms_fall_back():
+    # `cd -` and `cd ~` are not resolvable to a concrete path here.
+    assert hook.resolve_push_cwd("cd - && git push", "/repo") == "/repo"
+    assert hook.resolve_push_cwd("cd ~/x && git push", "/repo") == "/repo"
+
+
+def test_no_payload_cwd_returns_none():
+    assert hook.resolve_push_cwd("git push", None) is None
+
+
+def test_push_detection_unchanged():
+    assert hook._command_contains_push("git push")
+    assert hook._command_contains_push("cd /x && git push -u origin b")
+    assert hook._command_contains_push("gh pr create --fill")
+    assert not hook._command_contains_push('echo "git push"')
+    assert not hook._command_contains_push("git status")
+
+
+# --- end to end: run the hook the way Claude Code runs it ---------------------
+
+def _git(*args, cwd):
+    return subprocess.run(["git", *args], cwd=cwd, check=True,
+                          capture_output=True, text=True).stdout.strip()
+
+
+def _run_hook(command, payload_cwd, hook_cwd):
+    """Invoke the hook as a subprocess with a PreToolUse payload on stdin."""
+    payload = {"hook_event_name": "PreToolUse", "cwd": payload_cwd,
+               "tool_name": "Bash", "tool_input": {"command": command}}
+    p = subprocess.run([sys.executable, str(_ENFORCE)], input=json.dumps(payload),
+                       cwd=hook_cwd, capture_output=True, text=True)
+    assert p.returncode == 0, p.stderr          # hook contract: always exit 0
+    if not p.stdout.strip():
+        return "allow"
+    decision = json.loads(p.stdout)["hookSpecificOutput"]["permissionDecision"]
+    return decision
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A repo whose `main` has an origin, plus a `feat:` branch missing
+    UPDATE.json — the shape that makes the hook deny."""
+    origin = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "--bare", "-q", str(origin)], check=True)
+    root = tmp_path / "work"
+    subprocess.run(["git", "init", "-q", "-b", "main", str(root)], check=True)
+    env = [("user.email", "t@example.com"), ("user.name", "t"), ("commit.gpgsign", "false")]
+    for k, v in env:
+        _git("config", k, v, cwd=root)
+    (root / "UPDATE.json").write_text('{"releases": []}\n')
+    (root / "app.py").write_text("x = 1\n")
+    _git("add", "-A", cwd=root)
+    _git("commit", "-qm", "chore: base", cwd=root)
+    _git("remote", "add", "origin", str(origin), cwd=root)
+    _git("push", "-q", "origin", "main", cwd=root)
+
+    # Project root sits on a feat: branch with no UPDATE.json change -> deny.
+    _git("checkout", "-qb", "feat/noisy", cwd=root)
+    (root / "app.py").write_text("x = 2\n")
+    _git("commit", "-qam", "feat: something user facing", cwd=root)
+    return root
+
+
+def test_denies_feat_branch_without_update_json(repo):
+    assert _run_hook("git push", str(repo), str(repo)) == "deny"
+
+
+def test_allows_when_update_json_is_touched(repo, tmp_path):
+    (repo / "UPDATE.json").write_text('{"releases": [{"tag": "2026-08-22"}]}\n')
+    _git("commit", "-qam", "feat: with release note", cwd=repo)
+    assert _run_hook("git push", str(repo), str(repo)) == "allow"
+
+
+def test_worktree_push_is_judged_on_its_own_branch(repo, tmp_path):
+    """The regression. A fix-only worktree must not inherit the project
+    root's feat: branch verdict."""
+    wt = tmp_path / "wt"
+    _git("worktree", "add", "-q", "-b", "fix/only", str(wt), "main", cwd=repo)
+    (wt / "app.py").write_text("x = 3\n")
+    _git("commit", "-qam", "fix: a fix only branch", cwd=wt)
+
+    # Hook process cwd is the project root (on the denying feat: branch),
+    # exactly as Claude Code invokes it.
+    assert _run_hook(f"cd {wt} && git push", str(repo), str(repo)) == "allow"
+    assert _run_hook(f"git -C {wt} push", str(repo), str(repo)) == "allow"
+    # And the payload cwd route, i.e. after EnterWorktree.
+    assert _run_hook("git push", str(wt), str(repo)) == "allow"
+
+
+def test_worktree_feat_branch_still_denied(repo, tmp_path):
+    """The fix must not let a real feat: worktree through."""
+    wt = tmp_path / "wt2"
+    _git("worktree", "add", "-q", "-b", "feat/real", str(wt), "main", cwd=repo)
+    (wt / "app.py").write_text("x = 4\n")
+    _git("commit", "-qam", "feat: shipped something", cwd=wt)
+    assert _run_hook(f"cd {wt} && git push", str(repo), str(repo)) == "deny"
+
+
+def test_main_branch_is_always_allowed(repo, tmp_path):
+    wt = tmp_path / "wt3"
+    _git("worktree", "add", "-q", str(wt), "main", cwd=repo)
+    assert _run_hook(f"cd {wt} && git push", str(repo), str(repo)) == "allow"


### PR DESCRIPTION
## Summary

Both pre-push hooks resolved the repo with `git rev-parse --show-toplevel`
from their own process cwd, which is the session's project root. That is not
where the push runs once Claude is in a worktree, or once the command starts
with `cd <dir> && ...`, so a worktree push was judged against whatever branch
the project root happened to be sitting on.

This repo does most of its work in worktrees, so the hooks were routinely
answering about the wrong branch.

## What went wrong in practice

A worktree branch carrying only `fix:` commits was denied, because the project
root sat on a `feat:` branch whose `UPDATE.json` change was still uncommitted.
Per `.claude/CLAUDE.md` case 1, a pure `fix:` branch should have been allowed
silently.

The same path also denied a worktree checked out on `main`, despite the hook's
explicit "skip enforcement if we're on main" rule, because the branch it read
was never `main` to begin with.

## The fix

Adds `resolve_push_cwd()` to `enforce-update-json.py`; both hooks call it
before asking git anything. Precedence, most explicit first:

1. `git -C <dir>` in the push fragment itself
2. the accumulated `cd <dir>` prefix of the same command chain
3. the payload's `cwd` field, which is the worktree root after Claude enters a
   worktree
4. the hook's own cwd, i.e. today's behaviour

Relative paths compose against whatever is current at that point. Forms that
can't be resolved to a concrete path (`cd -`, `cd ~/x`) fall back rather than
guess.

Non-worktree pushes are unaffected: the payload cwd equals the process cwd, so
every path resolves exactly as it does today.

## Type of change

- [x] Bug fix
- [ ] New feature (new agent support, new dashboard view, etc.)
- [ ] Improvement / refactor
- [ ] Docs / chore

## How to test

`backend/test_hooks.py` (new, 15 tests) covers the resolver directly and
drives `enforce-update-json.py` end to end as a subprocess with a real
PreToolUse payload, over throwaway repos and real `git worktree` checkouts.

    pytest backend/test_hooks.py

Eleven of the fifteen fail against the unfixed hooks, including the two
behavioural ones (`test_worktree_push_is_judged_on_its_own_branch`,
`test_main_branch_is_always_allowed`). The guard tests pass either way, so the
fix doesn't loosen the gate:

- `test_denies_feat_branch_without_update_json`
- `test_worktree_feat_branch_still_denied` (a real `feat:` worktree is still denied)
- `test_allows_when_update_json_is_touched`
- `test_push_detection_unchanged`

Verified against this repo as well: the previously-denied push from a
`fix:`-only worktree is now allowed, and the live `feat/local-model-insights`
branch is still correctly denied.

Full backend suite: 461 passed, with the same pre-existing failure set as
`main` (22, all unrelated local-config pollution in `test_power_config` /
`test_pricing` / `test_update_check`).

## Checklist

- [x] I tested this locally
- [x] No secrets or API keys are included
- [x] PR is focused on one change
- [ ] README or CHANGELOG updated if needed

## Related issue

N/A. Found while pushing a follow-up to #285 from a worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
