### PR TITLE
fix: show a published artifact once per project, not once per session

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -9726,7 +9726,15 @@ async def get_projects(include_hidden: bool = False):
         p["agents"] = list(p["agents"])
         p["mcp_tools"] = list(p["mcp_tools"])
         p["plans"] = sorted(p["plans"], key=lambda x: str(x["timestamp"]), reverse=True)
-        p["artifacts"] = sorted(p["artifacts"], key=lambda x: str(x.get("timestamp") or ""), reverse=True)
+        # One artifact, one card. `published_artifacts` is deduped by url
+        # *within* a session, but a project sums several sessions and a resumed
+        # or forked session replays the original publish record verbatim — same
+        # url, same path, same timestamp, only a different session_id. Extending
+        # without a dedupe therefore surfaced one publish once per session that
+        # carried it, which rendered as duplicate cards (and duplicate React
+        # keys, since the UI keys on the same identity).
+        p["artifacts"] = _dedupe_artifacts(
+            sorted(p["artifacts"], key=lambda x: str(x.get("timestamp") or ""), reverse=True))
         # Status: is this project folder still on disk?
         try:
             p["status"] = "active" if Path(p["path"]).exists() else "missing"
@@ -9859,20 +9867,50 @@ async def get_projects(include_hidden: bool = False):
         # publishes usually happen from worktree sessions but belong to the repo.
         # Identity is the hosted url for "page" artifacts, the file path for
         # "document" ones.
-        seen_keys = {a.get("url") or a.get("path") for a in parent.get("artifacts", [])}
+        seen_keys = {_artifact_key(a) for a in parent.get("artifacts", [])}
         for c in children:
             for a in c.get("artifacts", []):
-                key = a.get("url") or a.get("path")
+                key = _artifact_key(a)
                 if key and key not in seen_keys:
                     parent.setdefault("artifacts", []).append(a)
                     seen_keys.add(key)
-        parent["artifacts"] = sorted(parent.get("artifacts", []),
-                                     key=lambda x: str(x.get("timestamp") or ""), reverse=True)
+        parent["artifacts"] = _dedupe_artifacts(
+            sorted(parent.get("artifacts", []),
+                   key=lambda x: str(x.get("timestamp") or ""), reverse=True))
         for c in children:
             c["parent_path"] = repo
             c["parent_name"] = parent["name"]
 
     out.extend(synthesized)
