### PR TITLE
fix(grok): apply documented Build pricing cutovers

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -3262,6 +3262,14 @@ def _scan_grok_sessions() -> List[Dict[str, Any]]:
                 except Exception:
                     signals = {}
 
+            # Resolve the model BEFORE pricing. signals.modelsUsed is the
+            # fallback when summary.json carries no current_model_id; leaving
+            # this below the token block meant a session could be priced as
+            # "grok-build" while displaying the model it actually ran.
+            models_used = signals.get("modelsUsed")
+            if isinstance(models_used, list) and models_used:
+                model = summary.get("current_model_id") or models_used[0] or model
+
             # Token forensics. Prefer billed per-turn usage from unified.jsonl.
             # Session files only record contextTokensUsed (current window
             # footprint) — that is not a prompt/completion split and must not
@@ -3312,11 +3320,6 @@ def _scan_grok_sessions() -> List[Dict[str, Any]]:
                 tokens["cached"] = 0
                 tokens["source"] = "context"
                 tokens["cost"] = calculate_cost(model, tokens.get("input", 0), tokens.get("output", 0), tokens.get("cached", 0), at=ts)
-
-            # Prefer signals.modelsUsed for the model when available.
-            models_used = signals.get("modelsUsed")
-            if isinstance(models_used, list) and models_used:
-                model = summary.get("current_model_id") or models_used[0] or model
 
             # Tool names — prefer signals.toolsUsed (accurate, deduped) and avoid the
             # redundant full events.jsonl scan when it's available.

