### PR TITLE
fix(frontend): sync active step and scroll views on session playback scrubber seek

### DIFF
--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -857,6 +857,18 @@ export default function SessionDetailPage() {
     });
   };
 
+  const handlePlayback = (idx: number) => {
+    setPlaybackIndex(idx);
+    if (events.length === 0) return;
+    const targetIdx = idx > 0 ? idx - 1 : 0;
+    setActiveStep(targetIdx);
+    requestAnimationFrame(() => {
+      stepRefs.current[targetIdx]?.scrollIntoView({ behavior: "smooth", block: "center" });
+      stepIndexRefs.current[targetIdx]?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+      waterfallRefs.current[targetIdx]?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+    });
+  };
+
   // Sync active step and inspector on dialogue card click
   const handleStepCardClick = (e: React.MouseEvent, idx: number) => {
     if ((e.target as HTMLElement).closest("button, a, summary, input, textarea, select, [role='button']")) {
@@ -1066,7 +1078,7 @@ export default function SessionDetailPage() {
             <div className="bg-[var(--tt-sunken)] px-4 py-3 rounded-[var(--tt-radius)] border border-[var(--tt-border)] flex items-center gap-4">
               <div className="flex items-center gap-1">
                 <button
-                  onClick={() => setPlaybackIndex(Math.max(0, playbackIndex - 1))}
+                  onClick={() => handlePlayback(Math.max(0, playbackIndex - 1))}
                   aria-label="Previous step"
                   className="h-8 w-8 grid place-items-center rounded-md text-[var(--tt-fg-muted)] hover:text-[var(--tt-fg)] hover:tt-tint-1 transition-colors"
                 >
@@ -1080,7 +1092,7 @@ export default function SessionDetailPage() {
                   {isPlaying ? <Pause size={14} /> : <Play size={14} />}
                 </button>
                 <button
-                  onClick={() => setPlaybackIndex(Math.min(events.length, playbackIndex + 1))}
+                  onClick={() => handlePlayback(Math.min(events.length, playbackIndex + 1))}
                   aria-label="Next step"
                   className="h-8 w-8 grid place-items-center rounded-md text-[var(--tt-fg-muted)] hover:text-[var(--tt-fg)] hover:tt-tint-1 transition-colors"
                 >
@@ -1093,7 +1105,7 @@ export default function SessionDetailPage() {
                   min="0"
                   max={events.length}
                   value={playbackIndex}
-                  onChange={(e) => setPlaybackIndex(parseInt(e.target.value))}
+                  onChange={(e) => handlePlayback(parseInt(e.target.value))}
                   className="w-full h-1 rounded-full appearance-none cursor-pointer accent-[var(--tt-brand)]"
                   style={{ background: `linear-gradient(to right, var(--tt-brand) 0%, var(--tt-brand) ${(playbackIndex / Math.max(1, events.length)) * 100}%, rgba(255,255,255,0.06) ${(playbackIndex / Math.max(1, events.length)) * 100}%, rgba(255,255,255,0.06) 100%)` }}
                 />


### PR DESCRIPTION

## Summary
Synchronize the active step and scroll views (center conversation, left Step Index, and bottom Execution Timeline) when seeking through the timeline using the playback scrubber or step navigation buttons on `/sessions/[id]`.

- **Issue**: During automated replay, `setActiveStep` and `scrollIntoView` for `stepRefs`, `stepIndexRefs`, and `waterfallRefs` run on each interval. However, manual interactions with the scrubber slider (`onChange`) and step buttons (`onClick`) only updated `playbackIndex`, without updating `activeStep` or scrolling views to the selected step.
- **Solution**: Added a lightweight helper function `handlePlayback` that updates `playbackIndex`, sets `activeStep`, and triggers `requestAnimationFrame`-wrapped `scrollIntoView` calls across all three views (`stepRefs`, `stepIndexRefs`, `waterfallRefs`). Replaced direct `setPlaybackIndex` calls on the scrubber controls with `handlePlayback`.

## Type of change
- [x] Bug fix
- [ ] New feature (new agent support, new dashboard view, etc.)
- [ ] Improvement / refactor
- [ ] Docs / chore

## How to test
1. Run `./start.sh`
2. Open any session detail page (`/sessions/[id]`) with multiple steps.
3. Drag the timeline scrubber thumb left and right while paused, or click the `<` and `>` step buttons.
4. Verify that the center conversation, left Step Index list, and bottom Execution Timeline all scroll to and highlight the corresponding step in real time.

## Checklist
- [x] I tested this locally with `./start.sh`
- [x] No secrets or API keys are included
- [x] PR is focused on one change
- [x] README or CHANGELOG updated if needed

## Related issue
Closes #288 
