### PR TITLE
fix(hooks): judge the branch being pushed, not the session directory

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -62,6 +62,9 @@ This is enforced by `.claude/hooks/enforce-update-json.py`, wired up via
 
 1. Detects `git push` / `gh pr create` invocations (via proper shell
    tokenisation — not substring matching, so `echo "git push"` is fine).
+   Then resolves **which directory the push runs in** — following a
+   `cd <dir> &&` prefix or `git -C <dir>` — because the hook process's own
+   cwd is the session's project directory, not the worktree being pushed.
 2. Skips enforcement if we're on `main` itself.
 3. Scans `git log origin/main..HEAD` for Conventional Commit subjects
    matching `feat:` / `feat(scope):` / `feat!:` etc.
@@ -131,6 +134,7 @@ The hook is intentionally narrow. Cases:
 2. **Mixed branch with one `feat:` + several `fix:` commits**: hook still requires UPDATE.json — write an entry for the feature, fixes get a free ride.
 3. **`feat:` branch where the feature genuinely isn't user-visible** (e.g. internal refactor mis-labeled `feat:`): re-label the commit to `refactor:` / `chore:` and amend, OR add a UPDATE.json note explaining what you shipped to users.
 4. **Pushing main itself** (rebase, force-push for cleanup): hook skips automatically.
+   Same for a detached HEAD.
 5. **Repo without `origin/main`**: hook allows through (assumes you know your setup).
 6. **Last resort**: `claude --no-hooks` for that session — but if you find yourself reaching for this often, the rule is mis-tuned and worth revisiting.
 
@@ -147,7 +151,8 @@ fast remote-access ship), every change destined for `main` passes two gates:
    explicit high-confidence `block` verdict**. It **fails open**: missing
    `claude` CLI, empty/huge diff, timeout, or unparseable output all ALLOW the
    push — a flaky reviewer never blocks legit work. Reuses the push-detection
-   helpers from `enforce-update-json.py` (imported, not duplicated). Skips
+   **and push-directory** helpers from `enforce-update-json.py` (imported, not
+   duplicated), so both hooks agree on what a push is and where it happens. Skips
    docs/asset-only pushes. Bypass with `--no-hooks`.
 2. **`.github/workflows/security-audit.yml`** (CI, deterministic). Runs
    `npm audit --omit=dev --audit-level=high` across root / `frontend` / `website`

