### PR TITLE
fix(hermes): preserve hermes session explorer list(limit) and scroll state

### DIFF
--- a/frontend/src/components/hermes/HermesSessionExplorer.tsx
+++ b/frontend/src/components/hermes/HermesSessionExplorer.tsx
@@ -9,6 +9,7 @@ import {
 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useResource } from "@/lib/api";
+import { useScrollState } from "@/lib/useScrollState";
 import {
   buildHermesSessionsPath, formatHermesProject, type HermesSessionPage,
   type HermesSessionQuery, type HermesSessionSort,
@@ -35,7 +36,12 @@ function readQuery(searchParams: { get(name: string): string | null }): HermesSe
   const sort: HermesSessionSort = rawSort === "oldest" || rawSort === "cost" || rawSort === "tokens"
     ? rawSort
     : "newest";
+  const rawLimit = Number(searchParams.get("limit"));
+  const pageSize = Number.isInteger(rawLimit) && rawLimit >= PAGE_SIZE && rawLimit <= MAX_ROWS
+    ? rawLimit
+    : PAGE_SIZE;
   return {
+    pageSize,
     search: searchParams.get("search") || "",
     project: searchParams.get("project") || "",
     source: searchParams.get("source") || "",
@@ -49,6 +55,7 @@ export default function HermesSessionExplorer() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const query = useMemo(() => readQuery(searchParams), [searchParams]);
+  const rowLimit = query.pageSize ?? PAGE_SIZE;
   const [searchInput, setSearchInput] = useState(query.search || "");
 
   useEffect(() => {
@@ -78,7 +85,6 @@ export default function HermesSessionExplorer() {
   // How many rows to ask for. "Load more" grows this rather than walking pages,
   // so one request always returns the whole visible list and there is no page
   // number to fall out of sync with the results.
-  const [rowLimit, setRowLimit] = useState(PAGE_SIZE);
 
   const path = useMemo(
     () => buildHermesSessionsPath({ ...query, page: 1, pageSize: rowLimit }),
@@ -88,6 +94,9 @@ export default function HermesSessionExplorer() {
     pollMs: 15_000,
     initial: { sessions: [], pagination: { page: 1, page_size: PAGE_SIZE, total: 0, total_pages: 0 } },
   });
+
+  // Restore scroll position when data fetch is complete.
+  useScrollState("key_hermes_sessions_page", !loading);
 
   const activeFilterCount = [query.project, query.source, query.model, query.search].filter(Boolean).length;
 
@@ -100,11 +109,17 @@ export default function HermesSessionExplorer() {
     // Left over from the old paginated view; harmless in the URL but misleading.
     next.delete("page");
     // Any filter change re-scopes the list, so start from one screenful again.
-    setRowLimit(PAGE_SIZE);
+    next.delete("limit");
     const nextQuery = next.toString();
     // Clearing writes an empty string, so a cleared list stays cleared.
     sessionStorage.setItem(FILTER_MEMORY_KEY, nextQuery);
     router.replace(nextQuery ? `${pathname}?${nextQuery}` : pathname, { scroll: false });
+  }
+
+  function loadMore() {
+    const next = new URLSearchParams(searchParams.toString());
+    next.set("limit", String(Math.min(MAX_ROWS, rowLimit + PAGE_SIZE)));
+    router.replace(`${pathname}?${next.toString()}`, { scroll: false });
   }
 
   function clearFilters() {
@@ -196,7 +211,7 @@ export default function HermesSessionExplorer() {
                 variant="ghost"
                 size="sm"
                 disabled={loadingMore}
-                onClick={() => setRowLimit((limit) => Math.min(MAX_ROWS, limit + PAGE_SIZE))}
+                onClick={loadMore}
               >
                 {loadingMore ? "Loading…" : <>Load more <ChevronDown size={14} /></>}
               </Button>

--- a/frontend/src/lib/useScrollState.ts
+++ b/frontend/src/lib/useScrollState.ts
@@ -41,6 +41,8 @@ export function useScrollState(key: string, isReady: boolean = true) {
 
   const saveScrollPosition = useCallback((top: number) => {
     if (isRestoringRef.current) return;
+    // Ignore programmatic scrolls that fire before the initial restore runs.
+    if (!restoredRef.current) return;
     sessionStorage.setItem(`scroll_${key}`, String(top));
   },[key]);
 


### PR DESCRIPTION
## Summary
This PR preserves the expanded list and scroll position in the Hermes Session Explorer (`/hermes/sessions`) after visiting a session and navigating back.

The scroll position is now preserved even when the list has been expanded with **Load more**. To support this, the expanded `limit` state is stored and managed in the URL.

It is a focused follow-up to [PR #252](https://github.com/VasiHemanth/tokentelemetry/pull/252). It includes the Session Explorer scroll restoration and initial-restore guard from that PR, then adds URL-backed Load more state so the same rows are available before the saved scroll position is restored.

## Changes:

- Read a validated `limit` value from the URL and use it as the explorer's row limit.
- Update `limit` when **Load more** is clicked while preserving the existing filters in the URL.
- Remove `limit` when search, filter, or sort options change, preserving the previous reset-to-50 behavior.
- Restore the explorer scroll position after its data request completes.
- Prevent scroll events before the initial restore from overwriting the saved offset.

No API contract, dependency, or unrelated component structure is changed.

## Type of change
- [ ] Bug fix
- [ ] New feature (new agent support, new dashboard view, etc.)
- [x] Improvement / refactor
- [ ] Docs / chore

## How to test
1. Run `./start.sh`.
2. Open `/hermes/sessions` with more than 50 sessions.
3. Click **Load more** twice and verify that the URL contains `limit=150`.
4. Scroll into the additional rows and open a session.
5. Return using the session page's back control or browser Back.
6. Verify that the URL still contains `limit=150`, the expanded rows are loaded, and the previous scroll position is restored.
7. Change a search, filter, or sort option and verify that `limit` is removed and the list starts from 50 rows again.


## Checklist
- [x] I tested this locally with `./start.sh`
- [x] No secrets or API keys are included
- [x] PR is focused on one change
- [X] README or CHANGELOG updated if needed

## Related issue
Closes #251
Follow-up to #252. This PR includes its scroll-restoration behavior and extends it by preserving the expanded Load more limit in the URL.