### PR TITLE
feat: integrate Qoder as a supported agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Token Telemetry (TokenTelemetry)
 
-> **Local observability for AI coding agents and autonomous agents — Claude Code, Codex, Gemini CLI, Cursor, Copilot, Qwen, OpenCode, Vibe, Antigravity, Grok Build, Cline, SmallCode, Pi, Muse Code, Prime Agent, _and_ Nous Research's Hermes Agent.**
+> **Local observability for AI coding agents and autonomous agents — Claude Code, Codex, Gemini CLI, Cursor, Copilot, Qwen, OpenCode, Vibe, Antigravity, Grok Build, Cline, SmallCode, Pi, Muse Code, Prime Agent, Qoder, _and_ Nous Research's Hermes Agent.**
 
 **Token Telemetry** (one word: **TokenTelemetry**) — free, open-source, 100% local.
 
@@ -60,6 +60,7 @@ TokenTelemetry reads session logs from these agents automatically.
 | **Pi Coding Agent**         | ✅ Fully supported |
 | **Muse Code** (Meta)        | ✅ Fully supported |
 | **Prime Agent**             | ✅ Fully supported |
+| **Qoder** (Alibaba)         | ✅ Fully supported — credits, not tokens (Qoder records none) |
 
 ### Autonomous agents
 

