### PR TITLE
fix(cost): pass provider from the Codex and Cline scanners to calculate_cost

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -3891,7 +3891,12 @@ def _scan_cline_sessions() -> List[Dict[str, Any]]:
             if not is_parent and isinstance(meta_cost, (int, float)) and meta_cost > 0:
                 tokens["cost"] = float(meta_cost)
             else:
-                tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"], at=ts)
+                # sessions.db carries a `provider` column and no endpoint, so the
+                # provider is the only routing signal available here. Passing it
+                # reaches PRICING_BY_PROVIDER, the local-provider branch (ollama
+                # and friends price by electricity, not cloud rates), and the
+                # subscriptionProviders branch (cline-pass is flat monthly).
+                tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"], provider=row["provider"], at=ts)
 
             display = (row["prompt"] or metadata.get("title") or "")[:120]
 
@@ -3969,6 +3974,9 @@ def _scan_cline_sessions() -> List[Dict[str, Any]]:
                 if isinstance(total_cost, (int, float)) and total_cost > 0:
                     tokens["cost"] = float(total_cost)
                 else:
+                    # No provider here, unlike the CLI path above: taskHistory.json
+                    # HistoryItems carry no provider or endpoint field, so there is
+                    # nothing to pass. Left per-token deliberately.
                     tokens["cost"] = calculate_cost(model, tokens["input"], tokens["output"], tokens["cached"], at=ts)
 
                 transcript_path = CLINE_VSCODE_DIR / "tasks" / sid / "api_conversation_history.json"
@@ -6355,7 +6363,11 @@ def _scan_sessions_sync():
                                     sess["tokens"]["output"] = max(sess["tokens"]["output"], output_billable)
                                     sess["tokens"]["total"]  = sess["tokens"]["input"] + sess["tokens"]["cached"] + sess["tokens"]["output"]
                                     # Codex/OpenAI usage has no cache-write field (only cached read); nothing to pass.
-                                    sess["cost"] = calculate_cost(sess.get("model"), sess["tokens"]["input"], sess["tokens"]["output"], sess["tokens"]["cached"], at=sess["timestamp"])
+                                    # _provider comes from the rollout's session_meta (model_provider).
+                                    # Without it the lookup can't reach PRICING_BY_PROVIDER, so a Codex
+                                    # session routed to a non-OpenAI provider was priced off the flat
+                                    # table — or by _default when the model id was unknown there.
+                                    sess["cost"] = calculate_cost(sess.get("model"), sess["tokens"]["input"], sess["tokens"]["output"], sess["tokens"]["cached"], provider=sess.get("_provider"), at=sess["timestamp"])
                             if data.get("type") == "response_item":
                                 if data.get("payload", {}).get("type") == "function_call":
                                     tool = data["payload"].get("name")
@@ -6382,7 +6394,11 @@ def _scan_sessions_sync():
             if day_snap:
                 tbd = {}
                 pg = pc = po = 0
-                model_for_cost = sess.get("model") or sess.get("_provider")
+                # NB: no `or sess.get("_provider")` fallback here. That put a
+                # provider id ("openai", "deepseek") into the MODEL slot, where it
+                # either matched nothing and fell to _default anyway, or fuzzy-hit
+                # an unrelated key. An unknown model should reach _default plainly.
+                model_for_cost = sess.get("model")
                 for day in sorted(day_snap.keys()):
                     g, c, o = day_snap[day]
                     dg, dc, do = max(0, g - pg), max(0, c - pc), max(0, o - po)
@@ -6399,7 +6415,7 @@ def _scan_sessions_sync():
                         # DeepSeek's cutover was 16:00 UTC, so the cutover day bills
                         # entirely at the old rate. Deliberate: a day bucket has no
                         # finer timestamp to offer.
-                        "cost": calculate_cost(model_for_cost, net_in, do, dc, at=day)
+                        "cost": calculate_cost(model_for_cost, net_in, do, dc, provider=sess.get("_provider"), at=day)
                     }
                 sess["tokens_by_day"] = tbd
 

--- a/backend/power_config.py
+++ b/backend/power_config.py
@@ -60,6 +60,12 @@ DEFAULT_SUBSCRIPTION_ENDPOINTS: List[str] = []
 # endpoint served them (one proxy can front both subscription and pay-per-token
 # models). Opt-in; empty by default. Matched by exact case-insensitive model id.
 DEFAULT_SUBSCRIPTION_MODELS: List[str] = []