--- a/.claude/hooks/enforce-update-json.py
+++ b/.claude/hooks/enforce-update-json.py
@@ -178,6 +178,67 @@ def _git(*args: str, cwd: Optional[str] = None, timeout: int = 10) -> Optional[s
         return None
 
 
+def _git_dash_c_dir(tokens: List[str]) -> Optional[str]:
+    """The directory from `git -C <dir> ...`, if the command uses one."""
+    for i, tok in enumerate(tokens):
+        if tok == "-C" and i + 1 < len(tokens):
+            return tokens[i + 1]
+        if tok.startswith("-C") and len(tok) > 2:
+            return tok[2:]
+    return None
+
+
+def resolve_push_cwd(command_str: str, base: str) -> str:
+    """Directory the push will actually run in.
+
+    The hook process's cwd is the session's project directory, which is NOT
+    where the push happens when the command is `cd <worktree> && git push` or
+    `git -C <worktree> push`. Enforcing against the session's directory checks a
+    different branch entirely: a worktree push of a clean `fix:` branch was
+    denied because the *session* directory happened to sit on an unrelated
+    branch carrying a `feat:` commit.
+
+    Walks the command chain in order, tracking `cd` (relative paths resolve
+    against whatever the previous `cd` set, and `cd -` is ignored as
+    unresolvable), and stops at the fragment that actually pushes. Falls back to
+    ``base`` whenever the result isn't a real directory, so a malformed or
+    exotic command keeps the old behaviour instead of silently skipping the gate.
+    """
+    cwd = base
+    for frag in _split_on_chain_operators(command_str):
+        frag = frag.strip()
+        if not frag:
+            continue
+        try:
+            tokens = shlex.split(frag)
+        except ValueError:
+            continue
+
+        i = 0
+        while i < len(tokens) and re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", tokens[i]):
+            i += 1
+        if i >= len(tokens):
+            continue
+
+        if _is_push_subcommand(tokens):
+            explicit = _git_dash_c_dir(tokens[i:])
+            if explicit:
+                cand = os.path.abspath(os.path.join(cwd, os.path.expanduser(explicit)))
+                if os.path.isdir(cand):
+                    return cand
+            return cwd if os.path.isdir(cwd) else base
+
+        if tokens[i] == "cd" and i + 1 < len(tokens):
+            target = tokens[i + 1]
+            if target == "-":
+                continue  # previous-directory; not reconstructable here
+            cand = os.path.abspath(os.path.join(cwd, os.path.expanduser(target)))
+            if os.path.isdir(cand):
+                cwd = cand
+
+    return cwd if os.path.isdir(cwd) else base
+
+
 def main() -> None:
     try:
         payload = json.load(sys.stdin)
@@ -194,8 +255,11 @@ def main() -> None:
         _allow()
         return
 
-    # It IS a push / PR-create. Now check the branch state.
-    repo_root = _git("rev-parse", "--show-toplevel")
+    # It IS a push / PR-create. Now check the branch state — of the repository
+    # the push actually runs in, which for a worktree push is not this process's
+    # cwd. See resolve_push_cwd.
+    push_cwd = resolve_push_cwd(command, (payload.get("cwd") or os.getcwd()))
+    repo_root = _git("rev-parse", "--show-toplevel", cwd=push_cwd)
     if not repo_root:
         _allow()
         return

--- a/.claude/hooks/prepush-claude-review.py
+++ b/.claude/hooks/prepush-claude-review.py
@@ -89,6 +89,22 @@ def _deny(reason: str) -> None:
     sys.exit(0)
 
 
+def _resolve_push_cwd(command_str: str, base: str) -> str:
+    """Directory the push runs in — see enforce_update_json.resolve_push_cwd.
+
+    Reused rather than duplicated so both hooks agree on where a push happens,
+    the same way they already share what counts AS a push. If the sibling can't
+    be imported, fall back to ``base``: that is the pre-fix behaviour, and this
+    hook fails open by design.
+    """
+    if _SIB is not None and hasattr(_SIB, "resolve_push_cwd"):
+        try:
+            return _SIB.resolve_push_cwd(command_str, base)
+        except Exception:
+            return base
+    return base
+
+
 def _git(*args: str, cwd: Optional[str] = None, timeout: int = 10) -> Optional[str]:
     if _SIB is not None:
         return _SIB._git(*args, cwd=cwd, timeout=timeout)
@@ -177,7 +193,10 @@ def main() -> None:
     if os.environ.get("TT_PREPUSH_REVIEW_RUNNING"):
         _allow()
 
-    repo_root = _git("rev-parse", "--show-toplevel")
+    # Review the branch actually being pushed: for a worktree push that is not
+    # this process's cwd, which sits in the session's project directory.
+    push_cwd = _resolve_push_cwd(command, (payload.get("cwd") or os.getcwd()))
+    repo_root = _git("rev-parse", "--show-toplevel", cwd=push_cwd)
     if not repo_root:
         _allow()
 

--- a/backend/test_hook_push_cwd.py
+++ b/backend/test_hook_push_cwd.py
@@ -9,8 +9,10 @@ reviewed that unrelated diff.
 """
 
 import importlib.util
+import json
 import os
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
 
@@ -35,6 +37,66 @@ def _dirs():
     os.makedirs(base)
     os.makedirs(wt)
     return base, wt
+
+
+def _git(*args: str, cwd: Path) -> str:
+    """Run git in an isolated test repository."""
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _run_hook(command: str, payload_cwd: Path, hook_cwd: Path) -> str:
+    """Invoke the guard exactly as Claude Code's PreToolUse hook does."""
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "cwd": str(payload_cwd),
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+    }
+    result = subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(payload),
+        cwd=hook_cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    if not result.stdout.strip():
+        return "allow"
+    return json.loads(result.stdout)["hookSpecificOutput"]["permissionDecision"]
+
+
+def _make_repo(tmp_path: Path) -> Path:
+    """Create the branch shape that used to mislead the guard hook."""
+    origin = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "--bare", "-q", str(origin)], check=True)
+    root = tmp_path / "work"
+    subprocess.run(["git", "init", "-q", "-b", "main", str(root)], check=True)
+    for key, value in (
+        ("user.email", "t@example.com"),
+        ("user.name", "t"),
+        ("commit.gpgsign", "false"),
+    ):
+        _git("config", key, value, cwd=root)
+    (root / "UPDATE.json").write_text('{"releases": []}\n')
+    (root / "app.py").write_text("x = 1\n")
+    _git("add", "-A", cwd=root)
+    _git("commit", "-qm", "chore: base", cwd=root)
+    _git("remote", "add", "origin", str(origin), cwd=root)
+    _git("push", "-q", "origin", "main", cwd=root)
+
+    # The session directory is deliberately on a feature branch that should
+    # be denied; worktree tests prove its state is not accidentally reused.
+    _git("checkout", "-qb", "feat/noisy", cwd=root)
+    (root / "app.py").write_text("x = 2\n")
+    _git("commit", "-qam", "feat: something user facing", cwd=root)
+    return root
 
 
 def test_cd_prefix_is_followed():
