### PR TITLE
fix(pricing): price tokens at the rate in force when they were generated

### DIFF
--- a/UPDATE.json
+++ b/UPDATE.json
@@ -1,6 +1,17 @@
 {
   "releases": [
     {
+      "tag": "2026-08-29",
+      "title": "DeepSeek costs corrected",
+      "highlights": [
+        {
+          "title": "DeepSeek V4 sessions were billed at under half their real cost",
+          "description": "DeepSeek raised its prices on 16 August and our tables still carried the old ones, so every direct DeepSeek session showed roughly 45% of what it actually cost. Flash and Pro now use the current published rates, and deepseek-v4-flash-vision-exp has an entry of its own instead of borrowing Flash's. Peak-hours sessions still read low, because DeepSeek charges double between 01:00-04:00 and 06:00-10:00 UTC and a session cost carries one rate. Thanks to Pauliehedron for reporting this (issue #303).",
+          "href": "/analytics"
+        }
+      ]
+    },
+    {
       "tag": "2026-08-27",
       "title": "Click an agent, see what it stores",
       "highlights": [

--- a/backend/main.py
+++ b/backend/main.py
@@ -617,7 +617,7 @@ def _scan_muse_sessions() -> List[Dict[str, Any]]:
         tokens = summary["tokens"]
         total = sum(tokens.values())
         tokens["total"] = total
-        tokens["cost"] = calculate_cost(summary["model"], tokens["input"], tokens["output"], tokens["cached"], cache_creation_tokens=tokens["cache_creation"])
+        tokens["cost"] = calculate_cost(summary["model"], tokens["input"], tokens["output"], tokens["cached"], cache_creation_tokens=tokens["cache_creation"], at=summary["timestamp"])
         subagents = []
         delegated = {"input": 0, "output": 0, "cached": 0, "cache_creation": 0, "reasoning": 0}
         root = path.parent.resolve()
@@ -637,7 +637,7 @@ def _scan_muse_sessions() -> List[Dict[str, Any]]:
                 "agent_type": "muse-subagent",
                 "model": child["model"],
                 "tokens": {**child_tokens, "total": sum(child_tokens.values())},
-                "cost": calculate_cost(child["model"], child_tokens["input"], child_tokens["output"], child_tokens["cached"], cache_creation_tokens=child_tokens["cache_creation"]),
+                "cost": calculate_cost(child["model"], child_tokens["input"], child_tokens["output"], child_tokens["cached"], cache_creation_tokens=child_tokens["cache_creation"], at=summary["timestamp"]),
             })
         delegated_total = sum(delegated.values())
         delegation = {"supported": True, "tokens_recorded": True, "spawn_count": len(subagents),
@@ -3311,7 +3311,7 @@ def _scan_grok_sessions() -> List[Dict[str, Any]]:
                 tokens["output"] = 0
                 tokens["cached"] = 0
                 tokens["source"] = "context"
-                tokens["cost"] = calculate_cost(model, tokens.get("input", 0), tokens.get("output", 0), tokens.get("cached", 0))
+                tokens["cost"] = calculate_cost(model, tokens.get("input", 0), tokens.get("output", 0), tokens.get("cached", 0), at=ts)
 
             # Prefer signals.modelsUsed for the model when available.
             models_used = signals.get("modelsUsed")
@@ -3663,7 +3663,7 @@ def _scan_smallcode_sessions(roots: Iterable[str]) -> List[Dict[str, Any]]:
                 "input": input_tokens, "output": output_tokens, "cached": 0,
                 "total": input_tokens + output_tokens, "cost": 0.0,
             }
-            tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"])
+            tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"], at=ts)
 
             prompt = trace.get("prompt") or ""
             mcp_tools: List[str] = []
@@ -3891,7 +3891,7 @@ def _scan_cline_sessions() -> List[Dict[str, Any]]:
             if not is_parent and isinstance(meta_cost, (int, float)) and meta_cost > 0:
                 tokens["cost"] = float(meta_cost)
             else:
-                tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"])
+                tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"], at=ts)
 
             display = (row["prompt"] or metadata.get("title") or "")[:120]
 
@@ -3969,7 +3969,7 @@ def _scan_cline_sessions() -> List[Dict[str, Any]]:
                 if isinstance(total_cost, (int, float)) and total_cost > 0:
                     tokens["cost"] = float(total_cost)
                 else:
-                    tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"])
+                    tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"], at=ts)
 
                 transcript_path = CLINE_VSCODE_DIR / "tasks" / sid / "api_conversation_history.json"
                 artifacts: List[Dict[str, Any]] = []
@@ -4397,6 +4397,16 @@ def _dsh_parse_session(path: Path) -> Optional[Dict[str, Any]]:
                 last_provider, last_model = msg_provider, msg_model
 
     tokens = {"input": 0, "output": 0, "cached": 0, "cache_creation": 0, "reasoning": 0, "total": 0}
+    # Resolve the session timestamp BEFORE the cost loop: calculate_cost prices
+    # date-banded models by when the tokens were generated, and `ts` used to be
+    # computed further down, after this loop had already run.
+    if last_ts:
+        ts = _aware(datetime.fromtimestamp(last_ts / 1000, tz=timezone.utc))
+    elif isinstance(header.get("createdAt"), (int, float)) and header["createdAt"] > 0:
+        ts = _aware(datetime.fromtimestamp(header["createdAt"] / 1000, tz=timezone.utc))
+    else:
+        ts = _file_mtime_utc(path)
+
     cost = 0.0
     models_used: List[str] = []
     for u in usage_by_step.values():
@@ -4413,7 +4423,7 @@ def _dsh_parse_session(path: Path) -> Optional[Dict[str, Any]]:
         model = u.get("model")
         if model and model not in models_used:
             models_used.append(model)
-        cost += calculate_cost(model, in_t, out_t, cr, cache_creation_tokens=cw, provider=u.get("provider"))
+        cost += calculate_cost(model, in_t, out_t, cr, cache_creation_tokens=cw, provider=u.get("provider"), at=ts)
     tokens["total"] = tokens["input"] + tokens["output"] + tokens["cached"]
 
     # --- latency breakdown (formulas noted where the inputs are collected)
@@ -4441,13 +4451,6 @@ def _dsh_parse_session(path: Path) -> Optional[Dict[str, Any]]:
     # reports "Input 16.5K" for an 8.3K + 8.2K split. Mirror it so the two agree.
     billed_input = tokens["input"] + tokens["cached"]
     metrics["cache_hit_pct"] = round(tokens["cached"] / billed_input * 100, 1) if billed_input else None
-
-    if last_ts:
-        ts = _aware(datetime.fromtimestamp(last_ts / 1000, tz=timezone.utc))
-    elif isinstance(header.get("createdAt"), (int, float)) and header["createdAt"] > 0:
-        ts = _aware(datetime.fromtimestamp(header["createdAt"] / 1000, tz=timezone.utc))
-    else:
-        ts = _file_mtime_utc(path)
 
     return {
         "id": sid,
@@ -5942,7 +5945,7 @@ def _scan_sessions_sync():
                                             gu["cache_creation"] += cc
                                             gu["cache_creation_1h"] += cc_1h
                                     sess["tokens"]["total"] = sess["tokens"]["input"] + sess["tokens"]["output"] + sess["tokens"]["cached"]
-                                    sess["cost"] = calculate_cost(sess.get("model"), sess["tokens"]["input"], sess["tokens"]["output"], sess["tokens"].get("_cached_sum", sess["tokens"]["cached"]), cache_creation_tokens=sess["tokens"].get("cache_creation", 0), cache_creation_1h_tokens=sess["tokens"].get("cache_creation_1h", 0))
+                                    sess["cost"] = calculate_cost(sess.get("model"), sess["tokens"]["input"], sess["tokens"]["output"], sess["tokens"].get("_cached_sum", sess["tokens"]["cached"]), cache_creation_tokens=sess["tokens"].get("cache_creation", 0), cache_creation_1h_tokens=sess["tokens"].get("cache_creation_1h", 0), at=sess["timestamp"])
                                     for item in msg.get("content", []):
                                         if item.get("type") == "tool_use":
                                             tool = item.get("name")
@@ -6352,7 +6355,7 @@ def _scan_sessions_sync():
                                     sess["tokens"]["output"] = max(sess["tokens"]["output"], output_billable)
                                     sess["tokens"]["total"]  = sess["tokens"]["input"] + sess["tokens"]["cached"] + sess["tokens"]["output"]
                                     # Codex/OpenAI usage has no cache-write field (only cached read); nothing to pass.
-                                    sess["cost"] = calculate_cost(sess.get("model"), sess["tokens"]["input"], sess["tokens"]["output"], sess["tokens"]["cached"])
+                                    sess["cost"] = calculate_cost(sess.get("model"), sess["tokens"]["input"], sess["tokens"]["output"], sess["tokens"]["cached"], at=sess["timestamp"])
                             if data.get("type") == "response_item":
                                 if data.get("payload", {}).get("type") == "function_call":
                                     tool = data["payload"].get("name")
@@ -6390,7 +6393,13 @@ def _scan_sessions_sync():
                         "cached": dc,
                         "output": do,
                         "total": net_in + dc + do,
-                        "cost": calculate_cost(model_for_cost, net_in, do, dc)
+                        # `day` (not the session timestamp) is the right instant here:
+                        # a session spanning a repricing gets each day at that day's
+                        # rate. Caveat: "YYYY-MM-DD" parses as 00:00 UTC while
+                        # DeepSeek's cutover was 16:00 UTC, so the cutover day bills
+                        # entirely at the old rate. Deliberate: a day bucket has no
+                        # finer timestamp to offer.
+                        "cost": calculate_cost(model_for_cost, net_in, do, dc, at=day)
                     }
                 sess["tokens_by_day"] = tbd
 
@@ -6561,7 +6570,7 @@ def _scan_sessions_sync():
                             except Exception: pass
 
                             # Antigravity/Gemini token records expose no cache-write field; nothing to pass.
-                            tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"])
+                            tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"], at=ts)
                             if sid in _seen_antigravity: continue
                             _seen_antigravity.add(sid)
                             _g_sess = {"id": sid, "agent": effective_agent, "project": project_path, "timestamp": ts, "display": first_msg[:100], "tokens": tokens, "mcp_tools": mcp_tools, "has_plan": has_plan, "plans": plans, "model": model, "artifacts": artifacts, "antigravity_source": _ag_surface.get(sid), "cost": tokens["cost"]}
@@ -6796,7 +6805,7 @@ def _scan_sessions_sync():
                                                     plans.append({"session_id": sid, "agent": "qwen", "timestamp": last_ts, "content": t_text})
                                 except Exception: continue
                         tokens["total"] = tokens["input"] + tokens["output"] + tokens["cached"]
-                        tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens.get("_cached_sum", tokens["cached"]), cache_creation_tokens=tokens.get("cache_creation", 0), cache_creation_1h_tokens=tokens.get("cache_creation_1h", 0))
+                        tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens.get("_cached_sum", tokens["cached"]), cache_creation_tokens=tokens.get("cache_creation", 0), cache_creation_1h_tokens=tokens.get("cache_creation_1h", 0), at=last_ts)
                         _q_sess = {"id": sid, "agent": "qwen", "project": project_path, "timestamp": last_ts, "display": first_msg[:100], "tokens": tokens, "mcp_tools": mcp_tools, "has_plan": has_plan, "plans": plans, "model": model, "artifacts": artifacts, "cost": tokens["cost"]}
                         _attach_tool_usage(_q_sess, tool_counts, q_skill_counts)
                         sessions.append(_q_sess)