+# Provider ids billed under a flat monthly subscription. Needed alongside
+# subscriptionEndpoints because some harnesses record only a provider id and no
+# endpoint URL — Cline's sessions.db has a `provider` column and nothing to
+# derive a base URL from, so its `cline-pass` subscription routing is
+# unmatchable by endpoint. Opt-in; empty by default. Exact, case-insensitive.
+DEFAULT_SUBSCRIPTION_PROVIDERS: List[str] = []
 # Extra endpoints (beyond loopback) the user runs models on locally, e.g. a LAN
 # box at http://192.168.1.50:11434. Loopback is always treated as local.
 DEFAULT_LOCAL_ENDPOINTS: List[str] = []
@@ -70,6 +76,7 @@ DEFAULTS: Dict[str, Any] = {
     "gridCarbonIntensity": DEFAULT_CARBON_INTENSITY,
     "subscriptionEndpoints": list(DEFAULT_SUBSCRIPTION_ENDPOINTS),
     "subscriptionModels": list(DEFAULT_SUBSCRIPTION_MODELS),
+    "subscriptionProviders": list(DEFAULT_SUBSCRIPTION_PROVIDERS),
     "localEndpoints": list(DEFAULT_LOCAL_ENDPOINTS),
     "referenceCloudModel": "claude-sonnet-4-6",
 }
@@ -171,6 +178,7 @@ def load_power_config() -> Dict[str, Any]:
     config = dict(DEFAULTS)
     config["subscriptionEndpoints"] = list(DEFAULT_SUBSCRIPTION_ENDPOINTS)
     config["subscriptionModels"] = list(DEFAULT_SUBSCRIPTION_MODELS)
+    config["subscriptionProviders"] = list(DEFAULT_SUBSCRIPTION_PROVIDERS)
     # Baseline wattage is device-aware (chip estimate) — an explicit value in
     # power.json below still overrides it.
     config["loadWatts"] = device_default_watts()
@@ -208,6 +216,12 @@ def load_power_config() -> Dict[str, Any]:
     if isinstance(sms, list):
         config["subscriptionModels"] = [
             m.strip() for m in sms if isinstance(m, str) and m.strip()
+        ]
+
+    sps = raw.get("subscriptionProviders")
+    if isinstance(sps, list):
+        config["subscriptionProviders"] = [
+            pv.strip() for pv in sps if isinstance(pv, str) and pv.strip()
         ]
 
     leps = raw.get("localEndpoints")
@@ -253,6 +267,12 @@ def save_power_config(updates: Dict[str, Any]) -> Dict[str, Any]:
     if isinstance(sms, list):
         config["subscriptionModels"] = [
             m.strip() for m in sms if isinstance(m, str) and m.strip()
+        ]
+
+    sps = updates.get("subscriptionProviders")
+    if isinstance(sps, list):
+        config["subscriptionProviders"] = [
+            pv.strip() for pv in sps if isinstance(pv, str) and pv.strip()
         ]
 
     leps = updates.get("localEndpoints")
