### PR TITLE
fix(backend): fold / vs \ separator variants into one project identity

### DIFF
--- a/backend/harness_config.py
+++ b/backend/harness_config.py
@@ -21,7 +21,7 @@ import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Set
 
-from tt_paths import data_dir
+from tt_paths import canonical_project, data_dir
 
 # Resolved once at import. The data dir is an install-time setting (exported via
 # TOKENTELEMETRY_DATA_DIR / TOKENTELEMETRY_HOME before the backend launches), so
@@ -118,16 +118,21 @@ def save_hidden(paths: Set[str]) -> None:
 
 def hide_project(path: str) -> Set[str]:
     current = load_hidden()
-    current.add(path)
+    # Store the canonical form so membership checks against canonicalised
+    # card paths match regardless of the separator style that was submitted.
+    current.add(canonical_project(path))
     save_hidden(current)
     return current
 
 
 def unhide_project(path: str) -> Set[str]:
-    current = load_hidden()
-    current.discard(path)
-    save_hidden(current)
-    return current
+    # Rebuild the set in canonical form while removing the target, so an
+    # entry saved under another separator style (pre-canonicalisation) is
+    # removed too instead of surviving as an unremovable stale entry.
+    target = canonical_project(path)
+    updated = {p for p in (canonical_project(c) for c in load_hidden()) if p != target}
+    save_hidden(updated)
+    return updated
 
 
 def load_preferences() -> Dict[str, Any]:

--- a/backend/history_store.py
+++ b/backend/history_store.py
@@ -32,11 +32,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple
 
-from tt_paths import data_dir
+from tt_paths import canonical_project, data_dir
 
 _log = logging.getLogger("tokentelemetry.history")
 
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 # Sub-dicts folded into ``ecosystem_json`` and expanded back out on read. These
 # are the keys the analytics aggregation + delegation views consume beyond the
@@ -133,6 +133,28 @@ def _migrate(con: sqlite3.Connection) -> None:
             pass
         con.execute(f"PRAGMA user_version={SCHEMA_VERSION}")
         con.commit()
+    if ver < 3:
+        # v3 folds separator variants of the same project folder into the
+        # canonical identity (see tt_paths.canonical_project). Sessions are
+        # canonicalised at scan time from now on; without this one-time pass,
+        # rows persisted before the change (especially pruned ones, which are
+        # never re-written) would stop matching filters and cards written
+        # against the new form. DISTINCT keeps it cheap; idempotent by nature.
+        try:
+            rows = con.execute(
+                "SELECT DISTINCT project FROM sessions WHERE project IS NOT NULL"
+            ).fetchall()
+            for r in rows:
+                canon = canonical_project(r["project"])
+                if canon != r["project"]:
+                    con.execute(
+                        "UPDATE sessions SET project=? WHERE project=?",
+                        (canon, r["project"]),
+                    )
+            con.execute(f"PRAGMA user_version={SCHEMA_VERSION}")
+            con.commit()
+        except sqlite3.Error:
+            _log.exception("history migrate v3 (project canonicalisation) failed")
 
 
 # ── serialization helpers ────────────────────────────────────────────────────