--- a/backend/main.py
+++ b/backend/main.py
@@ -3124,7 +3124,8 @@ def _grok_usage_from_unified_log(path: Optional[Path] = None) -> Dict[str, Dict[
       input  = prompt_tokens − cached_prompt_tokens
       cached = cached_prompt_tokens
       output = completion_tokens
-    Turns are kept so cost can apply xAI's per-request 200k long-context 2×.
+    Turns retain their log timestamp so cost can apply both xAI's per-request
+    200k long-context 2× and any price cutover that occurs mid-session.
     Missing / unreadable log → {}.
     """
     log_path = path if path is not None else GROK_UNIFIED_LOG
@@ -3164,6 +3165,14 @@ def _grok_usage_from_unified_log(path: Optional[Path] = None) -> Dict[str, Dict[
                 if prompt < 0 or cached < 0 or completion < 0:
                     continue
                 cached = min(cached, prompt)
+                turn_ts = rec.get("ts")
+                if not isinstance(turn_ts, str):
+                    turn_ts = None
+                else:
+                    try:
+                        datetime.fromisoformat(turn_ts.replace("Z", "+00:00"))
+                    except ValueError:
+                        turn_ts = None
                 row = by_sid.get(sid)
                 if row is None:
                     row = {
@@ -3178,7 +3187,7 @@ def _grok_usage_from_unified_log(path: Optional[Path] = None) -> Dict[str, Dict[
                 row["output"] += completion
                 row["cached"] += cached
                 row["reasoning"] += max(reasoning, 0)
-                row["turns"].append((prompt, cached, completion))
+                row["turns"].append((prompt, cached, completion, turn_ts))
     except OSError:
         return {}
 
@@ -3187,11 +3196,15 @@ def _grok_usage_from_unified_log(path: Optional[Path] = None) -> Dict[str, Dict[
     return by_sid
 
 
-def _grok_price_turns(model: str, turns: List[Tuple[int, int, int]]) -> float:
-    """Sum per-request xAI cost (applies the 200k-prompt 2× cliff per turn)."""
+def _grok_price_turns(model: str, turns, at=None) -> float:
+    """Sum per-request xAI cost, using each log timestamp when it exists."""
     from pricing import calculate_xai_turn_cost
-    return sum(calculate_xai_turn_cost(model, prompt, completion, cached)
-               for prompt, cached, completion in turns)
+    total = 0.0
+    for turn in turns:
+        prompt, cached, completion = turn[:3]
+        turn_at = turn[3] if len(turn) > 3 and turn[3] else at
+        total += calculate_xai_turn_cost(model, prompt, completion, cached, at=turn_at)
+    return total
 
 
 def _scan_grok_sessions() -> List[Dict[str, Any]]:
@@ -3282,7 +3295,7 @@ def _scan_grok_sessions() -> List[Dict[str, Any]]:
                 tokens["cached"] = usage["cached"]
                 tokens["total"] = usage["input"] + usage["output"] + usage["cached"]
                 tokens["source"] = "usage"
-                tokens["cost"] = _grok_price_turns(model, usage["turns"])
+                tokens["cost"] = _grok_price_turns(model, usage["turns"], at=ts)
             else:
                 ctx_used = signals.get("contextTokensUsed")
                 if isinstance(ctx_used, (int, float)) and ctx_used > 0:

--- a/backend/pricing.py
+++ b/backend/pricing.py
@@ -131,15 +131,16 @@ PRICING = {
     "grok-4.5":                     {"in": 2.00,  "out": 6.00,  "cached_read": 0.30},
     "grok-4.3":                     {"in": 1.25,  "out": 2.50,  "cached_read": 0.20},
     "grok-4.3-latest":              {"in": 1.25,  "out": 2.50,  "cached_read": 0.20},
-    # Grok Build — xAI's agentic coding CLI. Sessions record the model id as the
-    # generic "grok-build"; the underlying model is grok-build-0.1 (256K context;
-    # grok-code-fast-1 requests route here after 2026-05-15). These are
-    # grok-build-0.1's own rates, not grok-code-fast-1's; the two differ, and
-    # the id we bill under is grok-build-0.1.
-    # https://docs.x.ai/developers/models/grok-build-0.1
-    "grok-build":                   {"in": 1.00,  "out": 2.00,  "cached_read": 0.20},
+    # Grok Build is powered by Grok 4.6 today. Older generic Build sessions
+    # used Build 0.1; _XAI_BANDS keeps those historical costs intact.
+    # https://docs.x.ai/build/overview
+    "grok-build":                   {"in": 2.00,  "out": 6.00,  "cached_read": 0.50},
     "grok-build-0.1":               {"in": 1.00,  "out": 2.00,  "cached_read": 0.20},
-    "grok-code-fast-1":             {"in": 0.20,  "out": 1.50,  "cached_read": None},
+    # The retired grok-code-fast-1 alias routes to Build 0.1. Its pre-retirement
+    # prices are in _XAI_BANDS, so historical sessions are not reassigned this
+    # current rate.
+    # https://docs.x.ai/developers/migration/may-15-retirement
+    "grok-code-fast-1":             {"in": 1.00,  "out": 2.00,  "cached_read": 0.20},
     "grok-code-fast":               {"in": 0.20,  "out": 1.50,  "cached_read": None},
 
     # --- Moonshot (Kimi, direct) ---
@@ -418,7 +419,27 @@ _GPT56_BANDS = {
     ],
 }
 
-PRICING_HISTORY: dict = {**_DEEPSEEK_BANDS, **_GPT56_BANDS}
+_XAI_BANDS = {
+    # grok-code-fast-1 was retired at 12:00 PT (19:00 UTC) on 2026-05-15 and
+    # redirected to grok-build-0.1. The old cached-read rate is calculated from
+    # its historical $0.20 input rate, matching calculate_cost's former fallback.
+    # https://docs.x.ai/developers/migration/may-15-retirement
+    "grok-code-fast-1": [
+        ("2000-01-01T00:00:00Z", {"in": 0.20, "out": 1.50, "cached_read": 0.02}),
+        ("2026-05-15T19:00:00Z", {"in": 1.00, "out": 2.00, "cached_read": 0.20}),
+    ],
+    # Grok 4.6 became available in Grok Build on 2026-08-12. xAI published a
+    # date but not a time, so this follows the repository convention of a
+    # midnight-UTC boundary for date-only announcements. A session on that date
+    # may therefore be off by up to a day, but older Build 0.1 sessions retain
+    # their documented $1/$2/$0.20 rate. https://x.ai/news/grok-4-6
+    "grok-build": [
+        ("2000-01-01T00:00:00Z", {"in": 1.00, "out": 2.00, "cached_read": 0.20}),
+        ("2026-08-12T00:00:00Z", {"in": 2.00, "out": 6.00, "cached_read": 0.50}),
+    ],
+}
+
+PRICING_HISTORY: dict = {**_DEEPSEEK_BANDS, **_GPT56_BANDS, **_XAI_BANDS}
 
 # Same bands, keyed by (provider, model) so a provider-qualified lookup gets the
 # historical rate too. Built from the same source so the two can never disagree.
@@ -427,6 +448,8 @@ for _m, _b in _DEEPSEEK_BANDS.items():
     PRICING_BY_PROVIDER_HISTORY[("deepseek", _m)] = _b
 for _m, _b in _GPT56_BANDS.items():
     PRICING_BY_PROVIDER_HISTORY[("openai", _m)] = _b
+for _m, _b in _XAI_BANDS.items():
+    PRICING_BY_PROVIDER_HISTORY[("xai", _m)] = _b
 
 
 def _as_utc(at) -> Optional[datetime]:
@@ -652,18 +675,20 @@ def calculate_xai_turn_cost(
     prompt_tokens: int,
     completion_tokens: int,
     cached_tokens: int = 0,
+    at=None,
 ) -> float:
     """Price one xAI request, applying the 200k-prompt 2x cliff.
 
     ``prompt_tokens`` is the full prompt (cached + uncached). Uncached input is
     ``prompt − cached``. The 2x multiplier applies to the whole request when
-    the prompt reaches ``XAI_LONG_PROMPT_THRESHOLD``.
+    the prompt reaches ``XAI_LONG_PROMPT_THRESHOLD``. ``at`` is forwarded to
+    calculate_cost so a recorded turn uses the xAI rate in force at that time.
     """
     prompt = max(int(prompt_tokens or 0), 0)
     cached = min(max(int(cached_tokens or 0), 0), prompt)
     uncached = prompt - cached
     completion = max(int(completion_tokens or 0), 0)
-    cost = calculate_cost(model_name, uncached, completion, cached)
+    cost = calculate_cost(model_name, uncached, completion, cached, at=at)
     if prompt >= XAI_LONG_PROMPT_THRESHOLD:
         return cost * 2.0
     return cost

--- a/backend/pricing.py
+++ b/backend/pricing.py
@@ -133,9 +133,12 @@ PRICING = {
     "grok-4.3-latest":              {"in": 1.25,  "out": 2.50,  "cached_read": 0.20},
     # Grok Build — xAI's agentic coding CLI. Sessions record the model id as the
     # generic "grok-build"; the underlying model is grok-build-0.1 (256K context;
-    # grok-code-fast-1 requests route here after 2026-05-15). API rates below.
-    "grok-build":                   {"in": 0.20,  "out": 1.50,  "cached_read": None},
-    "grok-build-0.1":               {"in": 0.20,  "out": 1.50,  "cached_read": None},
+    # grok-code-fast-1 requests route here after 2026-05-15). These are
+    # grok-build-0.1's own rates, not grok-code-fast-1's; the two differ, and
+    # the id we bill under is grok-build-0.1.
+    # https://docs.x.ai/developers/models/grok-build-0.1
+    "grok-build":                   {"in": 1.00,  "out": 2.00,  "cached_read": 0.20},
+    "grok-build-0.1":               {"in": 1.00,  "out": 2.00,  "cached_read": 0.20},
     "grok-code-fast-1":             {"in": 0.20,  "out": 1.50,  "cached_read": None},
     "grok-code-fast":               {"in": 0.20,  "out": 1.50,  "cached_read": None},
 

--- a/backend/test_grok_usage.py
+++ b/backend/test_grok_usage.py
@@ -138,3 +138,46 @@ def test_xai_turn_cost_short_vs_long():
     base = calculate_cost("grok-4.6", 190_000, 1_000, 10_000)
     assert long == pytest.approx(base * 2)
     assert long > short * 2
+
+
+def test_grok_build_uses_grok_build_0_1_rates():
+    # grok-build sessions bill under grok-build-0.1, not grok-code-fast-1.
+    # https://docs.x.ai/developers/models/grok-build-0.1
+    for key in ("grok-build", "grok-build-0.1"):
+        rates = PRICING[key]
+        assert rates["in"] == 1.00, key
+        assert rates["out"] == 2.00, key
+        assert rates["cached_read"] == 0.20, key
+    assert calculate_cost("grok-build", 1_000_000, 0, 0) == pytest.approx(1.00)
+    assert calculate_cost("grok-build", 0, 1_000_000, 0) == pytest.approx(2.00)
+    assert calculate_cost("grok-build", 0, 0, 1_000_000) == pytest.approx(0.20)
+    # grok-code-fast-1 is a different model and keeps its own rates.
+    assert calculate_cost("grok-code-fast-1", 1_000_000, 0, 0) == pytest.approx(0.20)
+
+
+def test_model_resolved_before_pricing(tmp_path, monkeypatch):
+    """No current_model_id + modelsUsed present must price as the used model.
+
+    The model used to be reassigned from signals.modelsUsed *after* the token
+    block, so the session displayed one model and was priced as grok-build.
+    """
+    sessions = tmp_path / "sessions"
+    log = tmp_path / "unified.jsonl"
+    d = _make_session(sessions, SID, ctx=9_999, model="grok-4.6")
+    summary = json.loads((d / "summary.json").read_text(encoding="utf-8"))
+    del summary["current_model_id"]
+    (d / "summary.json").write_text(json.dumps(summary), encoding="utf-8")
+    _write_log(log, [_inference(SID, 100, 20, 10)])
+    monkeypatch.setattr(main, "GROK_SESSIONS_DIR", sessions)
+    monkeypatch.setattr(main, "GROK_UNIFIED_LOG", log)
+    monkeypatch.setattr(main, "PROJECT_ALIASES_FILE", tmp_path / "aliases.json")
+
+    sess = {s["id"]: s for s in main._scan_grok_sessions()}[SID]
+    assert sess["model"] == "grok-4.6"
+    assert sess["tokens"]["cost"] == pytest.approx(
+        calculate_xai_turn_cost("grok-4.6", 100, 10, 20)
+    )
+    # grok-build's rates would give a different figure; the two must not agree.
+    assert sess["tokens"]["cost"] != pytest.approx(
+        calculate_xai_turn_cost("grok-build", 100, 10, 20)
+    )

--- a/backend/test_grok_usage.py
+++ b/backend/test_grok_usage.py
@@ -13,7 +13,7 @@ SID = "01a0test-0000-0000-0000-000000000001"
 SID_NO_LOG = "01a0test-0000-0000-0000-000000000002"
 
 
-def _inference(sid, prompt, cached, completion, reasoning=0):
+def _inference(sid, prompt, cached, completion, reasoning=0, ts=None):
     return {
         "msg": "shell.turn.inference_done",
         "sid": sid,
@@ -23,7 +23,7 @@ def _inference(sid, prompt, cached, completion, reasoning=0):
             "completion_tokens": completion,
             "reasoning_tokens": reasoning,
         },
-    }
+    } | ({"ts": ts} if ts else {})
 
 
 def _write_log(path: Path, rows):
@@ -31,13 +31,19 @@ def _write_log(path: Path, rows):
     path.write_text("".join(json.dumps(r) + "\n" for r in rows), encoding="utf-8")
 
 
-def _make_session(root: Path, sid: str, ctx: int, model="grok-4.6"):
+def _make_session(
+    root: Path,
+    sid: str,
+    ctx: int,
+    model="grok-4.6",
+    updated_at="2026-08-21T00:01:00Z",
+):
     bucket = root / "%2Ftmp%2Fx"
     d = bucket / sid
     d.mkdir(parents=True)
     (d / "summary.json").write_text(json.dumps({
-        "created_at": "2026-08-21T00:00:00Z",
-        "updated_at": "2026-08-21T00:01:00Z",
+        "created_at": updated_at,
+        "updated_at": updated_at,
         "generated_title": f"sess {sid[:8]}",
         "current_model_id": model,
         "info": {"cwd": "/tmp/x"},
@@ -64,7 +70,7 @@ def test_parse_unified_log_aggregates_turns(tmp_path):
     assert row["cached"] == 20 + 200_000
     assert row["output"] == 10 + 50
     assert row["reasoning"] == 47
-    assert row["turns"] == [(100, 20, 10), (250_000, 200_000, 50)]
+    assert row["turns"] == [(100, 20, 10, None), (250_000, 200_000, 50, None)]
     assert "other" in by_sid
 
 
@@ -140,19 +146,53 @@ def test_xai_turn_cost_short_vs_long():
     assert long > short * 2
 
 
-def test_grok_build_uses_grok_build_0_1_rates():
-    # grok-build sessions bill under grok-build-0.1, not grok-code-fast-1.
-    # https://docs.x.ai/developers/models/grok-build-0.1
-    for key in ("grok-build", "grok-build-0.1"):
-        rates = PRICING[key]
-        assert rates["in"] == 1.00, key
-        assert rates["out"] == 2.00, key
-        assert rates["cached_read"] == 0.20, key
-    assert calculate_cost("grok-build", 1_000_000, 0, 0) == pytest.approx(1.00)
-    assert calculate_cost("grok-build", 0, 1_000_000, 0) == pytest.approx(2.00)
-    assert calculate_cost("grok-build", 0, 0, 1_000_000) == pytest.approx(0.20)
-    # grok-code-fast-1 is a different model and keeps its own rates.
-    assert calculate_cost("grok-code-fast-1", 1_000_000, 0, 0) == pytest.approx(0.20)
+def test_grok_build_and_code_fast_follow_xai_cutovers():
+    """Retired aliases and generic Build sessions retain their actual rates."""
+    # grok-code-fast-1 was retired at noon PT (19:00 UTC) on 2026-05-15 and
+    # routed to Grok Build 0.1. https://docs.x.ai/developers/migration/may-15-retirement
+    assert calculate_cost(
+        "grok-code-fast-1", 1_000_000, 0, 0, at="2026-05-15T18:59:59Z"
+    ) == pytest.approx(0.20)
+    assert calculate_cost(
+        "grok-code-fast-1", 1_000_000, 0, 0, at="2026-05-15T19:00:00Z"
+    ) == pytest.approx(1.00)
+
+    # Grok 4.6 became the Grok Build model on 2026-08-12. xAI announced only
+    # the date, so pricing bands consistently start at midnight UTC.
+    # https://x.ai/news/grok-4-6
+    assert calculate_cost("grok-build", 1_000_000, 0, 0, at="2026-08-11T23:59:59Z") == pytest.approx(1.00)
+    assert calculate_cost("grok-build", 1_000_000, 0, 0, at="2026-08-12T00:00:00Z") == pytest.approx(2.00)
+    assert PRICING["grok-build"] == {"in": 2.00, "out": 6.00, "cached_read": 0.50}
+    assert PRICING["grok-build-0.1"] == {"in": 1.00, "out": 2.00, "cached_read": 0.20}
+    assert PRICING["grok-code-fast-1"] == {"in": 1.00, "out": 2.00, "cached_read": 0.20}
+    # The migration notice names only grok-code-fast-1; don't silently reroute
+    # the distinct grok-code-fast alias without a source proving that change.
+    assert calculate_cost("grok-code-fast", 1_000_000, 0, 0, at="2026-08-30T00:00:00Z") == pytest.approx(0.20)
+
+
+def test_scan_prices_each_generic_grok_build_turn_at_its_log_timestamp(tmp_path, monkeypatch):
+    sessions = tmp_path / "sessions"
+    log = tmp_path / "unified.jsonl"
+    _make_session(
+        sessions,
+        SID,
+        ctx=0,
+        model="grok-build",
+        updated_at="2026-08-12T00:01:00Z",
+    )
+    _write_log(log, [
+        _inference(SID, 100_000, 10_000, 1_000, ts="2026-08-11T23:59:59Z"),
+        _inference(SID, 100_000, 10_000, 1_000, ts="2026-08-12T00:00:00Z"),
+    ])
+    monkeypatch.setattr(main, "GROK_SESSIONS_DIR", sessions)
+    monkeypatch.setattr(main, "GROK_UNIFIED_LOG", log)
+    monkeypatch.setattr(main, "PROJECT_ALIASES_FILE", tmp_path / "aliases.json")
+
+    sess = {s["id"]: s for s in main._scan_grok_sessions()}[SID]
+    assert sess["tokens"]["cost"] == pytest.approx(
+        calculate_xai_turn_cost("grok-build", 100_000, 1_000, 10_000, at="2026-08-11T23:59:59Z")
+        + calculate_xai_turn_cost("grok-build", 100_000, 1_000, 10_000, at="2026-08-12T00:00:00Z")
+    )
 
 
 def test_model_resolved_before_pricing(tmp_path, monkeypatch):
@@ -163,7 +203,7 @@ def test_model_resolved_before_pricing(tmp_path, monkeypatch):
     """
     sessions = tmp_path / "sessions"
     log = tmp_path / "unified.jsonl"
-    d = _make_session(sessions, SID, ctx=9_999, model="grok-4.6")
+    d = _make_session(sessions, SID, ctx=9_999, model="grok-4.5")
     summary = json.loads((d / "summary.json").read_text(encoding="utf-8"))
     del summary["current_model_id"]
     (d / "summary.json").write_text(json.dumps(summary), encoding="utf-8")
@@ -173,9 +213,9 @@ def test_model_resolved_before_pricing(tmp_path, monkeypatch):
     monkeypatch.setattr(main, "PROJECT_ALIASES_FILE", tmp_path / "aliases.json")
 
     sess = {s["id"]: s for s in main._scan_grok_sessions()}[SID]
-    assert sess["model"] == "grok-4.6"
+    assert sess["model"] == "grok-4.5"
     assert sess["tokens"]["cost"] == pytest.approx(
-        calculate_xai_turn_cost("grok-4.6", 100, 10, 20)
+        calculate_xai_turn_cost("grok-4.5", 100, 10, 20)
     )
     # grok-build's rates would give a different figure; the two must not agree.
     assert sess["tokens"]["cost"] != pytest.approx(


### PR DESCRIPTION
## Summary

This fixes Grok pricing without rewriting historical spend:

- Generic `grok-build` sessions use Build 0.1 rates before **2026-08-12** and Grok 4.6 rates from that date. xAI states that Grok 4.6 became available in Grok Build on August 12: https://x.ai/news/grok-4-6
- Retired `grok-code-fast-1` uses its legacy rate before xAI's **2026-05-15 12:00 PT** retirement, then its documented `grok-build-0.1` redirect rate: https://docs.x.ai/developers/migration/may-15-retirement
- The scanner preserves each `unified.jsonl` inference record's timestamp, so a session crossing the Grok Build cutover is costed turn by turn. The session timestamp is used only when a log row has no usable timestamp.
- `grok-code-fast` is deliberately unchanged: xAI's migration notice names `grok-code-fast-1`, not that separate alias.

The existing model-resolution fix remains: `signals.modelsUsed` is selected before any session is priced.

## Rebased

Rebased onto current `main`, which includes the date-banded pricing mechanism from #307 and the worktree hook fix from #306.

## Verification

- Regression coverage for both cutover instants, the unmodified alias, and a two-turn session that crosses the Grok Build boundary.
- Direct historical-pricing assertions passed.
- Isolated scanner routing check passed.
- Python compilation and whitespace checks passed.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Improvement / refactor
- [ ] Docs / chore
