### PR TITLE
fix(pricing): bill Claude Sonnet 5 at its real $2/$10, not Sonnet 4.6's rate

### DIFF
--- a/UPDATE.json
+++ b/UPDATE.json
@@ -1,6 +1,17 @@
 {
   "releases": [
     {
+      "tag": "2026-08-30",
+      "title": "Claude Sonnet 5 costs corrected",
+      "highlights": [
+        {
+          "title": "Sonnet 5 sessions read 50% higher than they cost",
+          "description": "Claude Sonnet 5 was priced at Sonnet 4.6's rate, $3 and $15 per million tokens instead of $2 and $10, so every Sonnet 5 session showed half again what it actually cost. Opus 5, Opus 4.8 and Fable 5 were already right but are now written down explicitly rather than read from an external table, so a refresh of that table cannot move them. Existing sessions reprice on the next scan. Thanks to mariadb-KyleHutchinson for spotting this (PR #250).",
+          "href": "/analytics"
+        }
+      ]
+    },
+    {
       "tag": "2026-08-29",
       "title": "Qoder is now tracked",
       "highlights": [

--- a/backend/pricing.py
+++ b/backend/pricing.py
@@ -44,6 +44,19 @@ _PROVIDER_SEP = "\x00"
 # Direct first-party pricing — used as the flat-fallback when provider unknown.
 PRICING = {
     # --- Anthropic (Claude) ---
+    # The Claude 5 generation was resolving entirely through the models.dev
+    # overlay, and the overlay contradicts itself on Sonnet 5: its flat entry
+    # said $3.00/$15.00 (Sonnet 4.6's price, carried forward) while its
+    # anthropic-keyed entry said the correct $2.00/$10.00. So the same model
+    # cost 1.5x more when the scanner did not happen to know the provider.
+    # Curated here so both paths agree and a future overlay refresh cannot
+    # move them. Rates: https://docs.claude.com/en/docs/about-claude/pricing
+    "claude-fable-5":    {"in": 10.00, "out": 50.00, "cached_read": 1.00},
+    "claude-mythos-5":   {"in": 10.00, "out": 50.00, "cached_read": 1.00},
+    "claude-opus-5":     {"in": 5.00,  "out": 25.00, "cached_read": 0.50},
+    "claude-opus-4-8":   {"in": 5.00,  "out": 25.00, "cached_read": 0.50},
+    "claude-sonnet-5":   {"in": 2.00,  "out": 10.00, "cached_read": 0.20},
+
     "claude-opus-4-7":   {"in": 5.00,  "out": 25.00, "cached_read": 0.50},
     "claude-opus-4-6":   {"in": 5.00,  "out": 25.00, "cached_read": 0.50},
     "claude-opus-4-5":   {"in": 5.00,  "out": 25.00, "cached_read": 0.50},
@@ -194,6 +207,18 @@ PRICING = {
 # we use this when available to capture markup/discount on aggregator providers.
 # Key: (provider_lower, model_id_lower)
 PRICING_BY_PROVIDER = {
+    # --- Anthropic (direct) ---
+    # Pinned for the same reason as the DeepSeek block below: the overlay only
+    # yields to an inline entry, so without these tuples a provider-qualified
+    # lookup keeps resolving through models.dev. Today its anthropic-keyed
+    # Sonnet 5 rate is right and its flat one is wrong; nothing stops the next
+    # refresh from breaking the half we are not pinning.
+    ("anthropic", "claude-fable-5"):                 {"in": 10.00, "out": 50.00, "cached_read": 1.00},
+    ("anthropic", "claude-mythos-5"):                {"in": 10.00, "out": 50.00, "cached_read": 1.00},
+    ("anthropic", "claude-opus-5"):                  {"in": 5.00,  "out": 25.00, "cached_read": 0.50},
+    ("anthropic", "claude-opus-4-8"):                {"in": 5.00,  "out": 25.00, "cached_read": 0.50},
+    ("anthropic", "claude-sonnet-5"):                {"in": 2.00,  "out": 10.00, "cached_read": 0.20},
+
     # --- DeepSeek (direct) ---
     # These MUST exist even though they duplicate the flat table above.
     # models.dev ships ("deepseek", "deepseek-v4-pro") at $0.435/$0.87 — a rate

--- a/backend/scan_cache.py
+++ b/backend/scan_cache.py
@@ -34,7 +34,7 @@ logger = logging.getLogger("tokentelemetry.scan_cache")
 # update that affects cached costs. `_mtime` only detects source-transcript
 # changes; this detects code changes. A mismatch is a miss, so stale entries
 # are transparently reparsed and rewritten — never migrated in place.
-CACHE_VERSION = 9  # v2: added "loop" field; v3: added loop footprint_tokens/footprint_cost; v4: added published_artifacts; v5: page artifacts carry source path; v6: added "goals" (/goal); v7: Claude cached-read costs use cumulative usage and record untracked background activity; v8: Muse/Prime/Codex model metadata; v9: DeepSeek V4 repricing (#303) — cached sessions store a computed cost, so a rate change must invalidate them
+CACHE_VERSION = 10  # v2: added "loop" field; v3: added loop footprint_tokens/footprint_cost; v4: added published_artifacts; v5: page artifacts carry source path; v6: added "goals" (/goal); v7: Claude cached-read costs use cumulative usage and record untracked background activity; v8: Muse/Prime/Codex model metadata; v9: DeepSeek V4 repricing (#303) — cached sessions store a computed cost, so a rate change must invalidate them; v10: claude-sonnet-5 repriced to its real $2/$10 (#250) — cached sessions store a computed cost, so a rate change must invalidate them
 
 
 def _require_safe_component(candidate: str) -> str:

--- a/backend/test_claude_5_pricing.py
+++ b/backend/test_claude_5_pricing.py
@@ -1,0 +1,101 @@
+"""Claude 5 generation pricing (from #250's pricing half).
+
+claude-sonnet-5 was billed at $3.00/$15.00 — Sonnet 4.6's price — against a real
+rate of $2.00/$10.00, a uniform 1.5x overcharge on every component.
+
+Two things made it invisible:
+
+1. No curated inline entry existed for any Claude 5 model, so the whole
+   generation resolved through the models.dev overlay unchallenged. The
+   divergence report (#309) compares the two layers, so a model present in only
+   one of them produces no row.
+2. The overlay contradicts itself. Its flat `claude-sonnet-5` said $3/$15 while
+   its `("anthropic", "claude-sonnet-5")` said the correct $2/$10 — so the cost
+   depended on whether the scanner happened to pass a provider.
+
+Rates: https://docs.claude.com/en/docs/about-claude/pricing
+"""
+
+import pricing
+from pricing import PRICING, PRICING_BY_PROVIDER, calculate_cost
+
+MTOK = 1_000_000
+
+CLAUDE_5 = {
+    "claude-fable-5":  {"in": 10.00, "out": 50.00, "cached_read": 1.00},
+    "claude-mythos-5": {"in": 10.00, "out": 50.00, "cached_read": 1.00},
+    "claude-opus-5":   {"in": 5.00,  "out": 25.00, "cached_read": 0.50},
+    "claude-opus-4-8": {"in": 5.00,  "out": 25.00, "cached_read": 0.50},
+    "claude-sonnet-5": {"in": 2.00,  "out": 10.00, "cached_read": 0.20},
+}
+
+
+def test_flat_table_matches_published_rates():
+    for model, rates in CLAUDE_5.items():
+        assert PRICING[model] == rates, f"{model}: {PRICING[model]} != {rates}"
+
+
+def test_provider_keyed_matches_flat():
+    """Cost must not depend on whether the caller knew the provider.
+
+    This is the actual bug: the overlay's flat and anthropic-keyed Sonnet 5
+    entries disagreed by 1.5x, so two identical sessions priced differently
+    based on whether the scanner supplied a provider.
+    """
+    for model, rates in CLAUDE_5.items():
+        assert PRICING_BY_PROVIDER[("anthropic", model)] == rates
+        without = calculate_cost(model, MTOK, MTOK)
+        with_prov = calculate_cost(model, MTOK, MTOK, provider="anthropic")
+        assert without == with_prov, f"{model}: {without} vs {with_prov}"
+
+
+def test_sonnet_5_is_not_sonnet_4_6s_price():
+    """Regression: the $3/$15 carry-forward must not come back."""
+    assert PRICING["claude-sonnet-5"]["in"] != 3.00
+    assert PRICING["claude-sonnet-5"]["out"] != 15.00
+    # Sonnet 4.6 legitimately IS $3/$15 — the two must stay distinct.
+    assert PRICING["claude-sonnet-4-6"] == {"in": 3.00, "out": 15.00, "cached_read": 0.30}
+
+
+def test_cached_read_is_explicit_not_derived():
+    """A None cached_read makes calculate_cost derive in_rate * 0.1.
+
+    That fallback is a ratio, so it silently inherits a wrong input rate. With
+    the old $3.00 input it produced $0.30/MTok instead of $0.20 — and on a
+    cache-heavy workload that derived rate dominates the bill, not the headline
+    output price.
+    """
+    for model, rates in CLAUDE_5.items():
+        assert PRICING[model]["cached_read"] is not None, model
+        assert PRICING[model]["cached_read"] == rates["in"] * 0.1
+
+
+def test_no_claude_5_model_falls_through_to_default():
+    default = PRICING["_default"]
+    for model in CLAUDE_5:
+        assert PRICING[model] != default, model
+
+
+def test_measured_overcharge_is_a_uniform_1_5x():
+    """Every component was off by the same multiple, so totals scaled uniformly.
+
+    89 real sessions on this machine billed $344.16 against a true $229.44.
+    """
+    old = {"in": 3.00, "out": 15.00, "cached_read": 0.30}
+    new = PRICING["claude-sonnet-5"]
+    for field in ("in", "out", "cached_read"):
+        # Tolerance, not equality: 0.3 / 0.2 is 1.4999999999999998 in binary float.
+        assert abs(old[field] / new[field] - 1.5) < 1e-9, field
+
+
+def test_cache_version_bumped_for_repricing():
+    """Cached sessions store a computed cost, so a rate change must invalidate them."""
+    import scan_cache
+    assert scan_cache.CACHE_VERSION >= 10
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(list(globals().items())):
+        if name.startswith("test_") and callable(fn):
+            fn()
+    print("All tests passed!")


### PR DESCRIPTION
Lifts the pricing half of #250. The rest of that PR is not included — see the bottom.

## The bug

`claude-sonnet-5` was billed at **$3.00/$15.00** — Sonnet 4.6's price, carried forward — against a real rate of **$2.00/$10.00**.

Every component is off by the same 1.5x (input, output, cache read, and the 1.25x cache-write derived from input), so totals scale uniformly:

| 89 real Sonnet 5 sessions | |
|---|---|
| Billed | **$344.16** |
| Correct | **$229.44** |
| Overstated | **$114.72** |

## Why it stayed invisible

**The Claude 5 generation had no curated inline entry at all**, so it resolved through the models.dev overlay unchallenged. The divergence report added in #309 compares the two layers *against each other*, so a model present in only one produces no row. That's a different blind spot from the both-layers-stale case #309 documents, and a much larger one: the curated table holds ~150 models against the overlay's 2,608.

**The overlay contradicts itself.** Its flat `claude-sonnet-5` said $3/$15 while its `("anthropic", "claude-sonnet-5")` said the correct $2/$10 — so cost depended on whether the scanner happened to pass a provider. Same failure shape as GPT-5.6 Luna in #307.

## What changed

| Model | Before | After |
|---|---|---|
| `claude-sonnet-5` | 3.00 / 15.00 (overlay) | **2.00 / 10.00** |
| `claude-opus-5` | 5.00 / 25.00 (overlay) | 5.00 / 25.00 (curated) |
| `claude-opus-4-8` | 5.00 / 25.00 (overlay) | 5.00 / 25.00 (curated) |
| `claude-fable-5` | 10.00 / 50.00 (overlay) | 10.00 / 50.00 (curated) |
| `claude-mythos-5` | **absent** → `_default` | 10.00 / 50.00 (curated) |

`cached_read` is now explicit on all five rather than left `None`. `calculate_cost` derives a missing `cached_read` as `in_rate * 0.1`, and because that's a *ratio* it silently inherits a wrong input rate — $0.30 instead of $0.20 here. On a cache-heavy workload that derived rate dominates the bill: of the 889M tokens in those 89 sessions, cache reads are the overwhelming majority.

The four already-correct models are curated anyway, with matching `PRICING_BY_PROVIDER` tuples, because the overlay only yields to an inline entry — nothing otherwise stops a future refresh from moving them the way it moved Sonnet 5.

`CACHE_VERSION` 9 → 10: cached sessions store a computed cost, so a rate change must invalidate them or users keep seeing the old number.

## Verification

- 7 new tests, **all 7 fail on main**, all pass here.
- Full suite: **658 passing** vs main's 651, same 22 pre-existing failures on both.
- Rates checked against Anthropic's published pricing, not the PR description — #250's claim that four models "fell back to the generic default" is not accurate; three of its four entries are no-ops and only Sonnet 5 changes behaviour.

## Deliberately not lifted from #250

The delegated-cost fold-in, the `history_store` schema change, and the cost-by-day table. That PR's `SCHEMA_VERSION 3` collides with main's own v3 — resolving it naively would silently no-op its entire history half — and none of it is related to this bug. #250 stays open on its own merits.

Thanks to @mariadb-KyleHutchinson for reporting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)