@@ -341,6 +363,9 @@ def query(
         where.append("last_ts <= ?"); params.append(to)
     for col, vals in (("agent", agents), ("model", models), ("project", projects)):
         vals = [v for v in (vals or []) if v]
+        if col == "project" and vals:
+            # Rows store the canonical form; accept either separator style.
+            vals = [canonical_project(v) for v in vals]
         if vals:
             where.append(f"{col} IN ({','.join('?' * len(vals))})")
             params.extend(vals)

--- a/backend/main.py
+++ b/backend/main.py
@@ -21,7 +21,7 @@ from harness_config import (
     load_preferences, save_preferences,
 )
 import notifications as notif
-from tt_paths import data_dir
+from tt_paths import canonical_project, data_dir
 import scan_cache
 import codex_goals
 import hermes_telemetry as _ht
@@ -7445,6 +7445,13 @@ def _scan_sessions_sync():
     # loop session (raw facts were parsed above; liveness is never cached).
     _annotate_loop_lifecycle(sessions, datetime.now(timezone.utc))
 
+    # One folder, one identity: agent CLIs disagree on separator style
+    # (`C:\a\b` vs `C:/a/b`), which used to split real projects into duplicate
+    # /projects cards. Canonicalise once here so every consumer downstream
+    # (rollups, filters, durable history) sees the same string.
+    for s in sessions:
+        s["project"] = canonical_project(s["project"])
+
     # Global sort by timestamp descending
     sessions.sort(key=lambda x: x["timestamp"], reverse=True)
     return sessions
@@ -8945,7 +8952,10 @@ def canonical_repo(path: str) -> str:
     *dir* means the main checkout: the repo root and any plain subdirectory of it
     are left unchanged (they are the same working tree, not separate worktrees —
     folding every `frontend/`/`backend/` into the repo is not the intent here).
-    Returns `path` unchanged when no worktree is found. Memoised."""
+    Returns `path` unchanged when no worktree is found — in canonical form
+    (see `tt_paths.canonical_project`) either way, so callers can compare the
+    result against canonicalised card paths with startswith()/dict lookups.
+    Memoised."""
     if not path:
         return path
     cached = _canonical_repo_cache.get(path)
@@ -8974,6 +8984,10 @@ def canonical_repo(path: str) -> str:
                 result = path[:m.start()]
     except Exception:
         result = path
+    # `str(Path)` above yields native separators (`C:\repo` on Windows) while
+    # card paths are forward-slashed; emit both in one identity space or the
+    # worktree grouping below would synthesise duplicate repo cards.
+    result = canonical_project(result)
     _canonical_repo_cache[path] = result
     return result
 
@@ -9003,7 +9017,8 @@ def _repo_worktree_paths(repo: str) -> List[str]:
                 # gitdir points at <worktree>/.git — strip the trailing /.git
                 wp = _GITDIR_TAIL_RE.sub("", gd.read_text("utf-8", errors="ignore").strip())
                 if wp:
-                    paths.append(wp)
+                    # Canonical form: these keys are looked up with card paths.
+                    paths.append(canonical_project(wp))
     except Exception:
         pass
     _worktree_registry_cache[repo] = paths
@@ -9013,7 +9028,9 @@ def _repo_worktree_paths(repo: str) -> List[str]:
 @app.get("/projects")
 async def get_projects(include_hidden: bool = False):
     sessions = await get_sessions_cached(); projects = {}
-    hidden = load_hidden()
+    # Compare canonically: entries saved before project canonicalisation (or
+    # by hand) may use another separator style than the cards do now.
+    hidden = {canonical_project(p) for p in load_hidden()}
     for s in sessions:
         proj = s["project"]
         # The Antigravity "unassigned" sentinel isn't a real workspace — skip it
@@ -9742,7 +9759,10 @@ def _budget_window(period: str, now_local: datetime):
 def _session_matches_filters(s: Dict[str, Any], filters: Dict[str, str]) -> bool:
     """A session matches iff every present filter key equals the session's value.
     Empty filters ({}) match everything (global budget)."""
-    if "project" in filters and s.get("project") != filters["project"]:
+    if "project" in filters and \
+            canonical_project(s.get("project")) != canonical_project(filters["project"]):
+        # Canonical on both sides: budgets saved before project paths were
+        # canonicalised may use another separator style than sessions do now.
         return False
     if "agent" in filters and s.get("agent") != filters["agent"]:
         return False

--- a/backend/test_cline_smallcode.py
+++ b/backend/test_cline_smallcode.py
@@ -21,6 +21,7 @@ import pytest
 
 sys.path.insert(0, os.path.dirname(__file__))
 import main  # noqa: E402
+from tt_paths import canonical_project  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -164,7 +165,9 @@ def test_smallcode_reuses_known_project_roots(scan_env, monkeypatch):
     smallcode = [s for s in sessions if s["agent"] == "smallcode"]
     assert len(smallcode) == 1
     assert smallcode[0]["id"] == "reuse-1"
-    assert smallcode[0]["project"] == str(proj)
+    # Scan output is canonicalised (tt_paths.canonical_project), so compare
+    # against the canonical form of the root, not its raw on-disk spelling.
+    assert smallcode[0]["project"] == canonical_project(str(proj))
 
 
 def test_smallcode_extra_roots_env(scan_env, monkeypatch):
@@ -178,7 +181,7 @@ def test_smallcode_extra_roots_env(scan_env, monkeypatch):
     smallcode = [s for s in sessions if s["agent"] == "smallcode"]
     assert len(smallcode) == 1
     assert smallcode[0]["id"] == "extra-1"
-    assert smallcode[0]["project"] == str(extra)
+    assert smallcode[0]["project"] == canonical_project(str(extra))
 
 
 def test_session_detail_smallcode(tmp_path, monkeypatch):

--- a/backend/test_project_paths.py
+++ b/backend/test_project_paths.py
@@ -1,0 +1,270 @@
+"""Regression tests: one real folder must yield ONE /projects card.
+
+Agent CLIs log cwd in their own separator style — some emit `C:\\a\\b`,
+others `C:/a/b`, a few mix both — and projects were grouped by exact string,
+so a single Windows workspace could surface as duplicate cards. These tests
+pin canonicalisation at the scan choke point plus every identity boundary
+that reads persisted config (hidden projects, budgets).
+
+Run:  python backend/test_project_paths.py   (no pytest needed)
+      pytest backend/test_project_paths.py   (also works)
+"""
+import asyncio
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(__file__))
+import harness_config  # noqa: E402
+import main  # noqa: E402
+from tt_paths import canonical_project  # noqa: E402
+
+SID_BACKSLASH = "11111111-aaaa-bbbb-cccc-000000000001"
+SID_FORWARD = "22222222-aaaa-bbbb-cccc-000000000002"
+PROJ_BACKSLASH = "C:\\Users\\dev\\proj"
+PROJ_FORWARD = "C:/Users/dev/proj"
+CANONICAL = "C:/Users/dev/proj"
+
+
+def _write_claude_session(claude_dir: Path, sid: str, cwd: str) -> None:
+    """Minimal Claude Code transcript whose first line logs `cwd` verbatim."""
+    p_dir = claude_dir / "projects" / ("proj-" + sid[:8])
+    p_dir.mkdir(parents=True)
+    (p_dir / f"{sid}.jsonl").write_text(
+        json.dumps({"type": "user", "timestamp": "2026-08-01T10:00:00Z",
+                    "cwd": cwd,
+                    "message": {"content": "hello"}}) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _hermetic(tmp: str):
+    """Point every agent store at tmp so the scan reads nothing real.
+
+    Mirrors the `scan_env` fixture used by other suites, minus pytest.
+    Returns a restore callable."""
+    missing = Path(tmp) / "missing"
+    saved_attrs = {}
+    paths = {
+        "CODEX_DIR": missing / "codex", "GEMINI_DIR": missing / "gemini",
+        "QWEN_DIR": missing / "qwen", "VIBE_DIR": missing / "vibe",
+        "OLLAMA_DIR": missing / "ollama", "GROK_SESSIONS_DIR": missing / "grok-sessions",
+        "GROK_UNIFIED_LOG": missing / "grok-unified.jsonl",
+        "VSCODE_STORAGE": missing / "vscode", "CURSOR_STORAGE": missing / "cursor-storage",
+        "COPILOT_CLI_DIR": missing / "copilot-cli", "ANTIGRAVITY_BRAIN_DIR": missing / "ag-brain",
+        "ANTIGRAVITY_CLI_DIR": missing / "ag-cli", "HERMES_DIR": missing / "hermes",
+        "PI_SESSIONS_DIR": missing / "pi", "CLAUDE_DIR": Path(tmp) / ".claude",
+        "CURSOR_DIR": Path(tmp) / ".cursor", "OPENCODE_DB": missing / "opencode.db",
+        "HERMES_DB": missing / "hermes-state.db",
+        "HERMES_PROFILES_DIR": missing / "hermes-profiles",
+        "PROJECT_ALIASES_FILE": Path(tmp) / "aliases.json",
+        # Stores the published_artifacts scan_env fixture does not patch; on a
+        # dev machine they point at real agent data and would slow the scan
+        # down (or leak rows in). Assertions filter to our session ids anyway.
+        "CLINE_DIR": missing / "cline", "CLINE_VSCODE_DIR": missing / "cline-vscode",
+        "MUSE_SESSIONS_DIR": missing / "muse", "PRIME_SESSIONS_DIR": missing / "prime",
+        "DSH_SESSIONS_DIR": missing / "dsh",
+    }
+    for attr, val in paths.items():
+        saved_attrs[attr] = getattr(main, attr)
+        setattr(main, attr, val)
+    for attr in ("ANTIGRAVITY_BRAIN_SOURCES", "ANTIGRAVITY_BRAIN_DIRS"):
+        saved_attrs[attr] = getattr(main, attr)
+        setattr(main, attr, [])
+    saved_attrs["SMALLCODE_EXTRA_ROOTS"] = main.SMALLCODE_EXTRA_ROOTS
+    main.SMALLCODE_EXTRA_ROOTS = []
+    saved_attrs["_antigravity_cli_meta"] = main._antigravity_cli_meta
+    main._antigravity_cli_meta = lambda *a, **k: {}
+    saved_env = os.environ.get("TOKENTELEMETRY_DATA_DIR")
+    os.environ["TOKENTELEMETRY_DATA_DIR"] = str(Path(tmp) / "tt_data")
+
+    def _restore():
+        for attr, val in saved_attrs.items():
+            setattr(main, attr, val)
+        if saved_env is None:
+            os.environ.pop("TOKENTELEMETRY_DATA_DIR", None)
+        else:
+            os.environ["TOKENTELEMETRY_DATA_DIR"] = saved_env
+
+    return _restore
+
+
+def _seed_two_separator_variants(claude_dir: Path):
+    """Same folder, logged by two sessions with opposite separator styles."""
+    _write_claude_session(claude_dir, SID_BACKSLASH, PROJ_BACKSLASH)
+    _write_claude_session(claude_dir, SID_FORWARD, PROJ_FORWARD)
+
+
+# ---------------------------------------------------------------------------
+# Pure helper
+# ---------------------------------------------------------------------------
+
+def test_canonical_project_folds_windows_separators():
+    f = canonical_project
+    assert f(PROJ_BACKSLASH) == CANONICAL
+    assert f(PROJ_FORWARD) == CANONICAL          # already canonical
+    assert f("C:\\Users\\dev\\proj\\") == CANONICAL   # mixed style + trailing sep
+    assert f("\\\\server\\share\\proj") == "//server/share/proj"  # UNC
+
+
+def test_canonical_project_trims_trailing_posix_sep():
+    f = canonical_project
+    assert f("/tmp/proj/") == "/tmp/proj"
+    assert f("/tmp/proj") == "/tmp/proj"
+
+
+def test_canonical_project_keeps_filesystem_root():
+    # A lone separator must not collapse to "" (would corrupt the value).
+    f = canonical_project
+    assert f("/") == "/"
+    assert f("//") == "//"
+
+
+def test_canonical_project_leaves_posix_backslashes_alone():
+    # On POSIX a backslash is a legal filename character — rewriting it into
+    # "/" would corrupt a perfectly valid directory into two.
+    assert canonical_project("/data/weird\\name") == "/data/weird\\name"
+
+
+def test_canonical_project_passes_sentinels_through():
+    f = canonical_project
+    assert f("unknown") == "unknown"
+    assert f(main.ANTIGRAVITY_UNASSIGNED) == main.ANTIGRAVITY_UNASSIGNED
+    assert f("relative/path") == "relative/path"
+    assert f("") == ""
+    assert f(None) is None
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: scan + /projects rollup
+# ---------------------------------------------------------------------------
+
+def test_scan_folds_separator_variants_into_one_identity():
+    with tempfile.TemporaryDirectory() as d:
+        restore = _hermetic(d)
+        try:
+            _seed_two_separator_variants(Path(d) / ".claude")
+            mine_ids = {SID_BACKSLASH, SID_FORWARD}
+            projs = {s["project"] for s in main._scan_sessions_sync()
+                     if s["agent"] == "claude" and s["id"] in mine_ids}
+            assert len(projs) == 1, f"separator variants split the project: {projs}"
+            assert projs == {CANONICAL}
+        finally:
+            restore()
+
+
+def test_separator_variants_yield_single_card():
+    with tempfile.TemporaryDirectory() as d:
+        restore = _hermetic(d)
+        try:
+            claude_dir = Path(d) / ".claude"
+            _seed_two_separator_variants(claude_dir)
+            mine_ids = {SID_BACKSLASH, SID_FORWARD}
+            sessions = [s for s in main._scan_sessions_sync()
+                        if s["agent"] == "claude" and s["id"] in mine_ids]
+            assert len(sessions) == 2
+
+            async def fake_cached(fresh=False):
+                return sessions
+
+            saved_cached, saved_hidden = main.get_sessions_cached, main.load_hidden
+            main.get_sessions_cached = fake_cached
+            main.load_hidden = lambda: set()
+            try:
+                cards = asyncio.run(main.get_projects())
+            finally:
+                main.get_sessions_cached = saved_cached
+                main.load_hidden = saved_hidden
+
+            assert len(cards) == 1, \
+                f"expected one card, got {[c['path'] for c in cards]}"
+            card = cards[0]
+            assert card["path"] == CANONICAL
+            assert card["session_count"] == 2
+        finally:
+            restore()
+
+
+def test_hidden_entry_in_other_separator_style_still_hides_card():
+    # A project hidden before canonicalisation (backslash form) must keep
+    # hiding the now forward-slashed card.
+    with tempfile.TemporaryDirectory() as d:
+        restore = _hermetic(d)
+        try:
+            claude_dir = Path(d) / ".claude"
+            _seed_two_separator_variants(claude_dir)
+            mine_ids = {SID_BACKSLASH, SID_FORWARD}
+            sessions = [s for s in main._scan_sessions_sync()
+                        if s["agent"] == "claude" and s["id"] in mine_ids]
+
+            async def fake_cached(fresh=False):
+                return sessions
+
+            saved_cached, saved_hidden = main.get_sessions_cached, main.load_hidden
+            main.get_sessions_cached = fake_cached
+            main.load_hidden = lambda: {PROJ_BACKSLASH}
+            try:
+                # include_hidden=True: the default view drops hidden cards,
+                # and we want to assert the flag itself.
+                cards = asyncio.run(main.get_projects(include_hidden=True))
+            finally:
+                main.get_sessions_cached = saved_cached
+                main.load_hidden = saved_hidden
+
+            assert len(cards) == 1 and cards[0]["hidden"] is True, cards
+        finally:
+            restore()
+
+
+def test_unhide_removes_entries_saved_in_any_separator_style(tmp=None):
+    # unhide must rebuild the stored set canonically; an exact-discard would
+    # leave a pre-canonicalisation backslash entry stuck forever.
+    with tempfile.TemporaryDirectory() as d:
+        saved_file = harness_config.HIDDEN_FILE
+        harness_config.HIDDEN_FILE = Path(d) / "hidden.json"
+        try:
+            harness_config.hide_project(PROJ_BACKSLASH)
+            harness_config.hide_project("/tmp/other")
+            updated = harness_config.unhide_project(PROJ_FORWARD)
+            assert updated == {"/tmp/other"}
+            assert json.loads(harness_config.HIDDEN_FILE.read_text("utf-8")) == ["/tmp/other"]
+        finally:
+            harness_config.HIDDEN_FILE = saved_file
+
+
+def test_hide_stores_canonical_form():
+    with tempfile.TemporaryDirectory() as d:
+        saved_file = harness_config.HIDDEN_FILE
+        harness_config.HIDDEN_FILE = Path(d) / "hidden.json"
+        try:
+            harness_config.hide_project(PROJ_BACKSLASH)
+            assert json.loads(harness_config.HIDDEN_FILE.read_text("utf-8")) == [CANONICAL]
+        finally:
+            harness_config.HIDDEN_FILE = saved_file
+
+
+def test_budget_filters_match_across_separator_styles():
+    # Budgets created before canonicalisation hold raw-style project paths;
+    # they must keep matching canonicalised sessions.
+    sess = {"project": CANONICAL, "agent": "claude", "model": "m"}
+    assert main._session_matches_filters(sess, {"project": PROJ_BACKSLASH})
+    assert main._session_matches_filters(sess, {"project": PROJ_FORWARD})
+    assert not main._session_matches_filters(
+        {"project": "C:/Users/dev/other", "agent": "claude", "model": "m"},
+        {"project": PROJ_FORWARD})
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS  {t.__name__}")
+        except Exception as e:  # noqa: BLE001
+            failed += 1
+            print(f"FAIL  {t.__name__}: {e!r}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    sys.exit(1 if failed else 0)

--- a/backend/tt_paths.py
+++ b/backend/tt_paths.py
@@ -22,11 +22,39 @@ read never materialises an empty folder in the wrong place.
 from __future__ import annotations
 
 import os
+import re
 from pathlib import Path
 
 # The conventional folder name appended under the user's home (or under
 # TOKENTELEMETRY_HOME). Not appended when TOKENTELEMETRY_DATA_DIR is used.
 DEFAULT_DIRNAME = ".tokentelemetry"
+
+# Windows-shaped path prefixes: a drive letter (`C:`) or a UNC root (`\\`).
+_WIN_PATH_RE = re.compile(r"^(?:[A-Za-z]:|\\\\)")
+
+
+def canonical_project(path: str | None) -> str | None:
+    """Fold separator variants of the same folder into one project identity.
+
+    Agent CLIs log cwd in their own style — some emit ``C:\\a\\b``, others
+    ``C:/a/b``, a few mix both — and grouping compared those strings verbatim,
+    so one real folder could surface as several project cards on Windows.
+    Windows-shaped paths (drive-letter or UNC prefix) are unified to forward
+    slashes; every path loses trailing separators. A backslash inside a POSIX
+    path is a legal filename character there, so it is never rewritten.
+
+    Not folded on purpose: letter case (``C:\\Repo`` vs ``c:/repo`` stay
+    distinct — folding would merge different directories on case-sensitive
+    filesystems). Non-path values ("unknown", agent sentinels, ``None``,
+    ``""``) pass through unchanged.
+    """
+    if not isinstance(path, str) or not path:
+        return path
+    if _WIN_PATH_RE.match(path):
+        path = path.replace("\\", "/")
+    trimmed = path.rstrip("/")
+    # A lone "/" or "//" must not collapse to "".
+    return trimmed if trimmed else path
 
 
 def data_dir() -> Path:


### PR DESCRIPTION
Agent CLIs log cwd in their own separator style: some emit C:\a\b, others C:/a/b, a few mix both. Projects were grouped by exact string, so one real Windows folder could surface as several project cards.

Introduce tt_paths.canonical_project() and apply it at every identity boundary:

- end of _scan_sessions_sync(): every session carries one identity, so rollups, filters and durable history agree
- canonical_repo()/_repo_worktree_paths(): emit canonical form too; otherwise worktree grouping synthesises duplicate repo cards on Windows (native-separator str(Path) vs forward-slashed cards)
- get_projects(): hidden-set membership compares canonically, so entries saved before the change keep working in either style
- harness_config hide/unhide: store the canonical form; unhide rebuilds the set so a legacy entry saved in another style is removed too instead of sticking forever
- budgets: per-project filters match across separator styles
- history_store v3 migration: one-time re-canonicalisation of stored rows (DISTINCT projects, idempotent) so analytics over pruned sessions keeps matching after upgrade; query() also accepts either style as filter input

Windows-shaped paths (drive-letter or UNC prefix) are unified to forward slashes with trailing separators trimmed. POSIX paths are only trailing-trimmed: a backslash is a legal filename character there. Letter case is intentionally not folded (case-sensitive filesystems). Sentinels ("unknown", "Antigravity / unassigned") pass through.

New backend/test_project_paths.py pins the behaviour end-to-end: two Claude transcripts logging C:\Users\dev\proj and C:/Users/dev/proj now yield exactly one card holding both sessions. It runs under pytest and standalone (python backend/test_project_paths.py), no new deps. Two smallcode assertions move to canonical comparison for the same reason.