@@ -6816,7 +6825,7 @@ def _scan_sessions_sync():
                     model = meta.get("agent_config", {}).get("active_model")
                     project_path = apply_alias(meta.get("environment", {}).get("working_directory", "unknown"))
                     # Vibe stats expose no cache-write field; nothing to pass.
-                    tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"])
+                    tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"], at=ts)
                     sessions.append({"id": sid, "agent": "vibe", "project": project_path, "timestamp": ts, "display": f"Vibe Session {sid[:8]}", "tokens": tokens, "mcp_tools": list(set(mcp_tools)), "has_plan": False, "plans": [], "model": model, "artifacts": [], "cost": tokens["cost"]})
             except Exception: continue
 
@@ -6912,7 +6921,7 @@ def _scan_sessions_sync():
                                                         has_plan = True
                                                         plans.append({"session_id": sid, "agent": "cursor", "timestamp": mtime, "content": t_text})
                                 tokens["total"] = tokens["input"] + tokens["output"] + tokens["cached"]
-                                tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens.get("_cached_sum", tokens["cached"]), cache_creation_tokens=tokens.get("cache_creation", 0), cache_creation_1h_tokens=tokens.get("cache_creation_1h", 0))
+                                tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens.get("_cached_sum", tokens["cached"]), cache_creation_tokens=tokens.get("cache_creation", 0), cache_creation_1h_tokens=tokens.get("cache_creation_1h", 0), at=mtime)
                                 # Cursor writes subagent transcripts to <sid>/subagents/
                                 # but they carry NO usage fields (verified), so we can
                                 # only count spawns — never estimate their tokens.