@@ -307,6 +327,24 @@ def is_subscription_model(
         config = load_power_config()
     m = str(model_name).lower().strip()
     return any(m == s.lower().strip() for s in config.get("subscriptionModels", []) if s and s.strip())
+
+
+def is_subscription_provider(
+    provider: Optional[str], config: Optional[Dict[str, Any]] = None
+) -> bool:
+    """True if ``provider`` exactly matches a configured flat-subscription provider.
+
+    Exact match, not substring: provider ids are short and collide easily
+    (``cline`` would otherwise swallow ``cline-pass`` and vice-versa), unlike
+    endpoints where substring matching lets a configured host match a fuller
+    request URL.
+    """
+    if not provider:
+        return False
+    if config is None:
+        config = load_power_config()
+    pv = str(provider).lower().strip()
+    return any(pv == s.lower().strip() for s in config.get("subscriptionProviders", []) if s and s.strip())
 
 
 _LOOPBACK_HOSTS = ("localhost", "127.0.0.1", "0.0.0.0", "::1", "[::1]")

--- a/backend/pricing.py
+++ b/backend/pricing.py
@@ -566,6 +566,18 @@ def calculate_cost(
     except Exception:
         pass
 
+    # Provider-level flat subscription. Same idea as the endpoint branch above,
+    # keyed on the provider id instead — some harnesses record a provider and no
+    # endpoint at all (Cline's sessions.db has a `provider` column and no base
+    # URL), so routing like `cline-pass` is unreachable by endpoint matching.
+    # Opt-in via power.json subscriptionProviders; empty by default.
+    try:
+        from power_config import is_subscription_provider
+        if is_subscription_provider(provider):
+            return 0.0
+    except Exception:
+        pass
+
     # Confirmed-local sessions (loopback/local endpoint, a local provider id, or
     # the agent set to `local` billing mode) are priced by electricity and WIN
     # over the pricing table — so a local llama-3.3-70b isn't billed at cloud

--- a/backend/test_provider_pricing.py
+++ b/backend/test_provider_pricing.py
@@ -1,0 +1,128 @@
+"""Provider reaches calculate_cost from the Codex and Cline scanners (issue #304).
+
+Both scanners already held the routing signal and dropped it on the floor: Codex
+captures ``sess["_provider"]`` from the rollout's session_meta, Cline reads a
+``provider`` column out of sessions.db. Neither passed it, so cost never reached
+the provider-keyed table, the subscription branch, or the local-electricity
+branch — the three things provider exists to select.
+
+These tests pin the wiring at the source level (the call sites actually pass it)
+and the behaviour at the pricing level (passing it changes the answer in the
+ways it should).
+"""
+
+import json
+import os
+import re
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+
+import pricing
+from pricing import calculate_cost
+
+MAIN = (Path(__file__).parent / "main.py").read_text()
+MTOK = 1_000_000
+
+
+def _call_site(pattern: str) -> str:
+    m = re.search(pattern, MAIN, re.S)
+    assert m, f"call site not found: {pattern}"
+    return m.group(0)
+
+
+def test_codex_turn_cost_passes_provider():
+    # Anchored on the Codex-only comment: the Claude scanner has a near-identical
+    # call two thousand lines up, and a looser pattern matches that one instead.
+    site = _call_site(
+        r'# Codex/OpenAI usage has no cache-write field.*?sess\["cost"\] = calculate_cost\([^\n]*\)'
+    )
+    assert 'provider=sess.get("_provider")' in site, site
+
+
+def test_codex_daily_cost_passes_provider():
+    site = _call_site(r'"cost": calculate_cost\(model_for_cost[^\n]*\)')
+    assert 'provider=sess.get("_provider")' in site, site
+
+
+def test_codex_model_slot_no_longer_falls_back_to_provider():
+    """A provider id must never be passed as a model.
+
+    `model_for_cost = sess.get("model") or sess.get("_provider")` put "openai" /
+    "deepseek" into the model argument, where it fuzzy-matched or hit _default.
+    """
+    assert 'model_for_cost = sess.get("model") or sess.get("_provider")' not in MAIN
+    assert 'model_for_cost = sess.get("model")' in MAIN
+
+
+def test_cline_cli_cost_passes_provider():
+    # Tolerate further kwargs after provider= (the call also carries at=).
+    site = _call_site(r'tokens\["cost"\] = calculate_cost\(model, tokens\["input"\], tokens\["output"\], tokens\["cached"\], provider=row\["provider"\][^\n]*\)')
+    assert 'provider=row["provider"]' in site
+
+
+def test_provider_changes_the_rate_when_tables_differ():
+    """together marks up deepseek-v4-pro; dropping provider silently bills direct."""
+    direct = calculate_cost("deepseek-v4-pro", MTOK, 0)
+    marked_up = calculate_cost("deepseek-v4-pro", MTOK, 0, provider="together")
+    assert marked_up > direct, (marked_up, direct)
+
+
+@contextmanager
+def _power_config(cfg: dict):
+    """Run the block with power.json set to ``cfg``.
+
+    Pins TOKENTELEMETRY_DATA_DIR, not TOKENTELEMETRY_HOME. DATA_DIR wins in
+    tt_paths.data_dir(), and several test modules in this suite set it and never
+    restore it — so a HOME-based fixture passes alone and fails in a full run,
+    silently reading the developer's real ~/.tokentelemetry/power.json.
+    """
+    tmp = tempfile.mkdtemp()
+    (Path(tmp) / "power.json").write_text(json.dumps(cfg), encoding="utf-8")
+    prev_dd = os.environ.get("TOKENTELEMETRY_DATA_DIR")
+    prev_home = os.environ.get("TOKENTELEMETRY_HOME")
+    os.environ["TOKENTELEMETRY_DATA_DIR"] = tmp
+    os.environ.pop("TOKENTELEMETRY_HOME", None)
+    try:
+        yield
+    finally:
+        for k, v in (("TOKENTELEMETRY_DATA_DIR", prev_dd), ("TOKENTELEMETRY_HOME", prev_home)):
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+def test_subscription_provider_prices_at_zero():
+    """cline-pass is flat monthly; sessions.db has no endpoint to match on."""
+    with _power_config({"subscriptionProviders": ["cline-pass"]}):
+        assert calculate_cost("deepseek-v4-pro", MTOK, MTOK, provider="cline-pass") == 0.0
+        # A different provider on the same model is unaffected.
+        assert calculate_cost("deepseek-v4-pro", MTOK, MTOK, provider="deepseek") > 0
+
+
+def test_subscription_provider_is_exact_not_substring():
+    """`cline` configured must not swallow `cline-pass` (provider ids collide)."""
+    with _power_config({"subscriptionProviders": ["cline"]}):
+        assert calculate_cost("deepseek-v4-pro", MTOK, MTOK, provider="cline") == 0.0
+        assert calculate_cost("deepseek-v4-pro", MTOK, MTOK, provider="cline-pass") > 0
+
+
+def test_local_provider_prices_by_electricity_not_cloud_rates():
+    """Cline's own db reports provider='ollama'; that must not bill at cloud rates."""
+    cloud = calculate_cost("deepseek-v4-pro", 0, MTOK)
+    local = calculate_cost("deepseek-v4-pro", 0, MTOK, provider="ollama")
+    assert local < cloud, (local, cloud)
+
+
+def test_cache_version_bumped_for_repricing():
+    """Cached sessions store a computed cost, so a rate change must invalidate them."""
+    import scan_cache
+    assert scan_cache.CACHE_VERSION >= 9
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(list(globals().items())):
+        if name.startswith("test_") and callable(fn):
+            fn()
+    print("All tests passed!")


### PR DESCRIPTION
Closes #304. **Stacked on #307** — base is `fix/deepseek-v4-rates`, retarget to `main` once that merges.

Both scanners already held the routing signal and dropped it. Codex captures `sess["_provider"]` from the rollout's `session_meta` (`model_provider`); Cline reads a `provider` column out of `sessions.db` and carries it into `rec["cline"]`. Neither passed it to `calculate_cost`, so cost never reached the provider-keyed table, the subscription branch, or the local-electricity branch — the three things the argument exists to select. A Cline session on `ollama` was billed at cloud rates; a Codex session on a non-OpenAI provider missed any markup.

Codex also had `model_for_cost = sess.get("model") or sess.get("_provider")`, which put a **provider id into the model slot**. That either matched nothing and reached `_default` anyway, or fuzzy-hit an unrelated key. Fallback dropped.

## subscriptionProviders

Cline's `sessions.db` has a `provider` column and **no base URL**, so its `cline-pass` flat-subscription routing is unmatchable by endpoint — there is no endpoint to match. Adds `subscriptionProviders` to `power.json` alongside the existing `subscriptionEndpoints` and `subscriptionModels`.

Matching is **exact**, not substring: provider ids are short and collide (`cline` would otherwise swallow `cline-pass`). Endpoints keep substring matching, since a configured host must match a fuller request URL.

The Cline VS Code path keeps per-token pricing: `taskHistory.json` HistoryItems carry neither provider nor endpoint, so there is nothing to pass. Noted inline.

## Why this is stacked, not independent

Before #307, `("deepseek", "deepseek-v4-pro")` resolved through the models.dev overlay at $0.435/$0.87 while the flat table said $1.74/$3.48. Teaching these scanners to pass a provider would have moved DeepSeek Pro costs **4x downward** — a large visible regression in the opposite direction, on a number users read off the UI. #307 closes that 4x split to 1.00x first.

## Tests

9 new — 7 fail on main. They pin the call sites (source-level) and the behaviour (pricing-level). They set `TOKENTELEMETRY_DATA_DIR` rather than `TOKENTELEMETRY_HOME`: DATA_DIR wins in `tt_paths.data_dir()`, and ten modules in this suite set it without restoring, so a HOME-based fixture passes alone and silently reads the developer's real `power.json` in a full run.

Thanks to @Pauliehedron for reporting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)