### PR TITLE
ci: report curated pricing entries that diverge from the models.dev overlay

### DIFF
--- a/.github/workflows/pricing-divergence.yml
+++ b/.github/workflows/pricing-divergence.yml
@@ -1,0 +1,60 @@
+name: Pricing divergence
+
+# Why this exists: issue #303. The curated rates in pricing.py went three months
+# stale while the weekly models.dev sync ran green every Monday. It could never
+# have caught it — _load_bundled_pricing() skips any key an inline entry already
+# claims, so a curated entry is invisible to every refresh after it is written.
+#
+# This reports where the two layers disagree. It does not decide who is right:
+# the inline table is authoritative on purpose, and models.dev is itself
+# sometimes stale (it still carried DeepSeek's pre-repricing rates eight days
+# after the change). A divergence means a human should look.
+#
+# Report-only for now. Once the existing backlog is triaged, add
+# `--fail-over <pct>` to the run below to make it a gate.
+
+on:
+  pull_request:
+    paths:
+      - "backend/pricing.py"
+      - "backend/pricing_data.json"
+      - "backend/pricing_divergence.py"
+      - ".github/workflows/pricing-divergence.yml"
+  # After the Monday sync lands its PR, so a refreshed snapshot is compared
+  # against the curated table while the diff is still in front of someone.
+  schedule:
+    - cron: "30 6 * * 1"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  divergence:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+
+      - name: Compare curated rates against the models.dev overlay
+        run: |
+          {
+            echo '### Pricing divergence'
+            echo
+            echo '```'
+            python backend/pricing_divergence.py --top 40
+            echo '```'
+            echo
+            echo 'Curated inline entries win over the overlay by design. A row here'
+            echo 'means the two layers disagree, not that the inline value is wrong.'
+            echo 'Check the provider price list before changing either.'
+            echo
+            echo 'A rising count is not automatically bad: correcting a curated rate'
+            echo 'against a provider price list raises it whenever models.dev is the'
+            echo 'stale side. Read the per-field breakdown to see which side moved.'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/backend/pricing_divergence.py
+++ b/backend/pricing_divergence.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Report curated pricing entries that disagree with the models.dev overlay.
+
+Why this exists: issue #303. DeepSeek repriced on 2026-08-16 and the curated
+rates in pricing.py sat three months stale while the weekly models.dev sync
+(.github/workflows/pricing-sync.yml) ran green every Monday. The sync could
+never have fixed it — `_load_bundled_pricing()` skips any key an inline entry
+already claims, and the workflow only writes pricing_data.json. So a curated
+entry, once written, is invisible to every refresh that follows.
+
+This turns that silent shadow into a reviewable signal. It does NOT decide who
+is right: the inline table is authoritative by design (it captures hand-checked
+direct-provider rates that aggregator-derived data gets wrong), and models.dev
+is itself sometimes stale — it still carried DeepSeek's old rates eight days
+after the repricing. A divergence means "a human should look", not "the inline
+value is wrong".
+
+There is a third failure mode worth naming, because it produced the largest
+divergence on this repo and neither layer was stale: the curated table held
+deepseek-v4-pro's $1.74/$3.48 LIST price while the overlay held $0.435/$0.87,
+the 75%-promotional price the provider was actually billing. List-vs-effective
+looks identical to staleness in this report. Check what the provider charges,
+not just what it lists.
+
+Detection relies on a property of the merge: because the overlay only inserts
+keys the inline table does not already hold, any key whose merged value differs
+from the raw overlay value MUST be an inline entry that won. Overlay-injected
+keys are equal by construction, so they can never appear here.
+
+Read the direction, not just the count. Correcting a curated rate against the
+provider's price list RAISES the number of rows here whenever the overlay is
+the stale side — fixing DeepSeek (#303) took this report from 25 entries to 30,
+because the inline table moved to the true rate while models.dev stayed on the
+old one. A rising count can mean the curated table just got more accurate. The
+per-field breakdown is what tells you which side moved.
+
+Known gap: an entry that is stale in BOTH layers is invisible to this check.
+deepseek-v4-flash was exactly that — inline and overlay both said $0.14/$0.28.
+Two agreeing sources are still wrong when both derive from the same stale
+upstream; this catches drift between layers, not drift from reality.
+
+Usage:
+    python backend/pricing_divergence.py                # report, always exit 0
+    python backend/pricing_divergence.py --fail-over 25 # exit 1 past 25% drift
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import pricing  # noqa: E402
+
+_DATA = Path(__file__).parent / "pricing_data.json"
+RATE_FIELDS = ("in", "out", "cached_read")
+
+
+def _rel_diff(a: Optional[float], b: Optional[float]) -> Optional[float]:
+    """Relative difference between two rates, as a percentage of the larger.
+
+    None on either side means "not comparable" rather than "differs": a missing
+    cached_read is a gap in the data, and calculate_cost substitutes 10% of the
+    input rate for it, so calling that a 100% divergence would be noise.
+    """
+    if a is None or b is None:
+        return None
+    if a == b:
+        return 0.0
+    scale = max(abs(a), abs(b))
+    if scale == 0:
+        return 0.0
+    return abs(a - b) / scale * 100.0
+
+
+def _worst(inline: Dict[str, Any], overlay: Dict[str, Any]) -> Tuple[float, List[str]]:
+    """Largest divergence across the rate fields, plus a per-field breakdown."""
+    worst, detail = 0.0, []
+    for f in RATE_FIELDS:
+        d = _rel_diff(inline.get(f), overlay.get(f))
+        if d is None:
+            continue
+        if d > 0:
+            detail.append(f"{f}: {inline.get(f)} vs {overlay.get(f)} ({d:.0f}%)")
+        worst = max(worst, d)
+    return worst, detail
+
+
+def find_divergences() -> List[Dict[str, Any]]:
+    raw = json.loads(_DATA.read_text(encoding="utf-8"))
+    rows: List[Dict[str, Any]] = []
+
+    for key, over in (raw.get("pricing") or {}).items():
+        inline = pricing.PRICING.get(str(key).lower().strip())
+        if not inline or not isinstance(over, dict):
+            continue
+        worst, detail = _worst(inline, over)
+        if worst > 0:
+            rows.append({"table": "flat", "key": key, "pct": worst, "detail": detail})
+
+    sep = pricing._PROVIDER_SEP
+    for combined, over in (raw.get("by_provider") or {}).items():
+        if sep not in str(combined):
+            continue
+        prov, model = str(combined).split(sep, 1)
+        inline = pricing.PRICING_BY_PROVIDER.get((prov.lower().strip(), model.lower().strip()))
+        if not inline or not isinstance(over, dict):
+            continue
+        worst, detail = _worst(inline, over)
+        if worst > 0:
+            rows.append(
+                {"table": "by_provider", "key": f"{prov}/{model}", "pct": worst, "detail": detail}
+            )
+
+    rows.sort(key=lambda r: r["pct"], reverse=True)
+    return rows
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--fail-over",
+        type=float,
+        default=None,
+        metavar="PCT",
+        help="exit 1 if any entry diverges by more than PCT (default: report only)",
+    )
+    ap.add_argument("--top", type=int, default=40, help="how many rows to print")
+    args = ap.parse_args()
+
+    rows = find_divergences()
+    # Read the snapshot date from the file rather than a module attribute: on
+    # older revisions the overlay overwrote PRICING_UPDATED instead of keeping
+    # its own field, so the attribute may not exist.
+    snapshot = json.loads(_DATA.read_text(encoding="utf-8")).get("updated")
+    print(f"curated inline date: {getattr(pricing, 'PRICING_UPDATED', '?')}")
+    print(f"models.dev snapshot: {snapshot}")
+    print(f"diverging entries:   {len(rows)}\n")
+
+    for r in rows[: args.top]:
+        print(f"  [{r['pct']:5.0f}%] {r['table']:11s} {r['key']}")
+        for d in r["detail"]:
+            print(f"            {d}")
+    if len(rows) > args.top:
+        print(f"\n  ... {len(rows) - args.top} more not shown")
+
+    if args.fail_over is not None:
+        over = [r for r in rows if r["pct"] > args.fail_over]
+        if over:
+            print(
+                f"\nFAIL: {len(over)} entr{'y' if len(over) == 1 else 'ies'} "
+                f"diverge by more than {args.fail_over:g}%."
+            )
+            print("Either refresh the curated rate against the provider's price "
+                  "list, or confirm the inline value is deliberate.")
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/test_pricing_divergence.py
+++ b/backend/test_pricing_divergence.py
@@ -1,0 +1,83 @@
+"""The pricing divergence report (issue #303).
+
+Guards the detection property the script relies on: because the overlay only
+inserts keys the inline table does not already hold, any key whose merged value
+differs from the raw overlay value must be an inline entry that shadowed it.
+"""
+
+import json
+from pathlib import Path
+
+import pricing
+import pricing_divergence as pd
+
+DATA = json.loads((Path(pd.__file__).parent / "pricing_data.json").read_text(encoding="utf-8"))
+
+
+def test_rel_diff_treats_missing_as_incomparable():
+    """A missing cached_read is a data gap, not a 100% divergence."""
+    assert pd._rel_diff(None, 1.0) is None
+    assert pd._rel_diff(1.0, None) is None
+    assert pd._rel_diff(0.0, 0.0) == 0.0
+    assert pd._rel_diff(1.0, 1.0) == 0.0
+    assert pd._rel_diff(1.0, 2.0) == 50.0
+    assert pd._rel_diff(2.0, 1.0) == 50.0
+
+
+def test_every_reported_key_is_actually_shadowed():
+    """No overlay-injected key can appear: those are equal by construction."""
+    sep = pricing._PROVIDER_SEP
+    for row in pd.find_divergences():
+        if row["table"] == "flat":
+            assert row["key"].lower().strip() in pricing.PRICING
+        else:
+            prov, model = row["key"].split("/", 1)
+            assert (prov.lower().strip(), model.lower().strip()) in pricing.PRICING_BY_PROVIDER
+        assert row["pct"] > 0
+
+
+def test_report_is_sorted_worst_first():
+    pcts = [r["pct"] for r in pd.find_divergences()]
+    assert pcts == sorted(pcts, reverse=True)
+
+
+def test_detects_a_planted_divergence():
+    """A curated entry that disagrees with the overlay must be reported."""
+    key = next(
+        (k for k, v in (DATA.get("pricing") or {}).items()
+         if isinstance(v, dict) and isinstance(v.get("in"), (int, float)) and v["in"] > 0),
+        None,
+    )
+    assert key, "no usable overlay entry to plant against"
+    k = key.lower().strip()
+    prev = pricing.PRICING.get(k)
+    pricing.PRICING[k] = {"in": DATA["pricing"][key]["in"] * 10, "out": 1.0, "cached_read": None}
+    try:
+        assert any(r["key"] == key for r in pd.find_divergences())
+    finally:
+        if prev is None:
+            pricing.PRICING.pop(k, None)
+        else:
+            pricing.PRICING[k] = prev
+
+
+def test_agreeing_layers_are_not_reported():
+    """The known gap, pinned so it is a decision and not a surprise.
+
+    deepseek-v4-flash was stale in BOTH layers at $0.14/$0.28. This check
+    compares the layers to each other, so it cannot see that.
+    """
+    key = next(
+        (k for k, v in (DATA.get("pricing") or {}).items()
+         if isinstance(v, dict) and pricing.PRICING.get(k.lower().strip()) == v),
+        None,
+    )
+    if key:
+        assert not any(r["key"] == key for r in pd.find_divergences())
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(list(globals().items())):
+        if name.startswith("test_") and callable(fn):
+            fn()
+    print("All tests passed!")


### PR DESCRIPTION
Refs #303. Independent of #307 and #308 — mergeable in any order.

Issue #303 went unnoticed for three months while the weekly models.dev sync ran green every Monday. The sync could never have caught it: `pricing-sync.yml` only writes `pricing_data.json`, and `_load_bundled_pricing()` skips any key an inline entry already claims. **A curated entry, once written, is invisible to every refresh that follows it.**

This reports where the two layers disagree. It deliberately does not decide who is right. Three different things produce a row, and they look alike:

1. the curated entry is stale (`deepseek-v4-flash` before #307);
2. the overlay is stale (models.dev still carried DeepSeek's pre-repricing rates eight days after the change);
3. the curated entry holds a **list** price while the provider bills a **promotion** (`deepseek-v4-pro`: $1.74/$3.48 curated vs $0.435/$0.87 actually charged — the largest divergence here, and neither side was stale).

## How it detects

The overlay only inserts keys the inline table does not hold, so overlay-injected keys are equal by construction, and any key whose merged value differs from the raw overlay value **must** be an inline entry that shadowed it. No AST parsing or import gymnastics.

## Evidence it points at real problems

On main it reports 25 entries, worst first, including `deepseek-v4-pro` (75%) and `grok-build-0.1` (80%) — the latter being the bug PR #287 fixes independently.

## Read the direction, not the count

Correcting a curated rate **raises** the number of rows whenever the overlay is the stale side: fixing DeepSeek takes this report from 25 to 30. The per-field breakdown shows which side moved. Called out in both the script docstring and the job summary, because a rising count reads as a regression at a glance.

Report-only for now — it writes a job summary and fails nothing. A threshold picked before seeing the backlog would be arbitrary; `--fail-over <pct>` is implemented and ready once the 25 are triaged.

## Known gap

Pinned by a test so it is a decision rather than a surprise: an entry stale in **both** layers is invisible. `deepseek-v4-flash` was exactly that, $0.14/$0.28 in each. This catches drift between layers, not drift from reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)