### PR TITLE
feat: report whether each detected harness can actually be read

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ optional outbound calls:
    content-free usage signals sent to a Cloudflare Worker: which pages you
    open, which features you use, summary success/engine, OS + CPU arch + app
    version, approximate country (derived at Cloudflare's edge — never your
-   IP), which AI agents are detected (generic names), and a random per-launch
+   IP), which AI agents are detected (generic names), whether each detected agent's sessions could be read at all (a size band, never a count), and a random per-launch
    session id that is not linked across launches. It never collects your code,
    prompts, model output, file/directory paths, project names, token counts,
    costs, IP address, or any stable user or device identifier. Full details:

--- a/UPDATE.json
+++ b/UPDATE.json
@@ -1,6 +1,26 @@
 {
   "releases": [
     {
+      "tag": "2026-08-30",
+      "title": "Telemetry you can read line by line",
+      "highlights": [
+        {
+          "title": "Settings lists every value we send, not a summary of it",
+          "description": "\"Show exactly what we send\" is now generated from the same allowlist the app checks against before anything is sent, so it lists every event, every property and every permitted value — and cannot drift from what actually leaves your machine. It also shows the values attached to your own events right now, rather than an example. Previously this was a hand-written list, and it had already fallen behind.",
+          "href": "/settings#usage-privacy"
+        },
+        {
+          "title": "We can now tell a broken agent from an unused one",
+          "description": "Once per launch, TokenTelemetry reports whether each coding agent it found could actually be read — as a size band like \"10-99\", never a real count, and never which project or session. Support for an agent can break quietly on machines that cannot be tested against: DeepSeek Harness shipped reporting zero sessions and it took a bug report to catch. This is the signal that catches it instead. Covered by the same one-click opt-out as everything else.",
+          "href": "/settings#usage-privacy"
+        },
+        {
+          "title": "Fixed: an event we described but never actually sent",
+          "description": "The transparency panel listed a retention event, complete with a sample payload, that no part of the app ever sent. It is now genuinely wired up, and a test keeps the panel and the code in agreement so the list can't overstate what we collect again."
+        }
+      ]
+    },
+    {
       "tag": "2026-08-29",
       "title": "Qoder is now tracked",
       "highlights": [

--- a/UPDATE.json
+++ b/UPDATE.json
@@ -5,18 +5,9 @@
       "title": "Telemetry you can read line by line",
       "highlights": [
         {
-          "title": "Settings lists every value we send, not a summary of it",
-          "description": "\"Show exactly what we send\" is now generated from the same allowlist the app checks against before anything is sent, so it lists every event, every property and every permitted value — and cannot drift from what actually leaves your machine. It also shows the values attached to your own events right now, rather than an example. Previously this was a hand-written list, and it had already fallen behind.",
+          "title": "See exactly what the usage stats send",
+          "description": "Settings now lists every event, property and permitted value that can leave your machine, generated from the app's own allowlist so it cannot fall out of date, with your actual current values shown next to it. It covers one new signal too: whether each coding agent found on your machine could be read at all, as a size band and never a count, so a broken agent integration shows up without you having to report it.",
           "href": "/settings#usage-privacy"
-        },
-        {
-          "title": "We can now tell a broken agent from an unused one",
-          "description": "Once per launch, TokenTelemetry reports whether each coding agent it found could actually be read — as a size band like \"10-99\", never a real count, and never which project or session. Support for an agent can break quietly on machines that cannot be tested against: DeepSeek Harness shipped reporting zero sessions and it took a bug report to catch. This is the signal that catches it instead. Covered by the same one-click opt-out as everything else.",
-          "href": "/settings#usage-privacy"
-        },
-        {
-          "title": "Fixed: an event we described but never actually sent",
-          "description": "The transparency panel listed a retention event, complete with a sample payload, that no part of the app ever sent. It is now genuinely wired up, and a test keeps the panel and the code in agreement so the list can't overstate what we collect again."
         }
       ]
     },

--- a/backend/main.py
+++ b/backend/main.py
@@ -8133,6 +8133,50 @@ def _persist_history_async(data: List[Dict[str, Any]]) -> None:
         _work()
 
 
+_harness_scan_reported = False
+
+
+def _report_harness_scan(data: List[Dict[str, Any]]) -> None:
+    """Emit one anonymous `harness.scanned` per detected agent, once per process.
+
+    The `agents` context prop already says which harnesses are *installed*.
+    Nothing said whether their readers actually returned anything, so a reader
+    that silently found nothing on someone else's machine stayed invisible until
+    a bug report arrived -- which is exactly how DeepSeek Harness shipped
+    reporting zero sessions.
+
+    Emitted after the first successful scan (the counts are free at that point)
+    and never again: the scan re-runs on a 30s TTL and clients poll it, so a
+    per-scan emit would be a firehose. Volume is an order-of-magnitude bucket,
+    never a raw count. Best-effort throughout -- telemetry must never affect the
+    scan's result.
+    """
+    global _harness_scan_reported
+    if _harness_scan_reported:
+        return
+    _harness_scan_reported = True
+    try:
+        from collections import Counter
+        counts = Counter(s.get("agent") for s in data)
+        # The union of "detected on disk" and "actually produced sessions", not
+        # just the former. The two disagree in both directions and each
+        # disagreement is the signal:
+        #   detected, 0 sessions -> the reader is broken (the DSH case);
+        #   sessions, not detected -> the detector is broken. SmallCode is
+        #     exactly this today: its traces are project-local, so
+        #     _list_available_agents() only sees it via an env-configured extra
+        #     root even while the scanner is finding its sessions.
+        agents = {a for a in counts if isinstance(a, str) and a}
+        agents.update(_list_available_agents())
+        for agent in sorted(agents):
+            _telemetry.emit("harness.scanned", {
+                "agent": agent,
+                "volume": _telemetry.volume_bucket(counts.get(agent, 0)),
+            })
+    except Exception:
+        pass
+
+
 async def get_sessions_cached(fresh: bool = False) -> List[Dict[str, Any]]:
     """Cached, non-blocking access to the session list.
 
@@ -8163,6 +8207,7 @@ async def get_sessions_cached(fresh: bool = False) -> List[Dict[str, Any]]:
             _sessions_cache["data"] = data
             _sessions_cache["at"] = _time.monotonic()
             _log.info("sessions scan: %d entries in %.0fms", len(data), (_time.monotonic() - t0) * 1000)
+            _report_harness_scan(data)
             # Durable rollup: persist a tiny summary of each session so history
             # outlives the agents' own transcript pruning. Fire-and-forget on a
             # worker thread — a store failure must never break a request, and the
@@ -10025,6 +10070,10 @@ async def post_retention(payload: dict = Body(...)):
     if not isinstance(enabled, bool):
         raise HTTPException(status_code=400, detail="'enabled' must be a boolean")
     flags = agent_retention.set_archive(agent, enabled)
+    # `tier` is the resulting retention level, so a turn-off is reported as
+    # "rollup" rather than going unrecorded. Only the tier rides along -- never
+    # which agent, and never any count.
+    _telemetry.emit("retention.opted_in", {"tier": "full" if enabled else "rollup"})
     return {"ok": True, "archive": flags}
 
 

--- a/backend/telemetry.py
+++ b/backend/telemetry.py
@@ -118,11 +118,17 @@ def _record_send(status: str, code: Optional[int] = None,
 # Per-event: the ONLY prop keys that may be sent. Anything else is dropped.
 _EVENT_PROPS: Dict[str, set] = {
     "app.launched":       set(),
-    "page.viewed":        {"route"},
+    "page.viewed":        {"route", "agent"},
     "trace.summarized":   {"backend", "outcome"},
     "analytics.filtered": {"dimension"},
     "feature.used":       {"name"},
     "retention.opted_in": {"tier"},
+    # One per *detected* harness, once per process, after the first successful
+    # scan. The `agents` context prop says which harnesses are installed; this
+    # says whether their readers actually returned anything. Without it a broken
+    # reader is invisible until someone files a bug -- which is how DeepSeek
+    # Harness shipped reporting zero sessions.
+    "harness.scanned":    {"agent", "volume"},
 }
 
 # Enum-controlled values. A value outside its set becomes "other" — never the
@@ -130,7 +136,8 @@ _EVENT_PROPS: Dict[str, set] = {
 _ENUMS: Dict[str, set] = {
     "route": {
         "dashboard", "analytics", "traces", "projects", "project-detail",
-        "hermes", "artifacts", "local-models", "settings", "sessions", "other",
+        "hermes", "artifacts", "local-models", "settings", "sessions",
+        "agent-panel", "other",
     },
     "dimension": {"agent", "model", "local-only", "day", "other"},
     "outcome": {"ok", "error", "empty", "unavailable", "other"},
@@ -147,6 +154,9 @@ _ENUMS: Dict[str, set] = {
         "other",
     },
     "tier": {"full", "rollup", "other"},
+    # Order-of-magnitude bucket, never a raw count -- enough to separate a
+    # reader that found one session from one that found four hundred.
+    "volume": {"0", "1-9", "10-99", "100-999", "1000-plus", "other"},
 }
 
 # Detected-agent names we recognise — must match _list_available_agents() in
@@ -157,6 +167,48 @@ _KNOWN_AGENTS = {
     "cursor", "copilot", "opencode", "hermes", "grok",
     "pi", "cline", "muse", "prime", "smallcode", "dsh", "qoder",
 }
+
+# `agent` rides on harness.scanned and on page.viewed for an agent panel. It is
+# the same closed set as the context list, so it adds no new privacy surface.
+# Off-list values collapse to the sanitizer's generic "other"; the context
+# `agents` list keeps its own "other-agent" spelling so it stays comparable with
+# data already collected.
+_ENUMS["agent"] = _KNOWN_AGENTS | {"other"}
+
+# Cap on the joined `agents` context string. Every recognised agent plus the
+# "other-agent" bucket has to fit, and a test asserts it -- so adding a harness
+# fails CI here rather than silently truncating the field in production.
+_AGENTS_FIELD_MAX = 256
+
+
+def _join_capped(names: List[str], limit: int = _AGENTS_FIELD_MAX) -> str:
+    """Join on commas without ever cutting a name in half.
+
+    A plain ``",".join(...)[:limit]`` slices mid-token: at 18 agents the string
+    was 117 of the old 120 characters, so one more harness would have ended it
+    on "small" -- inventing an agent that does not exist. Drop whole names
+    instead, so every value present in the field is a real one.
+    """
+    out = ""
+    for name in names:
+        candidate = f"{out},{name}" if out else name
+        if len(candidate) > limit:
+            break
+        out = candidate
+    return out
+
+
+def volume_bucket(n: int) -> str:
+    """Bucket a count for the `volume` enum. Never emit the raw number."""
+    if n <= 0:
+        return "0"
+    if n < 10:
+        return "1-9"
+    if n < 100:
+        return "10-99"
+    if n < 1000:
+        return "100-999"
+    return "1000-plus"
 
 
 def _safe_scalar(v: Any) -> Optional[Any]:
@@ -210,7 +262,7 @@ def _context_props() -> Dict[str, Any]:
         backend = _CTX.get("summarizer_backend", "none")
     known = sorted({a if a in _KNOWN_AGENTS else "other-agent" for a in agents})
     return {
-        "agents": ",".join(known)[:120],
+        "agents": _join_capped(known),
         "agent_count": len(agents),
         "summarizer_backend": backend if backend in _ENUMS["backend"] else "other",
     }
@@ -352,8 +404,65 @@ def sample_payloads() -> List[Dict[str, Any]]:
         "analytics.filtered": {"dimension": "local-only"},
         "feature.used": {"name": "plan-library"},
         "retention.opted_in": {"tier": "full"},
+        "harness.scanned": {"agent": "qoder", "volume": "1-9"},
     }
-    return [build_event(ev, p) for ev, p in samples.items()]
+    # Iterate the allowlist, not the sample dict: an event added to
+    # _EVENT_PROPS without a sample here still shows up in the panel (with
+    # empty props) rather than silently going undisclosed.
+    return [build_event(ev, samples.get(ev)) for ev in sorted(_EVENT_PROPS)]
+
+
+# Plain-English gloss for the props that ride on every event. The *keys* are
+# read from _context_props()/_system_props() at runtime, so a prop added there
+# still appears in Settings even if nobody writes a description for it here.
+_ALWAYS_SENT_NOTES = {
+    "agents": "Which coding agents were detected on this machine, by name. Anything unrecognised becomes \"other-agent\".",
+    "agent_count": "How many were detected.",
+    "summarizer_backend": "Which summarizer engine is configured, or \"none\".",
+    "locale": "The constant \"en-US\" -- not read from your system.",
+    "osName": "Operating system family (Darwin / Linux / Windows).",
+    "osVersion": "Operating system release string.",
+    "deviceModel": "CPU architecture only (arm64 / x86_64) -- never a device name.",
+    "isDebug": "Whether telemetry debug mode is on.",
+    "appVersion": "The commit this build was made from.",
+    "sdkVersion": "A constant client tag.",
+}
+
+
+def event_catalog() -> List[Dict[str, Any]]:
+    """Every event, every prop it may carry, and each prop's permitted values.
+
+    Derived wholly from the allowlists above, so the Settings panel gains a new
+    row the moment an event or prop is added -- there is no second, hand-written
+    list to fall out of date. `values: None` means the prop is free-form and
+    passes only the safe-scalar filter.
+    """
+    return [
+        {
+            "event": event,
+            "props": [
+                {"name": key, "values": sorted(_ENUMS[key]) if key in _ENUMS else None}
+                for key in sorted(_EVENT_PROPS[event])
+            ],
+        }
+        for event in sorted(_EVENT_PROPS)
+    ]
+
+
+def always_sent() -> List[Dict[str, Any]]:
+    """The context/system props attached to every event, with this machine's
+    actual current values -- so the panel shows what would really be sent rather
+    than a description of it."""
+    rows: List[Dict[str, Any]] = []
+    for scope, values in (("context", _context_props()), ("system", _system_props())):
+        for key in sorted(values):
+            rows.append({
+                "name": key,
+                "scope": scope,
+                "value": values[key],
+                "note": _ALWAYS_SENT_NOTES.get(key, ""),
+            })
+    return rows
 
 
 def preview() -> Dict[str, Any]:
@@ -370,6 +479,8 @@ def preview() -> Dict[str, Any]:
             "any stable device or user identifier",
         ],
         "events": sorted(_EVENT_PROPS.keys()),
+        "event_catalog": event_catalog(),
+        "always_sent": always_sent(),
         "sample": sample_payloads(),
         "recent_sent": list(_SENT),
         "last_send": dict(_LAST_SEND),

--- a/backend/test_telemetry_harness_coverage.py
+++ b/backend/test_telemetry_harness_coverage.py
@@ -1,0 +1,217 @@
+"""Guardrails that keep telemetry honest as new coding harnesses are added.
+
+`test_telemetry_redaction.py` proves a payload can't carry content. These tests
+prove something different and equally load-bearing: that the four places which
+have to agree about the harness list actually do, and that a value we decide to
+send survives all the way to the sink instead of being dropped en route.
+
+Every one of these covers a failure that has already happened or came within one
+commit of happening:
+
+* the `agents` context field was 117 of its 120 characters, so the next harness
+  would have truncated it *mid-name* — turning "smallcode" into "small" and
+  inventing an agent that does not exist;
+* the Cloudflare Worker keeps its own copy of the event allowlist, so a new
+  backend event is accepted by the app, POSTed, answered 204 and then silently
+  never written to the dataset;
+* the Settings "exactly what we send" panel is the product's privacy promise, so
+  an event missing from it is an inaccurate disclosure, not a cosmetic gap.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+
+import telemetry
+
+REPO = Path(__file__).resolve().parent.parent
+WORKER = REPO / "proxy" / "cloudflare-worker.js"
+WORKER_SRC = REPO / "proxy" / "cloudflare" / "src" / "index.js"
+
+
+# --- the harness list, in all the places that must agree -------------------
+
+def test_known_agents_matches_the_panel_builders():
+    """telemetry's allowlist and the harness-panel registry are the same set.
+
+    The comment on _KNOWN_AGENTS has always *claimed* this; nothing enforced it.
+    An agent missing here is not a crash — it is quietly bucketed as
+    "other-agent", so the new harness looks like it has no users at all.
+    """
+    from harness_panels import BUILDERS
+    assert telemetry._KNOWN_AGENTS == set(BUILDERS), (
+        "telemetry._KNOWN_AGENTS and harness_panels.BUILDERS disagree; "
+        "missing from telemetry: %s; missing from BUILDERS: %s"
+        % (sorted(set(BUILDERS) - telemetry._KNOWN_AGENTS),
+           sorted(telemetry._KNOWN_AGENTS - set(BUILDERS)))
+    )
+
+
+def test_agents_field_holds_every_agent_without_truncating():
+    """The whole recognised set, plus the "other-agent" bucket, must fit.
+
+    This is the test that makes adding a harness fail here rather than silently
+    corrupting the field in production.
+    """
+    names = sorted(telemetry._KNOWN_AGENTS | {"other-agent"})
+    joined = ",".join(names)
+    assert len(joined) <= telemetry._AGENTS_FIELD_MAX, (
+        "the agents field would truncate: %d chars vs cap %d. Raise "
+        "_AGENTS_FIELD_MAX *and* the matching blob() cap in the Cloudflare "
+        "worker, which re-caps independently." % (len(joined), telemetry._AGENTS_FIELD_MAX)
+    )
+    assert telemetry._join_capped(names) == joined
+
+
+def test_join_capped_never_emits_a_partial_agent_name():
+    """Below the cap it drops whole names; it never cuts one in half.
+
+    The plain `",".join(...)[:120]` this replaced ended the string on "small",
+    which reads downstream as a real agent named "small".
+    """
+    names = sorted(telemetry._KNOWN_AGENTS | {"other-agent"})
+    for limit in range(1, len(",".join(names)) + 8):
+        out = telemetry._join_capped(names, limit)
+        assert len(out) <= limit
+        if out:
+            assert all(tok in names for tok in out.split(",")), (
+                "limit=%d produced a partial name: %r" % (limit, out))
+
+
+def test_agent_enum_cannot_leak_a_custom_harness_name():
+    props = telemetry._sanitize_props(
+        "harness.scanned", {"agent": "my-employers-internal-agent", "volume": "1-9"})
+    assert props["agent"] == "other"
+    props = telemetry._sanitize_props("page.viewed", {"route": "agent-panel", "agent": "qoder"})
+    assert props == {"route": "agent-panel", "agent": "qoder"}
+
+
+def test_volume_is_bucketed_and_never_a_raw_count():
+    assert telemetry.volume_bucket(0) == "0"
+    assert telemetry.volume_bucket(7) == "1-9"
+    assert telemetry.volume_bucket(42) == "10-99"
+    assert telemetry.volume_bucket(500) == "100-999"
+    assert telemetry.volume_bucket(9_999_999) == "1000-plus"
+    # Whatever the count, the emitted value is always one of the enum members —
+    # a raw session count can never ride through.
+    allowed = telemetry._ENUMS["volume"]
+    for n in (0, 1, 9, 10, 99, 100, 999, 1000, 12345, 10**9):
+        assert telemetry.volume_bucket(n) in allowed
+
+
+# --- the sink has its own allowlist ----------------------------------------
+
+def _worker_allowed_events() -> set:
+    src = WORKER.read_text(encoding="utf-8")
+    block = re.search(r"const ALLOWED_EVENTS = new Set\(\[(.*?)\]\)", src, re.S)
+    assert block, "could not find ALLOWED_EVENTS in the worker"
+    return set(re.findall(r'"([^"]+)"', block.group(1)))
+
+
+def test_worker_accepts_every_event_the_app_sends():
+    """An event the sink does not know is dropped, not stored.
+
+    The Worker answers 204 either way and the app fire-and-forgets, so this
+    failure is completely invisible at runtime: the event looks sent, and the
+    dataset simply never gains a row.
+    """
+    missing = set(telemetry._EVENT_PROPS) - _worker_allowed_events()
+    assert not missing, (
+        "these events would be silently discarded by the Cloudflare worker: %s "
+        "— add them to ALLOWED_EVENTS in proxy/cloudflare-worker.js and "
+        "proxy/cloudflare/src/index.js" % sorted(missing))
+
+
+def test_worker_does_not_allow_events_the_app_never_sends():
+    """Keeps the sink's allowlist from accumulating names nothing emits."""
+    extra = _worker_allowed_events() - set(telemetry._EVENT_PROPS)
+    assert not extra, "worker allows events the app never sends: %s" % sorted(extra)
+
+
+def test_worker_agents_cap_matches_the_backend():
+    """The Worker re-caps `agents` independently; a stale cap there silently
+    undoes the backend fix at the edge."""
+    src = WORKER.read_text(encoding="utf-8")
+    m = re.search(r"blob\(p\.agents,\s*(\d+)\)", src)
+    assert m, "could not find the agents blob cap in the worker"
+    assert int(m.group(1)) >= telemetry._AGENTS_FIELD_MAX, (
+        "worker caps agents at %s but the backend allows %d"
+        % (m.group(1), telemetry._AGENTS_FIELD_MAX))
+
+
+def test_worker_copies_stay_byte_identical():
+    """proxy/cloudflare-worker.js is a reference copy of the deployed entry
+    point. They are meant to be the same file; drift means one of them is a lie
+    about what is running."""
+    a = hashlib.sha256(WORKER.read_bytes()).hexdigest()
+    b = hashlib.sha256(WORKER_SRC.read_bytes()).hexdigest()
+    assert a == b, "proxy/cloudflare-worker.js and proxy/cloudflare/src/index.js differ"
+
+
+def test_worker_blob_positions_are_append_only():
+    """Blob indices are the dataset schema every saved query reads by position.
+
+    Renumbering silently re-labels historical rows, so the ordering is asserted
+    rather than trusted. Append new fields at the end and extend this list.
+    """
+    src = WORKER.read_text(encoding="utf-8")
+    order = re.findall(r"//\s*blob(\d+)", src)
+    assert [int(n) for n in order] == list(range(1, len(order) + 1)), (
+        "blob comments are not a contiguous 1..N sequence: %s" % order)
+    expected_tail = ["blob17", "blob18"]
+    assert ["blob" + n for n in order[-2:]] == expected_tail
+
+
+# --- the disclosure surface -------------------------------------------------
+
+def test_every_event_appears_in_the_settings_disclosure():
+    """The Settings panel renders `event_catalog`; an event absent from it is an
+    inaccurate privacy disclosure."""
+    catalog = telemetry.event_catalog()
+    assert {row["event"] for row in catalog} == set(telemetry._EVENT_PROPS)
+    for row in catalog:
+        assert {p["name"] for p in row["props"]} == telemetry._EVENT_PROPS[row["event"]]
+
+
+def test_disclosure_lists_the_real_permitted_values():
+    """Each enum-controlled prop shows its actual closed set, so the panel can't
+    describe a narrower set than the sanitizer will accept."""
+    for row in telemetry.event_catalog():
+        for prop in row["props"]:
+            if prop["name"] in telemetry._ENUMS:
+                assert prop["values"] == sorted(telemetry._ENUMS[prop["name"]])
+            else:
+                assert prop["values"] is None
+
+
+def test_always_sent_covers_every_context_and_system_prop():
+    rows = telemetry.always_sent()
+    named = {(r["scope"], r["name"]) for r in rows}
+    expected = {("context", k) for k in telemetry._context_props()}
+    expected |= {("system", k) for k in telemetry._system_props()}
+    assert named == expected
+
+
+def test_preview_is_json_serialisable():
+    """It is returned straight over HTTP to the Settings panel."""
+    json.dumps(telemetry.preview())
+
+
+def test_declared_events_are_actually_emitted_somewhere():
+    """No event may be declared, disclosed to users, and then never sent.
+
+    `retention.opted_in` shipped in exactly that state: it appeared in the
+    Settings panel's sample payloads for months with no emitter anywhere, so the
+    transparency surface advertised something the app never did.
+    """
+    sources = [(REPO / "backend" / "main.py").read_text(encoding="utf-8")]
+    ts = REPO / "frontend" / "src" / "lib" / "telemetry.ts"
+    sources.append(ts.read_text(encoding="utf-8"))
+    blob = "\n".join(sources)
+    # Events the frontend raises go through the bridge allowlist rather than a
+    # literal emit() call, so accept either spelling.
+    for event in telemetry._EVENT_PROPS:
+        assert '"%s"' % event in blob, (
+            "%s is declared and disclosed but nothing emits it" % event)

--- a/frontend/src/components/TelemetryNotice.tsx
+++ b/frontend/src/components/TelemetryNotice.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { usePathname } from "next/navigation";
 import Link from "next/link";
 import { BarChart3, X } from "lucide-react";
-import { trackEvent, routeOf, getTelemetry, setTelemetry, ackTelemetryNotice } from "@/lib/telemetry";
+import { trackEvent, routeOf, agentOf, getTelemetry, setTelemetry, ackTelemetryNotice } from "@/lib/telemetry";
 
 const SEEN_KEY = "tt-telemetry-notice";
 
@@ -32,9 +32,13 @@ export default function TelemetryNotice() {
   useEffect(() => {
     if (!pathname) return;
     const route = routeOf(pathname);
-    if (route === lastRoute.current) return;
-    lastRoute.current = route;
-    trackEvent("page.viewed", { route });
+    const agent = agentOf(pathname);
+    // Dedupe on route *and* agent, or moving between two harness panels would
+    // look like one view of "agent-panel".
+    const key = agent ? `${route}:${agent}` : route;
+    if (key === lastRoute.current) return;
+    lastRoute.current = key;
+    trackEvent("page.viewed", agent ? { route, agent } : { route });
   }, [pathname]);
 
   // 2. First-run notice — the server `notice_ack` flag (local preferences DB) is

--- a/frontend/src/components/settings/UsagePrivacySettings.tsx
+++ b/frontend/src/components/settings/UsagePrivacySettings.tsx
@@ -18,6 +18,7 @@ export default function UsagePrivacySettings() {
   const [state, setState] = useState<TelemetryPreview | null>(null);
   const [toggling, setToggling] = useState(false);
   const [showPayload, setShowPayload] = useState(false);
+  const [showRaw, setShowRaw] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -129,23 +130,113 @@ export default function UsagePrivacySettings() {
               <ChevronDown size={14} className={cn("transition-transform", showPayload && "rotate-180")} />
             </button>
             {showPayload && (
-              <div className="border-t border-[var(--tt-border)] bg-[var(--tt-sunken)] p-3 space-y-3">
+              <div className="border-t border-[var(--tt-border)] bg-[var(--tt-sunken)] p-3 space-y-4">
                 <div>
-                  <h3 className="text-[12px] font-medium text-[var(--tt-fg-muted)] mb-2">What we collect</h3>
+                  <h3 className="text-[12px] font-medium text-[var(--tt-fg-muted)] mb-2">In plain English</h3>
                   <ul className="text-[12px] text-[var(--tt-fg-dim)] space-y-1 pl-4">
-                    <li className="list-disc">Which pages you open</li>
+                    <li className="list-disc">Which pages you open — including which coding agent&apos;s panel</li>
                     <li className="list-disc">Which features you use (summaries, filters, budgets, Hermes, etc.)</li>
                     <li className="list-disc">When you open or save a budget — the count only, never the limit or amount</li>
                     <li className="list-disc">Whether a summary succeeded or failed, and which engine</li>
+                    <li className="list-disc">
+                      For each coding agent found on this machine, whether we could read any sessions
+                      from it — as a size band (&ldquo;10-99&rdquo;), never the actual number. This is
+                      how we find out that support for an agent is broken without you having to report it.
+                    </li>
                     <li className="list-disc">Your OS, CPU type, and app version</li>
                     <li className="list-disc">Your country (from the network edge — never your IP)</li>
                     <li className="list-disc">Which AI agents are detected (Claude, Codex, …)</li>
                     <li className="list-disc">A random per-launch session id (reset each launch, not linked to you)</li>
                   </ul>
                 </div>
-                <pre className="max-h-[280px] overflow-auto bg-[var(--tt-panel)] p-3 text-[11px] font-mono text-[var(--tt-fg-dim)] leading-relaxed rounded border border-[var(--tt-border)]">
-                  {JSON.stringify(state.sample, null, 2)}
-                </pre>
+
+                {/* The authoritative list. Generated from the same allowlists the
+                    sender validates against, so it cannot drift from what is
+                    actually sent — every value below is one a real payload can
+                    contain, and nothing outside these lists can be transmitted. */}
+                <div>
+                  <h3 className="text-[12px] font-medium text-[var(--tt-fg-muted)] mb-1">
+                    Every event, and every value it can carry
+                  </h3>
+                  <p className="text-[11px] text-[var(--tt-fg-dim)] mb-2 max-w-[560px]">
+                    Read straight from the allowlist the app validates against before sending, so
+                    it is always current. Anything not on these lists is replaced with
+                    <span className="font-mono"> other</span> — it is never transmitted.
+                  </p>
+                  <div className="space-y-2">
+                    {state.event_catalog.map((spec) => (
+                      <div
+                        key={spec.event}
+                        className="rounded border border-[var(--tt-border)] bg-[var(--tt-panel)] px-2.5 py-2"
+                      >
+                        <div className="font-mono text-[11px] text-[var(--tt-fg-muted)]">{spec.event}</div>
+                        {spec.props.length === 0 ? (
+                          <div className="text-[11px] text-[var(--tt-fg-dim)] mt-0.5">
+                            no properties — the event name alone
+                          </div>
+                        ) : (
+                          <div className="mt-1 space-y-1">
+                            {spec.props.map((prop) => (
+                              <div key={prop.name} className="text-[11px] leading-relaxed">
+                                <span className="font-mono text-[var(--tt-fg-dim)]">{prop.name}</span>
+                                <span className="text-[var(--tt-fg-dim)]">: </span>
+                                {prop.values ? (
+                                  <span className="text-[var(--tt-fg-dim)]">
+                                    {prop.values.join(" · ")}
+                                  </span>
+                                ) : (
+                                  <span className="text-[var(--tt-fg-dim)] italic">
+                                    short plain text only (no paths, emails, or free text)
+                                  </span>
+                                )}
+                              </div>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                {/* Real current values, not a description of them. */}
+                <div>
+                  <h3 className="text-[12px] font-medium text-[var(--tt-fg-muted)] mb-1">
+                    Attached to every event
+                  </h3>
+                  <p className="text-[11px] text-[var(--tt-fg-dim)] mb-2 max-w-[560px]">
+                    These are this machine&apos;s actual values right now — not an example.
+                  </p>
+                  <div className="rounded border border-[var(--tt-border)] bg-[var(--tt-panel)] divide-y divide-[var(--tt-border)]">
+                    {state.always_sent.map((row) => (
+                      <div key={`${row.scope}.${row.name}`} className="px-2.5 py-1.5">
+                        <div className="flex items-baseline gap-2 flex-wrap">
+                          <span className="font-mono text-[11px] text-[var(--tt-fg-dim)]">{row.name}</span>
+                          <span className="font-mono text-[11px] text-[var(--tt-fg-muted)] break-all">
+                            {String(row.value) === "" ? "(empty)" : String(row.value)}
+                          </span>
+                        </div>
+                        {row.note && (
+                          <div className="text-[11px] text-[var(--tt-fg-dim)] mt-0.5">{row.note}</div>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                <div>
+                  <button
+                    onClick={() => setShowRaw((v) => !v)}
+                    className="flex items-center gap-1.5 text-[11px] font-medium text-[var(--tt-fg-muted)] hover:text-[var(--tt-fg)] transition-colors"
+                  >
+                    <ChevronDown size={12} className={cn("transition-transform", showRaw && "rotate-180")} />
+                    {showRaw ? "Hide" : "Show"} the raw payloads
+                  </button>
+                  {showRaw && (
+                    <pre className="mt-2 max-h-[280px] overflow-auto bg-[var(--tt-panel)] p-3 text-[11px] font-mono text-[var(--tt-fg-dim)] leading-relaxed rounded border border-[var(--tt-border)]">
+                      {JSON.stringify(state.sample, null, 2)}
+                    </pre>
+                  )}
+                </div>
               </div>
             )}
           </div>

--- a/frontend/src/lib/telemetry.ts
+++ b/frontend/src/lib/telemetry.ts
@@ -14,11 +14,36 @@ export interface TelemetryState {
   notice_ack: boolean;
 }
 
+/** One prop an event may carry. `values` is the closed set it is validated
+ *  against, or null when the prop is free-form (safe-scalar filter only). */
+export interface TelemetryProp {
+  name: string;
+  values: string[] | null;
+}
+
+/** One event and every prop it can carry. Derived server-side from the
+ *  allowlists, so this list can never drift from what is actually sent. */
+export interface TelemetryEventSpec {
+  event: string;
+  props: TelemetryProp[];
+}
+
+/** A context/system prop attached to every event, with this machine's real
+ *  current value — so the panel shows what would be sent, not a description. */
+export interface TelemetryAlwaysSent {
+  name: string;
+  scope: "context" | "system";
+  value: string | number | boolean;
+  note: string;
+}
+
 /** Exactly-what-we-send transparency payload (`GET /config/telemetry/preview`). */
 export interface TelemetryPreview extends TelemetryState {
   session_id: string;
   never_collected: string[];
   events: string[];
+  event_catalog: TelemetryEventSpec[];
+  always_sent: TelemetryAlwaysSent[];
   sample: unknown[];
   recent_sent: unknown[];
 }
@@ -72,7 +97,19 @@ export function routeOf(pathname: string): string {
   if (p.startsWith("/local-models")) return "local-models";
   if (p.startsWith("/sessions")) return "traces";
   if (p.startsWith("/projects")) return p === "/projects" ? "projects" : "project-detail";
+  if (p.startsWith("/agents/")) return "agent-panel";
   if (p.startsWith("/hermes")) return "hermes";
   if (p.startsWith("/settings")) return "settings";
   return "other";
+}
+
+/** The harness key from an `/agents/<key>` path, else undefined.
+ *
+ *  Paired with `routeOf`, this is what makes "is anyone actually opening the
+ *  Qoder panel?" answerable. The backend re-validates the key against its own
+ *  closed agent list, so an unrecognised one is reported as "other" rather than
+ *  riding through. */
+export function agentOf(pathname: string): string | undefined {
+  const m = pathname.replace(/\/+$/, "").match(/^\/agents\/([A-Za-z0-9_-]+)/);
+  return m ? m[1].toLowerCase() : undefined;
 }

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -90,6 +90,41 @@ editor); `events` for `budget-set` is the configure count (the "clicks").
 sessionId resets every launch and isn't linkable, so this is a usage floor, not
 a unique-user count.
 
+#### Is a newly added harness actually working?
+
+`harness.scanned` fires once per launch for each agent detected on the machine,
+carrying that agent (`blob17`) and how many sessions its reader returned as an
+order-of-magnitude bucket (`blob18`) — never a raw count. A row with
+`blob18 = '0'` is the interesting one: the harness is installed and we found
+nothing, which is the shape of a broken reader.
+
+```sql
+SELECT blob17 AS agent,
+       blob18 AS sessions,
+       count(DISTINCT blob2) AS launches   -- blob2 = per-launch session id
+FROM tt_telemetry
+WHERE blob1 = 'harness.scanned'
+  AND timestamp > now() - INTERVAL '30' DAY
+GROUP BY agent, sessions
+ORDER BY agent, sessions
+```
+
+An agent whose launches sit overwhelmingly in the `0` bucket is failing in the
+field even though it detects fine. That is the exact state DeepSeek Harness
+shipped in, and it took a bug report to find.
+
+To ask the narrower question — do people ever *open* a given harness panel —
+use `page.viewed`, which is gated behind a real browser interaction and so is
+far less bot-contaminated than anything hanging off launch:
+
+```sql
+SELECT blob17 AS agent, count() AS views, count(DISTINCT blob2) AS launches
+FROM tt_telemetry
+WHERE blob1 = 'page.viewed' AND blob7 = 'agent-panel'
+  AND timestamp > now() - INTERVAL '30' DAY
+GROUP BY agent ORDER BY views DESC
+```
+
 ### 2. Grafana (the "holistic picture")
 Install the official **Cloudflare Analytics Engine** Grafana data-source plugin,
 point it at the SQL API with the same token, and build panels (DAU, top routes,
@@ -108,7 +143,13 @@ agent mix, summary outcomes). This is the recommended long-term dashboard.
 | `blob6` | appVersion | `blob14` | summarizer_backend (context) |
 | `blob7` | route (`page.viewed`) | `blob15` | country (edge, no IP) |
 | `blob8` | feature name (`feature.used`) | `blob16` | sdkVersion |
+| `blob17` | agent — a *single* harness | `blob18` | volume (bucketed count) |
 | `double1` | agent_count | `double2` | isDebug (0/1) |
+
+Note `blob13` and `blob17` are different things: `blob13` is the whole detected
+set as a CSV (context, on every event), `blob17` is one harness — the subject of
+a `harness.scanned`, or the panel being viewed on a `page.viewed`. Positions are
+append-only; renumbering silently re-labels every historical row.
 
 Plus the automatic `timestamp` and `_sample_interval` columns.
 

--- a/proxy/cloudflare-worker.js
+++ b/proxy/cloudflare-worker.js
@@ -53,6 +53,7 @@ const MAX_BODY = 8 * 1024; // events are tiny; reject anything bigger as abuse.
 const ALLOWED_EVENTS = new Set([
   "app.launched", "page.viewed", "trace.summarized",
   "analytics.filtered", "feature.used", "retention.opted_in",
+  "harness.scanned",
 ]);
 
 // Cheap, stateless validation. This is NOT anti-spoof (an open-source client
@@ -125,10 +126,17 @@ export default {
           blob(p.backend),            // blob10
           blob(p.outcome),            // blob11
           blob(p.tier),               // blob12
-          blob(p.agents, 120),        // blob13
+          blob(p.agents, 256),        // blob13
           blob(p.summarizer_backend), // blob14
           blob(country, 8),           // blob15
           blob(s.sdkVersion),         // blob16
+          // Appended, never renumbered -- blob positions are the schema that
+          // saved SQL/Grafana queries read by index.
+          blob(p.agent),              // blob17 -- ONE harness (harness.scanned,
+                                      //   or the agent panel on page.viewed).
+                                      //   Distinct from blob13 `agents`, which
+                                      //   is the full detected set.
+          blob(p.volume),             // blob18 -- bucketed session count
         ],
         doubles: [
           num(p.agent_count),         // double1

--- a/proxy/cloudflare/src/index.js
+++ b/proxy/cloudflare/src/index.js
@@ -53,6 +53,7 @@ const MAX_BODY = 8 * 1024; // events are tiny; reject anything bigger as abuse.
 const ALLOWED_EVENTS = new Set([
   "app.launched", "page.viewed", "trace.summarized",
   "analytics.filtered", "feature.used", "retention.opted_in",
+  "harness.scanned",
 ]);
 
 // Cheap, stateless validation. This is NOT anti-spoof (an open-source client
@@ -125,10 +126,17 @@ export default {
           blob(p.backend),            // blob10
           blob(p.outcome),            // blob11
           blob(p.tier),               // blob12
-          blob(p.agents, 120),        // blob13
+          blob(p.agents, 256),        // blob13
           blob(p.summarizer_backend), // blob14
           blob(country, 8),           // blob15
           blob(s.sdkVersion),         // blob16
+          // Appended, never renumbered -- blob positions are the schema that
+          // saved SQL/Grafana queries read by index.
+          blob(p.agent),              // blob17 -- ONE harness (harness.scanned,
+                                      //   or the agent panel on page.viewed).
+                                      //   Distinct from blob13 `agents`, which
+                                      //   is the full detected set.
+          blob(p.volume),             // blob18 -- bucketed session count
         ],
         doubles: [
           num(p.agent_count),         // double1

--- a/website/content/docs/configuration/privacy.mdx
+++ b/website/content/docs/configuration/privacy.mdx
@@ -35,7 +35,9 @@ export TT_NO_UPDATE_CHECK=1
 
 TokenTelemetry optionally sends anonymous, content-free feature-usage events to help the maintainer understand which features are used and prioritize development. This is distinct from the update check.
 
-**What is sent:** Event names only (e.g. "opened Analytics page", "generated summary"). No session content, no tokens, no costs, no file paths, no identifiers that could link events to a person or machine.
+**What is sent:** An event name plus a handful of values drawn from fixed lists — which page you opened (including which coding agent's panel), which feature you used, whether a summary succeeded, and for each coding agent detected on your machine whether its sessions could be read at all, as a size band rather than a count. No session content, no tokens, no costs, no file paths, no identifiers that could link events to a person or machine.
+
+Anything outside those fixed lists is replaced with `other` before sending, so an unexpected value cannot ride along. Settings → *Anonymous usage stats* → **Show exactly what we send** lists every event and every permitted value, generated from the same allowlist the app validates against — so it is always current rather than a description someone remembered to update.
 
 **What is not sent:** Anything from your agent sessions.
 
@@ -43,7 +45,7 @@ Telemetry is **on by default** (opt-out). It is automatically disabled in CI env
 
 ### Disabling product telemetry
 
-**In the app:** Settings → *Updates & privacy* → toggle off *Share anonymous usage data*.
+**In the app:** Settings → *Updates & privacy* → toggle off *Anonymous usage stats*.
 
 **Via environment variable:** Set `TT_NO_TELEMETRY=1` before launching. Like `TT_NO_UPDATE_CHECK`, this wins over the in-app toggle:
 

--- a/website/src/app/privacy/page.tsx
+++ b/website/src/app/privacy/page.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
   robots: { index: true, follow: true },
 };
 
-const UPDATED = "June 15, 2026";
+const UPDATED = "August 30, 2026";
 
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
@@ -42,7 +42,7 @@ export default function PrivacyPage() {
       <Section title="What we collect">
         <p>Anonymous usage signals only — nothing about your code, prompts, or work:</p>
         <ul className="list-disc pl-5 space-y-2 mt-2">
-          <li>Which pages you open in the app</li>
+          <li>Which pages you open in the app, including which coding agent&apos;s panel</li>
           <li>Which features you use (e.g. trace summaries, analytics filters, the Hermes dashboard)</li>
           <li>Whether a summary succeeded or failed, and which summarizer engine was used</li>
           <li>Your OS family, CPU architecture, and the app version</li>
@@ -51,6 +51,13 @@ export default function PrivacyPage() {
             IP (we never receive or store your IP)
           </li>
           <li>Which AI agents are detected on your machine (e.g. Claude, Codex), as a generic list</li>
+          <li>
+            For each detected agent, whether TokenTelemetry could read any sessions from it — as a
+            size band (&ldquo;0&rdquo;, &ldquo;10-99&rdquo;), never the real number. Support for an
+            agent can break silently on machines we cannot test on; this is how we find out without
+            waiting for someone to report it
+          </li>
+          <li>When you turn full transcript retention on or off — the setting only, never which agent</li>
           <li>
             A random session id that is regenerated every launch and is never linked to you across
             sessions


### PR DESCRIPTION
Stacked on `feat/qoder-agent` (#310) so the diff here is only the telemetry work. GitHub will retarget this to `main` when #310 merges.

## Why

Adding a harness has never told us whether it works anywhere but the machine it was built on. The telemetry context already carried which agents are *installed*; nothing carried whether their readers actually returned anything.

That gap has a track record. DeepSeek Harness shipped reporting zero sessions and it took a bug report to catch. Qoder was built against two sessions on one machine, by a maintainer with no Qoder subscription — #282 is currently asking a community member to verify it by hand, because there is no other way to know.

## What this adds

**`harness.scanned`** — one event per harness, emitted once per process after the first successful scan. It carries the agent and an order-of-magnitude bucket of how many sessions were read (`0`, `1-9`, `10-99`, `100-999`, `1000-plus`), never a raw count. A harness whose launches cluster in the `0` bucket is installed and unreadable, which is the shape of a broken reader.

Once per process is deliberate: the scan re-runs on a 30s TTL and clients poll it, so a per-scan emit would be a firehose.

It covers the **union** of detected agents and agents that actually produced sessions, because the two disagree in both directions and each disagreement is the signal:

- detected, 0 sessions → the reader is broken
- sessions, not detected → the detector is broken

The second case is live right now. SmallCode's traces are project-local, so `_list_available_agents()` only sees it through an env-configured extra root while the scanner is finding its sessions perfectly well. On this machine that is 6 sessions the agent list does not know about. Iterating detection alone would have silently omitted it. (The underlying detection gap is left alone here — it changes `/agents` and the UI, so it wants its own change.)

**An `agent` dimension on `page.viewed`**, plus `/agents/<key>` mapping to a new `agent-panel` route instead of falling through to `other`. That pairing answers "is anyone opening the Qoder panel", and being gated behind a real browser interaction it is far less bot-contaminated than anything hanging off launch.

## The sink needed wiring too

The Cloudflare worker keeps **its own copy** of the event allowlist. Without that half, a new event is accepted by the app, POSTed, answered `204`, and then never written — completely invisible at runtime. I nearly shipped exactly that.

Its blob list is positional and *is* the schema saved SQL/Grafana queries read by index, so `agent` and `volume` are appended as `blob17`/`blob18` and nothing is renumbered. `proxy/README.md` gains the schema rows and a query for finding an agent stuck in the `0` bucket.

## Two bugs found on the way

**The `agents` field was three characters from corrupting itself.** With 18 agents the string was 117 of its 120 characters, and `",".join(...)[:120]` slices mid-token. One more harness and the field would have ended on `small` — inventing an agent that does not exist in the data. With a 19th it ends on `q`.

Truncation is now on a comma boundary, the cap is 256 in both the backend and the worker (which re-caps independently, so a stale cap there silently undoes the fix at the edge), and a test asserts the whole recognised set fits — so the next harness fails CI rather than corrupting the field in production.

**`retention.opted_in` was declared but never sent.** It sat in the allowlist, in the worker's allowlist, and in the Settings panel complete with a sample payload — while no code path anywhere emitted it. The transparency surface was advertising something the app did not do. Now wired to the retention endpoint, with a test that fails if any declared event has no emitter.

## Settings now generates its own disclosure

"Show exactly what we send" was a hand-written bullet list, and it had already fallen behind. It is now generated from the same allowlists the sender validates against: every event, every property, every permitted value, and the context/system fields with **this machine's real current values** rather than an example. A new event or prop appears there the moment it is added, with no second list to go stale. `sample_payloads()` now iterates `_EVENT_PROPS` for the same reason.

## Privacy posture is unchanged

Same worker URL, same one-click opt-out, same `DO_NOT_TRACK` / `TT_NO_TELEMETRY` / CI kill switches. The `agent` prop draws on the existing closed agent list, so an unrecognised name still collapses to `other` and never rides through. Volume is bucketed at the source; a raw session count cannot be emitted. No new outbound path.

## Verification

Not asserted — checked, with the sink pointed at a dead local port throughout so nothing left the machine during testing.

| Check | Result |
|---|---|
| Events on a real scan | 18 fired, one per harness |
| Buckets vs an independent recount of `/sessions` | all 18 match (1295 sessions; antigravity 360 → `100-999`, qoder 2 → `1-9`) |
| Real worker run in node | new event written to blob17/18; blob7/12/13 unmoved; forged event still dropped |
| 129-char agents field through the worker | survives intact, last token `vibe` |
| Backend suite | 658 passed / 22 failed |
| Failure names vs baseline | byte-identical (baseline via `git archive`: 643 passed / 22 failed) |
| New tests | 15 |
| `tsc --noEmit` | clean |
| Settings panel | confirmed rendering in the running app |

Each new guard was checked against its own bug: removing `harness.scanned` from the worker allowlist fails `test_worker_accepts_every_event_the_app_sends` with the file to edit named in the message.

## Not done here

- The SmallCode detection gap itself (`_list_available_agents()` misses project-local traces). Reported, not fixed — it changes `/agents` and the UI.
- Antigravity detection is nested inside the Gemini check and truthiness-tests a generator, so a stray file in `~/.gemini/tmp/` reads as "Antigravity detected". Pre-existing; noted while auditing.
- The route enum still declares `artifacts` and `sessions`, which `routeOf()` never produces. Harmless, left alone rather than churn a live enum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
