### PR TITLE
fix(deps): assert locked versions satisfy the specifiers that declared them

### DIFF
--- a/backend/test_requirements_lock.py
+++ b/backend/test_requirements_lock.py
@@ -1,72 +1,122 @@
-"""Guard that requirements.lock covers every direct dep in requirements.txt.
+"""Guard that requirements.lock stays consistent with requirements.txt.
 
 bin/cli.js installs from requirements.lock whenever it exists and carries
 hashes, falling back to requirements.txt only for checkouts predating the lock.
-So a dep added to requirements.txt without regenerating the lock is never
-installed, and the feature that needs it fails at runtime instead of at install
-time.
+So requirements.txt is a statement of intent and the lock is what users
+actually get. When the two drift, the drift is silent: the install succeeds and
+ships the wrong thing.
 
-That is not hypothetical: `zstandard` was added for the DeepSeek Harness
-scanner but the lock was not regenerated, so every venv built from the lock
-lacked it. `_dsh_read_events` treats ImportError as "skip this session", so the
-dashboard silently reported zero DSH sessions rather than erroring.
+Both failure modes have happened or are pending:
+
+* A dep present in requirements.txt but absent from the lock is never
+  installed. `zstandard` was added for the DeepSeek Harness scanner without
+  regenerating the lock, so every venv built from the lock lacked it.
+  `_dsh_read_events` treats ImportError as "skip this session", so the
+  dashboard reported zero DSH sessions rather than erroring.
+* A dep pinned in the lock at a version the specifier excludes ships that
+  excluded version. Bumping a floor in requirements.txt without regenerating
+  the lock does exactly this, and nothing downstream notices.
 
 Regenerate with the command recorded in the lock's own header:
     uv pip compile --universal --generate-hashes --python-version 3.9 \
         backend/requirements.txt -o backend/requirements.lock