@@ -6985,7 +6994,7 @@ def _scan_sessions_sync():
                                 for part in req["response"]: tokens["output"] += part.get("tokens", 0) or 0
                         tokens["total"] = tokens["input"] + tokens["output"] + tokens["cached"]
                         # Copilot (VS Code) chat records expose no cache-write field; nothing to pass.
-                        tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"])
+                        tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"], at=last_ts)
                         sessions.append({"id": sid, "agent": "copilot", "project": project_path, "timestamp": last_ts, "display": first_msg[:100], "tokens": tokens, "mcp_tools": [], "has_plan": len(plans) > 0, "plans": plans, "model": model, "artifacts": [], "copilot_source": "vscode", "cost": tokens["cost"]})
                     except Exception: continue
             except Exception: continue
@@ -7042,7 +7051,7 @@ def _scan_sessions_sync():
                     tokens["output"] = out_tokens
                 tokens["total"] = tokens["input"] + tokens["output"] + tokens["cached"]
                 tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"],
-                                                cache_creation_tokens=tokens.get("cache_creation", 0))
+                                                cache_creation_tokens=tokens.get("cache_creation", 0), at=ts)
                 if model and model not in models_used: models_used.insert(0, model)
                 ts = last_ts or start_ts or _file_mtime_utc(ev_file)
                 sessions.append({
@@ -7185,7 +7194,7 @@ def _scan_sessions_sync():
                             # cache writes ARE billed per event → cumulative; priced at 1.25x input.
                             tokens["cache_creation"] = tokens.get("cache_creation", 0) + cache_write
                     tokens["total"] = tokens["input"] + tokens["output"] + tokens["cached"]
-                    tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"], cache_creation_tokens=tokens.get("cache_creation", 0), provider=provider_id)
+                    tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"], cache_creation_tokens=tokens.get("cache_creation", 0), provider=provider_id, at=ts)
                     project_path = srow["directory"] or "unknown"
                     title = srow["title"] or ""
                     display = (first_user or title)[:100]
@@ -7347,7 +7356,7 @@ def _scan_sessions_sync():
                         except Exception:
                             _measured_tps = None
                         cost = calculate_cost(
-                            model, in_t, out_t, cached,
+                            model, in_t, out_t, cached, at=ts,
                             provider=srow["billing_provider"],
                             cache_creation_tokens=cache_write,
                             endpoint=srow["billing_base_url"],
@@ -7496,7 +7505,7 @@ def _scan_sessions_sync():
 # and asyncio.to_thread keeps the event loop free while we scan.
 import asyncio as _asyncio
 import time as _time
-from pricing import calculate_cost, PRICING, PRICING_UPDATED
+from pricing import calculate_cost, PRICING, PRICING_UPDATED, PRICING_OVERLAY_UPDATED
 import logging as _logging
 
 _log = _logging.getLogger("tokentelemetry.cache")
@@ -7633,8 +7642,18 @@ async def get_sessions(fresh: bool = False):
 
 @app.get("/pricing")
 async def get_pricing():
-    """Return the static pricing table and the date it was last refreshed."""
-    return {"updated": PRICING_UPDATED, "models": PRICING}
+    """Return the static pricing table and the dates its two layers were refreshed.
+
+    ``updated`` is the curated inline table; ``overlay_updated`` is the bundled
+    models.dev snapshot. They move independently, and the curated table is the
+    one that wins on conflict, so reporting only the (usually newer) overlay
+    date would overstate how fresh the authoritative rates are.
+    """
+    return {
+        "updated": PRICING_UPDATED,
+        "overlay_updated": PRICING_OVERLAY_UPDATED,
+        "models": PRICING,
+    }
 
 
 @app.get("/remote-access")
@@ -10347,6 +10366,7 @@ async def get_analytics(
         "coverage": history_store.coverage(),
         "granularity": granularity,
         "pricing_updated": PRICING_UPDATED,
+        "pricing_overlay_updated": PRICING_OVERLAY_UPDATED,
     }
 
 def _parse_skill_md(p: Path):

--- a/backend/pricing.py
+++ b/backend/pricing.py
@@ -9,7 +9,7 @@
 #      treated as canonical.
 #
 # Same model on different providers can cost very different things. Example:
-#   deepseek-v4-pro on DeepSeek direct: $1.74 in / $3.48 out
+#   deepseek-v4-pro on DeepSeek direct: $0.66 in / $1.98 out (off-peak)
 #   deepseek-v4-pro on Together:        $2.10 in / $4.40 out
 #   deepseek-v4-pro on Fireworks:       $1.74 in / $3.48 out
 # Don't flatten — keep provider-keyed entries where they conflict.
@@ -18,9 +18,16 @@
 
 import json
 from pathlib import Path
-from typing import Optional
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
 
-PRICING_UPDATED = "2026-05-17"
+# Date the CURATED inline tables below were last hand-checked against provider
+# price lists. This is deliberately NOT overwritten by the bundled overlay:
+# the two move independently, and reporting the overlay's date for the inline
+# table hid a three-month-stale DeepSeek rate behind a fresh-looking timestamp.
+PRICING_UPDATED = "2026-08-29"
+# Date of the bundled models.dev snapshot. Set by _load_bundled_pricing().
+PRICING_OVERLAY_UPDATED = None
 
 # Build-time pricing dataset (models.dev), refreshed maintainer/CI-side and
 # committed alongside this module — see pricing_sync.py. We read ONLY this
@@ -54,6 +61,16 @@ PRICING = {
     "claude-3.5-haiku":  {"in": 0.80, "out": 4.00,  "cached_read": 0.08},
 
     # --- OpenAI (GPT-5 series) ---
+    # --- GPT-5.6 (Sol / Terra / Luna) ---
+    # Current rates. Both cuts are date-banded in PRICING_HISTORY below, so a
+    # session from before a cut is still priced at what it actually cost.
+    # Sol's $4/$20 is promotional and guaranteed only through 2026-11-21; if it
+    # reverts, that becomes a third band rather than an edit to these numbers.
+    "gpt-5.6-sol":       {"in": 4.00,  "out": 20.00, "cached_read": 0.40},
+    "gpt-5.6-terra":     {"in": 2.00,  "out": 12.00, "cached_read": 0.20},
+    "gpt-5.6-luna":      {"in": 0.20,  "out": 1.20,  "cached_read": 0.02},
+    "gpt-5.6":           {"in": 4.00,  "out": 20.00, "cached_read": 0.40},
+
     "gpt-5.5":           {"in": 5.00,  "out": 30.00, "cached_read": 0.50},
     "gpt-5-5":           {"in": 5.00,  "out": 30.00, "cached_read": 0.50},
     "gpt-5.5-pro":       {"in": 30.00, "out": 180.00, "cached_read": 3.00},
@@ -84,10 +101,26 @@ PRICING = {
     "gemini":                       {"in": 1.25,  "out": 5.00,  "cached_read": 0.125},
 
     # --- DeepSeek (direct) ---
-    "deepseek-v4-flash":            {"in": 0.14,  "out": 0.28,  "cached_read": 0.0028},
-    "deepseek-chat":                {"in": 0.14,  "out": 0.28,  "cached_read": 0.0028},
-    "deepseek-reasoner":            {"in": 0.14,  "out": 0.28,  "cached_read": 0.0028},
-    "deepseek-v4-pro":              {"in": 1.74,  "out": 3.48,  "cached_read": 0.0145},
+    # OFF-PEAK rates, per DeepSeek's 2026-08-16 repricing.
+    # https://api-docs.deepseek.com/quick_start/pricing
+    #
+    # DeepSeek bills two rates by clock time: peak (01:00-04:00 and 06:00-10:00
+    # UTC, Mon-Fri) costs exactly 2x off-peak. calculate_cost carries ONE rate
+    # per model and takes no timestamp, and a session routinely spans both
+    # windows anyway, so a single rate is the only thing this schema can express.
+    # We bill off-peak because that is the list price the docs lead with; a
+    # session that ran entirely in peak hours is therefore understated 2x.
+    # Don't "fix" this by halving/doubling — plumb a timestamp or leave it.
+    #
+    # vision-exp is listed explicitly rather than left to the fuzzy prefix
+    # matcher. It happens to share flash's rates today, but _fuzzy_key_matches
+    # would silently price ANY deepseek-v4-flash-* variant at flash's rate,
+    # including a future one that costs something else.
+    "deepseek-v4-flash":            {"in": 0.22,  "out": 0.66,  "cached_read": 0.007},
+    "deepseek-v4-flash-vision-exp": {"in": 0.22,  "out": 0.66,  "cached_read": 0.007},
+    "deepseek-chat":                {"in": 0.22,  "out": 0.66,  "cached_read": 0.007},
+    "deepseek-reasoner":            {"in": 0.22,  "out": 0.66,  "cached_read": 0.007},
+    "deepseek-v4-pro":              {"in": 0.66,  "out": 1.98,  "cached_read": 0.022},
 
     # --- xAI (Grok) ---
     # List prices are the <200k-prompt band. Requests whose prompt reaches
@@ -157,6 +190,30 @@ PRICING = {
 # we use this when available to capture markup/discount on aggregator providers.
 # Key: (provider_lower, model_id_lower)
 PRICING_BY_PROVIDER = {
+    # --- DeepSeek (direct) ---
+    # These MUST exist even though they duplicate the flat table above.
+    # models.dev ships ("deepseek", "deepseek-v4-pro") at $0.435/$0.87 — a rate
+    # that predates the 2026-08-16 repricing and is ~2.3x under list. The
+    # bundled overlay only skips a key when an inline entry already claims it
+    # (see _load_bundled_pricing), so without these tuples the overlay wins for
+    # any caller that passes provider="deepseek" and the same model prices 4x
+    # apart depending on whether the scanner happened to supply a provider.
+    ("deepseek", "deepseek-v4-flash"):               {"in": 0.22, "out": 0.66,  "cached_read": 0.007},
+    ("deepseek", "deepseek-v4-flash-vision-exp"):    {"in": 0.22, "out": 0.66,  "cached_read": 0.007},
+    ("deepseek", "deepseek-chat"):                   {"in": 0.22, "out": 0.66,  "cached_read": 0.007},
+    ("deepseek", "deepseek-reasoner"):               {"in": 0.22, "out": 0.66,  "cached_read": 0.007},
+    ("deepseek", "deepseek-v4-pro"):                 {"in": 0.66, "out": 1.98,  "cached_read": 0.022},
+
+    # --- OpenAI (direct) ---
+    # The overlay disagrees with itself on this family: its flat gpt-5.6-luna is
+    # the pre-cut $1.00/$6.00 while its openai-keyed one is the current
+    # $0.20/$1.20. Pin the direct rates so the lookup is not decided by which
+    # table happened to be consulted.
+    ("openai", "gpt-5.6-sol"):                       {"in": 4.00, "out": 20.00, "cached_read": 0.40},
+    ("openai", "gpt-5.6-terra"):                     {"in": 2.00, "out": 12.00, "cached_read": 0.20},
+    ("openai", "gpt-5.6-luna"):                      {"in": 0.20, "out": 1.20,  "cached_read": 0.02},
+    ("openai", "gpt-5.6"):                           {"in": 4.00, "out": 20.00, "cached_read": 0.40},
+
     # --- Together AI (aggregator markup) ---
     ("together", "glm-5.1"):                         {"in": 1.40, "out": 4.40,  "cached_read": None},
     ("together", "glm-5"):                           {"in": 1.00, "out": 3.20,  "cached_read": None},
@@ -269,11 +326,154 @@ def _load_bundled_pricing() -> None:
 
     updated = data.get("updated")
     if isinstance(updated, str) and updated.strip():
-        global PRICING_UPDATED
-        PRICING_UPDATED = updated.strip()
+        global PRICING_OVERLAY_UPDATED
+        PRICING_OVERLAY_UPDATED = updated.strip()
 
 
 _load_bundled_pricing()
+
+
+# ---------------------------------------------------------------------------
+# Historical rates
+# ---------------------------------------------------------------------------
+# A provider that reprices does not reprice the past. Tokens generated in July
+# were billed at July's rate, and re-costing an old session at today's rate
+# makes a user's spend history silently wrong — which is exactly what correcting
+# the DeepSeek tables did before these bands existed (#303).
+#
+# Each entry is a list of (effective_from, rates) ascending. A band applies from
+# its instant until the next band starts; a timestamp older than the first band
+# uses the first band. The LAST band must equal the model's entry in the tables
+# above — test_pricing_history.py asserts this, so the two can't drift.
+#
+# Only models whose price actually MOVED belong here. Everything else resolves
+# through the normal tables and is unaffected, so this stays small.
+#
+# Timestamps are UTC. DeepSeek's cutover has a published time (16:00 UTC); the
+# OpenAI cuts were announced by date only, so those bands start at 00:00 UTC and
+# a session on the cut date itself may be off by up to a day. Recorded here
+# rather than hidden, because it is the one imprecise thing in this table.
+_DEEPSEEK_BANDS = {
+    # https://api-docs.deepseek.com/quick_start/pricing — V4 repricing, and the
+    # point peak/off-peak was introduced. Post-cut rates are OFF-PEAK; see the
+    # note on the DeepSeek block above.
+    #
+    # V4-Pro's pre-cut band is $0.435/$0.87, NOT the $1.74/$3.48 list price. Pro
+    # launched at list in April 2026 under a 75% promotion that was extended past
+    # its stated 31 May deadline and remained the effective price until the
+    # repricing. Billing the list price would overstate every pre-August Pro
+    # session by 4x.
+    "deepseek-v4-flash": [
+        ("2000-01-01T00:00:00Z", {"in": 0.14, "out": 0.28, "cached_read": 0.0028}),
+        ("2026-08-16T16:00:00Z", {"in": 0.22, "out": 0.66, "cached_read": 0.007}),
+    ],
+    "deepseek-v4-flash-vision-exp": [
+        ("2000-01-01T00:00:00Z", {"in": 0.14, "out": 0.28, "cached_read": 0.0028}),
+        ("2026-08-16T16:00:00Z", {"in": 0.22, "out": 0.66, "cached_read": 0.007}),
+    ],
+    # deepseek-chat / deepseek-reasoner are DeepSeek's own API aliases and moved
+    # with the same repricing. Their PRE-cut band is the $0.14/$0.28 this repo's
+    # curated table recorded at its 2026-05-17 hand-check, not models.dev's
+    # $0.29/$0.43 — that figure is an aggregator's rate for the same name, and
+    # these bands describe DeepSeek direct. Flagged because it is the one band
+    # here taken from a prior hand-check rather than the provider's price list.
+    "deepseek-chat": [
+        ("2000-01-01T00:00:00Z", {"in": 0.14, "out": 0.28, "cached_read": 0.0028}),
+        ("2026-08-16T16:00:00Z", {"in": 0.22, "out": 0.66, "cached_read": 0.007}),
+    ],
+    "deepseek-reasoner": [
+        ("2000-01-01T00:00:00Z", {"in": 0.14, "out": 0.28, "cached_read": 0.0028}),
+        ("2026-08-16T16:00:00Z", {"in": 0.22, "out": 0.66, "cached_read": 0.007}),
+    ],
+    "deepseek-v4-pro": [
+        ("2000-01-01T00:00:00Z", {"in": 0.435, "out": 0.87, "cached_read": 0.003625}),
+        ("2026-08-16T16:00:00Z", {"in": 0.66,  "out": 1.98, "cached_read": 0.022}),
+    ],
+}
+
+_GPT56_BANDS = {
+    # 2026-07-30: Terra cut 20%, Luna cut 80%, Sol unchanged.
+    # 2026-08-22: Sol cut to $4/$20 from $5/$30 (promotional, held to 2026-11-21).
+    # Pre-cut cached-read rates are 10% of input, the ratio every published
+    # GPT-5.6 rate uses and the value the models.dev snapshot carries for the
+    # pre-cut prices.
+    "gpt-5.6-sol": [
+        ("2000-01-01T00:00:00Z", {"in": 5.00, "out": 30.00, "cached_read": 0.50}),
+        ("2026-08-22T00:00:00Z", {"in": 4.00, "out": 20.00, "cached_read": 0.40}),
+    ],
+    "gpt-5.6": [
+        ("2000-01-01T00:00:00Z", {"in": 5.00, "out": 30.00, "cached_read": 0.50}),
+        ("2026-08-22T00:00:00Z", {"in": 4.00, "out": 20.00, "cached_read": 0.40}),
+    ],
+    "gpt-5.6-terra": [
+        ("2000-01-01T00:00:00Z", {"in": 2.50, "out": 15.00, "cached_read": 0.25}),
+        ("2026-07-30T00:00:00Z", {"in": 2.00, "out": 12.00, "cached_read": 0.20}),
+    ],
+    "gpt-5.6-luna": [
+        ("2000-01-01T00:00:00Z", {"in": 1.00, "out": 6.00,  "cached_read": 0.10}),
+        ("2026-07-30T00:00:00Z", {"in": 0.20, "out": 1.20,  "cached_read": 0.02}),
+    ],
+}
+
+PRICING_HISTORY: dict = {**_DEEPSEEK_BANDS, **_GPT56_BANDS}
+
+# Same bands, keyed by (provider, model) so a provider-qualified lookup gets the
+# historical rate too. Built from the same source so the two can never disagree.
+PRICING_BY_PROVIDER_HISTORY: dict = {}
+for _m, _b in _DEEPSEEK_BANDS.items():
+    PRICING_BY_PROVIDER_HISTORY[("deepseek", _m)] = _b
+for _m, _b in _GPT56_BANDS.items():
+    PRICING_BY_PROVIDER_HISTORY[("openai", _m)] = _b
+
+
+def _as_utc(at) -> Optional[datetime]:
+    """Coerce a datetime or ISO-8601 string to an aware UTC datetime.
+
+    A naive datetime is assumed UTC rather than local: session timestamps reach
+    us from a dozen harnesses and guessing a local zone would shift a session
+    across a repricing boundary by hours. Unparseable input returns None, which
+    makes the caller fall back to current rates.
+    """
+    if at is None:
+        return None
+    if isinstance(at, str):
+        txt = at.strip()
+        if not txt:
+            return None
+        try:
+            at = datetime.fromisoformat(txt.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    if not isinstance(at, datetime):
+        return None
+    if at.tzinfo is None:
+        return at.replace(tzinfo=timezone.utc)
+    return at.astimezone(timezone.utc)
+
+
+def _rates_at(bands, at: datetime) -> Dict[str, Any]:
+    """The band in force at ``at``. Older than every band → the earliest one."""
+    chosen = bands[0][1]
+    for start, rates in bands:
+        if at >= _as_utc(start):
+            chosen = rates
+        else:
+            break
+    return chosen
+
+
+def rates_for(model: str, provider: Optional[str] = None, at=None) -> Optional[Dict[str, Any]]:
+    """Historical rates for a model at a point in time, or None if not banded."""
+    when = _as_utc(at)
+    if when is None or not model:
+        return None
+    m = _normalize_model_id(str(model))
+    if provider:
+        bands = PRICING_BY_PROVIDER_HISTORY.get((str(provider).lower().strip(), m))
+        if bands:
+            return _rates_at(bands, when)
+    bands = PRICING_HISTORY.get(m)
+    return _rates_at(bands, when) if bands else None
 
 
 # xAI long-context cliff: a request whose prompt reaches this many tokens is
@@ -320,6 +520,7 @@ def calculate_cost(
     endpoint: Optional[str] = None,
     tok_per_sec: Optional[float] = None,
     billing_mode: Optional[str] = None,
+    at=None,
 ) -> float:
     """Estimate cost in USD. Prefer (provider, model) when provider is known.
 
@@ -328,6 +529,12 @@ def calculate_cost(
     rate — distinct from ``cached_tokens`` (cache READ), billed at the much
     cheaper ``cached_read`` rate. Defaults to 0 so existing positional callers
     are unaffected.
+
+    ``at`` is when the tokens were generated (datetime or ISO string). Models
+    whose price changed on a known date are listed in PRICING_HISTORY; passing
+    ``at`` prices those at the rate in force THEN rather than now, so correcting
+    a table doesn't silently rewrite a user's spend history. Omitting it keeps
+    the previous behaviour exactly: current rates for everything.
 
     ``endpoint`` and ``tok_per_sec`` are optional and only affect the
     local/subscription branches: if the session was served by a flat-subscription
@@ -382,8 +589,10 @@ def calculate_cost(
         config = PRICING["_default"]
     else:
         m_norm = _normalize_model_id(str(model_name))
-        config = None
-        if provider:
+        # A dated rate beats both tables: the tables hold today's price, and for
+        # a session that predates a repricing today's price is the wrong answer.
+        config = rates_for(m_norm, provider, at)
+        if provider and not config:
             config = PRICING_BY_PROVIDER.get((provider.lower(), m_norm))
         if not config:
             config = PRICING.get(m_norm)

--- a/backend/scan_cache.py
+++ b/backend/scan_cache.py
@@ -34,7 +34,7 @@ logger = logging.getLogger("tokentelemetry.scan_cache")
 # update that affects cached costs. `_mtime` only detects source-transcript
 # changes; this detects code changes. A mismatch is a miss, so stale entries
 # are transparently reparsed and rewritten — never migrated in place.
-CACHE_VERSION = 8  # v2: added "loop" field; v3: added loop footprint_tokens/footprint_cost; v4: added published_artifacts; v5: page artifacts carry source path; v6: added "goals" (/goal); v7: Claude cached-read costs use cumulative usage and record untracked background activity; v8: Muse/Prime/Codex model metadata
+CACHE_VERSION = 9  # v2: added "loop" field; v3: added loop footprint_tokens/footprint_cost; v4: added published_artifacts; v5: page artifacts carry source path; v6: added "goals" (/goal); v7: Claude cached-read costs use cumulative usage and record untracked background activity; v8: Muse/Prime/Codex model metadata; v9: DeepSeek V4 repricing (#303) — cached sessions store a computed cost, so a rate change must invalidate them
 
 
 def _require_safe_component(candidate: str) -> str:

--- a/backend/test_deepseek_pricing.py
+++ b/backend/test_deepseek_pricing.py
@@ -1,0 +1,99 @@
+"""DeepSeek V4 direct pricing (issue #303).
+
+DeepSeek repriced on 2026-08-16; the curated tables still carried the pre-repricing
+rates, so every direct DeepSeek session was billed at ~45% of actual. These tests
+pin the documented OFF-PEAK rates and guard the two structural traps that let the
+staleness hide:
+
+1. The flat table and the provider-keyed table must agree. models.dev ships
+   ("deepseek", "deepseek-v4-pro") at $0.435/$0.87, and the bundled overlay only
+   yields to an inline entry. Without inline tuples the same model priced 4x apart
+   depending on whether the caller passed a provider — which is exactly what
+   issue #304's fix would have unmasked.
+2. vision-exp must resolve to its own entry, not to a fuzzy prefix hit on
+   deepseek-v4-flash.
+
+Rates: https://api-docs.deepseek.com/quick_start/pricing
+"""
+
+import pricing
+from pricing import PRICING, PRICING_BY_PROVIDER, calculate_cost
+
+MTOK = 1_000_000
+
+# Documented off-peak rates per 1M tokens. Peak (01:00-04:00 / 06:00-10:00 UTC,
+# Mon-Fri) is exactly 2x these; calculate_cost has no timestamp so we bill off-peak.
+OFFPEAK = {
+    "deepseek-v4-flash":            {"in": 0.22, "out": 0.66, "cached_read": 0.007},
+    "deepseek-v4-flash-vision-exp": {"in": 0.22, "out": 0.66, "cached_read": 0.007},
+    "deepseek-chat":                {"in": 0.22, "out": 0.66, "cached_read": 0.007},
+    "deepseek-reasoner":            {"in": 0.22, "out": 0.66, "cached_read": 0.007},
+    "deepseek-v4-pro":              {"in": 0.66, "out": 1.98, "cached_read": 0.022},
+}
+
+
+def test_flat_table_matches_official_offpeak():
+    for model, rates in OFFPEAK.items():
+        assert PRICING[model] == rates, f"{model}: {PRICING[model]} != {rates}"
+
+
+def test_provider_keyed_matches_flat():
+    """A DeepSeek model must cost the same whether or not the caller knows the provider.
+
+    This is the #303/#304 interaction guard: the scanners in #304 started passing
+    provider="deepseek", which routes the lookup through PRICING_BY_PROVIDER. If
+    that table falls back to the models.dev overlay the cost silently drops 4x.
+    """
+    for model, rates in OFFPEAK.items():
+        assert PRICING_BY_PROVIDER[("deepseek", model)] == rates
+        without = calculate_cost(model, MTOK, MTOK)
+        with_prov = calculate_cost(model, MTOK, MTOK, provider="deepseek")
+        assert without == with_prov, f"{model}: {without} vs {with_prov}"
+
+
+def test_vision_exp_is_explicit_not_a_fuzzy_hit():
+    """vision-exp resolves to its own key, not to deepseek-v4-flash by substring.
+
+    _fuzzy_key_matches only rejects a *dotted* version suffix, so "-vision-exp"
+    matches "deepseek-v4-flash" and would price any future flash-* variant at
+    flash's rate regardless of what it actually costs.
+    """
+    assert "deepseek-v4-flash-vision-exp" in PRICING
+    # The fuzzy path would still match; the point is we never reach it.
+    assert pricing._fuzzy_key_matches("deepseek-v4-flash", "deepseek-v4-flash-vision-exp")
+
+
+def test_pro_is_not_the_pre_repricing_rate():
+    """Regression: the stale $1.74/$3.48 must not come back."""
+    assert PRICING["deepseek-v4-pro"]["in"] != 1.74
+    assert PRICING["deepseek-v4-pro"]["out"] != 3.48
+    # Nor the models.dev value the overlay would supply.
+    assert PRICING_BY_PROVIDER[("deepseek", "deepseek-v4-pro")]["in"] != 0.435
+
+
+def test_reported_case_from_issue_303():
+    """The exact session in the report: 5,369 in / 13,615 out, all cache-miss."""
+    cost = calculate_cost("deepseek-v4-flash-vision-exp", 5369, 13615, 0, provider="deepseek")
+    expected = (5369 * 0.22 + 13615 * 0.66) / MTOK  # $0.010167
+    assert abs(cost - expected) < 1e-9, f"{cost} != {expected}"
+
+
+def test_overlay_does_not_clobber_curated_date():
+    """PRICING_UPDATED describes the inline table, not the models.dev snapshot.
+
+    The overlay used to overwrite it, so a three-month-stale curated rate was
+    reported to the UI under the snapshot's fresh date.
+    """
+    assert pricing.PRICING_UPDATED == "2026-08-29"
+    if pricing.PRICING_OVERLAY_UPDATED is not None:
+        assert pricing.PRICING_OVERLAY_UPDATED != pricing.PRICING_UPDATED
+
+
+if __name__ == "__main__":
+    test_flat_table_matches_official_offpeak()
+    test_provider_keyed_matches_flat()
+    test_vision_exp_is_explicit_not_a_fuzzy_hit()
+    test_pro_is_not_the_pre_repricing_rate()
+    test_reported_case_from_issue_303()
+    test_overlay_does_not_clobber_curated_date()
+    print("All tests passed!")

--- a/backend/test_pricing_history.py
+++ b/backend/test_pricing_history.py
@@ -1,0 +1,134 @@
+"""Date-banded rates: price tokens at the rate in force when they were generated.
+
+A provider that reprices does not reprice the past. Correcting a table without
+this would rewrite every historical session at today's rate — which is what
+fixing DeepSeek (#303) did before these bands existed, overstating a pre-August
+Flash session by 2.2x and a pre-August Pro session by 4x.
+
+Covered here: the band boundaries themselves, the invariant that the newest band
+matches the live table (so the two can't drift on the next repricing), and the
+timestamp coercion that decides which side of a boundary a session lands on.
+"""
+
+from datetime import datetime, timezone
+
+import pricing
+from pricing import PRICING, PRICING_BY_PROVIDER, calculate_cost
+
+MTOK = 1_000_000
+DEEPSEEK_CUTOVER = "2026-08-16T16:00:00Z"
+
+
+# --- the invariant that keeps the bands honest -----------------------------
+
+def test_newest_band_matches_the_live_flat_table():
+    for model, bands in pricing.PRICING_HISTORY.items():
+        newest = bands[-1][1]
+        assert PRICING[model] == newest, (
+            f"{model}: table {PRICING[model]} != newest band {newest}. "
+            "A repricing must add a band AND update the table."
+        )
+
+
+def test_newest_band_matches_the_live_provider_table():
+    for key, bands in pricing.PRICING_BY_PROVIDER_HISTORY.items():
+        if key in PRICING_BY_PROVIDER:
+            assert PRICING_BY_PROVIDER[key] == bands[-1][1], key
+
+
+def test_bands_are_sorted_ascending():
+    for model, bands in pricing.PRICING_HISTORY.items():
+        starts = [pricing._as_utc(b[0]) for b in bands]
+        assert starts == sorted(starts), model
+
+
+def test_no_at_is_unchanged_behaviour():
+    """Omitting `at` must price at current rates, exactly as before."""
+    for model in pricing.PRICING_HISTORY:
+        assert calculate_cost(model, MTOK, MTOK) == calculate_cost(
+            model, MTOK, MTOK, at=datetime.now(timezone.utc)
+        )
+
+
+# --- boundaries -------------------------------------------------------------
+
+def test_deepseek_boundary_is_inclusive_from_the_cutover_instant():
+    before = calculate_cost("deepseek-v4-flash", 0, MTOK, at="2026-08-16T15:59:59Z")
+    at_it = calculate_cost("deepseek-v4-flash", 0, MTOK, at=DEEPSEEK_CUTOVER)
+    after = calculate_cost("deepseek-v4-flash", 0, MTOK, at="2026-08-16T16:00:01Z")
+    assert before == 0.28
+    assert at_it == 0.66, "the cutover instant itself is the NEW rate"
+    assert after == 0.66
+
+
+def test_deepseek_pro_pre_cut_uses_the_promotional_price():
+    """V4-Pro's pre-cut band is $0.435/$0.87, not the $1.74/$3.48 list.
+
+    Pro launched at list under a 75% promotion that was extended past its stated
+    31 May deadline and stayed the effective price until the repricing. Billing
+    list would overstate every pre-August Pro session by 4x.
+    """
+    assert calculate_cost("deepseek-v4-pro", MTOK, 0, at="2026-07-01T00:00:00Z") == 0.435
+    assert calculate_cost("deepseek-v4-pro", MTOK, 0, at="2026-08-25T00:00:00Z") == 0.66
+
+
+def test_gpt56_two_cuts_land_on_their_own_dates():
+    # Terra and Luna were cut 2026-07-30; Sol was not touched until 2026-08-22.
+    assert calculate_cost("gpt-5.6-terra", 0, MTOK, at="2026-07-29T00:00:00Z") == 15.00
+    assert calculate_cost("gpt-5.6-terra", 0, MTOK, at="2026-07-31T00:00:00Z") == 12.00
+    assert calculate_cost("gpt-5.6-luna", 0, MTOK, at="2026-07-29T00:00:00Z") == 6.00
+    assert calculate_cost("gpt-5.6-luna", 0, MTOK, at="2026-07-31T00:00:00Z") == 1.20
+    # Sol still at the old rate on the day Terra/Luna moved.
+    assert calculate_cost("gpt-5.6-sol", 0, MTOK, at="2026-07-31T00:00:00Z") == 30.00
+    assert calculate_cost("gpt-5.6-sol", 0, MTOK, at="2026-08-23T00:00:00Z") == 20.00
+
+
+def test_timestamp_older_than_every_band_uses_the_earliest():
+    assert calculate_cost("deepseek-v4-flash", 0, MTOK, at="2019-01-01T00:00:00Z") == 0.28
+
+
+def test_provider_qualified_lookup_is_also_banded():
+    """Passing provider must not bypass the historical rate."""
+    for prov, model in (("deepseek", "deepseek-v4-pro"), ("openai", "gpt-5.6-luna")):
+        old = calculate_cost(model, 0, MTOK, provider=prov, at="2026-07-01T00:00:00Z")
+        new = calculate_cost(model, 0, MTOK, provider=prov, at="2026-08-25T00:00:00Z")
+        assert old != new, (prov, model)
+
+
+# --- timestamp coercion -----------------------------------------------------
+
+def test_naive_datetime_is_treated_as_utc():
+    """Session timestamps arrive both aware and naive from a dozen harnesses."""
+    naive = datetime(2026, 7, 1, 12, 0, 0)
+    aware = datetime(2026, 7, 1, 12, 0, 0, tzinfo=timezone.utc)
+    assert calculate_cost("deepseek-v4-flash", 0, MTOK, at=naive) == \
+           calculate_cost("deepseek-v4-flash", 0, MTOK, at=aware)
+
+
+def test_non_utc_offset_is_converted_not_ignored():
+    """21:00+07:00 is 14:00Z — before the 16:00Z cutover, despite the later clock."""
+    assert calculate_cost("deepseek-v4-flash", 0, MTOK, at="2026-08-16T21:00:00+07:00") == 0.28
+
+
+def test_day_string_is_accepted():
+    """tokens_by_day passes a 'YYYY-MM-DD' key."""
+    assert calculate_cost("deepseek-v4-flash", 0, MTOK, at="2026-07-01") == 0.28
+
+
+def test_unparseable_at_falls_back_to_current_rates():
+    for bad in ("", "not-a-date", 12345, None):
+        assert calculate_cost("deepseek-v4-flash", 0, MTOK, at=bad) == 0.66
+
+
+def test_unbanded_model_ignores_at():
+    """Only models that actually repriced are affected."""
+    a = calculate_cost("claude-sonnet-4-6", 0, MTOK)
+    b = calculate_cost("claude-sonnet-4-6", 0, MTOK, at="2019-01-01T00:00:00Z")
+    assert a == b
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(list(globals().items())):
+        if name.startswith("test_") and callable(fn):
+            fn()
+    print("All tests passed!")


### PR DESCRIPTION
Closes #303.

Providers reprice; they do not reprice the past. Correcting a rate table without a notion of **when** re-costs every historical session at today's price, silently rewriting a user's spend history. This adds date-banded rates and uses them to fix three live pricing bugs.

## DeepSeek V4 (#303)

DeepSeek repriced at **16:00 UTC on 2026-08-16**. The curated tables still carried the old rates, so every direct DeepSeek session was billed at ~45% of actual.

The reporter's session (5,369 in / 13,615 out) now prices by when it ran:

| Ran | Cost |
|---|---|
| July | $0.004564 |
| 16 Aug 15:59 UTC | $0.004564 |
| 16 Aug 16:01 UTC | $0.010167 |
| late August | $0.010167 |

**V4-Pro's pre-cut band is $0.435/$0.87, not the $1.74/$3.48 the curated table held.** Pro launched at list in April 2026 under a 75% promotion that was extended past its stated 31 May deadline and stayed the effective price until the repricing. The curated table held a list price nobody paid — which is the whole explanation for its 4x disagreement with the models.dev overlay. That was list-vs-effective, not staleness. Billing list would overstate every pre-August Pro session by 4x.

Post-cut rates are **off-peak**. DeepSeek charges exactly 2x between 01:00-04:00 and 06:00-10:00 UTC Mon-Fri; `calculate_cost` carries one rate per model and a session spans both windows anyway, so a single rate is all the schema can express. Peak sessions are understated 2x, noted at the entry.

## GPT-5.6

Missing from the curated tables entirely, so it resolved through the overlay — which carries **pre-cut** rates and contradicts itself: its flat `gpt-5.6-luna` is $1.00/$6.00 while its `openai`-keyed entry is $0.20/$1.20. Sol, Terra and Luna are now curated with both cuts banded (Terra −20% and Luna −80% on 2026-07-30; Sol $5/$30 → $4/$20 on 2026-08-22). Sol's rate is promotional and guaranteed only to 2026-11-21; a reversion becomes a third band.

## Also

- `deepseek-v4-flash-vision-exp` gets an explicit entry. It resolved via `_fuzzy_key_matches`, whose only guard rejects a *dotted* version suffix, so it landed on `deepseek-v4-flash`'s rate — right today, silently wrong for any future `flash-*` variant priced differently.
- The `PRICING_BY_PROVIDER` tuples are load-bearing, not duplication: the overlay only yields to an inline entry, so without them the same model priced 4x apart depending on whether the caller passed a provider.
- `CACHE_VERSION` 8 → 9 is load-bearing twice: cached sessions store a computed cost, so a rate change must invalidate them, **and** without the bump a cache hit restores the old cost and never reaches the newly-dated call sites.
- The overlay no longer clobbers `PRICING_UPDATED`. It reported the models.dev snapshot date for the curated table, so a three-month-stale rate showed under a fresh timestamp. `/pricing` now returns both dates.

## Scope

`at` is optional and defaults to current rates, so every existing caller is unchanged. 18 scanner call sites pass a session timestamp; Codex's per-day breakdown passes the day key so a session spanning a repricing gets each day at that day's rate. Sites with no timestamp in scope degrade to current rates — today's behaviour, not a new gap.

Known imprecision, commented in the table: DeepSeek's cutover has a published time (16:00 UTC), but the OpenAI cuts were announced by date only, so those bands start at 00:00 UTC and a session on the cut date itself may be off by up to a day.

## Tests

20 new, all failing on main and passing here. Full suite 605 passing vs main's 585, same 22 pre-existing failures on both.

Thanks to @Pauliehedron for reporting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)