### PR TITLE
fix(cli): stamp the frontend install against the lockfile, not just package.json

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -371,18 +371,29 @@ function ensureBackend() {
 
 function ensureFrontend() {
   if (!which('npm')) die('npm is required but was not found in PATH.');
-  // Reinstall when package.json changed since the last install — not just when
-  // node_modules is missing. A bare existence check let stale installs linger:
-  // users who installed before a new dependency was declared (e.g. qrcode.react,
-  // issue #92) kept an old node_modules and hit "Module not found" at runtime.
-  // Mirrors ensureBackend()'s requirements.txt SHA stamp. A missing stamp (old
-  // install predating this check) hashes to a mismatch, so affected users
-  // self-heal on their next launch.
+  // Reinstall when the declared dependencies changed since the last install —
+  // not just when node_modules is missing. A bare existence check let stale
+  // installs linger: users who installed before a new dependency was declared
+  // (e.g. qrcode.react, issue #92) kept an old node_modules and hit
+  // "Module not found" at runtime. Mirrors ensureBackend()'s SHA stamp, which
+  // hashes the file it actually installs from. A missing stamp (old install
+  // predating this check) hashes to a mismatch, so affected users self-heal on
+  // their next launch.
   const nmDir = path.join(frontendDir, 'node_modules');
   const pkgPath = path.join(frontendDir, 'package.json');
   const lockPath = path.join(frontendDir, 'package-lock.json');
   const stampPath = path.join(nmDir, '.package-json.sha');
-  const currentSha = require('crypto').createHash('sha1').update(fs.readFileSync(pkgPath)).digest('hex');
+  // Hash the lockfile too, because `npm ci` below installs exactly what the lock
+  // pins — the lock, not package.json, decides what lands in node_modules.
+  // Stamping package.json alone meant a lockfile-only change was invisible here:
+  // a transitive security bump moves the lock while every declared range stays
+  // put, so existing installs kept the vulnerable versions until package.json
+  // happened to change for some unrelated reason. package.json stays in the
+  // hash to cover the `npm install` fallback path when no lock is present.
+  const stampInputs = fs.existsSync(lockPath) ? [pkgPath, lockPath] : [pkgPath];
+  const hash = require('crypto').createHash('sha1');
+  for (const input of stampInputs) hash.update(fs.readFileSync(input));
+  const currentSha = hash.digest('hex');
   let cachedSha = null;
   try { cachedSha = fs.readFileSync(stampPath, 'utf8').trim(); } catch {}
   if (fs.existsSync(nmDir) && cachedSha === currentSha) return;


### PR DESCRIPTION
## The bug

`ensureFrontend()` installs with `npm ci`, which resolves nothing and lays down exactly what `package-lock.json` pins. The skip-reinstall stamp hashed `package.json` alone, so the file that decides what lands in `node_modules` was not the file being watched.

That is invisible until a change moves the lock without moving a declared range, which is what every transitive security bump looks like. #299 bumps `brace-expansion` 1.1.16 → 1.1.18 and `js-yaml` 4.3.0 → 4.3.1 in `frontend/package-lock.json` and does not touch `frontend/package.json`. On any tree that already has `node_modules`, the stamp matched, `npm ci` was skipped, and the vulnerable versions survived the upgrade. Only fresh installs got the fix.

`ensureBackend()` already gets this right: it hashes `installFrom`, the manifest it actually installs from. This makes the frontend match.

## The fix

Hash `package.json` and the lockfile together. `package.json` stays in the hash so the `npm install` fallback (no lockfile committed) keeps working, and that path produces the same digest as before, so lockfile-less checkouts see no spurious reinstall. Trees with a lockfile take one reinstall on first launch after this change, which is how the pending bump reaches them.

## Validation

Fixture is the real #299 lockfile diff: identical `package.json`, lockfile differing only by the two bumps.

```
old logic: 13848cc7bc9f -> 13848cc7bc9f   MATCH  (npm ci skipped, bump never applied)
new logic: 8947eaac531d -> ebe7fd2b471a   DIFFER (npm ci runs, bump applied)
```

End to end on a stale tree carrying the old stamp and the new lock: the fixed logic decided `RUN npm ci`, and after it ran, `brace-expansion 1.1.18`, `js-yaml 4.3.1`, `found 0 vulnerabilities`.

Behaviour that must not change, each checked:

| Scenario | Result |
|---|---|
| Nothing changed | skips, no reinstall churn |
| `package.json` edited | reinstalls (issue #92 guard intact) |
| No lockfile present | falls back to `package.json` only, same digest as before |
| Both changed | reinstalls |

`node --check bin/cli.js` passes. No conflict with #299, which does not touch this function.

## Merge note

Worth landing before or alongside #299, otherwise that PR's dependency bump reaches only new installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