+    return out
+
+
+def _artifact_key(a: Dict[str, Any]) -> Optional[str]:
+    """Identity of one artifact: the hosted url for a published page, the file
+    path for a document. Two records sharing this are the same artifact, not two
+    of them — a redeploy reuses the url by design."""
+    return a.get("url") or a.get("path")
+
+
+def _dedupe_artifacts(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Collapse artifacts that share an identity, keeping the first seen.
+
+    Callers pass a list already sorted newest-first, so "first" is the most
+    recent record and therefore the freshest title/description a later redeploy
+    may have changed. Records with no identity at all are kept as-is rather than
+    silently dropped.
+    """
+    seen = set()
+    out: List[Dict[str, Any]] = []
+    for a in items:
+        key = _artifact_key(a)
+        if key is None:
+            out.append(a)
+            continue
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(a)
     return out
 
 

--- a/backend/test_published_artifacts.py
+++ b/backend/test_published_artifacts.py
@@ -242,3 +242,89 @@ def test_projects_rollup(scan_env, monkeypatch):
     assert len(proj["artifacts"]) == 1
     assert proj["artifacts"][0]["url"] == URL1
     assert proj["artifacts"][0]["session_id"] == SID
+
+
+# --- one artifact, one card -------------------------------------------------
+
+SID2 = "ffffffff-1111-2222-3333-444444444444"
+
+
+def _write_session_as(claude_dir, sid, lines):
+    """Same project, a different session file — what a resume or fork produces."""
+    p_dir = claude_dir / "projects" / PROJ_DIR
+    p_dir.mkdir(parents=True, exist_ok=True)
+    (p_dir / f"{sid}.jsonl").write_text(
+        _jl(type="user", timestamp="2026-07-20T10:00:00Z", cwd="/tmp/proj",
+            message={"content": "make me a page"}) + "".join(lines),
+        encoding="utf-8",
+    )
+
+
+def test_dedupe_artifacts_keeps_first_and_never_drops_keyless():
+    items = [
+        {"url": "u1", "title": "newest"},
+        {"url": "u1", "title": "older copy"},
+        {"path": "/p/a", "title": "doc"},
+        {"title": "no identity at all"},
+        {"title": "also no identity"},
+    ]
+    out = main._dedupe_artifacts(items)
+    assert [a["title"] for a in out] == [
+        "newest", "doc", "no identity at all", "also no identity"]
+
+
+def test_url_beats_path_as_identity():
+    """A page's identity is its url even when two records disagree on path —
+    a redeploy from a different file still targets the same artifact."""
+    items = [{"url": "u1", "path": "/a.html"}, {"url": "u1", "path": "/b.html"}]
+    assert len(main._dedupe_artifacts(items)) == 1
+
+
+def test_same_publish_in_two_sessions_is_one_artifact(scan_env, monkeypatch):
+    """The bug: a resumed/forked session replays the original publish record, so
+    the project rolled the same artifact up once per session carrying it. That
+    rendered duplicate cards and, because the UI keys on the same identity,
+    duplicate React keys."""
+    records = [
+        _artifact_call("t1", "2026-07-20T10:01:00Z", file_path="/tmp/a.html", title="A"),
+        _artifact_result("t1", "2026-07-20T10:01:05Z", f"Published a at {URL1}"),
+    ]
+    _write_session_as(scan_env / ".claude", SID, records)
+    _write_session_as(scan_env / ".claude", SID2, records)   # the replay
+
+    sessions = main._scan_sessions_sync()
+
+    async def fake_cached(fresh=False):
+        return sessions
+    monkeypatch.setattr(main, "get_sessions_cached", fake_cached)
+    monkeypatch.setattr(main, "load_hidden", lambda: set())
+    projects = asyncio.run(main.get_projects())
+    proj = next(p for p in projects if p["path"] == "/tmp/proj")
+
+    # Both sessions really do carry the publish...
+    carriers = [s for s in sessions if s.get("published_artifacts")]
+    assert len(carriers) == 2, "fixture should reproduce the replay"
+    # ...but the project shows it once.
+    assert len(proj["artifacts"]) == 1
+    assert proj["artifacts"][0]["url"] == URL1
+
+
+def test_project_artifact_keys_are_unique(scan_env, monkeypatch):
+    """Guards the React key directly: the UI keys on `url || path`, so that
+    expression has to be unique across a project's artifacts."""
+    records = [
+        _artifact_call("t1", "2026-07-20T10:01:00Z", file_path="/tmp/a.html", title="A"),
+        _artifact_result("t1", "2026-07-20T10:01:05Z", f"Published a at {URL1}"),
+    ]
+    _write_session_as(scan_env / ".claude", SID, records)
+    _write_session_as(scan_env / ".claude", SID2, records)
+    sessions = main._scan_sessions_sync()
+
+    async def fake_cached(fresh=False):
+        return sessions
+    monkeypatch.setattr(main, "get_sessions_cached", fake_cached)
+    monkeypatch.setattr(main, "load_hidden", lambda: set())
+    for proj in asyncio.run(main.get_projects()):
+        keys = [a.get("url") or a.get("path") for a in proj.get("artifacts", [])]
+        assert len(keys) == len(set(keys)), (
+            "duplicate React key in %s: %s" % (proj.get("name"), keys))

--- a/frontend/src/app/projects/[path]/artifacts/page.tsx
+++ b/frontend/src/app/projects/[path]/artifacts/page.tsx
@@ -28,6 +28,17 @@ function rawFileUrl(path: string): string {
    pointer events — it's a thumbnail, not an embed; clicking opens the hosted
    url. Mounted lazily (IntersectionObserver) and only after a HEAD check
    confirms the source file still exists — it may have been deleted since. */
+/* React key for one artifact row/card.
+ *
+ * The backend collapses artifacts that share an identity (hosted url for a
+ * page, file path for a document), so in practice this is unique on the first
+ * term. The index is a backstop: a duplicate key makes React omit or duplicate
+ * children silently, which is a worse failure than a key that is merely
+ * position-dependent, and this list is re-rendered whole on every fetch. */
+function artifactKey(a: PublishedArtifact, i: number): string {
+  return `${a.url || a.path || "artifact"}::${i}`;
+}
+
 const FRAME_W = 1280;
 const PREVIEW_H = 200;
 
@@ -322,15 +333,15 @@ export default function ArtifactsTab() {
 
       {view === "cards" ? (
         <div className="space-y-5">
-          {artifacts.map((a) => (
-            <ArtifactCard key={a.url || a.path} a={a} sessionHref={sessionHrefFor(a)} />
+          {artifacts.map((a, i) => (
+            <ArtifactCard key={artifactKey(a, i)} a={a} sessionHref={sessionHrefFor(a)} />
           ))}
         </div>
       ) : (
         <Card padding="none">
           <div className="divide-y divide-[var(--tt-border)]">
-            {artifacts.map((a) => (
-              <ArtifactRow key={a.url || a.path} a={a} sessionHref={sessionHrefFor(a)} />
+            {artifacts.map((a, i) => (
+              <ArtifactRow key={artifactKey(a, i)} a={a} sessionHref={sessionHrefFor(a)} />
             ))}
           </div>
         </Card>


### PR DESCRIPTION
Fixes the console error on the project Artifacts tab:

```
Encountered two children with the same key,
`https://claude.ai/code/artifact/faaea0c3-...`
src/app/projects/[path]/artifacts/page.tsx (325:25) @ ArtifactsTab
```

## Cause

The duplicate key is a symptom — the same artifact really was in the list twice.

`published_artifacts` is deduped by url **within** a session: the scan keys on the url and lets a later publish win, because a redeploy reuses the url by design. A project, though, sums several sessions, and `projects[proj]["artifacts"].extend(...)` had no dedupe of its own.

A resumed or forked session replays the original publish record verbatim, so the same artifact arrived once per session carrying it. The two records in the report were identical in url, path, title, timestamp (to the millisecond), agent and kind — differing only in `session_id`.

The UI keys on `url || path`, which is the same identity the scan uses, so duplicated data became a duplicated key. Not cosmetic: React may omit or duplicate children when keys collide.

## Fix

The rule already existed a few lines below, in the repo-root/worktree merge:

> Identity is the hosted url for "page" artifacts, the file path for "document" ones.

This lifts it into `_artifact_key` / `_dedupe_artifacts` and applies it to the per-project rollup as well, so one rule governs both places instead of one having a rule and the other not. Lists are already sorted newest-first, so keeping the first occurrence keeps the freshest metadata a later redeploy may have changed. Records with no identity are kept, not collapsed.

The React key also gains an index as a backstop. Deduping upstream is the actual fix; the key change just means malformed data degrades to a harmless repeated render rather than children silently vanishing.

## Verification

Against the live store, before and after:

| | before | after |
|---|---|---|
| projects scanned | 175 | 175 |
| artifacts total | 115 | 114 |
| duplicate keys | 1 | **0** |
| the reported project | 5 artifacts | 4 |

The page now renders one card for that artifact with a clean console.

Four new tests, each checked against the bug rather than just passing. Reverting the rollup dedupe fails:

- `test_same_publish_in_two_sessions_is_one_artifact` → `assert 2 == 1`
- `test_project_artifact_keys_are_unique` → the same duplicate-key message the browser printed

Backend suite 671 passed / 22 failed, failure names identical to the baseline. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