@@ -88,49 +150,63 @@ def test_unparseable_command_falls_back_to_base():
     assert H.resolve_push_cwd('cd "unterminated && git push', base) == base
 
 
-def test_end_to_end_worktree_push_is_allowed(tmp_path):
-    """The exact case that was denied: a fix-only worktree branch, pushed while
-    the session's directory sits on a feat: branch with no UPDATE.json."""
-    def git(*a, cwd):
-        subprocess.run(["git", *a], cwd=cwd, check=True,
-                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+def test_push_detection_unchanged():
+    assert H._command_contains_push("git push")
+    assert H._command_contains_push("cd /x && git push -u origin branch")
+    assert H._command_contains_push("gh pr create --fill")
+    assert not H._command_contains_push('echo "git push"')
+    assert not H._command_contains_push("git status")
 
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    git("init", "-q", "-b", "main", cwd=repo)
-    git("config", "user.email", "t@e.st", cwd=repo)
-    git("config", "user.name", "t", cwd=repo)
-    (repo / "UPDATE.json").write_text("{}")
-    git("add", "-A", cwd=repo)
-    git("commit", "-qm", "chore: init", cwd=repo)
-    # Stand in for origin/main.
-    git("branch", "origin/main", cwd=repo)
 
-    # Session directory sits on a feat: branch that never touched UPDATE.json.
-    git("checkout", "-q", "-b", "feat/session", cwd=repo)
-    (repo / "other.txt").write_text("x")
-    git("add", "-A", cwd=repo)
-    git("commit", "-qm", "feat: something user facing", cwd=repo)
+def test_denies_feature_branch_without_update_json():
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = _make_repo(Path(tmp))
+        assert _run_hook("git push", repo, repo) == "deny"
 
-    # The worktree we actually push: fix: only.
-    wt = tmp_path / "wt"
-    git("worktree", "add", "-q", "-b", "fix/thing", str(wt), "origin/main", cwd=repo)
-    (wt / "f.txt").write_text("y")
-    git("add", "-A", cwd=wt)
-    git("commit", "-qm", "fix: a bug", cwd=wt)
 
-    # Resolution picks the worktree...
-    assert H.resolve_push_cwd(f"cd {wt} && git push", str(repo)) == str(wt)
-    # ...and that branch carries no feat:, so the hook's own rule allows it.
-    log = H._git("log", "origin/main..HEAD", "--pretty=format:%s", cwd=str(wt)) or ""
-    assert "feat:" not in log
-    # The session branch, judged by mistake before, does carry one.
-    log_session = H._git("log", "origin/main..HEAD", "--pretty=format:%s", cwd=str(repo)) or ""
-    assert "feat:" in log_session
+def test_allows_feature_branch_when_update_json_changed():
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = _make_repo(Path(tmp))
+        (repo / "UPDATE.json").write_text('{"releases": [{"tag": "2026-08-22"}]}\n')
+        _git("commit", "-am", "feat: with release note", cwd=repo)
+        assert _run_hook("git push", repo, repo) == "allow"
+
+
+def test_worktree_fix_branch_is_judged_on_its_own_branch():
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = _make_repo(Path(tmp))
+        worktree = Path(tmp) / "fix-worktree"
+        _git("worktree", "add", "-q", "-b", "fix/only", str(worktree), "main", cwd=repo)
+        (worktree / "app.py").write_text("x = 3\n")
+        _git("commit", "-am", "fix: a fix-only branch", cwd=worktree)
+
+        assert _run_hook(f"cd {worktree} && git push", repo, repo) == "allow"
+        assert _run_hook(f"git -C {worktree} push", repo, repo) == "allow"
+        assert _run_hook("git push", worktree, repo) == "allow"
+
+
+def test_worktree_feature_branch_without_update_json_is_denied():
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = _make_repo(Path(tmp))
+        worktree = Path(tmp) / "feature-worktree"
+        _git("worktree", "add", "-q", "-b", "feat/real", str(worktree), "main", cwd=repo)
+        (worktree / "app.py").write_text("x = 4\n")
+        _git("commit", "-am", "feat: shipped something", cwd=worktree)
+
+        assert _run_hook(f"cd {worktree} && git push", repo, repo) == "deny"
+
+
+def test_main_worktree_is_always_allowed():
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = _make_repo(Path(tmp))
+        worktree = Path(tmp) / "main-worktree"
+        _git("worktree", "add", "-q", str(worktree), "main", cwd=repo)
+
+        assert _run_hook(f"cd {worktree} && git push", repo, repo) == "allow"
 
 
 if __name__ == "__main__":
     for name, fn in sorted(list(globals().items())):
-        if name.startswith("test_") and callable(fn) and "tmp_path" not in fn.__code__.co_varnames:
+        if name.startswith("test_") and callable(fn):
             fn()
     print("All tests passed!")

--- a/backend/test_hook_push_cwd.py
+++ b/backend/test_hook_push_cwd.py
@@ -1,0 +1,136 @@
+"""The pre-push hooks must judge the branch actually being pushed.
+
+Both hooks resolved the repository from their OWN cwd, which is the session's
+project directory. For a push issued from a git worktree (`cd <worktree> &&
+git push`) that is a different checkout on a different branch — so a clean
+`fix:` branch was denied because the session's directory happened to sit on an
+unrelated branch carrying a `feat:` commit, and the reviewer hook would have
+reviewed that unrelated diff.
+"""
+
+import importlib.util
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+HOOK = Path(__file__).resolve().parents[1] / ".claude" / "hooks" / "enforce-update-json.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("enforce_update_json", HOOK)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+H = _load()
+
+
+def _dirs():
+    """A base dir with two subdirectories, standing in for repo + worktree."""
+    tmp = tempfile.mkdtemp()
+    base = os.path.join(tmp, "repo")
+    wt = os.path.join(tmp, "worktree")
+    os.makedirs(base)
+    os.makedirs(wt)
+    return base, wt
+
+
+def test_cd_prefix_is_followed():
+    base, wt = _dirs()
+    assert H.resolve_push_cwd(f"cd {wt} && git push -u origin br", base) == wt
+
+
+def test_plain_push_stays_in_base():
+    base, _ = _dirs()
+    assert H.resolve_push_cwd("git push -u origin br", base) == base
+
+
+def test_git_dash_c_is_honoured():
+    base, wt = _dirs()
+    assert H.resolve_push_cwd(f"git -C {wt} push origin br", base) == wt
+    assert H.resolve_push_cwd(f"git -C{wt} push origin br", base) == wt
+
+
+def test_relative_cd_resolves_against_base():
+    base, wt = _dirs()
+    rel = os.path.relpath(wt, base)
+    assert H.resolve_push_cwd(f"cd {rel} && git push", base) == wt
+
+
+def test_last_cd_before_the_push_wins():
+    base, wt = _dirs()
+    other = os.path.join(os.path.dirname(base), "other")
+    os.makedirs(other, exist_ok=True)
+    assert H.resolve_push_cwd(f"cd {other} && cd {wt} && git push", base) == wt
+
+
+def test_cd_after_the_push_is_ignored():
+    """Only directories entered BEFORE the push affect it."""
+    base, wt = _dirs()
+    assert H.resolve_push_cwd(f"git push && cd {wt}", base) == base
+
+
+def test_nonexistent_directory_falls_back_to_base():
+    """A bad path must not silently skip the gate."""
+    base, _ = _dirs()
+    assert H.resolve_push_cwd("cd /no/such/dir/anywhere && git push", base) == base
+
+
+def test_cd_dash_is_ignored():
+    base, wt = _dirs()
+    assert H.resolve_push_cwd(f"cd {wt} && cd - && git push", base) == wt
+
+
+def test_unparseable_command_falls_back_to_base():
+    base, _ = _dirs()
+    assert H.resolve_push_cwd('cd "unterminated && git push', base) == base
+
+
+def test_end_to_end_worktree_push_is_allowed(tmp_path):
+    """The exact case that was denied: a fix-only worktree branch, pushed while
+    the session's directory sits on a feat: branch with no UPDATE.json."""
+    def git(*a, cwd):
+        subprocess.run(["git", *a], cwd=cwd, check=True,
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    git("init", "-q", "-b", "main", cwd=repo)
+    git("config", "user.email", "t@e.st", cwd=repo)
+    git("config", "user.name", "t", cwd=repo)
+    (repo / "UPDATE.json").write_text("{}")
+    git("add", "-A", cwd=repo)
+    git("commit", "-qm", "chore: init", cwd=repo)
+    # Stand in for origin/main.
+    git("branch", "origin/main", cwd=repo)
+
+    # Session directory sits on a feat: branch that never touched UPDATE.json.
+    git("checkout", "-q", "-b", "feat/session", cwd=repo)
+    (repo / "other.txt").write_text("x")
+    git("add", "-A", cwd=repo)
+    git("commit", "-qm", "feat: something user facing", cwd=repo)
+
+    # The worktree we actually push: fix: only.
+    wt = tmp_path / "wt"
+    git("worktree", "add", "-q", "-b", "fix/thing", str(wt), "origin/main", cwd=repo)
+    (wt / "f.txt").write_text("y")
+    git("add", "-A", cwd=wt)
+    git("commit", "-qm", "fix: a bug", cwd=wt)
+
+    # Resolution picks the worktree...
+    assert H.resolve_push_cwd(f"cd {wt} && git push", str(repo)) == str(wt)
+    # ...and that branch carries no feat:, so the hook's own rule allows it.
+    log = H._git("log", "origin/main..HEAD", "--pretty=format:%s", cwd=str(wt)) or ""
+    assert "feat:" not in log
+    # The session branch, judged by mistake before, does carry one.
+    log_session = H._git("log", "origin/main..HEAD", "--pretty=format:%s", cwd=str(repo)) or ""
+    assert "feat:" in log_session
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(list(globals().items())):
+        if name.startswith("test_") and callable(fn) and "tmp_path" not in fn.__code__.co_varnames:
+            fn()
+    print("All tests passed!")


### PR DESCRIPTION
## Summary

Both local pre-push hooks previously resolved Git state from the Claude session directory. A command such as cd worktree and then git push could therefore validate a different branch than the one being pushed.

This PR resolves the actual push directory by following command-chain cd prefixes and git -C, validates the resolved directory, and shares that logic with the local security reviewer.

It prevents both false denies on clean fix worktrees and false allows for feature worktrees missing UPDATE.json.

## Verification

The self-contained regression suite now runs 15 checks, including real PreToolUse hook subprocess tests for:

- feature branches with and without UPDATE.json
- fix-only worktrees through cd, git -C, and payload cwd
- feature worktrees without UPDATE.json
- main worktrees
- malformed paths, quoted commands, and push detection

Run: python3 backend/test_hook_push_cwd.py

## Supersedes

Supersedes #286, with its end-to-end regression coverage restored here.