--- a/UPDATE.json
+++ b/UPDATE.json
@@ -1,6 +1,22 @@
 {
   "releases": [
     {
+      "tag": "2026-08-30",
+      "title": "Qoder is now tracked",
+      "highlights": [
+        {
+          "title": "Qoder sessions, traces and subagents",
+          "description": "Qoder (Alibaba) is the 17th coding agent TokenTelemetry reads. Its sessions appear in the dashboard, analytics and projects like any other agent, with full traces and the subagents each session spawned. Nothing to configure — if you have run Qoder, it shows up.",
+          "href": "/"
+        },
+        {
+          "title": "Qoder bills in credits, so that is what we show",
+          "description": "Qoder records no token counts at all: every turn reports zero tokens and charges credits instead. Rather than invent a number, Qoder sessions show 0 tokens and $0.00, and its agent page shows the credits actually spent — including how much went to subagents, which on a typical run is about half. The page says plainly why the zeros are there, so they never read as a failed scan.",
+          "href": "/agents/qoder"
+        }
+      ]
+    },
+    {
       "tag": "2026-08-29",
       "title": "DeepSeek costs corrected",
       "highlights": [

--- a/UPDATE.json
+++ b/UPDATE.json
@@ -1,7 +1,7 @@
 {
   "releases": [
     {
-      "tag": "2026-08-30",
+      "tag": "2026-08-29",
       "title": "Qoder is now tracked",
       "highlights": [
         {

--- a/backend/agent_retention.py
+++ b/backend/agent_retention.py
@@ -133,6 +133,13 @@ _RETENTION: Dict[str, Dict[str, Any]] = {
         "settings_hint": None,
         "note": "Zstd-compressed session logs under ~/.dsh/sessions; no auto-pruning.",
     },
+    "qoder": {
+        "label": "Qoder",
+        "default_days": None,
+        "configurable": False,
+        "settings_hint": None,
+        "note": "JSONL transcripts under ~/.qoder/projects; no auto-pruning.",
+    },
 }
 
 # Which agents we can actually archive (single-file resolvable transcript).

--- a/backend/billing_mode.py
+++ b/backend/billing_mode.py
@@ -55,6 +55,9 @@ DEFAULT_MODES: Dict[str, str] = {
     "cline": "api",                # BYOK across providers (Anthropic/OpenAI/Ollama/etc.)
     "smallcode": "local",          # runs local models (e.g. ollama-served nemotron)
     "dsh": "api",                  # BYOK; routes to any provider (cerebras/groq/ollama/…)
+    # Credit-metered plan. Qoder records no token counts at all and bills in
+    # its own credits, so $0.00 is the correct API-equivalent cost, not a gap.
+    "qoder": "subscription",
 }
 
 # Human-readable note on where a detected value came from (shown in Settings so

--- a/backend/harness_panels/__init__.py
+++ b/backend/harness_panels/__init__.py
@@ -46,6 +46,7 @@ BUILDERS: Dict[str, Callable[..., Dict[str, Any]]] = {
     "prime": clis.build_prime,
     "pi": clis.build_pi,
     "dsh": clis.build_dsh,
+    "qoder": clis.build_qoder,
     "smallcode": clis.build_smallcode,
     "hermes": hermes.build_hermes,
 }

--- a/backend/harness_panels/clis.py
+++ b/backend/harness_panels/clis.py
@@ -26,8 +26,9 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from .base import (
-    dir_size, field, human_bytes, iso, iso_ms, newest_mtime, not_installed,
-    panel, preview, ro_sqlite, safe, section, table_exists, tilde, unavailable,
+    dir_size, field, human_bytes, iso, iso_ms, meter, newest_mtime,
+    not_installed, panel, preview, ro_sqlite, safe, section, table_exists,
+    tilde, unavailable,
 )
 from . import paths
 
@@ -662,6 +663,264 @@ def build_dsh(*, with_disk: bool = True) -> Dict[str, Any]:
         "dsh", root, sections=sections, not_available=not_avail,
         last_active=iso(newest_mtime([root / "sessions"])),
         disk=safe(lambda: _simple_disk(root), "dsh disk") if with_disk else None,
+    )
+
+
+# --- Qoder ------------------------------------------------------------------
+#
+# These readers duplicate a little of main._qoder_parse_session on purpose: this
+# package is imported BY main, so importing back would be circular — the same
+# reason paths.py restates the directory constants.
+
+_QODER_REMINDER_RE = re.compile(r"<system-reminder>.*?</system-reminder>", re.DOTALL)
+
+
+def _qoder_stats(path: Path) -> Optional[Dict[str, Any]]:
+    """Session id, model, branch, turn count and credit total for one transcript."""
+    out: Dict[str, Any] = {
+        "id": path.stem, "model": None, "branch": "", "turns": 0,
+        "credits": 0.0, "display": "", "version": None, "mtime": None,
+    }
+    try:
+        out["mtime"] = path.stat().st_mtime
+    except OSError:
+        return None
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                try:
+                    row = json.loads(line)
+                except Exception:
+                    continue
+                if not isinstance(row, dict):
+                    continue
+                if isinstance(row.get("sessionId"), str) and row["sessionId"]:
+                    out["id"] = row["sessionId"]
+                if isinstance(row.get("gitBranch"), str) and row["gitBranch"]:
+                    out["branch"] = row["gitBranch"]
+                if isinstance(row.get("version"), str) and row["version"]:
+                    out["version"] = row["version"]
+                rtype = row.get("type")
+                if rtype == "assistant":
+                    msg = row.get("message") or {}
+                    out["turns"] += 1
+                    if isinstance(msg.get("model"), str) and msg["model"]:
+                        out["model"] = msg["model"]
+                    usage = msg.get("usage")
+                    if isinstance(usage, dict):
+                        credits = usage.get("credits")
+                        if isinstance(credits, (int, float)) and not isinstance(credits, bool):
+                            out["credits"] += float(credits)
+                elif rtype == "user" and not out["display"]:
+                    # Only a human turn, and only after stripping the plugin
+                    # block Qoder splices onto the opening prompt.
+                    if (row.get("origin") or {}).get("kind") == "human":
+                        text = "".join(
+                            b.get("text") or ""
+                            for b in ((row.get("message") or {}).get("content") or [])
+                            if isinstance(b, dict) and b.get("type") == "text"
+                        )
+                        out["display"] = _QODER_REMINDER_RE.sub("", text).strip()
+    except OSError:
+        return None
+    return out
+
+
+def _qoder_child_stats(session_dir: Path) -> List[Dict[str, Any]]:
+    """Subagent transcripts for one session, with their credit spend."""
+    sub = session_dir / "subagents"
+    if not sub.is_dir():
+        return []
+    kids: List[Dict[str, Any]] = []
+    for transcript in sorted(sub.glob("*.jsonl")):
+        stats = _qoder_stats(transcript)
+        if not stats:
+            continue
+        # Children carry the parent's sessionId, so the filename is the only
+        # thing that tells two spawns apart.
+        stats["id"] = transcript.stem
+        meta = _json(transcript.with_suffix(".meta.json"))
+        if isinstance(meta, dict):
+            stats["agent_type"] = meta.get("agentType") or "subagent"
+            stats["description"] = meta.get("description") or ""
+        kids.append(stats)
+    return kids
+
+
+def _qoder_ide_titles() -> Dict[str, Dict[str, Any]]:
+    """Human-readable session titles from the IDE's mirror database.
+
+    The IDE projects the same sessions into SQLite (rows are marked
+    source="sdk-projection" and reuse the JSONL uuids), so it is used only to
+    name them — never counted as sessions of its own. Opened read-only and
+    best-effort; the app holds a large WAL while running.
+    """
+    db = paths.QODER_IDE_DIR / "main.sqlite"
+    conn = ro_sqlite(db)
+    if conn is None:
+        return {}
+    out: Dict[str, Dict[str, Any]] = {}
+    try:
+        if not table_exists(conn, "chat_sessions"):
+            return {}
+        for sid, title, kind in conn.execute(
+            "SELECT session_id, title, session_kind FROM chat_sessions "
+            "WHERE deleted_at IS NULL"
+        ):
+            if isinstance(sid, str) and sid:
+                out[sid] = {"title": (title or "").strip(), "kind": kind or "standard"}
+    except Exception:
+        return out
+    finally:
+        conn.close()
+    return out
+
+
+def _qoder_disk(cli: Path, ide: Path) -> Optional[Dict[str, Any]]:
+    """Footprint across BOTH Qoder roots.
+
+    The CLI tree under ~/.qoder is the smaller half; the Electron store in
+    Application Support is usually twice its size. Reporting only the dotfile
+    root would understate the agent by about two thirds.
+    """
+    doc = _simple_disk(cli)
+    if doc is None:
+        return None
+    if ide.is_dir():
+        size, complete = dir_size(ide)
+        doc["total_bytes"] += size
+        doc["total_human"] = human_bytes(doc["total_bytes"])
+        doc["complete"] = doc.get("complete", True) and complete
+        doc["parts"].append({"label": "IDE (Application Support)", "bytes": size})
+        doc["parts"].sort(key=lambda p: -p["bytes"])
+        doc["parts"] = doc["parts"][:8]
+    return doc
+
+
+def build_qoder(*, with_disk: bool = True) -> Dict[str, Any]:
+    """Qoder: credits, sessions and delegation from its Claude-shaped JSONL.
+
+    Everything money-shaped here is denominated in CREDITS. Qoder writes an
+    Anthropic-shaped `usage` block whose token counters are all zero and puts
+    the real figure in `credits`, so a credit total is the only spend this
+    harness actually records.
+
+    Reads no credential: ~/.qoder/.auth, auth.v1.dat, auth.machine-id and the
+    IDE's byok_model_credentials / mcp_oauth_credentials tables are never
+    opened. `.qoder-app-status.json` holds the account holder's name and email
+    and is deliberately not read at all.
+    """
+    root = paths.QODER_DIR
+    projects = root / "projects"
+    if not projects.is_dir():
+        return not_installed("qoder")
+
+    sections: List[Dict[str, Any]] = []
+    ide_titles = safe(lambda: _qoder_ide_titles(), "qoder ide titles") or {}
+
+    rows: List[List[Any]] = []
+    total_credits = 0.0
+    delegated_credits = 0.0
+    spawns = 0
+    version = None
+    for transcript in sorted(projects.glob("*/*.jsonl")):
+        stats = safe(lambda p=transcript: _qoder_stats(p), "qoder session")
+        if not stats:
+            continue
+        version = stats.get("version") or version
+        kids = safe(lambda p=transcript: _qoder_child_stats(p.parent / p.stem),
+                    "qoder subagents") or []
+        kid_credits = round(sum(k["credits"] for k in kids), 4)
+        total_credits += stats["credits"]
+        delegated_credits += kid_credits
+        spawns += len(kids)
+        meta = ide_titles.get(stats["id"]) or {}
+        rows.append([
+            preview(meta.get("title") or stats["display"] or stats["id"][-8:]),
+            stats["model"] or "—",
+            stats["branch"] or "—",
+            stats["turns"],
+            round(stats["credits"], 3),
+            kid_credits or 0,
+            iso(stats["mtime"]),
+        ])
+
+    if rows:
+        rows.sort(key=lambda r: r[6] or "", reverse=True)
+        sections.append(section(
+            "table", "Sessions", tilde(projects),
+            columns=["Session", "Model", "Branch", "Turns", "Credits",
+                     "Delegated", "Updated"],
+            rows=rows[:40], total=len(rows),
+            note="Credits are Qoder's own billing unit, read from each turn's "
+                 "usage record. Delegated credits are spent by subagents and "
+                 "are additional to the parent's own.",
+        ))
+
+    if total_credits or delegated_credits:
+        combined = total_credits + delegated_credits
+        share = (delegated_credits / combined * 100.0) if combined else 0.0
+        sections.append(section(
+            "meter", "Credit spend", tilde(projects),
+            meters=[
+                meter("Delegated to subagents", share,
+                      detail=f"{delegated_credits:.2f} of {combined:.2f} credits "
+                             f"across {spawns} spawn{'' if spawns == 1 else 's'}"),
+            ],
+            count=round(combined, 2),
+            note=f"{combined:.2f} credits total — {total_credits:.2f} in the "
+                 f"main sessions, {delegated_credits:.2f} in subagents. Qoder "
+                 f"publishes no credit-to-currency rate locally, so this is "
+                 f"deliberately not converted to dollars.",
+        ))
+
+    plugins = safe(lambda: _json(root / "plugins" / "installed_plugins_v2.json"),
+                   "qoder plugins")
+    fields: List[Dict[str, Any]] = []
+    if version:
+        fields.append(field("CLI version", version))
+    if isinstance(plugins, dict) and isinstance(plugins.get("plugins"), dict):
+        names = sorted(plugins["plugins"].keys())
+        fields.append(field("Installed plugins", len(names),
+                            hint=", ".join(names[:6]) if names else None))
+    settings = safe(lambda: _json(root / "settings.json"), "qoder settings")
+    if isinstance(settings, dict) and isinstance(settings.get("enabledPlugins"), dict):
+        fields.append(field("Enabled plugins",
+                            sum(1 for v in settings["enabledPlugins"].values() if v)))
+    for name, label in ((".auth", "Credential store"),
+                        (".qoder-app-status.json", "Account status file")):
+        target = root / name
+        if target.exists():
+            fields.append(field(label, "present",
+                                hint="Existence only — never opened."))
+    if fields:
+        sections.append(section("fields", "Install", tilde(root), fields=fields))
+
+    not_avail = [
+        unavailable("tokens",
+            "Qoder records no token counts. Every turn carries an "
+            "Anthropic-shaped usage block whose input, output and cache "
+            "counters are all zero, and bills in credits instead — so the "
+            "0 tokens and $0.00 shown elsewhere are what Qoder reports, not a "
+            "failed scan. The credit figures above are the real spend."),
+        unavailable("models",
+            "Model ids stay opaque. Qoder reports internal names such as "
+            "qmodel_38max, and its catalogue at .models/<uid>/catalog-v6 is "
+            "encrypted at rest, so there is no offline mapping to a real "
+            "model — and no published price list to cost it against."),
+        unavailable("session state",
+            "Per-session state.json is encrypted (each item carries a "
+            "ciphertext payload and an auth tag), so resumable context, "
+            "compaction state and todos cannot be read. Opaque by design, "
+            "not a missing store."),
+    ]
+
+    return panel(
+        "qoder", root, sections=sections, not_available=not_avail,
+        version=version,
+        last_active=iso(newest_mtime([projects])),
+        disk=(safe(lambda: _qoder_disk(root, paths.QODER_IDE_DIR), "qoder disk")
+              if with_disk else None),
     )
 
 

--- a/backend/harness_panels/paths.py
+++ b/backend/harness_panels/paths.py
@@ -42,6 +42,12 @@ CURSOR_DIR = HOME / ".cursor"
 PI_DIR = HOME / ".pi" / "agent"
 DSH_DIR = _env_path("DSH_HOME") or (HOME / ".dsh")
 CLINE_DIR = _env_path("TT_CLINE_DIR") or (HOME / ".cline")
+# Same contract as main.py's QODER_DIR / QODER_IDE_DIR. Qoder keeps its CLI
+# transcripts under ~/.qoder and a separate Electron store in Application
+# Support; the panel spans both because neither alone is the agent's footprint.
+QODER_DIR = _env_path("QODER_HOME") or (HOME / ".qoder")
+QODER_IDE_DIR = (_env_path("QODER_IDE_HOME")
+                 or (HOME / "Library" / "Application Support" / "com.qoder.app.stable"))
 # Same contract as main.py's HERMES_DIR.
 HERMES_DIR = _env_path("HERMES_HOME") or (HOME / ".hermes")
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -4872,6 +4872,12 @@ def _qoder_ide_sessions() -> Dict[str, Dict[str, Any]]:
     Best-effort by design: opened read-only, and a missing, locked or
     schema-changed database degrades to CLI-only data rather than failing the
     scan. Credential tables are never touched.
+
+    Known limitation: `session_kind` also admits `sideChat` and
+    `automationExecution`. Every observed row is `standard` and its id matches a
+    transcript, so there is no evidence either kind skips the JSONL -- but if
+    one does, it would be invisible here. Unioning on session_id would cover it;
+    that is deliberately not built against a shape nobody has seen yet.
     """
     db = QODER_IDE_DIR / "main.sqlite"
     if not db.exists():

--- a/backend/main.py
+++ b/backend/main.py
@@ -306,6 +306,21 @@ DSH_SESSIONS_DIR = DSH_DIR / "sessions"
 # backend/omnigent_policy.py. Absent file = plugin not installed, which is the
 # normal case and must never be an error.
 DSH_LIFECYCLE_FILE = data_dir() / "dsh_lifecycle.jsonl"
+# Qoder (Alibaba) ships two surfaces over ONE set of sessions. The CLI writes
+# Claude-Code-shaped JSONL under ~/.qoder/projects/<slugged-cwd>/<uuid>.jsonl;
+# the Electron IDE keeps ~/Library/Application Support/com.qoder.app.stable/
+# main.sqlite, whose chat_session_messages rows are marked source="sdk-projection"
+# and carry the SAME message uuids. The DB is therefore a mirror, not a second
+# store — scanning both would double-count every session. We read the JSONL and
+# use the DB only to enrich (it has a human-readable title the JSONL lacks).
+# Qoder has no relocation env var of its own (its launcher reads only HOME);
+# QODER_HOME exists so tests can point the scan at a fixture tree.
+QODER_DIR = Path(os.environ.get("QODER_HOME") or (HOME / ".qoder")).expanduser()
+QODER_PROJECTS_DIR = QODER_DIR / "projects"
+QODER_IDE_DIR = Path(
+    os.environ.get("QODER_IDE_HOME")
+    or (HOME / "Library/Application Support/com.qoder.app.stable")
+).expanduser()
 HF_DIR = HOME / ".cache/huggingface"
 def _opencode_dbs_in(d: Path) -> List[Path]:
     """DB files OpenCode may have written inside data dir ``d``, canonical first.
@@ -2876,6 +2891,9 @@ def _list_available_agents() -> list:
     if MUSE_SESSIONS_DIR.is_dir(): agents.append("muse")
     if PRIME_SESSIONS_DIR.is_dir(): agents.append("prime")
     if DSH_DIR.exists(): agents.append("dsh")
+    # projects/, not the root: Qoder's installer creates ~/.qoder before the
+    # first session exists, so the root alone would advertise an empty agent.
+    if QODER_PROJECTS_DIR.is_dir(): agents.append("qoder")
     # SmallCode traces are project-local; cheaply check only the explicitly
     # configured extra roots here (the full project-derived root set is only
     # known after _scan_sessions_sync runs the other scanners).
@@ -4582,6 +4600,525 @@ def _scan_dsh_sessions() -> List[Dict[str, Any]]:
     return out
 
 
+# ------------------------------------------------------------------ Qoder --
+#
+# Qoder's CLI is a Claude Code derivative: identical JSONL record shape (cwd,
+# gitBranch, isSidechain, parentUuid, sessionId, version, userType, entrypoint)
+# plus five record types of its own -- workspace-directories, runtime-config,
+# last-prompt, active-leaf and attachment.
+#
+# What makes it different is billing. Every assistant record carries an
+# Anthropic-shaped `usage` object whose input_tokens, output_tokens,
+# cache_read_input_tokens and cache_creation_input_tokens are ALL ZERO, with the
+# real figure in `credits`. Tokens are not merely unread here, they are not
+# recorded, and they cannot be reconstructed: `context_usage_ratio` is a
+# fraction of an unknown denominator (runtime-config.contextWindow is null) and
+# .models/<uid>/catalog-v6 is encrypted at rest, so even the model id stays
+# opaque. See _scan_qoder_sessions.
+
+# Context Qoder splices into the transcript as `attachment` records. None is a
+# user turn. This is an ALLOWLIST on purpose: an unrecognised attachment type
+# may carry file bodies or pasted content, and passing one through to the trace
+# renderer would display it as conversation.
+_QODER_ATTACHMENT_KINDS = frozenset({
+    "skill_listing", "critical_system_reminder", "agent_listing_delta", "hook_output",
+})
+
+# Qoder prepends a plugin/system block to the first human prompt -- in both
+# message.content[0].text and humanInput.text. Rendering it verbatim shows the
+# harness's own instructions as if the user had typed them.
+_QODER_REMINDER_RE = re.compile(r"<system-reminder>.*?</system-reminder>", re.DOTALL)
+
+
+def _qoder_ts(value: Any) -> Optional[datetime]:
+    """Qoder writes ISO strings on message records and epoch MILLIseconds on
+    runtime-config, so both shapes turn up inside one file."""
+    if isinstance(value, str) and value:
+        try:
+            return _aware(datetime.fromisoformat(value.replace("Z", "+00:00")))
+        except ValueError:
+            return None
+    if isinstance(value, (int, float)) and not isinstance(value, bool) and value > 0:
+        try:
+            return _aware(datetime.fromtimestamp(value / 1000.0, tz=timezone.utc))
+        except (OverflowError, OSError, ValueError):
+            return None
+    return None
+
+
+def _qoder_num(value: Any) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return 0.0
+    return float(value)
+
+
+def _qoder_strip_reminder(text: Any) -> str:
+    if not isinstance(text, str):
+        return ""
+    return _QODER_REMINDER_RE.sub("", text).strip()
+
+
+def _qoder_human_text(row: Dict[str, Any]) -> str:
+    """The words the user actually typed, or "" when this is not a human turn.
+
+    `origin.kind` is the only reliable discriminator -- Qoder replays tool
+    results and harness injections through the same `user` record type.
+    """
+    if (row.get("origin") or {}).get("kind") != "human":
+        return ""
+    human = row.get("humanInput")
+    if isinstance(human, dict):
+        direct = _qoder_strip_reminder(human.get("text"))
+        if direct:
+            return direct
+    parts = [
+        block.get("text") or ""
+        for block in ((row.get("message") or {}).get("content") or [])
+        if isinstance(block, dict) and block.get("type") == "text"
+    ]
+    return _qoder_strip_reminder("".join(parts))
+
+
+def _qoder_fold_attachment(att: Any, skills: Set[str], servers: Set[str],
+                           hooks: Dict[str, int]) -> None:
+    """Mine one attachment for metadata. Unknown types are ignored entirely.
+
+    These record what was AVAILABLE to the session, not what it used -- the
+    skill catalog is injected whether or not a skill is ever invoked. Real
+    usage comes from tool_use blocks instead, so this never feeds skills_used.
+    """
+    if not isinstance(att, dict):
+        return
+    kind = att.get("type")
+    if kind not in _QODER_ATTACHMENT_KINDS:
+        return
+    if kind == "skill_listing":
+        for name in (att.get("names") or []):
+            if isinstance(name, str) and name:
+                skills.add(name)
+    elif kind == "critical_system_reminder":
+        for name in (att.get("serverNames") or []):
+            if isinstance(name, str) and name:
+                servers.add(name)
+    elif kind == "hook_output":
+        event = att.get("hookEventName")
+        if isinstance(event, str) and event:
+            hooks[event] = hooks.get(event, 0) + 1
+
+
+def _qoder_parse_session(path: Path) -> Optional[Dict[str, Any]]:
+    """Parse one Qoder transcript. Returns None when the file yields no turns.
+
+    Read defensively line by line: a live session is being appended to while we
+    read, so the final line can be torn.
+    """
+    session_id = ""
+    cwd = ""
+    git_branch = ""
+    version = ""
+    entrypoint = ""
+    model: Optional[str] = None
+    credits = 0.0
+    original_credits = 0.0
+    billable_turns = 0
+    assistant_turns = 0
+    context_ratio: Optional[float] = None
+    first_text = ""
+    last_prompt = ""
+    first_ts: Optional[datetime] = None
+    last_ts: Optional[datetime] = None
+    is_sidechain = False
+    tool_counts: Dict[str, int] = {}
+    skills: Set[str] = set()
+    servers: Set[str] = set()
+    hooks: Dict[str, int] = {}
+
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                try:
+                    row = json.loads(line)
+                except Exception:
+                    continue
+                if not isinstance(row, dict):
+                    continue
+
+                if not session_id and isinstance(row.get("sessionId"), str):
+                    session_id = row["sessionId"]
+                if isinstance(row.get("cwd"), str) and row["cwd"]:
+                    cwd = row["cwd"]
+                if isinstance(row.get("gitBranch"), str) and row["gitBranch"]:
+                    git_branch = row["gitBranch"]
+                if isinstance(row.get("version"), str) and row["version"]:
+                    version = row["version"]
+                if isinstance(row.get("entrypoint"), str) and row["entrypoint"]:
+                    entrypoint = row["entrypoint"]
+                if row.get("isSidechain"):
+                    is_sidechain = True
+
+                stamp = _qoder_ts(row.get("timestamp"))
+                if stamp:
+                    first_ts = stamp if first_ts is None else min(first_ts, stamp)
+                    last_ts = stamp if last_ts is None else max(last_ts, stamp)
+
+                rtype = row.get("type")
+                if rtype == "workspace-directories":
+                    dirs = row.get("directories") or []
+                    if not cwd and dirs and isinstance(dirs[0], str):
+                        cwd = dirs[0]
+                elif rtype == "runtime-config":
+                    if isinstance(row.get("model"), str) and row["model"]:
+                        model = row["model"]
+                elif rtype == "last-prompt":
+                    last_prompt = _qoder_strip_reminder(row.get("lastPrompt"))
+                elif rtype == "attachment":
+                    _qoder_fold_attachment(row.get("attachment"), skills, servers, hooks)
+                elif rtype == "user":
+                    if not first_text:
+                        first_text = _qoder_human_text(row)
+                elif rtype == "assistant":
+                    msg = row.get("message") or {}
+                    assistant_turns += 1
+                    if isinstance(msg.get("model"), str) and msg["model"]:
+                        model = msg["model"]
+                    usage = msg.get("usage")
+                    if isinstance(usage, dict):
+                        credits += _qoder_num(usage.get("credits"))
+                        original_credits += _qoder_num(usage.get("original_credits"))
+                        if usage.get("billable"):
+                            billable_turns += 1
+                        ratio = usage.get("context_usage_ratio")
+                        if isinstance(ratio, (int, float)) and not isinstance(ratio, bool):
+                            context_ratio = float(ratio)
+                    for block in (msg.get("content") or []):
+                        if isinstance(block, dict) and block.get("type") == "tool_use":
+                            name = block.get("name")
+                            if isinstance(name, str) and name:
+                                tool_counts[name] = tool_counts.get(name, 0) + 1
+    except OSError:
+        return None
+
+    if last_ts is None:
+        return None
+
+    return {
+        "id": session_id or path.stem,
+        "path": path,
+        "project": cwd or "unknown",
+        "timestamp": last_ts,
+        "started_at": first_ts,
+        "display": first_text or last_prompt,
+        "model": model,
+        "credits": round(credits, 6),
+        "original_credits": round(original_credits, 6),
+        "billable_turns": billable_turns,
+        "assistant_turns": assistant_turns,
+        "context_usage_ratio": context_ratio,
+        "git_branch": git_branch,
+        "cli_version": version,
+        "entrypoint": entrypoint,
+        "is_sidechain": is_sidechain,
+        "tool_counts": tool_counts,
+        "skills_available": sorted(skills),
+        "mcp_servers": sorted(servers),
+        "hook_events": hooks,
+    }
+
+
+def _qoder_subagents(session_dir: Path) -> List[Dict[str, Any]]:
+    """Child transcripts spawned by one Qoder session.
+
+    Children live at <session-dir>/subagents/<name>.jsonl with a sibling
+    <name>.meta.json naming the agent type and the task it was given. They are
+    NOT top-level sessions -- counting the whole projects/ tree would return
+    every child as a session of its own.
+    """
+    sub_dir = session_dir / "subagents"
+    if not sub_dir.is_dir():
+        return []
+    kids: List[Dict[str, Any]] = []
+    for transcript in sorted(sub_dir.glob("*.jsonl")):
+        parsed = _qoder_parse_session(transcript)
+        if not parsed:
+            continue
+        meta: Dict[str, Any] = {}
+        try:
+            meta_path = transcript.with_suffix(".meta.json")
+            if meta_path.exists():
+                loaded = json.loads(meta_path.read_text(encoding="utf-8", errors="replace"))
+                if isinstance(loaded, dict):
+                    meta = loaded
+        except (OSError, ValueError):
+            meta = {}
+        # A child's records carry the PARENT's sessionId -- it is the same
+        # session -- so the in-record id is identical for every child and
+        # cannot identify one. Use the transcript's own filename, which
+        # already encodes the agent type and a per-spawn hash.
+        parsed["id"] = transcript.stem
+        parsed["agent_type"] = meta.get("agentType") or meta.get("invocationName") or "subagent"
+        parsed["description"] = meta.get("description") or ""
+        kids.append(parsed)
+    return kids
+
+
+def _qoder_ide_sessions() -> Dict[str, Dict[str, Any]]:
+    """Per-session enrichment from the IDE's mirror database, keyed by id.
+
+    The IDE projects the same SDK sessions into SQLite (its message rows are
+    marked source="sdk-projection" and reuse the JSONL uuids), so this is used
+    ONLY to enrich -- never as a second source of sessions. What it adds is a
+    human-readable title, which the JSONL has nowhere.
+
+    Best-effort by design: opened read-only, and a missing, locked or
+    schema-changed database degrades to CLI-only data rather than failing the
+    scan. Credential tables are never touched.
+    """
+    db = QODER_IDE_DIR / "main.sqlite"
+    if not db.exists():
+        return {}
+    out: Dict[str, Dict[str, Any]] = {}
+    conn = None
+    try:
+        conn = sqlite3.connect(f"file:{db}?mode=ro", uri=True, timeout=1.0)
+        for row in conn.execute(
+            "SELECT session_id, title, session_kind, product_mode, archived "
+            "FROM chat_sessions WHERE deleted_at IS NULL"
+        ):
+            sid = row[0]
+            if isinstance(sid, str) and sid:
+                out[sid] = {
+                    "title": (row[1] or "").strip(),
+                    "session_kind": row[2] or "standard",
+                    "product_mode": row[3] or "coding",
+                    "archived": bool(row[4]),
+                }
+        for row in conn.execute(
+            "SELECT session_id, "
+            "       SUM(COALESCE(json_extract(payload_json,'$.durationMs'),0)), "
+            "       COUNT(*) "
+            "FROM chat_session_messages "
+            "WHERE json_extract(payload_json,'$.role')='assistant' "
+            "GROUP BY session_id"
+        ):
+            entry = out.get(row[0])
+            if entry is not None:
+                entry["duration_ms"] = int(row[1] or 0)
+                entry["turn_count"] = int(row[2] or 0)
+    except (sqlite3.Error, ValueError):
+        return out
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass
+    return out
+
+
+def _scan_qoder_sessions() -> List[Dict[str, Any]]:
+    """Scan Qoder sessions under ~/.qoder/projects/.
+
+    Layout: projects/<slugged-cwd>/<session-uuid>.jsonl, with child transcripts
+    one level deeper at projects/<slugged-cwd>/<session-uuid>/subagents/*.jsonl.
+    The glob is deliberately ROOT-LEVEL ONLY (`*/*.jsonl`): a recursive walk
+    would return every subagent transcript as a session of its own, which on a
+    two-session install already inflates the count to four.
+
+    The directory slug is NOT reversible -- Qoder replaces "/" with "-" without
+    escaping dashes already in the path, so
+    "-Users-dev-Documents-Qoder-2026-08-30-d5db2e1b" has several valid readings.
+    The project comes from the records' own `cwd` (or the workspace-directories
+    header) instead.
+
+    Tokens are reported as an honest zero. Qoder records none (see the module
+    comment above) and bills in credits, which ride in the per-session "qoder"
+    blob and drive the panel meter -- the same treatment Copilot's AIU gets.
+    Under billing_mode "subscription" a $0.00 cost is the correct reading, not
+    a missing value.
+    """
+    if not QODER_PROJECTS_DIR.is_dir():
+        return []
+
+    aliases = _load_project_aliases()
+    ide = _qoder_ide_sessions()
+    out: List[Dict[str, Any]] = []
+
+    for transcript in sorted(QODER_PROJECTS_DIR.glob("*/*.jsonl")):
+        parsed = _qoder_parse_session(transcript)
+        if not parsed:
+            continue
+        # Belt and braces: the glob depth already excludes children, and the
+        # records flag them too.
+        if parsed["is_sidechain"]:
+            continue
+
+        sid = parsed["id"]
+        meta = ide.get(sid) or {}
+        kids = _qoder_subagents(transcript.parent / transcript.stem)
+
+        display = (meta.get("title") or parsed["display"]
+                   or f"Qoder session {sid[-8:]}")
+        # Qoder titles a thread with the user's whole first message when the
+        # IDE has not named it, so cap what is user-authored.
+        if len(display) > 120:
+            display = display[:117] + "..."
+
+        blob: Dict[str, Any] = {
+            "credits": parsed["credits"],
+            "original_credits": parsed["original_credits"],
+            "billable_turns": parsed["billable_turns"],
+            "assistant_turns": parsed["assistant_turns"],
+            "context_usage_ratio": parsed["context_usage_ratio"],
+            "entrypoint": parsed["entrypoint"] or "cli",
+            "git_branch": parsed["git_branch"],
+            "cli_version": parsed["cli_version"],
+            "skills_available": parsed["skills_available"],
+            "mcp_servers": parsed["mcp_servers"],
+            "hook_events": parsed["hook_events"],
+        }
+        for key in ("session_kind", "product_mode", "duration_ms", "turn_count"):
+            if key in meta:
+                blob[key] = meta[key]
+
+        sess: Dict[str, Any] = {
+            "id": sid,
+            "agent": "qoder",
+            "project": aliases.get(parsed["project"], parsed["project"]),
+            "timestamp": parsed["timestamp"],
+            "display": display,
+            "text": parsed["display"],
+            # Not a scan failure: Qoder records no token counts at all.
+            "tokens": {"input": 0, "output": 0, "cached": 0,
+                       "cache_creation": 0, "reasoning": 0, "total": 0},
+            "cost": 0.0,
+            "model": parsed["model"],
+            "provider": "qoder",
+            "mcp_tools": [t for t in parsed["tool_counts"] if t.startswith("mcp")],
+            "has_plan": False,
+            "plans": [],
+            "artifacts": [{"name": transcript.name, "path": str(transcript),
+                           "type": "document"}],
+            "qoder": blob,
+        }
+
+        if kids:
+            subagents = [{
+                "agent_id": kid["id"],
+                "agent_type": kid["agent_type"],
+                "description": kid["description"],
+                "model": kid["model"],
+                "tokens": {"input": 0, "output": 0, "cached": 0,
+                           "cache_creation": 0, "reasoning": 0, "total": 0},
+                "cost": 0.0,
+                "credits": kid["credits"],
+            } for kid in kids]
+            delegated_credits = round(sum(k["credits"] for k in kids), 6)
+            by_type: Dict[str, Dict[str, Any]] = {}
+            for kid in kids:
+                slot = by_type.setdefault(
+                    kid["agent_type"], {"count": 0, "total": 0, "cost": 0.0, "credits": 0.0})
+                slot["count"] += 1
+                slot["credits"] = round(slot["credits"] + kid["credits"], 6)
+            sess["delegation"] = {
+                "supported": True,
+                # Credits, not tokens -- the delegated spend is real, it just
+                # isn't denominated in tokens anywhere in Qoder.
+                "tokens_recorded": False,
+                "spawn_count": len(subagents),
+                "subagents": subagents,
+                "delegated_total": 0,
+                "delegated_cost": 0.0,
+                "delegated_credits": delegated_credits,
+                "by_type": by_type,
+            }
+            blob["delegated_credits"] = delegated_credits
+            blob["total_credits"] = round(parsed["credits"] + delegated_credits, 6)
+
+        _attach_tool_usage(sess, parsed["tool_counts"])
+        out.append(sess)
+
+    return out
+
+
+def _qoder_session_file(session_id: str) -> Optional[Path]:
+    """Locate one Qoder transcript by session id."""
+    if not QODER_PROJECTS_DIR.is_dir() or not session_id:
+        return None
+    if "/" in session_id or "\\" in session_id or ".." in session_id:
+        return None
+    for match in QODER_PROJECTS_DIR.glob(f"*/{session_id}.jsonl"):
+        return match
+    return None
+
+
+def _qoder_trace_events(path: Path) -> List[Dict[str, Any]]:
+    """Normalize a Qoder transcript into the Claude-shaped events the trace
+    renderer expects.
+
+    Qoder's records are already Claude-shaped, so this filters rather than
+    converts. Three things are dropped or rewritten:
+
+      * session metadata (workspace-directories, runtime-config, last-prompt,
+        active-leaf) is not a turn;
+      * `attachment` records are harness-injected context -- the renderer
+        displays Event.attachment if present, so passing them through would
+        show the harness's own prompt as conversation;
+      * the first human prompt carries an injected <system-reminder> block,
+        which is stripped so the user's words are what the trace shows.
+
+    Per-step token chips are suppressed: Qoder's usage block is all zeros, so
+    rendering it would imply a measurement that was never taken.
+    """
+    events: List[Dict[str, Any]] = []
+    for row in _parse_session_jsonl_cached(path):
+        rtype = row.get("type")
+        if rtype == "user":
+            # A `user` record is one of three things: a human turn, the result
+            # of a tool the assistant called, or a harness injection. Only the
+            # last is dropped -- tool results must survive or every tool_use in
+            # the trace renders with nothing paired to it.
+            content = (row.get("message") or {}).get("content") or []
+            results = [b for b in content
+                       if isinstance(b, dict) and b.get("type") == "tool_result"]
+            if results:
+                events.append({
+                    "type": "user",
+                    "uuid": row.get("uuid"),
+                    "timestamp": row.get("timestamp"),
+                    "normalized_timestamp": row.get("normalized_timestamp"),
+                    "message": {"role": "user", "content": results},
+                })
+                continue
+            text = _qoder_human_text(row)
+            if not text:
+                continue  # harness injection, not something the user typed
+            events.append({
+                "type": "user",
+                "uuid": row.get("uuid"),
+                "timestamp": row.get("timestamp"),
+                "normalized_timestamp": row.get("normalized_timestamp"),
+                "message": {"role": "user",
+                            "content": [{"type": "text", "text": text}]},
+            })
+        elif rtype == "assistant":
+            msg = row.get("message") or {}
+            blocks = [b for b in (msg.get("content") or []) if isinstance(b, dict)]
+            if not blocks:
+                continue
+            events.append({
+                "type": "assistant",
+                "uuid": row.get("uuid"),
+                "timestamp": row.get("timestamp"),
+                "normalized_timestamp": row.get("normalized_timestamp"),
+                "message": {"role": "assistant",
+                            "model": msg.get("model"),
+                            "content": blocks},
+            })
+    return events
+
+
+
+
 # Cordis FiberState (vendor/cordis/src/fiber.ts) -> readable names. It is a
 # `const enum`, so it inlines to these ordinals at runtime.
 _DSH_FIBER_STATES: Dict[int, str] = {
@@ -4911,8 +5448,11 @@ def _opencode_resolve_model(val):
 # antigravity: parent brain transcript INVOKE_SUBAGENT steps name the child
 # conversation ids. (All verified empirically by running the CLIs — see
 # DESIGN.md "probe findings".)
+# qoder: subagents/<name>.jsonl beside the parent transcript, with a sibling
+# .meta.json naming the agent type and the task — spend per child is real, but
+# denominated in credits rather than tokens.
 _DELEGATION_CAPABLE_AGENTS = {"claude", "cursor", "opencode", "hermes",
-                              "grok", "codex", "antigravity", "cline"}
+                              "grok", "codex", "antigravity", "cline", "qoder"}
 
 
 # content is JSON-escaped inside the INVOKE_SUBAGENT step record, so the quote
@@ -7254,6 +7794,10 @@ def _scan_sessions_sync():
     # 8b3. DeepSeek Harness (DSH) — zstd-compressed JSONL under ~/.dsh/sessions/
     sessions.extend(_scan_dsh_sessions())
 
+    # 8b4. Qoder — Claude-shaped JSONL under ~/.qoder/projects/. Bills in
+    # credits and records no token counts at all; see _scan_qoder_sessions.
+    sessions.extend(_scan_qoder_sessions())
+
     # 8c. Meta Muse Code + Prime Agent. Their root session records contain the
     # cwd, so they naturally participate in project/worktree navigation.
     for sess in _scan_muse_sessions() + _scan_prime_sessions():
@@ -8137,6 +8681,15 @@ async def get_session_detail(session_id: str, agent: str):
             return {"error": "Not found"}
         return _dsh_trace_events(sess_file)
 
+    elif agent == "qoder":
+        # Qoder writes Claude-shaped JSONL, so _qoder_trace_events filters
+        # rather than converts: it drops the harness's own injected context and
+        # strips the <system-reminder> prefix from the opening human prompt.
+        sess_file = _qoder_session_file(session_id)
+        if not sess_file:
+            return {"error": "Not found"}
+        return _qoder_trace_events(sess_file)
+
     elif agent in ["gemini", "antigravity"]:
         # Antigravity CLI (agy) sessions store the real per-step trajectory in
         # conversations/<id>.db — far richer than the brain markdown. Prefer it.
@@ -8807,6 +9360,30 @@ async def session_delegation(session_id: str, agent: str):
         return {"supported": True, "tokens_recorded": True, "spawn_count": len(subagents),
                 "subagents": subagents, "totals": totals,
                 "cost": sum(s["cost"] for s in subagents)}
+
+    if agent == "qoder":
+        # Qoder children sit beside the parent transcript, each with a
+        # .meta.json naming the agent type and the task it was given. Their
+        # spend is real but denominated in credits, so tokens_recorded is
+        # False and the figure to read is delegated_credits.
+        parent_file = _qoder_session_file(session_id)
+        if parent_file is None:
+            return {"error": "Not found"}
+        kids = _qoder_subagents(parent_file.parent / parent_file.stem)
+        subagents = [{
+            "agent_id": kid["id"],
+            "agent_type": kid["agent_type"],
+            "description": kid["description"],
+            "model": kid["model"],
+            "tokens": {"input": 0, "output": 0, "cached": 0,
+                       "cache_creation": 0, "reasoning": 0, "total": 0},
+            "cost": 0.0,
+            "credits": kid["credits"],
+        } for kid in kids]
+        return {"supported": True, "tokens_recorded": False,
+                "spawn_count": len(subagents), "subagents": subagents,
+                "totals": None, "cost": 0.0,
+                "delegated_credits": round(sum(k["credits"] for k in kids), 6)}
 
     if agent == "dsh":
         # DSH children are their own session logs, linked by an explicit

--- a/backend/telemetry.py
+++ b/backend/telemetry.py
@@ -155,7 +155,7 @@ _ENUMS: Dict[str, set] = {
 _KNOWN_AGENTS = {
     "claude", "codex", "gemini", "antigravity", "qwen", "vibe",
     "cursor", "copilot", "opencode", "hermes", "grok",
-    "pi", "cline", "muse", "prime", "smallcode", "dsh",
+    "pi", "cline", "muse", "prime", "smallcode", "dsh", "qoder",
 }
 
 

--- a/backend/test_harness_panels_agents.py
+++ b/backend/test_harness_panels_agents.py
@@ -38,7 +38,7 @@ def test_every_supported_agent_has_a_builder():
     supported = {
         "claude", "codex", "gemini", "antigravity", "qwen", "vibe", "cursor",
         "copilot", "opencode", "grok", "cline", "smallcode", "pi", "muse",
-        "prime", "dsh", "hermes",
+        "prime", "dsh", "qoder", "hermes",
     }
     assert supported == set(harness_panels.BUILDERS), (
         "every supported agent needs an extractor; "
@@ -297,6 +297,77 @@ def test_dsh_explains_zero_sessions_without_zstandard(tmp_path, monkeypatch):
     assert "start.sh" in note["reason"], "tell the user what to actually do"
 
 
+# --- Qoder ------------------------------------------------------------------
+
+def _qoder_turn(credits, model="qmodel_38max"):
+    """One assistant record. Qoder always writes zeroed token counters."""
+    return json.dumps({
+        "type": "assistant", "sessionId": "s1", "uuid": f"u{credits}",
+        "timestamp": "2026-08-29T19:58:50.418Z", "cwd": "/repo",
+        "gitBranch": "main", "version": "1.1.31", "isSidechain": False,
+        "message": {"role": "assistant", "model": model, "content": [],
+                    "usage": {"input_tokens": 0, "output_tokens": 0,
+                              "cache_read_input_tokens": 0,
+                              "cache_creation_input_tokens": 0,
+                              "credits": credits, "billable": True}},
+    })
+
+
+def test_qoder_reports_credits_and_flags_absent_tokens(tmp_path, monkeypatch):
+    """Credits are the spend; the zero tokens must explain themselves.
+
+    Qoder writes an Anthropic-shaped usage block with every token counter at
+    zero. A bare 0 on screen reads as a failed scan, so the panel has to name
+    the reason -- this pins both halves.
+    """
+    root = tmp_path / ".qoder"
+    proj = root / "projects" / "-repo"
+    proj.mkdir(parents=True)
+    (proj / "s1.jsonl").write_text("\n".join([
+        json.dumps({"type": "workspace-directories", "sessionId": "s1",
+                    "directories": ["/repo"]}),
+        _qoder_turn(1.5),
+        _qoder_turn(2.0),
+    ]), encoding="utf-8")
+    monkeypatch.setattr(hp_paths, "QODER_DIR", root)
+    monkeypatch.setattr(hp_paths, "QODER_IDE_DIR", tmp_path / "no-ide")
+
+    doc = clis.build_qoder()
+    assert doc["installed"] and doc["version"] == "1.1.31"
+
+    table = next(s for s in doc["sections"] if s["title"] == "Sessions")
+    assert table["rows"][0][4] == 3.5, "credits summed across turns"
+
+    kinds = {n["kind"] for n in doc["not_available"]}
+    assert {"tokens", "models", "session state"} <= kinds
+    tokens = next(n for n in doc["not_available"] if n["kind"] == "tokens")
+    assert "credits" in tokens["reason"]
+    assert "not a failed scan" in tokens["reason"]
+
+
+def test_qoder_panel_survives_a_missing_ide_database(tmp_path, monkeypatch):
+    """The IDE mirror only supplies titles; without it the panel still builds."""
+    root = tmp_path / ".qoder"
+    proj = root / "projects" / "-repo"
+    proj.mkdir(parents=True)
+    (proj / "s1.jsonl").write_text(_qoder_turn(1.0), encoding="utf-8")
+    monkeypatch.setattr(hp_paths, "QODER_DIR", root)
+    monkeypatch.setattr(hp_paths, "QODER_IDE_DIR", tmp_path / "absent")
+
+    doc = clis.build_qoder()
+    assert doc["installed"]
+    assert next(s for s in doc["sections"] if s["title"] == "Sessions")["rows"]
+
+
+def test_qoder_not_installed_before_any_session(tmp_path, monkeypatch):
+    """The installer creates ~/.qoder ahead of the first run, so the bare root
+    must not advertise an agent with nothing behind it."""
+    root = tmp_path / ".qoder"
+    (root / "logs").mkdir(parents=True)
+    monkeypatch.setattr(hp_paths, "QODER_DIR", root)
+    assert clis.build_qoder()["installed"] is False
+
+
 # --- Gemini -----------------------------------------------------------------
 
 def test_gemini_trust_and_project_resolver(tmp_path, monkeypatch):
@@ -503,7 +574,8 @@ def test_missing_directory_yields_not_installed(agent, tmp_path, monkeypatch):
     absent = tmp_path / "absent"
     for name in ("CLAUDE_DIR", "CODEX_DIR", "COPILOT_DIR", "GROK_DIR", "GEMINI_DIR",
                  "QWEN_DIR", "VIBE_DIR", "CURSOR_DIR", "PI_DIR", "DSH_DIR",
-                 "CLINE_DIR", "MUSE_DIR", "PRIME_DIR", "HERMES_DIR"):
+                 "CLINE_DIR", "MUSE_DIR", "PRIME_DIR", "HERMES_DIR",
+                 "QODER_DIR", "QODER_IDE_DIR"):
         monkeypatch.setattr(hp_paths, name, absent, raising=False)
     monkeypatch.setattr(hp_paths, "ANTIGRAVITY_SURFACES", [], raising=False)
     monkeypatch.setattr(hp_paths, "smallcode_roots", lambda: [], raising=False)

--- a/backend/test_qoder_scan.py
+++ b/backend/test_qoder_scan.py
@@ -1,0 +1,350 @@
+"""Tests for Qoder session scanning.
+
+Qoder (Alibaba) writes Claude-Code-shaped JSONL under
+~/.qoder/projects/<slugged-cwd>/<session-uuid>.jsonl, with child transcripts a
+level deeper in <session-uuid>/subagents/. Record shapes here (the zeroed usage
+block, `credits`, workspace-directories, origin.kind, the attachment types) are
+taken from real on-disk Qoder output, not guessed from docs.
+
+The behaviour worth pinning is that Qoder records NO token counts at all and
+bills in credits: a scanner that silently reports zero looks identical to one
+that failed, so several of these tests exist to keep the difference visible.
+
+Run: pytest backend/test_qoder_scan.py -q
+"""
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+import main  # noqa: E402
+
+
+def _usage(credits, billable=True, ratio=0.0268):
+    """Qoder's usage block: Anthropic-shaped, every token counter zero."""
+    return {
+        "input_tokens": 0, "output_tokens": 0,
+        "cache_read_input_tokens": 0, "cache_creation_input_tokens": 0,
+        "server_tool_use": {"web_search_requests": 0, "web_fetch_requests": 0},
+        "service_tier": "standard", "credits": credits,
+        "original_credits": credits * 2, "billable": billable,
+        "context_usage_ratio": ratio, "request_id": "req-1",
+    }
+
+
+def _user(text, uuid="u1", human=True, ts="2026-08-29T19:58:40.055Z"):
+    row = {
+        "type": "user", "uuid": uuid, "timestamp": ts, "sessionId": "SID",
+        "cwd": "/Users/dev/repo", "gitBranch": "main", "version": "1.1.31",
+        "isSidechain": False, "entrypoint": "cli", "userType": "external",
+        "message": {"role": "user", "content": [{"type": "text", "text": text}]},
+    }
+    if human:
+        row["origin"] = {"kind": "human"}
+        row["humanInput"] = {"text": text}
+    return row
+
+
+def _assistant(credits, uuid="a1", blocks=None, model="qmodel_38max",
+               ts="2026-08-29T19:58:50.418Z"):
+    return {
+        "type": "assistant", "uuid": uuid, "timestamp": ts, "sessionId": "SID",
+        "cwd": "/Users/dev/repo", "gitBranch": "main", "version": "1.1.31",
+        "isSidechain": False, "entrypoint": "cli",
+        "message": {"role": "assistant", "model": model,
+                    "content": blocks if blocks is not None else [
+                        {"type": "text", "text": "ok"}],
+                    "usage": _usage(credits)},
+    }
+
+
+def _write_session(projects, slug, session_id, rows):
+    d = projects / slug
+    d.mkdir(parents=True, exist_ok=True)
+    path = d / f"{session_id}.jsonl"
+    path.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+    return path
+
+
+def _write_subagent(projects, slug, session_id, name, rows, meta):
+    d = projects / slug / session_id / "subagents"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"{name}.jsonl").write_text(
+        "\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+    (d / f"{name}.meta.json").write_text(json.dumps(meta), encoding="utf-8")
+
+
+@pytest.fixture()
+def qoder(tmp_path, monkeypatch):
+    """A Qoder root with the scan pointed at it and no IDE database."""
+    root = tmp_path / ".qoder"
+    projects = root / "projects"
+    projects.mkdir(parents=True)
+    monkeypatch.setattr(main, "QODER_DIR", root)
+    monkeypatch.setattr(main, "QODER_PROJECTS_DIR", projects)
+    monkeypatch.setattr(main, "QODER_IDE_DIR", tmp_path / "no-ide")
+    return projects
+
+
+def test_no_projects_directory_scans_nothing(tmp_path, monkeypatch):
+    """The installer creates ~/.qoder before the first session exists."""
+    monkeypatch.setattr(main, "QODER_PROJECTS_DIR", tmp_path / "nope")
+    assert main._scan_qoder_sessions() == []
+
+
+def test_credits_are_summed_and_tokens_stay_zero(qoder):
+    """Qoder's spend is credits; the token total must be an honest zero.
+
+    Reporting a fabricated token count would be worse than zero -- there is
+    nothing on disk to derive one from.
+    """
+    _write_session(qoder, "-Users-dev-repo", "SID", [
+        {"type": "workspace-directories", "sessionId": "SID",
+         "directories": ["/Users/dev/repo"]},
+        _user("fix the build"),
+        _assistant(1.25),
+        _assistant(0.75, uuid="a2"),
+    ])
+    sessions = main._scan_qoder_sessions()
+    assert len(sessions) == 1
+    s = sessions[0]
+    assert s["agent"] == "qoder" and s["id"] == "SID"
+    assert s["tokens"]["total"] == 0
+    assert s["cost"] == 0.0
+    assert s["qoder"]["credits"] == 2.0
+    assert s["qoder"]["original_credits"] == 4.0
+    assert s["qoder"]["billable_turns"] == 2
+    assert s["qoder"]["assistant_turns"] == 2
+    assert s["qoder"]["cli_version"] == "1.1.31"
+    assert s["model"] == "qmodel_38max"
+    assert s["provider"] == "qoder"
+
+
+def test_subagent_transcripts_are_not_counted_as_sessions(qoder):
+    """The bug this guards: a recursive glob returns children as sessions.
+
+    Two transcripts on disk under one session is ONE session with two
+    delegated children, not three sessions.
+    """
+    _write_session(qoder, "-Users-dev-repo", "SID", [
+        _user("do the thing"), _assistant(3.0)])
+    _write_subagent(qoder, "-Users-dev-repo", "SID", "agent-a-1",
+                    [_assistant(2.0, uuid="k1")],
+                    {"agentType": "general-purpose", "toolUseId": "call_1",
+                     "description": "Map the architecture"})
+    _write_subagent(qoder, "-Users-dev-repo", "SID", "agent-a-2",
+                    [_assistant(1.5, uuid="k2")],
+                    {"agentType": "general-purpose", "toolUseId": "call_2",
+                     "description": "Find repeated work"})
+
+    sessions = main._scan_qoder_sessions()
+    assert len(sessions) == 1, "children are not top-level sessions"
+
+    deleg = sessions[0]["delegation"]
+    assert deleg["supported"] is True
+    assert deleg["spawn_count"] == 2
+    # Credits, not tokens -- the spend is real but Qoder denominates it
+    # differently, and claiming tokens were recorded would be a lie.
+    assert deleg["tokens_recorded"] is False
+    assert deleg["delegated_credits"] == 3.5
+    assert deleg["delegated_total"] == 0
+    assert {s["description"] for s in deleg["subagents"]} == {
+        "Map the architecture", "Find repeated work"}
+    assert sessions[0]["qoder"]["total_credits"] == 6.5
+
+
+def test_each_subagent_gets_a_distinct_id(qoder):
+    """Children carry the PARENT's sessionId, so the in-record id is identical
+    for every spawn. Using it made two children collide -- the UI rendered them
+    under one React key and they were indistinguishable. The filename, which
+    encodes the agent type and a per-spawn hash, is the only unique handle.
+    """
+    _write_session(qoder, "-Users-dev-repo", "SID", [_assistant(1.0)])
+    for name, desc in (("agent-a-first", "one"), ("agent-a-second", "two")):
+        _write_subagent(qoder, "-Users-dev-repo", "SID", name,
+                        [_assistant(1.0, uuid=name)],
+                        {"agentType": "general-purpose", "description": desc})
+
+    (sess,) = main._scan_qoder_sessions()
+    ids = [s["agent_id"] for s in sess["delegation"]["subagents"]]
+    assert len(set(ids)) == 2, f"subagent ids must be unique, got {ids}"
+    assert "SID" not in ids, "the parent's session id is not a child's id"
+
+
+def test_sidechain_transcript_at_root_is_skipped(qoder):
+    """Belt and braces: the records flag a child even if one is misplaced."""
+    rows = [_assistant(1.0)]
+    rows[0]["isSidechain"] = True
+    _write_session(qoder, "-Users-dev-repo", "CHILD", rows)
+    assert main._scan_qoder_sessions() == []
+
+
+def test_project_comes_from_records_not_the_directory_slug(qoder):
+    """Qoder's slug is lossy: it replaces "/" with "-" without escaping the
+    dashes already in the path, so "-Users-dev-Qoder-2026-08-30-abc" has
+    several valid readings. The cwd in the records is the only sound source."""
+    _write_session(qoder, "-Users-dev-Qoder-2026-08-30-abc", "SID", [
+        {"type": "workspace-directories", "sessionId": "SID",
+         "directories": ["/Users/dev/Qoder/2026-08-30/abc"]},
+        _assistant(1.0),
+    ])
+    (sess,) = main._scan_qoder_sessions()
+    assert sess["project"] == "/Users/dev/repo", "cwd on the record wins"
+
+
+def test_workspace_directories_supplies_the_project_when_no_cwd(qoder):
+    header = {"type": "workspace-directories", "sessionId": "SID",
+              "directories": ["/Users/dev/from-header"]}
+    turn = _assistant(1.0)
+    turn.pop("cwd")
+    _write_session(qoder, "-slug", "SID", [header, turn])
+    (sess,) = main._scan_qoder_sessions()
+    assert sess["project"] == "/Users/dev/from-header"
+
+
+def test_trace_strips_the_injected_system_reminder(qoder):
+    """Qoder prepends a plugin block to the opening prompt. Rendered verbatim
+    it shows the harness's own instructions as the user's words."""
+    injected = ("<system-reminder>\nPrefer the skills below.\n</system-reminder>\n\n"
+                "what does this repo do")
+    path = _write_session(qoder, "-Users-dev-repo", "SID", [
+        _user(injected), _assistant(1.0)])
+
+    events = main._qoder_trace_events(path)
+    first = next(e for e in events if e["message"]["role"] == "user")
+    text = first["message"]["content"][0]["text"]
+    assert "<system-reminder>" not in text
+    assert text == "what does this repo do"
+
+
+def test_trace_keeps_tool_results_and_drops_harness_injections(qoder):
+    """A tool_result arrives as a `user` record with no human origin. Dropping
+    every non-human user record would leave each tool_use unpaired."""
+    tool_use = _assistant(1.0, blocks=[
+        {"type": "tool_use", "id": "t1", "name": "Read", "input": {}}])
+    result = {
+        "type": "user", "uuid": "r1", "timestamp": "2026-08-29T19:59:00.000Z",
+        "sessionId": "SID", "isSidechain": False,
+        "message": {"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": "t1", "content": "file body"}]},
+    }
+    injection = {
+        "type": "user", "uuid": "r2", "timestamp": "2026-08-29T19:59:01.000Z",
+        "sessionId": "SID", "isSidechain": False,
+        "message": {"role": "user", "content": [
+            {"type": "text", "text": "harness noise"}]},
+    }
+    path = _write_session(qoder, "-Users-dev-repo", "SID", [
+        _user("read it"), tool_use, result, injection])
+
+    events = main._qoder_trace_events(path)
+    kinds = [b["type"] for e in events for b in e["message"]["content"]]
+    assert "tool_result" in kinds, "results must survive or tool calls dangle"
+    assert "harness noise" not in json.dumps(events)
+
+
+def test_trace_drops_attachment_records(qoder):
+    """Attachments are harness-injected context. The renderer displays
+    Event.attachment, so passing one through shows the prompt as conversation."""
+    attachment = {
+        "type": "attachment", "uuid": "at1", "sessionId": "SID",
+        "timestamp": "2026-08-29T19:58:45.000Z", "isSidechain": False,
+        "attachment": {"type": "skill_listing", "skillCount": 2,
+                       "names": ["alpha", "beta"],
+                       "content": "SECRET-LOOKING SKILL DOC BODY"},
+    }
+    path = _write_session(qoder, "-Users-dev-repo", "SID", [
+        _user("hi"), attachment, _assistant(1.0)])
+
+    events = main._qoder_trace_events(path)
+    assert "SECRET-LOOKING SKILL DOC BODY" not in json.dumps(events)
+    assert all(e["type"] in ("user", "assistant") for e in events)
+
+
+def test_attachments_record_availability_not_usage(qoder):
+    """The skill catalogue is injected whether or not a skill is ever used, so
+    it must not be reported as skills_used."""
+    attachment = {
+        "type": "attachment", "uuid": "at1", "sessionId": "SID",
+        "timestamp": "2026-08-29T19:58:45.000Z", "isSidechain": False,
+        "attachment": {"type": "skill_listing", "skillCount": 2,
+                       "names": ["alpha", "beta"], "content": "..."},
+    }
+    servers = {
+        "type": "attachment", "uuid": "at2", "sessionId": "SID",
+        "timestamp": "2026-08-29T19:58:46.000Z", "isSidechain": False,
+        "attachment": {"type": "critical_system_reminder",
+                       "serverNames": ["browser-use"], "content": "..."},
+    }
+    _write_session(qoder, "-Users-dev-repo", "SID", [
+        _user("hi"), attachment, servers, _assistant(1.0)])
+
+    (sess,) = main._scan_qoder_sessions()
+    assert sess["qoder"]["skills_available"] == ["alpha", "beta"]
+    assert sess["qoder"]["mcp_servers"] == ["browser-use"]
+    assert "skills_used" not in sess, "available is not the same as used"
+
+
+def test_unknown_attachment_types_are_ignored(qoder):
+    """Allowlist, not denylist: an unrecognised attachment may carry a file
+    body, and the safe default is to drop it."""
+    unknown = {
+        "type": "attachment", "uuid": "at1", "sessionId": "SID",
+        "timestamp": "2026-08-29T19:58:45.000Z", "isSidechain": False,
+        "attachment": {"type": "pasted_file", "path": "/Users/dev/.env",
+                       "content": "API_KEY=sk-should-never-appear"},
+    }
+    path = _write_session(qoder, "-Users-dev-repo", "SID", [
+        _user("hi"), unknown, _assistant(1.0)])
+
+    (sess,) = main._scan_qoder_sessions()
+    assert "sk-should-never-appear" not in json.dumps(sess, default=str)
+    assert "sk-should-never-appear" not in json.dumps(main._qoder_trace_events(path))
+
+
+def test_tool_calls_are_counted(qoder):
+    _write_session(qoder, "-Users-dev-repo", "SID", [
+        _user("go"),
+        _assistant(1.0, blocks=[
+            {"type": "tool_use", "id": "t1", "name": "Read", "input": {}},
+            {"type": "tool_use", "id": "t2", "name": "Read", "input": {}}]),
+        _assistant(1.0, uuid="a2", blocks=[
+            {"type": "tool_use", "id": "t3", "name": "Bash", "input": {}}]),
+    ])
+    (sess,) = main._scan_qoder_sessions()
+    assert sess["tool_counts"] == {"Read": 2, "Bash": 1}
+
+
+def test_torn_final_line_does_not_break_a_live_session(qoder):
+    """A session being appended to while we read it ends mid-JSON."""
+    d = qoder / "-Users-dev-repo"
+    d.mkdir(parents=True)
+    good = json.dumps(_assistant(2.0))
+    (d / "SID.jsonl").write_text(good + "\n" + '{"type":"assist', encoding="utf-8")
+    (sess,) = main._scan_qoder_sessions()
+    assert sess["qoder"]["credits"] == 2.0
+
+
+def test_display_falls_back_when_the_ide_database_is_absent(qoder):
+    """Titles come from the IDE mirror; without it the first prompt is used."""
+    _write_session(qoder, "-Users-dev-repo", "SID", [
+        _user("summarise the migration plan"), _assistant(1.0)])
+    (sess,) = main._scan_qoder_sessions()
+    assert sess["display"] == "summarise the migration plan"
+
+
+def test_long_first_prompt_is_truncated_for_the_title(qoder):
+    """Qoder titles a thread with the user's whole first message."""
+    _write_session(qoder, "-Users-dev-repo", "SID", [
+        _user("x" * 400), _assistant(1.0)])
+    (sess,) = main._scan_qoder_sessions()
+    assert len(sess["display"]) == 120 and sess["display"].endswith("...")
+
+
+def test_session_file_lookup_rejects_traversal(qoder):
+    _write_session(qoder, "-Users-dev-repo", "SID", [_assistant(1.0)])
+    assert main._qoder_session_file("SID") is not None
+    assert main._qoder_session_file("../../etc/passwd") is None
+    assert main._qoder_session_file("") is None

--- a/backend/test_qoder_scan.py
+++ b/backend/test_qoder_scan.py
@@ -335,6 +335,67 @@ def test_display_falls_back_when_the_ide_database_is_absent(qoder):
     assert sess["display"] == "summarise the migration plan"
 
 
+def _write_ide_db(path, rows):
+    """A minimal stand-in for the IDE's mirror database."""
+    import sqlite3
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE chat_sessions (session_id TEXT PRIMARY KEY, title TEXT, "
+                 "session_kind TEXT, product_mode TEXT, archived INTEGER, deleted_at TIMESTAMP)")
+    conn.execute("CREATE TABLE chat_session_messages (session_id TEXT, message_id TEXT, "
+                 "payload_json TEXT)")
+    for sid, title in rows:
+        conn.execute("INSERT INTO chat_sessions VALUES (?,?,'standard','coding',0,NULL)",
+                     (sid, title))
+        conn.execute("INSERT INTO chat_session_messages VALUES (?,?,?)",
+                     (sid, "m1", json.dumps({"role": "assistant", "durationMs": 1234})))
+    conn.commit()
+    conn.close()
+
+
+def test_ide_database_supplies_the_session_title(tmp_path, monkeypatch):
+    """The IDE mirrors the same sessions and is the only source of a real
+    title; the JSONL has nothing but the first prompt."""
+    root = tmp_path / ".qoder"
+    projects = root / "projects"
+    projects.mkdir(parents=True)
+    ide = tmp_path / "ide"
+    monkeypatch.setattr(main, "QODER_DIR", root)
+    monkeypatch.setattr(main, "QODER_PROJECTS_DIR", projects)
+    monkeypatch.setattr(main, "QODER_IDE_DIR", ide)
+
+    _write_session(projects, "-Users-dev-repo", "SID", [
+        _user("a very long rambling first prompt nobody would pick as a title"),
+        _assistant(1.0)])
+    _write_ide_db(ide / "main.sqlite", [("SID", "Fix the flaky test")])
+
+    (sess,) = main._scan_qoder_sessions()
+    assert sess["display"] == "Fix the flaky test"
+    assert sess["qoder"]["duration_ms"] == 1234
+    assert sess["qoder"]["turn_count"] == 1
+    assert sess["qoder"]["session_kind"] == "standard"
+
+
+def test_ide_database_never_adds_sessions_of_its_own(tmp_path, monkeypatch):
+    """The DB is a projection of the same sessions. A row with no transcript
+    must not become a session, or every session would be counted twice the
+    day Qoder changes how it writes them."""
+    root = tmp_path / ".qoder"
+    projects = root / "projects"
+    projects.mkdir(parents=True)
+    ide = tmp_path / "ide"
+    monkeypatch.setattr(main, "QODER_DIR", root)
+    monkeypatch.setattr(main, "QODER_PROJECTS_DIR", projects)
+    monkeypatch.setattr(main, "QODER_IDE_DIR", ide)
+
+    _write_session(projects, "-Users-dev-repo", "SID", [_assistant(1.0)])
+    _write_ide_db(ide / "main.sqlite",
+                  [("SID", "Real one"), ("GHOST", "No transcript")])
+
+    sessions = main._scan_qoder_sessions()
+    assert [s["id"] for s in sessions] == ["SID"]
+
+
 def test_long_first_prompt_is_truncated_for_the_title(qoder):
     """Qoder titles a thread with the user's whole first message."""
     _write_session(qoder, "-Users-dev-repo", "SID", [

--- a/docs/adr/0004-qoder-credits-as-native-unit.md
+++ b/docs/adr/0004-qoder-credits-as-native-unit.md
@@ -1,0 +1,80 @@
+# ADR-0004: Report Qoder spend in credits, and its token counts as zero
+
+- **Status:** Accepted
+- **Date:** 2026-08-30
+- **Deciders:** maintainer
+- **Related:** [Qoder survey](../research/harness-survey/harness-qoder.md)
+
+## Context
+
+Qoder (Alibaba) is the first supported agent that records no token counts at
+all. Every assistant turn writes a `usage` object in Anthropic's shape whose
+`input_tokens`, `output_tokens`, `cache_read_input_tokens` and
+`cache_creation_input_tokens` are all `0`, and puts the real figure in
+`credits`. This held across all 22 assistant turns on the surveyed install, in
+the CLI transcripts and in the IDE's own context snapshot alike.
+
+The counts cannot be reconstructed. `context_usage_ratio` is a fraction of an
+unknown denominator — `runtime-config.contextWindow` is `null` and the IDE's
+`chat_session_context_usage` reports `maxTokens: 0`. Model ids are internal
+(`qmodel_38max`, `qfmodel`) and the catalogue that would resolve them is
+encrypted at rest, so there is no model to price against even if counts existed,
+and no published credit-to-currency rate on disk.
+
+Every number TokenTelemetry shows is denominated in tokens or dollars. A new
+agent that has neither lands in surfaces that all assume they exist: the KPI
+strip, agent and model distribution, the session list, the trace header,
+analytics, and the billing and retention tables.
+
+The precedent that matters is DeepSeek Harness. Its sessions once counted zero
+because an optional codec was missing, and the zero looked exactly like a
+correctly-scanned empty agent. The lesson was not "avoid zeros" — it was that a
+zero with no explanation attached to it is indistinguishable from a bug.
+
+## Decision
+
+We will treat credits as Qoder's native billing unit and report its token counts
+as an honest zero, with the reason attached wherever the zero appears.
+
+Concretely: `tokens.total` is `0` and `cost` is `0.0`; `billing_mode` for qoder
+is `subscription`, under which a `$0.00` API-equivalent cost is the correct
+reading rather than a missing value (the same reading Hermes already ships);
+credits ride in the per-session `qoder` blob and drive a meter on the agent's
+panel; and the panel carries three `not_available` entries naming what is not
+derivable and why — tokens, model identity, and encrypted session state.
+
+Delegated spend is reported as `delegated_credits` with `tokens_recorded:
+False`, because subagent spend is real but is not denominated in tokens.
+
+## Alternatives considered
+
+- **Derive pseudo-tokens from `context_usage_ratio`** — impossible, not merely
+  inadvisable: the denominator is `null`/`0` in both stores. Anything produced
+  this way would be invented.
+- **Convert credits to dollars with a hardcoded rate** — Qoder publishes no rate
+  locally, and a guessed one would flow into budgets, analytics and the cost
+  KPI as though it were measured.
+- **A user-configurable credit-to-dollar rate** — a real option and not
+  rejected on merit, but it is a separate feature touching billing settings and
+  every cost aggregate. Deferred rather than bundled into the integration.
+- **Omit Qoder from cost surfaces entirely** — hiding an agent from analytics is
+  worse than a zero that explains itself, and it would make Qoder's spend
+  invisible rather than merely un-priced.
+
+## Consequences
+
+- ✅ Nothing is fabricated. Every figure shown for Qoder is one Qoder wrote.
+- ✅ Credits, including the ~49% that goes to subagents, are visible — a
+  parent-only view would halve the apparent cost of a session.
+- ✅ The pattern generalises: a second credit-metered agent needs the same three
+  pieces (native unit in the blob, `subscription` billing mode, an
+  `not_available` entry), not new machinery.
+- ⚠️ Qoder contributes `0` to fleet-wide token totals and dollar costs, so
+  cross-agent comparisons understate it. This is accurate but easy to
+  misread at a glance, which is why the reason travels with the number.
+- ⚠️ Credits are not comparable to any other agent's unit, so Qoder cannot be
+  ranked against Claude Code or Codex on cost.
+- 🔁 Undoing this means either Qoder starts recording tokens, or we accept a
+  user-supplied credit rate — at which point `billing_mode` moves off
+  `subscription` and the `tokens` `not_available` entry is rewritten rather
+  than removed.

--- a/docs/research/harness-survey/harness-qoder.md
+++ b/docs/research/harness-survey/harness-qoder.md
@@ -111,9 +111,16 @@ What the DB adds that the JSONL lacks:
 - `session_kind` ∈ {`standard`, `sideChat`, `automationExecution`} and
   `product_mode` ∈ {`coding`, `general`}
 
-Both surveyed rows are `standard`; whether `sideChat` and `automationExecution`
-also reach the JSONL is untested here, so a scanner should union and dedupe by
-`session_id` rather than assume the JSONL is complete.
+Both surveyed rows are `standard`, and the two `chat_sessions.session_id`
+values are exactly the two transcript ids — no IDE-only session exists on this
+install.
+
+**Known limitation.** TokenTelemetry therefore takes sessions from the JSONL
+alone and uses the DB only for titles. If `sideChat` or `automationExecution`
+sessions turn out not to write a transcript, they would be invisible. That
+cannot be observed here, so the union-and-dedupe that would cover it is
+deliberately not built rather than written against a shape nobody has seen.
+Re-check this the first time a Qoder side chat or scheduled automation runs.
 
 ### `main.sqlite` tables worth knowing about
 

--- a/docs/research/harness-survey/harness-qoder.md
+++ b/docs/research/harness-survey/harness-qoder.md
@@ -1,0 +1,214 @@
+# Qoder — filesystem survey
+
+Scope: `~/.qoder` and `~/Library/Application Support/com.qoder.app.stable`, on a
+fresh install with two sessions. Paths are written with a `/Users/dev/`
+placeholder; the real account name never appears here.
+
+Credential and account files are reported as existing only — never opened.
+
+Qoder is Alibaba's AI coding IDE. Two surfaces ship together: a CLI harness and
+an Electron app. They are **not** two data sets — see "One set of sessions".
+
+---
+
+## What this harness is
+
+`~/.qoder` is laid out exactly like `~/.claude`: `projects/<slugged-cwd>/<uuid>.jsonl`,
+`shell-snapshots/snapshot-zsh-<ms>-<rand>.sh`, per-session `state.json` and
+`subagents/`. Records carry `cwd`, `gitBranch`, `isSidechain`, `parentUuid`,
+`sessionId`, `version`, `userType` and `entrypoint` — Claude Code's schema
+verbatim. Qoder's CLI is a Claude Code derivative.
+
+Versions on the surveyed install: CLI `1.1.31`, app `0.1.2`.
+
+### Directory map
+
+```
+~/.qoder/                        20 MB
+├── projects/                    696 KB  — the sessions
+│   └── -Users-dev-Documents-Qoder-2026-08-30-<short>/
+│       ├── <session-uuid>.jsonl          # the transcript
+│       ├── <session-uuid>/
+│       │   ├── state.json                # ENCRYPTED (see below)
+│       │   ├── compression-v2/state.json # compaction state, encrypted
+│       │   └── subagents/
+│       │       ├── agent-a<type>-<hash>.jsonl       # child transcript
+│       │       └── agent-a<type>-<hash>.meta.json   # {agentType, toolUseId,
+│       │                                            #  description, invocationName}
+│       └── memory/                       # empty on this install
+├── plugins/                     10 MB   — installed_plugins_v2.json + cache/ + data/
+├── bin/                        6.5 MB   — bundled qoder-computer-use — SKIP, runtime
+├── logs/                       1.2 MB   — runs/, sessions/, qoder-context.log
+├── .models/                    112 KB   — default (plaintext), catalog-v6 (ENCRYPTED)
+├── shell-snapshots/                     — same shape as Claude Code's
+├── .cache/                              — dns-cache.json, endpoint-cache.json
+├── entry/qoder                          — launcher script; reads only HOME
+├── settings.json                        — {"enabledPlugins": {...}}
+├── installation_id
+├── .auth/                               — NEVER READ
+└── .qoder-app-status.json               — NEVER READ (see Secrets)
+
+~/Library/Application Support/com.qoder.app.stable/   40 MB
+├── main.sqlite (+ -wal, -shm)   1.9 MB + 4.4 MB WAL
+├── memoryMigration.sqlite, sessionMigration.sqlite
+├── qoder-data.v1.json
+├── auth.v1.dat, auth.machine-id, Cookies   — NEVER READ
+└── Cache/, GPUCache/, blob_storage/, …     — Electron runtime
+```
+
+---
+
+## The finding that matters: no token counts, credits instead
+
+Every assistant record carries a `usage` object in Anthropic's shape, and every
+token counter in it is **zero**:
+
+```json
+{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,
+ "cache_creation_input_tokens":0,
+ "server_tool_use":{"web_search_requests":0,"web_fetch_requests":0},
+ "service_tier":"standard","inference_geo":"","iterations":[],"speed":"standard",
+ "credits":1.5205821428571429,"original_credits":3.0411642857142858,
+ "billable":true,"request_id":"<uuid>","context_usage_ratio":0.026787}
+```
+
+This held for all 22 assistant turns across every session and subagent
+transcript on this install. `credits` is the only spend Qoder records.
+`original_credits` is consistently 2× `credits`, which looks like a list price
+against a charged price, though nothing on disk states the relationship.
+
+**Tokens cannot be reconstructed.** `context_usage_ratio` is a fraction of an
+unknown denominator: `runtime-config.contextWindow` is `null`, and the IDE's
+`chat_session_context_usage` snapshot reports `"totalTokens":0,"maxTokens":0`
+alongside a non-zero `percentage`. There is no local number to scale by.
+
+Measured spend on this install:
+
+| | credits |
+|---|---|
+| Root sessions (2) | 6.5609 |
+| Subagent transcripts (2) | 6.3803 |
+| Total | 12.9412 |
+
+Delegation is 49% of spend — worth surfacing, because a parent-only view halves
+the apparent cost of a Qoder session.
+
+---
+
+## One set of sessions, two surfaces
+
+`main.sqlite` looks like a second session store and is not. Its
+`chat_session_messages.source` is `sdk-projection`, its message ids are the CLI
+transcript's own uuids (`13bd5674-…` appears in both), and its two
+`chat_sessions.session_id` values are the two CLI session uuids. Scanning both
+would double-count every session.
+
+What the DB adds that the JSONL lacks:
+
+- `chat_sessions.title` — a real title ("better-harness specialty vs claude")
+  where the JSONL has only the first prompt
+- `durationMs` / `turnCount` per assistant message
+- `session_kind` ∈ {`standard`, `sideChat`, `automationExecution`} and
+  `product_mode` ∈ {`coding`, `general`}
+
+Both surveyed rows are `standard`; whether `sideChat` and `automationExecution`
+also reach the JSONL is untested here, so a scanner should union and dedupe by
+`session_id` rather than assume the JSONL is complete.
+
+### `main.sqlite` tables worth knowing about
+
+`chat_sessions`, `chat_session_messages`, `chat_session_context_usage`,
+`chat_session_recaps`, `chat_session_highlights`, `chat_session_search_fts*`,
+`turn_file_change_{sets,files,operations,patches}`, `scheduled_tasks` +
+`scheduled_task_settings` + `scheduled_task_run_logs`, `managed_worktrees` +
+`managed_worktree_sessions`, `mcp_connection_profiles`, `byok_model_profiles`,
+`plugin_inventory_*`, `marketplace_*`, `workspaces`, `remote_ssh_hosts`,
+`account_profiles`.
+
+On this install `workspaces`, `scheduled_tasks` and `turn_file_change_sets` are
+all empty — real schemas with nothing in them yet, which is a distinct state
+from "not supported".
+
+---
+
+## Encrypted at rest (opaque, not missing)
+
+- **`.models/<uid>/catalog-v6`** — base64 ciphertext. So the model ids in
+  transcripts (`qmodel_38max`, `qfmodel`) cannot be mapped to real model names
+  offline, and there is no published price list to cost them against.
+- **`projects/*/<uuid>/state.json`** — each item is `{c, u, n, p, t}` where `p`
+  is a ciphertext payload and `t` an auth tag. Resumable context, todos and
+  compaction state are unreadable.
+
+---
+
+## Record types in the transcript
+
+Beyond Claude Code's `user` / `assistant`:
+
+| Type | Contents |
+|---|---|
+| `workspace-directories` | `directories[]` — line 1 of every file, the reliable project source |
+| `runtime-config` | `model`, `reasoningEffort`, `contextWindow` (null), `timestamp` in **epoch ms** |
+| `last-prompt` | `lastPrompt` — the most recent user prompt |
+| `active-leaf` | `leafUuid`, `explicit` — conversation-tree pointer |
+| `attachment` | harness-injected context, four kinds (below) |
+
+`user` records are three different things: a human turn (`origin.kind ==
+"human"`, with a parallel `humanInput.text`), a tool result (content is
+`tool_result` blocks, no origin), or a harness injection. Only the first two
+belong in a trace.
+
+### Attachment kinds observed
+
+| `attachment.type` | Payload | Note |
+|---|---|---|
+| `skill_listing` | `names[]`, `skillCount`, `content` (~2.5 KB) | the injected skill catalogue — availability, not usage |
+| `critical_system_reminder` | `serverNames[]`, `content` (~1.7 KB) | MCP servers offered to the session |
+| `agent_listing_delta` | `addedTypes`, `addedLines`, `removedTypes` | subagent roster changes |
+| `hook_output` | `hookEventName`, `output` | hook results |
+
+None is a user turn. None carried a file body on this install, but an
+attachment type that does is plausible, so a consumer should allowlist known
+kinds rather than denylist these four.
+
+### The injected prompt prefix
+
+The first human prompt begins with a `<system-reminder>…</system-reminder>`
+block naming the enabled plugins, in **both** `message.content[0].text` and
+`humanInput.text`. Rendered verbatim it reads as if the user typed the
+harness's instructions.
+
+---
+
+## The directory slug is not reversible
+
+`-Users-dev-Documents-Qoder-2026-08-30-d5db2e1b` came from
+`/Users/dev/Documents/Qoder/2026-08-30/d5db2e1b`. Slashes became dashes and the
+dashes already in the path were left alone, so the slug has several valid
+readings. Use `cwd` from the records, or `workspace-directories.directories[0]`.
+
+---
+
+## Secrets — existence only, never read
+
+- `~/.qoder/.auth/**`
+- `~/Library/Application Support/com.qoder.app.stable/auth.v1.dat`,
+  `auth.machine-id`, `Cookies`
+- `main.sqlite` tables `byok_model_credentials`, `mcp_oauth_credentials`
+
+**`~/.qoder/.qoder-app-status.json` holds the account holder's real name and
+email address in plaintext.** It is not read at all — not for a version string,
+not for anything. `installation_id` and `.models/default`'s `uid` are stable
+account-scoped identifiers and are equally out of bounds.
+
+`main.sqlite` must be opened read-only; the app holds a 4.4 MB WAL while running.
+
+---
+
+## No relocation env var
+
+`~/.qoder/entry/qoder` references only `HOME`, `PATH`, `LC_ALL` and
+`VSCODE_IPC_HOOK_CLI`. There is no `QODER_HOME` upstream, so the root is fixed
+at `~/.qoder`. TokenTelemetry still honours `QODER_HOME` / `QODER_IDE_HOME` so
+tests can point the scan at a fixture tree.

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -47,6 +47,7 @@
   --agent-muse:        #2563eb;
   --agent-prime:       #D4FF47;
   --agent-dsh:         #4D6BFE;
+  --agent-qoder:       #e4e4e7;
 
   /* Radii + shadow */
   --tt-radius-sm: 6px;

--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -592,8 +592,9 @@ export default function SessionDetailPage() {
       // 5. Delegation overlay: subagent spawns + delegated token/cost attribution.
       // Only agents whose logs record spawns at all (claude full, cursor count-only,
       // grok/codex/antigravity/opencode/hermes parent-child links, dsh full via
-      // its children's own session logs).
-      if (["claude", "cursor", "opencode", "hermes", "grok", "codex", "antigravity", "dsh"].includes(agent)) {
+      // its children's own session logs, qoder full but in credits — it records
+      // no token counts at all).
+      if (["claude", "cursor", "opencode", "hermes", "grok", "codex", "antigravity", "dsh", "qoder"].includes(agent)) {
         apiFetch(`/sessions/${id}/delegation?agent=${agent}`)
           .then(res => res.json())
           .then(data => setDelegation(data && data.supported ? data : null))

--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -74,6 +74,15 @@ interface Session {
    *  session, read back from its own log. DSH loads skills/plugins dynamically,
    *  so this legitimately differs between sessions in the same workspace and
    *  must never be substituted with a scan of what is installed on disk. */
+  /** Qoder records no token counts — every usage block it writes has zeroed
+   *  counters — and bills in credits instead. The trace header shows these
+   *  rather than a row of zeros that reads like a failed scan. */
+  qoder?: {
+    credits?: number;
+    delegated_credits?: number;
+    total_credits?: number;
+    cli_version?: string;
+  };
   dsh?: {
     agent_preset?: string;
     /** Presets the session ran under, in order; >1 means it hot-swapped. */
@@ -1104,7 +1113,35 @@ export default function SessionDetailPage() {
               </div>
               {sessionInfo?.tokens && (
                 <div className="hidden lg:flex items-center gap-3 bg-[var(--tt-sunken)] px-3 h-9 rounded-[var(--tt-radius)] border border-[var(--tt-border)]">
-                  {agent === "grok" && sessionInfo.tokens.source !== "usage" ? (
+                  {agent === "qoder" ? (
+                    // Qoder writes a usage block with every token counter at
+                    // zero and bills in credits. Showing Input/Output/Cached
+                    // as 0 would read as a failed scan, which is exactly how
+                    // DSH's missing codec was misread — so show what Qoder
+                    // actually recorded, and say why the tokens are absent.
+                    <div
+                      className="flex items-center gap-3"
+                      title="Qoder records no token counts — its usage block reports zeros and it bills in credits instead. The $0.00 is a real subscription figure, not a missing value."
+                    >
+                      <TokenStat
+                        label="Credits"
+                        value={(sessionInfo.qoder?.credits ?? 0).toFixed(2)}
+                        accent="text-[var(--tt-brand)]"
+                      />
+                      {!!sessionInfo.qoder?.delegated_credits && (
+                        <>
+                          <span className="w-px h-5 bg-[var(--tt-border)]" />
+                          <TokenStat
+                            label="Delegated"
+                            value={`+${sessionInfo.qoder.delegated_credits.toFixed(2)}`}
+                            accent="text-[var(--tt-violet-fg)]"
+                          />
+                        </>
+                      )}
+                      <span className="w-px h-5 bg-[var(--tt-border)]" />
+                      <TokenStat label="Tokens" value="not recorded" />
+                    </div>
+                  ) : agent === "grok" && sessionInfo.tokens.source !== "usage" ? (
                     // Session files only record a context-window footprint.
                     // When unified.jsonl has billed usage, source === "usage"
                     // and we fall through to the Input/Output/Cached row.

--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -82,6 +82,11 @@ interface Session {
     delegated_credits?: number;
     total_credits?: number;
     cli_version?: string;
+    /** Skills and MCP servers THIS run was offered, read from the session's
+     *  own log. Many are plugin-scoped (better-harness, qoder-qmind), so the
+     *  generic /config list describes a different agent entirely. */
+    skills_available?: string[];
+    mcp_servers?: string[];
   };
   dsh?: {
     agent_preset?: string;
@@ -808,6 +813,9 @@ export default function SessionDetailPage() {
       projectConfig,
       // DSH's runtime-resolved capability set for THIS session (see backend).
       dsh: agent === "dsh" ? sessionInfo?.dsh : undefined,
+      // Same for Qoder: its session log records the skills and MCP servers the
+      // run was actually offered.
+      qoder: agent === "qoder" ? sessionInfo?.qoder : undefined,
     };
   }, [agent, events, rawEvents, sessionInfo, modelsUsed, projectConfig, id]);
 
@@ -818,7 +826,12 @@ export default function SessionDetailPage() {
   // (surfaced as sessionInfo.dsh), so rendering Claude's list there would
   // assert capabilities the run never had.
   useEffect(() => {
-    if (agent === "dsh") return;
+    // Qoder is the same case as DSH: it resolves skills and MCP servers at run
+    // time (many of them plugin-scoped, e.g. better-harness, qoder-qmind) and
+    // records the live set in its own session log. /config would have shown
+    // this project 48 skills that are all user-scoped Claude/Gemini/Qwen ones
+    // and none of Qoder's — capabilities the run never had.
+    if (agent === "dsh" || agent === "qoder") return;
     const cwd = events.find((e) => e.type === "session_meta")?.payload?.cwd || sessionInfo?.project;
     if (!cwd) return;
     apiFetch(`/config?project=${encodeURIComponent(cwd)}`)
@@ -1960,6 +1973,55 @@ function ContextPanel({ ctx }: { ctx: TraceValue }) {
                     <span className="text-[var(--tt-fg)] truncate" title={m.command || m.url || ""}>{m.name}</span>
                     <span className={`px-1.5 py-0.5 rounded text-[8px] font-black uppercase ${m.scope === "project" ? "bg-blue-500/10 text-[var(--tt-brand)] border border-blue-500/20" : "tt-tint-2 text-[var(--tt-fg-muted)] border border-[var(--tt-border-strong)]"}`}>{m.agent}</span>
                   </div>
+                ))}
+              </div>
+            </details>
+          )}
+        </div>
+      )}
+
+      {ctx.qoder && ((ctx.qoder.skills_available?.length ?? 0) > 0 || (ctx.qoder.mcp_servers?.length ?? 0) > 0) && (
+        <div className="space-y-3 pt-2 border-t border-[var(--tt-border)]">
+          <div className="flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--tt-fg-muted)]">
+            <Settings2 size={12} /> Runtime Capabilities
+          </div>
+          <div className="text-[9px] text-[var(--tt-fg-dim)] leading-relaxed">
+            What Qoder offered this run, from its own session log — not a scan of
+            what is installed now. Plugin-scoped entries carry their plugin prefix.
+          </div>
+          {(ctx.qoder.skills_available?.length ?? 0) > 0 && (
+            <details open>
+              <summary className="text-[9px] font-semibold uppercase tracking-[0.16em] text-[var(--tt-fg-dim)] cursor-pointer hover:text-[var(--tt-fg)]">
+                Skills ({ctx.qoder.skills_available.length}) ▸
+              </summary>
+              <div className="mt-2 flex flex-wrap gap-1.5">
+                {ctx.qoder.skills_available.map((s: string) => {
+                  const plugin = s.includes(":") ? s.split(":")[0] : null;
+                  return (
+                    <span
+                      key={s}
+                      title={plugin ? `provided by the ${plugin} plugin` : "user-level skill"}
+                      className={`text-[10px] font-mono px-2 py-0.5 rounded border ${plugin
+                        ? "bg-cyan-500/10 text-[var(--tt-cyan-fg)] border-cyan-500/20"
+                        : "tt-tint-2 text-[var(--tt-fg-muted)] border-[var(--tt-border-strong)]"}`}
+                    >
+                      {s}
+                    </span>
+                  );
+                })}
+              </div>
+            </details>
+          )}
+          {(ctx.qoder.mcp_servers?.length ?? 0) > 0 && (
+            <details open>
+              <summary className="text-[9px] font-semibold uppercase tracking-[0.16em] text-[var(--tt-fg-dim)] cursor-pointer hover:text-[var(--tt-fg)]">
+                MCP Servers ({ctx.qoder.mcp_servers.length}) ▸
+              </summary>
+              <div className="mt-2 flex flex-wrap gap-1.5">
+                {ctx.qoder.mcp_servers.map((m: string) => (
+                  <span key={m} className="text-[10px] font-mono px-2 py-0.5 rounded border tt-tint-2 text-[var(--tt-fg-muted)] border-[var(--tt-border-strong)]">
+                    {m}
+                  </span>
                 ))}
               </div>
             </details>

--- a/frontend/src/components/icons/AgentLogo.tsx
+++ b/frontend/src/components/icons/AgentLogo.tsx
@@ -1,7 +1,7 @@
 import type { SVGProps } from "react";
 import {
   Antigravity, ClaudeCode, Cline, Codex, Copilot, Cursor, GeminiCLI, Grok,
-  HermesAgent, OpenCode, Qwen,
+  HermesAgent, OpenCode, Qoder, Qwen,
 } from "@lobehub/icons";
 import { getAgent, type AgentKey } from "@/lib/agents";
 
@@ -37,6 +37,7 @@ export function AgentLogo({ agent, size = 16, decorative = true, className }: Lo
     case "hermes": return <HermesAgent {...props} />;
     case "grok": return <Grok {...props} />;
     case "cline": return <Cline {...props} />;
+    case "qoder": return <Qoder {...props} />;
     default: {
       const Fallback = meta.icon;
       return <Fallback {...props} color={meta.hex} />;

--- a/frontend/src/lib/agents.ts
+++ b/frontend/src/lib/agents.ts
@@ -12,7 +12,8 @@ import DshIcon from "@/components/icons/DshIcon";
 export type AgentKey =
   | "claude" | "codex" | "gemini" | "antigravity"
   | "qwen" | "vibe" | "cursor" | "copilot" | "opencode" | "hermes" | "grok"
-  | "openai_compat" | "cline" | "smallcode" | "pi" | "muse" | "prime" | "dsh";
+  | "openai_compat" | "cline" | "smallcode" | "pi" | "muse" | "prime" | "dsh"
+  | "qoder";
 
 export interface AgentMeta {
   key: AgentKey;
@@ -41,6 +42,9 @@ export const AGENTS: Record<AgentKey, AgentMeta> = {
   muse:        { key: "muse",        label: "Muse Code",   hex: "#2563eb", icon: MuseIcon },
   prime:       { key: "prime",       label: "Prime Agent", hex: "#D4FF47", icon: PrimeIcon },
   dsh:         { key: "dsh",         label: "DeepSeek Harness", hex: "#4D6BFE", icon: DshIcon },
+  // Qoder's mark is white-on-black, so the tint follows the other monochrome
+  // brands (grok, pi) rather than inventing a colour it doesn't use.
+  qoder:       { key: "qoder",       label: "Qoder",       hex: "#e4e4e7", icon: Boxes },
 };
 
 const FALLBACK: AgentMeta = {

--- a/llms.txt
+++ b/llms.txt
@@ -4,7 +4,7 @@
 
 ## What is TokenTelemetry?
 
-TokenTelemetry is a free, open-source observability dashboard that automatically tracks token usage, LLM costs, tool calls, session traces, reasoning steps, subagent delegations, scheduled-job (cron) health, and gateway health across AI coding agents AND autonomous agents — Claude Code, Gemini CLI, OpenAI Codex, Cursor, GitHub Copilot, Qwen, OpenCode, Vibe, Antigravity, Grok Build, Cline, SmallCode, Pi, Meta Muse Code, Prime Agent, DeepSeek Harness, and Nous Research's Hermes Agent.
+TokenTelemetry is a free, open-source observability dashboard that automatically tracks token usage, LLM costs, tool calls, session traces, reasoning steps, subagent delegations, scheduled-job (cron) health, and gateway health across AI coding agents AND autonomous agents — Claude Code, Gemini CLI, OpenAI Codex, Cursor, GitHub Copilot, Qwen, OpenCode, Vibe, Antigravity, Grok Build, Cline, SmallCode, Pi, Meta Muse Code, Prime Agent, DeepSeek Harness, Qoder, and Nous Research's Hermes Agent.
 
 It reads session logs and SQLite state directly from the filesystem (no SDK, no instrumentation) and presents them in a unified local web dashboard at http://localhost:3000.
 
@@ -40,6 +40,7 @@ It reads session logs and SQLite state directly from the filesystem (no SDK, no 
 - Meta Muse Code
 - Prime Agent
 - DeepSeek Harness (DeepSeek AI)
+- Qoder (Alibaba)
 
 ### Autonomous agents (1)
 
@@ -62,7 +63,7 @@ Hermes Agent is structurally different from coding agents — it runs across CLI
 
 ## Hermes Dashboard Plugin
 
-TokenTelemetry ships a plugin for Hermes Agent's own web dashboard (port 9119). After a one-command install, a "TokenTelemetry" tab appears inside Hermes Dashboard with deep-link cards that open TT pages (Hermes Overview, Skills, Memory, Analytics, Projects, All Agents) in a new browser tab. Important: the plugin is a launcher, not the engine — TokenTelemetry itself must be installed and running for the launcher to do anything. When TT isn't running, the plugin shows an onboarding card explaining what TokenTelemetry is (a local observability dashboard for Hermes Agent and 16 coding agents) with a copy-paste install command.
+TokenTelemetry ships a plugin for Hermes Agent's own web dashboard (port 9119). After a one-command install, a "TokenTelemetry" tab appears inside Hermes Dashboard with deep-link cards that open TT pages (Hermes Overview, Skills, Memory, Analytics, Projects, All Agents) in a new browser tab. Important: the plugin is a launcher, not the engine — TokenTelemetry itself must be installed and running for the launcher to do anything. When TT isn't running, the plugin shows an onboarding card explaining what TokenTelemetry is (a local observability dashboard for Hermes Agent and 17 coding agents) with a copy-paste install command.
 
 Install (recommended, via Hermes's own plugin manager):
 
@@ -158,7 +159,7 @@ Full docs site: https://tokentelemetry.com/docs
 - [Introduction](https://tokentelemetry.com/docs): What TokenTelemetry is and who it's for.
 - [Installation](https://tokentelemetry.com/docs/installation): One-line curl install, Windows PowerShell script, or clone from source.
 - [Quick Start](https://tokentelemetry.com/docs/quick-start): First launch, agent auto-detection, and opening the dashboard.
-- [Supported Agents](https://tokentelemetry.com/docs/supported-agents): The 16 coding agents and Hermes, how each is detected, and what data each captures.
+- [Supported Agents](https://tokentelemetry.com/docs/supported-agents): The 17 coding agents and Hermes, how each is detected, and what data each captures.
 
 ### Features
 

--- a/website/content/docs/features/dashboard.mdx
+++ b/website/content/docs/features/dashboard.mdx
@@ -55,6 +55,7 @@ Hermes Agent works the same way as the rest, but its page is deliberately narrow
 | **Prime Agent** | The Python variables its kernel keeps alive between turns, and its daemon workers |
 | **Pi** | MCP servers, trusted directories and model configuration |
 | **DeepSeek Harness** | Sandbox profiles, the workspace registry with real titles, and the default model |
+| **Qoder** | Credits spent, and how much of that went to subagents — Qoder records no token counts, so credits are the only spend it reports. Plus its sessions, installed plugins, and what stays encrypted |
 | **SmallCode** | Traces, when `TT_SMALLCODE_ROOTS` points at the repositories holding them |
 | **Hermes Agent** | Its own billing record per provider and model — what Hermes says it was charged, not a price-list estimate — plus the processes it has registered. A button opens the full [Hermes dashboard](/docs/features/hermes). |
 

--- a/website/content/docs/supported-agents.mdx
+++ b/website/content/docs/supported-agents.mdx
@@ -1,6 +1,6 @@
 ---
 title: Supported Agents
-description: The 16 coding agents and Hermes autonomous agent that TokenTelemetry tracks, how each is detected, and what data each captures.
+description: The 17 coding agents and Hermes autonomous agent that TokenTelemetry tracks, how each is detected, and what data each captures.
 ---
 
 TokenTelemetry reads log files from the agents listed below. Detection is automatic — no configuration needed. Just run your agent as normal and TokenTelemetry picks up the sessions.
@@ -25,6 +25,7 @@ TokenTelemetry reads log files from the agents listed below. Detection is automa
 | **Muse Code** | Meta | `${XDG_DATA_HOME:-~/.local/share}/muse/sessions/` | tokens, traces, model, subagents |
 | **Prime Agent** | Prime Intellect | `~/.prime/agent/sessions/` | tokens, traces, reported cost, model, active branch |
 | **DeepSeek Harness** | DeepSeek | `~/.dsh/sessions/` | tokens, traces, cost, model, provider, subagents, skills/tools, latency |
+| **Qoder** | Alibaba | `~/.qoder/projects/` | traces, credits, subagents, model, branch (no token counts — see below) |
 
 ## Autonomous agents
 
@@ -91,6 +92,16 @@ DeepSeek Harness (the `dsh` CLI, npm `@deepseek-ai/dsh`) writes one zstd-compres
 DSH records no cost of its own (its source zeroes the cost metadata deliberately), and it is bring-your-own-key across providers, so TokenTelemetry prices each `(turn, step)` with that step's own provider and model. A session that runs part of its work on a local Ollama model and part on a paid cloud model is priced correctly on both halves, with the local segments falling through to [local-model pricing](/docs/configuration/local-models). Tokens are de-duplicated per step, because DSH emits the same usage sample twice: once on the streaming chunk, once on the final message.
 
 Subagents spawned with the `subagent` and `subagent_fork` tools are linked through DSH's own `parentSession` and `origin` header fields, then folded into the parent with per-child tokens and cost. What a DSH trace shows beyond that (runtime skills and tools, sandbox and approval policy, latency breakdown) is covered in [Traces](/docs/features/traces#deepseek-harness-sessions).
+
+### Qoder
+
+Qoder writes one JSONL transcript per session to `~/.qoder/projects/<slugged-cwd>/<session-id>.jsonl`, in the same record shape Claude Code uses. TokenTelemetry reads it read-only. Child transcripts sit one level deeper in `<session-id>/subagents/`, each with a `.meta.json` naming the agent type and the task it was given; they are folded into the parent as delegation rather than counted as sessions of their own.
+
+**Qoder records no token counts.** Every turn carries a usage block whose input, output and cache counters are all zero, and reports `credits` instead — its own billing unit. So a Qoder session shows 0 tokens and $0.00 API-equivalent cost, and that is what Qoder itself reports, not a failed scan. The credit spend, including how much of it went to subagents, is on the agent's own page. There is no published credit-to-currency rate available locally, so TokenTelemetry does not convert credits to dollars rather than guess a rate.
+
+Two further things stay opaque by design: model ids are internal names such as `qmodel_38max`, and the catalogue that would resolve them (`.models/<uid>/catalog-v6`) is encrypted at rest; and each session's `state.json` is encrypted too, so resumable context and todos cannot be read. Both are listed on the agent page as unavailable, with the reason.
+
+Qoder also keeps an Electron store at `~/Library/Application Support/com.qoder.app.stable`. Its `main.sqlite` is a projection of the same sessions — the message rows are marked `sdk-projection` and reuse the transcript's ids — so TokenTelemetry reads it only for the human-readable session title, never as a second source of sessions. It counts towards the agent's disk footprint, which spans both directories.
 
 ### Hermes Agent
 

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -4,7 +4,7 @@
 
 ## What is TokenTelemetry?
 
-TokenTelemetry is a free, open-source observability dashboard that automatically tracks token usage, LLM costs, tool calls, session traces, reasoning steps, subagent delegations, scheduled-job (cron) health, and gateway health across AI coding agents AND autonomous agents — Claude Code, Gemini CLI, OpenAI Codex, Cursor, GitHub Copilot, Qwen, OpenCode, Vibe, Antigravity, Grok Build, Cline, SmallCode, Pi, Meta Muse Code, Prime Agent, DeepSeek Harness, and Nous Research's Hermes Agent.
+TokenTelemetry is a free, open-source observability dashboard that automatically tracks token usage, LLM costs, tool calls, session traces, reasoning steps, subagent delegations, scheduled-job (cron) health, and gateway health across AI coding agents AND autonomous agents — Claude Code, Gemini CLI, OpenAI Codex, Cursor, GitHub Copilot, Qwen, OpenCode, Vibe, Antigravity, Grok Build, Cline, SmallCode, Pi, Meta Muse Code, Prime Agent, DeepSeek Harness, Qoder, and Nous Research's Hermes Agent.
 
 It reads session logs and SQLite state directly from the filesystem (no SDK, no instrumentation) and presents them in a unified local web dashboard at http://localhost:3000.
 
@@ -40,6 +40,7 @@ It reads session logs and SQLite state directly from the filesystem (no SDK, no 
 - Meta Muse Code
 - Prime Agent
 - DeepSeek Harness (DeepSeek AI)
+- Qoder (Alibaba)
 
 ### Autonomous agents (1)
 
@@ -62,7 +63,7 @@ Hermes Agent is structurally different from coding agents — it runs across CLI
 
 ## Hermes Dashboard Plugin
 
-TokenTelemetry ships a plugin for Hermes Agent's own web dashboard (port 9119). After a one-command install, a "TokenTelemetry" tab appears inside Hermes Dashboard with deep-link cards that open TT pages (Hermes Overview, Skills, Memory, Analytics, Projects, All Agents) in a new browser tab. Important: the plugin is a launcher, not the engine — TokenTelemetry itself must be installed and running for the launcher to do anything. When TT isn't running, the plugin shows an onboarding card explaining what TokenTelemetry is (a local observability dashboard for Hermes Agent and 16 coding agents) with a copy-paste install command.
+TokenTelemetry ships a plugin for Hermes Agent's own web dashboard (port 9119). After a one-command install, a "TokenTelemetry" tab appears inside Hermes Dashboard with deep-link cards that open TT pages (Hermes Overview, Skills, Memory, Analytics, Projects, All Agents) in a new browser tab. Important: the plugin is a launcher, not the engine — TokenTelemetry itself must be installed and running for the launcher to do anything. When TT isn't running, the plugin shows an onboarding card explaining what TokenTelemetry is (a local observability dashboard for Hermes Agent and 17 coding agents) with a copy-paste install command.
 
 Install (recommended, via Hermes's own plugin manager):
 
@@ -158,7 +159,7 @@ Full docs site: https://tokentelemetry.com/docs
 - [Introduction](https://tokentelemetry.com/docs): What TokenTelemetry is and who it's for.
 - [Installation](https://tokentelemetry.com/docs/installation): One-line curl install, Windows PowerShell script, or clone from source.
 - [Quick Start](https://tokentelemetry.com/docs/quick-start): First launch, agent auto-detection, and opening the dashboard.
-- [Supported Agents](https://tokentelemetry.com/docs/supported-agents): The 16 coding agents and Hermes, how each is detected, and what data each captures.
+- [Supported Agents](https://tokentelemetry.com/docs/supported-agents): The 17 coding agents and Hermes, how each is detected, and what data each captures.
 
 ### Features
 

--- a/website/src/app/layout.tsx
+++ b/website/src/app/layout.tsx
@@ -12,7 +12,7 @@ const geistMono = Geist_Mono({ variable: "--font-geist-mono", subsets: ["latin"]
 const SITE_URL = "https://tokentelemetry.com";
 const TITLE = "Token Telemetry — Observability for coding & autonomous agents (DeepSeek Harness, Hermes, Claude Code, Codex …)";
 const DESCRIPTION =
-  "Token Telemetry is local, read-only observability for 16 coding agents (Claude Code, Codex, Gemini CLI, Cursor, Copilot, Qwen, OpenCode, Vibe, Antigravity, Grok Build, Cline, SmallCode, Pi, Muse Code, Prime Agent, DeepSeek Harness) plus Hermes Agent (Nous Research) — with a dedicated dashboard for gateway health, cron jobs, skills, memory, and 38 source platforms. One command, 100% on your machine.";
+  "Token Telemetry is local, read-only observability for 17 coding agents (Claude Code, Codex, Gemini CLI, Cursor, Copilot, Qwen, OpenCode, Vibe, Antigravity, Grok Build, Cline, SmallCode, Pi, Muse Code, Prime Agent, DeepSeek Harness, Qoder) plus Hermes Agent (Nous Research) — with a dedicated dashboard for gateway health, cron jobs, skills, memory, and 38 source platforms. One command, 100% on your machine.";
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),

--- a/website/src/components/AgentIcon.tsx
+++ b/website/src/components/AgentIcon.tsx
@@ -1,7 +1,7 @@
 import type { SVGProps } from "react";
 import {
   Antigravity, ClaudeCode, Cline, Codex, Copilot, Cursor, GeminiCLI, Grok,
-  HermesAgent, OpenCode, Qwen,
+  HermesAgent, OpenCode, Qoder, Qwen,
 } from "@lobehub/icons";
 import { Bot, Boxes, Zap } from "lucide-react";
 
@@ -44,6 +44,7 @@ export default function AgentIcon({ name, size = 16 }: Props) {
     case "Muse Code": return <MuseMark {...props} />;
     case "Prime Agent": return <PrimeMark {...props} />;
     case "DeepSeek Harness": return <DshMark {...props} />;
+    case "Qoder": return <Qoder {...props} />;
     case "Vibe": return <Zap {...props} />;
     case "SmallCode": return <Boxes {...props} />;
     default: return <Bot {...props} />;

--- a/website/src/components/AgentsGrid.tsx
+++ b/website/src/components/AgentsGrid.tsx
@@ -19,7 +19,7 @@ export default function AgentsGrid() {
         <div className="text-center max-w-[680px] mx-auto mb-10">
           <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--tt-fg-dim)] mb-3">Coverage</p>
           <h2 className="text-[clamp(26px,3.6vw,42px)] leading-[1.08] tracking-[-0.025em] font-semibold text-[var(--tt-fg)]">
-            Seventeen agents, <span className="text-[var(--tt-brand)]">one place.</span>
+            Eighteen agents, <span className="text-[var(--tt-brand)]">one place.</span>
           </h2>
           <p className="mt-3.5 text-[15.5px] text-[var(--tt-fg-muted)] leading-relaxed">
             Tap any agent to see what TokenTelemetry captures and where it reads from.

--- a/website/src/components/Hero.tsx
+++ b/website/src/components/Hero.tsx
@@ -45,7 +45,7 @@ export default function Hero() {
                 </span>
                 100% local
               </span>
-              {["MIT open source", "17 agents", "No signup"].map((c) => (
+              {["MIT open source", "18 agents", "No signup"].map((c) => (
                 <span key={c} className="inline-flex items-center h-7 px-2.5 rounded-full text-[11.5px] font-medium text-[var(--tt-fg-muted)] bg-[var(--tt-panel)] border border-[var(--tt-border)]">
                   {c}
                 </span>

--- a/website/src/components/HowItWorks.tsx
+++ b/website/src/components/HowItWorks.tsx
@@ -9,7 +9,7 @@ const STEPS = [
     n: "2",
     title: "It finds your agents",
     body: "Scans the log files Claude Code, Codex, Cursor & co. already write to your disk. Read-only. Nothing is sent anywhere.",
-    code: <><span className="text-[var(--tt-success-fg,#10b981)]">✓</span> detected 17 agents · 510 sessions</>,
+    code: <><span className="text-[var(--tt-success-fg,#10b981)]">✓</span> detected 18 agents · 510 sessions</>,
   },
   {
     n: "3",

--- a/website/src/data/agents.ts
+++ b/website/src/data/agents.ts
@@ -24,5 +24,6 @@ export const AGENTS: Agent[] = [
   { name: "Muse Code",      vendor: "Meta",      captures: ["tokens", "traces", "model", "subagents"],             logPath: "${XDG_DATA_HOME:-~/.local/share}/muse/sessions/", hex: "#2563eb" },
   { name: "Prime Agent",    vendor: "Prime Intellect", captures: ["tokens", "traces", "cost", "model", "branches"], logPath: "~/.prime/agent/sessions/",          hex: "#D4FF47" },
   { name: "DeepSeek Harness", vendor: "DeepSeek AI", captures: ["tokens", "traces", "cost", "model", "provider"], logPath: "~/.dsh/sessions/",                  hex: "#4D6BFE" },
+  { name: "Qoder",          vendor: "Alibaba",   captures: ["traces", "credits", "subagents", "model"],            logPath: "~/.qoder/projects/",              hex: "#e4e4e7" },
   { name: "Hermes Agent",   vendor: "Nous Research", captures: ["tokens", "traces", "cost", "subagents", "skills", "memory", "cron", "38 sources"], logPath: "~/.hermes/",                      hex: "#eab308" },
 ];


### PR DESCRIPTION
Adds Qoder (Alibaba) as a supported coding agent — sessions, traces, delegation and a harness panel. Requested in #282.

## What Qoder turned out to be

Its CLI is a Claude Code derivative. Same JSONL record shape (`cwd`, `gitBranch`, `isSidechain`, `parentUuid`, `version`) under `~/.qoder/projects/<slugged-cwd>/<uuid>.jsonl`, plus five record types of its own. So `_qoder_trace_events` filters the existing Claude-shaped parser rather than converting a new format.

**It records no token counts.** Every assistant turn carries a `usage` object in Anthropic's shape whose `input_tokens`, `output_tokens` and both cache counters are `0`, with the real figure in `credits`. That held for all 22 assistant turns on the install this was built against.

The counts can't be reconstructed either: `context_usage_ratio` is a fraction of an unknown denominator (`runtime-config.contextWindow` is `null`, the IDE's `maxTokens` is `0`), and `.models/<uid>/catalog-v6` is encrypted at rest, so even the model id stays opaque (`qmodel_38max`, `qfmodel`).

So Qoder reports 0 tokens and $0.00 under `billing_mode: subscription`, where that is the correct reading rather than a missing value, and the credits it actually spent drive a meter on its panel and the trace header. Three `not_available` entries say why the zeros are there — a bare zero is indistinguishable from a failed scan, which is exactly how DSH's missing codec read. ADR-0004 records the decision and the rejected alternatives, including a hardcoded credit-to-dollar rate.

## Two traps that would have produced wrong numbers

**Root sessions are globbed one level only.** A recursive walk returns every subagent transcript as a session of its own, turning two sessions into four. Same class of bug as the workflow count that was really counting subagent sidecars.

**The directory slug is not reversible.** Qoder replaces `/` with `-` without escaping dashes already in the path, so `-Users-dev-Documents-Qoder-2026-08-30-abc` has several valid readings. The project comes from the records' own `cwd`.

## One set of sessions, two surfaces

Qoder also keeps an Electron store in Application Support. Its `main.sqlite` looks like a second session store and isn't: message rows are marked `source = "sdk-projection"` and reuse the transcript uuids, and its `session_id`s are the transcript ids. Scanning both would double-count everything. It's read only for the human-readable session title, and counted towards the disk footprint (20 MB CLI + 40 MB IDE).

**Known limitation, stated rather than papered over:** `chat_sessions.session_kind` also admits `sideChat` and `automationExecution`. Every observed row is `standard` with a matching transcript, so there's no evidence either kind skips the JSONL — but if one does, it would be invisible. Unioning on `session_id` would cover it; that isn't built against a shape nobody has seen. Recorded in the code and the survey doc with the trigger to revisit.

## Read-only, and no credentials

`~/.qoder/.auth`, `auth.v1.dat`, `auth.machine-id` and the IDE's `byok_model_credentials` / `mcp_oauth_credentials` are existence-only, never opened. `.qoder-app-status.json` — which holds the account holder's name and email in plaintext — is not read at all, not even for a version string. SQLite opens read-only; the IDE holds a multi-megabyte WAL while running.

Attachment records are mapped by **allowlist**, not denylist: the four observed kinds are harness-injected context (skill catalogues, system reminders, hook output), and an unrecognised kind may carry file bodies, so it's dropped rather than passed to the renderer.

## Verified, not assumed

Per the repo's verify-before-done rule, every number was recomputed a second way.

| Claim | Independent check | Result |
| --- | --- | --- |
| Session count | 4 transcripts on disk decompose to 2 root + 2 subagent | `/sessions` returns the 2 parents |
| Root credits | scanner vs HTTP vs a separate `jq` path | 6.5609, three ways |
| Delegated credits | same | 6.3803 (49% of spend) |
| Regressions | full backend suite vs a pristine `git archive` of `origin/main` | failure sets byte-identical (22 pre-existing, none in qoder) |

Also checked the surfaces that took a new agent key but were never opened: `/config/billing` reports `subscription`, `/config/retention` reports non-configurable and non-archivable, and `/analytics` buckets a zero-token agent without dividing by zero.

## Three bugs this caught before merge

- **Subagent transcripts carry the parent's `sessionId`**, so keying children by it collided both under one React key and made them indistinguishable. They're keyed by their own filename now.
- **The trace showed `INPUT 0 / OUTPUT 0 / CACHED 0`** with credits nowhere on the page. A session with no subagents had no explanation at all — the DSH failure again. The header now reads `CREDITS · DELEGATED · TOKENS not recorded`.
- **`/config` was rendering another agent's skills.** A Qoder trace showed "Project Configuration — Skills (48)"; all 48 were `scope: user` from Claude Code (45), Gemini (2) and Qwen (1), and none were Qoder's. That call site already excluded DSH for exactly this reason. Qoder now shows Runtime Capabilities from its own session log — the 11 skills and 3 MCP servers that run was offered, with plugin-scoped entries (`better-harness:`, `qoder-qmind:`) marked as such.

## Test plan

- 19 new scanner tests (`backend/test_qoder_scan.py`) and 3 new panel tests, all synthetic fixtures under `tmp_path`; no test reads a real home directory.
- Covers root-vs-subagent separation, credit summing, the unreversible slug, the `<system-reminder>` strip, tool-result survival, unknown-attachment rejection, IDE-title enrichment, an IDE row with no transcript, a torn final line, and traversal in the id lookup.
- `tsc --noEmit` clean; no console errors on the trace page.
- Clicked through the dashboard tile, the agent page and both traces.
- Leak scan over the panel payload and the full diff: no credential-shaped strings, no absolute user paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