+
+A lock uv generated is consistent by construction: given a specifier it cannot
+satisfy on some supported Python it fails to resolve rather than emitting a
+violating pin. These tests therefore catch hand-edits and stale locks, which is
+where the real risk is.
+
+Known gap: extras are not checked. Dropping `[standard]` from uvicorn would
+pass both tests.
 
 Run: pytest backend/test_requirements_lock.py -q
 """
 import os
 import re
 
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
+from packaging.version import Version
+
 HERE = os.path.dirname(__file__)
 REQ = os.path.join(HERE, "requirements.txt")
 LOCK = os.path.join(HERE, "requirements.lock")
 
-# PEP 503: names compare case-insensitively with runs of -_. collapsed to -.
-_SEP = re.compile(r"[-_.]+")
+# A lock line pins one version and may carry an environment marker:
+#   zstandard==0.25.0 \
+#   uvicorn==0.51.0 ; python_full_version >= '3.10' \
+_PIN = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*)==([^\s;\\]+)\s*(?:;\s*(.*?))?\s*\\?$")
 
 
-def _canon(name):
-    return _SEP.sub("-", name.strip().lower())
-
-
-def _direct_deps(path):
-    """Top-level requirement names, dropping extras, markers and specifiers."""
-    names = set()
-    with open(path, encoding="utf-8") as fh:
+def _direct_requirements():
+    """Parsed requirements.txt entries, keyed by canonical name."""
+    reqs = {}
+    with open(REQ, encoding="utf-8") as fh:
         for line in fh:
             line = line.split("#", 1)[0].strip()
             # Skip blanks and pip's own flags (-r, --index-url, ...).
             if not line or line.startswith("-"):
                 continue
-            # "uvicorn[standard]>=0.27,<1.0" -> "uvicorn"
-            m = re.match(r"^([A-Za-z0-9][A-Za-z0-9._-]*)", line)
-            if m:
-                names.add(_canon(m.group(1)))
-    return names
+            req = Requirement(line)
+            reqs[canonicalize_name(req.name)] = req
+    return reqs
 
 
-def _locked_names(path):
-    """Names pinned in the lock. A universal lock may pin one name more than
-    once under different environment markers; we only care that it appears."""
-    names = set()
-    with open(path, encoding="utf-8") as fh:
+def _locked_pins():
+    """Every pin in the lock as {canonical name: [(version, marker), ...]}.
+
+    A universal lock pins one name more than once when a marker splits it
+    across Python versions, so the value is a list. Both tests read this one
+    parser: if its regex ever stops matching a line, the coverage test below
+    fails loudly rather than the version test passing on an empty list.
+    """
+    pins = {}
+    with open(LOCK, encoding="utf-8") as fh:
         for line in fh:
-            m = re.match(r"^([A-Za-z0-9][A-Za-z0-9._-]*)==", line)
+            m = _PIN.match(line.rstrip("\n"))
             if m:
-                names.add(_canon(m.group(1)))
-    return names
+                name, version, marker = m.group(1), m.group(2), m.group(3) or ""
+                pins.setdefault(canonicalize_name(name), []).append((version, marker))
+    return pins
 
 
 def test_lock_covers_every_direct_requirement():
-    missing = sorted(_direct_deps(REQ) - _locked_names(LOCK))
+    missing = sorted(set(_direct_requirements()) - set(_locked_pins()))
     assert not missing, (
         "requirements.txt lists {} that requirements.lock does not pin: {}. "
         "The lock is what bin/cli.js installs, so these would never reach a "
         "venv. Regenerate the lock (see this module's docstring)."
         .format("a dep" if len(missing) == 1 else "deps", ", ".join(missing))
+    )
+
+
+def test_locked_versions_satisfy_their_specifiers():
+    """Every pinned version must satisfy the specifier that declared it.
+
+    Catches the reverse of the missing-dep case: a floor raised in
+    requirements.txt while the lock still pins the version below it. The
+    install succeeds, so only this check surfaces the mismatch.
+    """
+    pins = _locked_pins()
+    violations = []
+    for name, req in sorted(_direct_requirements().items()):
+        for version, marker in pins.get(name, []):
+            if Version(version) not in req.specifier:
+                violations.append(
+                    "{} requires {} but the lock pins {}{}".format(
+                        name,
+                        req.specifier or "any version",
+                        version,
+                        " (for {})".format(marker) if marker else "",
+                    )
+                )
+    assert not violations, (
+        "requirements.lock pins versions requirements.txt excludes:\n  {}\n"
+        "bin/cli.js installs the lock, so these versions are what users get. "
+        "Regenerate the lock (see this module's docstring). If regeneration "
+        "fails as unsatisfiable, the requested floor is incompatible with the "
+        "Python floor the lock is compiled for."
+        .format("\n  ".join(violations))
     )
 
 


### PR DESCRIPTION
## Why

`requirements.txt` states intent, `requirements.lock` is what `bin/cli.js` installs. The existing guard checks only that every direct dep appears *somewhere* in the lock. That catches a dep added without regenerating (the `zstandard` case, #297) but not the reverse: a floor raised in `requirements.txt` while the lock still pins the version below it. That install succeeds and ships the excluded version, so nothing downstream notices.

## What

`test_locked_versions_satisfy_their_specifiers` parses each direct requirement with `packaging` and checks every pin the lock carries for that name against its specifier. Marker-gated duplicates are checked individually, so a universal lock that splits a dep across Python versions is validated on both sides rather than on whichever line matched first.

Strict checking is safe: `uv` fails to resolve rather than emitting a pin it cannot satisfy, so a lock it generated is consistent by construction. What this catches is hand-edited and stale locks, which is where both real incidents came from.

The two parsers are now one. `_locked_pins()` returns `{name: [(version, marker)]}` and the coverage test derives its names from those keys, so a regex that stops matching a lock line fails the coverage test loudly instead of leaving the version test iterating an empty list and passing green.

`packaging` is not a new dependency: pytest already requires it (`Requires: iniconfig, packaging, pluggy, pygments`), so it is importable anywhere this test can run.

## Validation

Against both real incidents, not just the passing case.

Floor raised, lock untouched, which is exactly #291's change:

```
FAIL uvicorn requires <1.0,>=0.52.4 but the lock pins 0.39.0 (for python_full_version < '3.10')
FAIL uvicorn requires <1.0,>=0.52.4 but the lock pins 0.51.0 (for python_full_version >= '3.10')
1 failed, 2 passed
```

`zstandard` dropped from the lock, the DSH incident:

```
AssertionError: requirements.txt lists a dep that requirements.lock does not pin: zstandard.
1 failed, 2 passed
```

Unmodified tree: `3 passed`. Parser sees 30 pins across 22 names, the 8 duplicates being the marker-gated split.

## Scope

Test file only. The lock is deliberately **not** regenerated here: with `requirements.txt` unchanged, `uv pip compile` would re-resolve against the live index and pull in whatever is newest today, which is an unreviewed dependency change riding inside a test PR, and it would invalidate every user's `.requirements.sha` stamp for no reason.

## Known gap

Extras are not checked. Dropping `[standard]` from uvicorn would pass both tests. Documented in the module docstring rather than coded around.

## Bearing on #291

Recorded here because this test is what would have caught it. #291 raises the uvicorn floor to `>=0.52.4`, and no lock can satisfy that today:

```
× No solution found when resolving dependencies for split (markers: python_full_version == '3.9.*'):
╰─▶ Because only uvicorn[standard]<=0.52.4 is available and the requested
    Python version (>=3.9) does not satisfy Python>=3.10 ...
```

uvicorn 0.52.4 requires Python >=3.10; the lock is compiled `--python-version 3.9` and the README promises Python 3.9+. So #291 is a product decision (close it, or drop 3.9), not a lock regeneration. Left for a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
