### PR TITLE
fix(frontend): seek the playhead through the trace instead of truncating to it

### DIFF
--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -857,6 +857,18 @@ export default function SessionDetailPage() {
     });
   };
 
+  const handlePlayback = (idx: number) => {
+    setPlaybackIndex(idx);
+    if (events.length === 0) return;
+    const targetIdx = idx > 0 ? idx - 1 : 0;
+    setActiveStep(targetIdx);
+    requestAnimationFrame(() => {
+      stepRefs.current[targetIdx]?.scrollIntoView({ behavior: "smooth", block: "center" });
+      stepIndexRefs.current[targetIdx]?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+      waterfallRefs.current[targetIdx]?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+    });
+  };
+
   // Sync active step and inspector on dialogue card click
   const handleStepCardClick = (e: React.MouseEvent, idx: number) => {
     if ((e.target as HTMLElement).closest("button, a, summary, input, textarea, select, [role='button']")) {
@@ -1066,7 +1078,7 @@ export default function SessionDetailPage() {
             <div className="bg-[var(--tt-sunken)] px-4 py-3 rounded-[var(--tt-radius)] border border-[var(--tt-border)] flex items-center gap-4">
               <div className="flex items-center gap-1">
                 <button
-                  onClick={() => setPlaybackIndex(Math.max(0, playbackIndex - 1))}
+                  onClick={() => handlePlayback(Math.max(0, playbackIndex - 1))}
                   aria-label="Previous step"
                   className="h-8 w-8 grid place-items-center rounded-md text-[var(--tt-fg-muted)] hover:text-[var(--tt-fg)] hover:tt-tint-1 transition-colors"
                 >
@@ -1080,7 +1092,7 @@ export default function SessionDetailPage() {
                   {isPlaying ? <Pause size={14} /> : <Play size={14} />}
                 </button>
                 <button
-                  onClick={() => setPlaybackIndex(Math.min(events.length, playbackIndex + 1))}
+                  onClick={() => handlePlayback(Math.min(events.length, playbackIndex + 1))}
                   aria-label="Next step"
                   className="h-8 w-8 grid place-items-center rounded-md text-[var(--tt-fg-muted)] hover:text-[var(--tt-fg)] hover:tt-tint-1 transition-colors"
                 >
@@ -1093,7 +1105,7 @@ export default function SessionDetailPage() {
                   min="0"
                   max={events.length}
                   value={playbackIndex}
-                  onChange={(e) => setPlaybackIndex(parseInt(e.target.value))}
+                  onChange={(e) => handlePlayback(parseInt(e.target.value))}
                   className="w-full h-1 rounded-full appearance-none cursor-pointer accent-[var(--tt-brand)]"
                   style={{ background: `linear-gradient(to right, var(--tt-brand) 0%, var(--tt-brand) ${(playbackIndex / Math.max(1, events.length)) * 100}%, rgba(255,255,255,0.06) ${(playbackIndex / Math.max(1, events.length)) * 100}%, rgba(255,255,255,0.06) 100%)` }}
                 />

--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -483,6 +483,12 @@ export default function SessionDetailPage() {
   // Trace View States
   const [splitView, setSplitView] = useState(false);
   const [playbackIndex, setPlaybackIndex] = useState(1000);
+  // High-water mark of how much of the trace has been revealed. Playback
+  // truncates the transcript to `playbackIndex`, but seeking BACK must not
+  // re-hide steps already on screen: if it did, the seek target would always
+  // be the last rendered card and the conversation would pin to the bottom
+  // with nothing below it. The visible slice is max(playbackIndex, this).
+  const [revealedCount, setRevealedCount] = useState(1000);
   const [isPlaying, setIsPlaying] = useState(false);
   const [sidebarTab, setSidebarTab] = useState<"context" | "tools" | "artifacts" | "raw">(initialTab);
   const [activeStep, setActiveStep] = useState<number | null>(null);
@@ -493,6 +499,7 @@ export default function SessionDetailPage() {
   const stepRefs = useRef<Record<number, HTMLDivElement | null>>({});
   const stepIndexRefs = useRef<Record<number, HTMLDivElement | null>>({});
   const waterfallRefs = useRef<Record<number, HTMLDivElement | null>>({});
+  const seekScrollRaf = useRef<number | null>(null);
 
   const [filterOpen, setFilterOpen] = useState(false);
   const [selectedFilters, setSelectedFilters] = useState<Set<string>>(new Set());
@@ -550,6 +557,7 @@ export default function SessionDetailPage() {
           setRawEvents(rawList);
           setEvents(evts);
           setPlaybackIndex(evts.length);
+          setRevealedCount(evts.length);
           setLoading(false)
         })
         .catch((err) => {
@@ -612,14 +620,15 @@ export default function SessionDetailPage() {
   const togglePlay = () => {
     if (!isPlaying && playbackIndex >= events.length) {
       setPlaybackIndex(0);
+      setRevealedCount(0);
       setActiveStep(null);
     }
     setIsPlaying((v) => !v);
   };
 
   const visibleEvents = useMemo(() => {
-     return events.slice(0, playbackIndex);
-  }, [events, playbackIndex]);
+     return events.slice(0, Math.max(playbackIndex, revealedCount));
+  }, [events, playbackIndex, revealedCount]);
 
   // SAFE Helper to check content for a type (Fixes TypeError)
   const hasContentType = (event: Event, type: string) => {
@@ -859,15 +868,32 @@ export default function SessionDetailPage() {
 
   const handlePlayback = (idx: number) => {
     setPlaybackIndex(idx);
+    // Keep what's already revealed on screen (including anything an in-flight
+    // replay had reached) so seeking moves the playhead through the transcript
+    // rather than truncating it to the target.
+    setRevealedCount((r) => Math.max(r, playbackIndex, idx));
     if (events.length === 0) return;
-    const targetIdx = idx > 0 ? idx - 1 : 0;
+    // Step 0 reveals nothing, so no step is active — same reset togglePlay uses.
+    // Using 0 here would light up row 000 while it is also dimmed as "beyond".
+    const targetIdx = idx > 0 ? idx - 1 : null;
     setActiveStep(targetIdx);
-    requestAnimationFrame(() => {
-      stepRefs.current[targetIdx]?.scrollIntoView({ behavior: "smooth", block: "center" });
-      stepIndexRefs.current[targetIdx]?.scrollIntoView({ behavior: "smooth", block: "nearest" });
-      waterfallRefs.current[targetIdx]?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+    if (targetIdx === null) return;
+    // A drag fires `input` on every pixel. A smooth scroll restarted on each
+    // one never arrives, so the pane appears frozen; seek instantly and keep at
+    // most one pending frame. Auto-play keeps `smooth` — one step per 600ms has
+    // room to animate.
+    if (seekScrollRaf.current !== null) cancelAnimationFrame(seekScrollRaf.current);
+    seekScrollRaf.current = requestAnimationFrame(() => {
+      seekScrollRaf.current = null;
+      stepRefs.current[targetIdx]?.scrollIntoView({ behavior: "auto", block: "center" });
+      stepIndexRefs.current[targetIdx]?.scrollIntoView({ behavior: "auto", block: "nearest" });
+      waterfallRefs.current[targetIdx]?.scrollIntoView({ behavior: "auto", block: "nearest" });
     });
   };
+
+  useEffect(() => () => {
+    if (seekScrollRaf.current !== null) cancelAnimationFrame(seekScrollRaf.current);
+  }, []);
 
   // Sync active step and inspector on dialogue card click
   const handleStepCardClick = (e: React.MouseEvent, idx: number) => {


### PR DESCRIPTION
Stacked on #289 by @hwantage — their commit is the first of the two here, unchanged. Merging this lands both; #289 can then be closed as included.

## Why this exists

#289 fixes the reported half of #288: seeking with the scrubber updated `playbackIndex` but never `activeStep`, so nothing highlighted and nothing scrolled. That part is correct and I verified it against a 168-step trace — on `main` a seek produces zero `scrollIntoView` calls and no active step; with #289 it produces three, on the right targets.

Validating it in a browser surfaced three follow-on problems, which this second commit fixes.

## 1. Seeking backward parked the conversation at the very end

`activeStep` is `playbackIndex - 1`, and the transcript was sliced to `playbackIndex`. So the active step was always the **last rendered card** — scrolling to it could only land at the bottom, with the remaining steps hidden and nothing below to scroll to, while the Step Index still listed them.

Measured on a 168-step session, seeking back to step 60:

| | before | after |
|---|---|---|
| scroll position | 49,840 of **49,840** (pinned) | 50,623 of **86,015** |
| room below | 0 | 35,393px |
| cards mounted | 62 | **170** |

Fix: track a reveal high-water mark and slice to `max(playbackIndex, revealedCount)`. Seeking now moves a playhead through the transcript instead of truncating it to the target.

Auto-play is untouched. It advances `playbackIndex` while `revealedCount` stays behind it, so progressive reveal still works — verified: replay-from-start drops 170 mounted cards to 3, then climbs. Seeking past the revealed frontier still reveals, and pausing mid-replay then seeking back keeps what was already on screen (paused at step 6 with 8 cards, seek back to 2, still 8 — not truncated to 4).

## 2. Dragging felt frozen

Every pixel of drag fires `input`, and a `smooth` `scrollIntoView` restarted on each one never arrives. Manual seeks now scroll instantly and coalesce to a single pending frame. Auto-play keeps `smooth`, where one step per 600ms has room to animate.

Note this is a deliberate deviation from #288's wording, which asks for smooth scrolling on manual seek. Smooth is what caused the freeze.

## 3. Step 0 lit up a row that wasn't there

At `idx === 0` the helper set step 0 active while nothing was revealed, so row `000` rendered highlighted (`bg-blue-500/10 border-blue-500`) and dimmed-as-beyond (`opacity-30`) at the same time, over an empty conversation pane. Now `null`, matching the reset `togglePlay` already performs.

## Verification

- `tsc --noEmit` clean.
- Instrumented A/B against a real trace: forward jump 10 → 150, backward 150 → 60 → 20, prev/next buttons, step 0, Step Index click, replay-from-start, and pause-then-seek-back. Assertions on active row index, in-view state, scroll position and mounted card count.
- The large forward jump was checked specifically: the target cards are not mounted when the frame is scheduled, and the refs still resolve correctly.

**Not verified:** how the drag *feels*. My check ran in a backgrounded tab, where `requestAnimationFrame` never fires and smooth scrolling is disabled, so instant scroll passing there says nothing about perceived smoothness. Worth one manual drag before merging.

`jumpTo` and `handleStepCardClick` are deliberately untouched.

Closes #288
