### PR TITLE
fix: stop the usage dedupe from swallowing a record's tool calls

### DIFF
--- a/UPDATE.json
+++ b/UPDATE.json
@@ -2,6 +2,17 @@
   "releases": [
     {
       "tag": "2026-08-30",
+      "title": "Codex Sites appear with your artifacts",
+      "highlights": [
+        {
+          "title": "Published Codex Sites now show in every project",
+          "description": "When Codex deploys a Site, TokenTelemetry records its title and live link as a project artifact alongside Claude Code pages and local documents. The card is labelled Codex Site and opens the deployed page. Only confirmed results from the Sites connector are recorded, never a link merely mentioned in a conversation.",
+          "href": "/projects"
+        }
+      ]
+    },
+    {
+      "tag": "2026-08-30",
       "title": "Telemetry you can read line by line",
       "highlights": [
         {

--- a/backend/main.py
+++ b/backend/main.py
@@ -6481,8 +6481,23 @@ def _scan_sessions_sync():
                                         message_id = msg.get("id")
                                         if message_id:
                                             if message_id in seen_assistant_message_ids:
-                                                continue
-                                            seen_assistant_message_ids.add(message_id)
+                                                # Claude splits ONE assistant message across several
+                                                # records — text first, then the tool_use blocks —
+                                                # and every one of them repeats the same id and the
+                                                # same cumulative usage. Count that usage once.
+                                                #
+                                                # This used to `continue`, which skipped the whole
+                                                # record: the tool_use loop below never ran for a
+                                                # continuation record, so its Skill/ExitPlanMode/
+                                                # CronCreate/Artifact blocks were invisible. A
+                                                # published artifact whose Artifact call landed in
+                                                # a continuation was silently dropped from the
+                                                # project's Artifacts tab. Drop the usage, keep
+                                                # reading the record.
+                                                usage = {}
+                                            else:
+                                                seen_assistant_message_ids.add(message_id)
+                                    if usage:
                                         cr = usage.get("cache_read_input_tokens", 0) or 0
                                         cc = usage.get("cache_creation_input_tokens", 0) or 0
                                         cc_1h = (usage.get("cache_creation", {}) or {}).get("ephemeral_1h_input_tokens", 0) or 0

--- a/backend/main.py
+++ b/backend/main.py
@@ -1368,11 +1368,12 @@ class Artifact(BaseModel):
 
 class PublishedArtifact(BaseModel):
     """A user-facing artifact an agent produced as a deliverable, shown on the
-    project Artifacts tab. Two kinds: "page" — a hosted claude.ai page from
-    Claude Code's Artifact tool (has `url`); "document" — a local doc like
-    Antigravity's task/plan/walkthrough (has `path`, served via
-    /artifacts?path=). Unlike `Artifact`, entries carry display metadata
-    (title/description) mined from the transcript or metadata sidecars."""
+    project Artifacts tab. Kinds: "page" — a hosted claude.ai page from
+    Claude Code's Artifact tool; "site" — a deployed Codex Site; and
+    "document" — a local doc like Antigravity's task/plan/walkthrough (has
+    `path`, served via /artifacts?path=). Unlike `Artifact`, entries carry
+    display metadata (title/description) mined from the transcript or metadata
+    sidecars."""
     kind: str = "page"
     url: Optional[str] = None
     path: Optional[str] = None
@@ -5962,6 +5963,84 @@ _LOOP_JOB_RE = re.compile(r"\bjob\s+([0-9a-fA-F]{6,})\b")
 # ("Published <path> at https://claude.ai/code/artifact/<uuid>").
 _ARTIFACT_URL_RE = re.compile(r"https://claude\.ai/code/artifact/[0-9a-f-]{36}")
 
+# A Codex Site is only a session artifact when a Codex Sites tool produced its
+# deployed URL. Do not mine arbitrary chatgpt.site strings from user prompts or
+# assistant prose: a session may discuss a Site it did not create.
+_CODEX_SITES_TOOL_RE = re.compile(
+    r"(?:mcp__codex_apps__)?sites_(?:create_site|save_site_version|"
+    r"deploy_(?:private_)?site_version|get_deployment_status|get_site)",
+    re.IGNORECASE,
+)
+_CODEX_SITE_URL_RE = re.compile(
+    r"https://[a-z0-9][a-z0-9.-]*\.chatgpt\.site(?:/[^\s<>\"']*)?",
+    re.IGNORECASE,
+)
+_CODEX_SITE_FIELD_RE = {
+    key: re.compile(rf"[\"']?{key}[\"']?\s*:\s*[\"']([^\"']{{1,240}})[\"']", re.IGNORECASE)
+    for key in ("title", "description", "slug")
+}
+
+
+def _codex_site_metadata(value: Any) -> Dict[str, str]:
+    """Return safe display fields from a Codex Sites call or its result.
+
+    Site transport records can be direct function-call JSON or a custom
+    `functions.exec` program. This extracts only bounded presentation fields;
+    credentials, project IDs, raw output, and arbitrary tool arguments never
+    leave the scanner.
+    """
+    parsed: Any = value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except (TypeError, ValueError):
+            parsed = None
+    if isinstance(parsed, dict) and isinstance(parsed.get("structuredContent"), dict):
+        parsed = parsed["structuredContent"]
+    result: Dict[str, str] = {}
+    if isinstance(parsed, dict):
+        for key in ("title", "description", "slug"):
+            field = parsed.get(key)
+            if isinstance(field, str) and field.strip():
+                result[key] = field.strip()[:240]
+    if result or not isinstance(value, str):
+        return result
+    for key, pattern in _CODEX_SITE_FIELD_RE.items():
+        match = pattern.search(value)
+        if match:
+            result[key] = match.group(1).strip()[:240]
+    return result
+
+
+def _codex_site_output_text(value: Any, limit: int = 16_000) -> str:
+    """Flatten a structured tool result without retaining it in session data."""
+    if isinstance(value, str):
+        return value[:limit]
+    if isinstance(value, list):
+        parts = [_codex_site_output_text(item, limit) for item in value]
+        return "\n".join(part for part in parts if part)[:limit]
+    if isinstance(value, dict):
+        # These are the only result fields that may contain a deployed URL.
+        # In particular, do not stringify whole MCP results: they can include
+        # opaque connector metadata that is neither needed nor safe to retain.
+        for key in ("url", "current_live_url", "current_preview_url", "structuredContent", "text", "output", "content"):
+            if key in value:
+                return _codex_site_output_text(value[key], limit)
+    return ""
+
+
+def _codex_site_urls(value: Any) -> List[str]:
+    """Extract HTTPS Sites URLs from a confirmed Sites tool output only."""
+    text = _codex_site_output_text(value)
+    seen: Set[str] = set()
+    urls: List[str] = []
+    for match in _CODEX_SITE_URL_RE.finditer(text):
+        url = match.group(0).rstrip(".,;:)")
+        if url not in seen:
+            seen.add(url)
+            urls.append(url)
+    return urls
+
 
 def _loop_parse_ts(ts: Any) -> Optional[datetime]:
     if not ts or not isinstance(ts, str):
@@ -6255,7 +6334,7 @@ def _apply_claude_cache_hit(sess: Dict[str, Any], cached: Dict[str, Any]) -> Non
 _CODEX_CACHE_FIELDS = (
     "tokens", "model", "models_used", "_provider", "cost", "mcp_tools", "has_plan", "plans",
     "text", "tokens_by_day", "tool_counts", "_skill_counts",
-    "parent_session_id", "subagent_info", "_raw_cwd",
+    "parent_session_id", "subagent_info", "_raw_cwd", "published_artifacts",
 )
 
 
@@ -6847,6 +6926,9 @@ def _scan_sessions_sync():
                 continue
 
             day_snap = {}
+            codex_site_calls: Dict[str, Dict[str, str]] = {}
+            codex_site_meta: Dict[str, str] = {}
+            published_sites: Dict[str, Dict[str, Any]] = {}
 
             def record_codex_model(value: Any) -> None:
                 """Keep full Codex model IDs in trace order, latest as primary."""
@@ -6859,6 +6941,23 @@ def _scan_sessions_sync():
                 # Codex logs model changes as later turn-context/settings events.
                 # The current model is the final observed model, not its provider.
                 sess["model"] = model_id
+
+            def record_codex_site_output(call_meta: Dict[str, str], output: Any, timestamp: Any) -> None:
+                """Project a confirmed Sites result into a compact artifact."""
+                output_meta = _codex_site_metadata(output)
+                if output_meta:
+                    codex_site_meta.update(output_meta)
+                for site_url in _codex_site_urls(output):
+                    existing = published_sites.get(site_url, {})
+                    published_sites[site_url] = {
+                        "kind": "site",
+                        "url": site_url,
+                        "title": call_meta.get("title") or codex_site_meta.get("title") or existing.get("title") or "Codex Site",
+                        "description": call_meta.get("description") or codex_site_meta.get("description") or existing.get("description"),
+                        "session_id": sid,
+                        "agent": "codex",
+                        "timestamp": timestamp or existing.get("timestamp"),
+                    }
 
             for rollout_file in rollout_files:
                 try:
@@ -6899,6 +6998,23 @@ def _scan_sessions_sync():
                                     settings = event_payload.get("thread_settings") or {}
                                     if isinstance(settings, dict):
                                         record_codex_model(settings.get("model"))
+                                # Current Codex records connected-app calls as
+                                # event messages, not response_item function calls.
+                                # Accept only the first-party Sites connector and
+                                # its known lifecycle tools, then project its result.
+                                if event_payload.get("type") == "item_completed":
+                                    item = event_payload.get("item") or {}
+                                    tool_name = item.get("tool")
+                                    normalized_tool = tool_name.replace(".", "_") if isinstance(tool_name, str) else ""
+                                    if (
+                                        item.get("type") == "McpToolCall"
+                                        and str(item.get("appName") or "").lower() == "sites"
+                                        and _CODEX_SITES_TOOL_RE.search(normalized_tool)
+                                    ):
+                                        call_meta = _codex_site_metadata(item.get("arguments"))
+                                        if call_meta:
+                                            codex_site_meta.update(call_meta)
+                                        record_codex_site_output(call_meta, item.get("result"), data.get("timestamp"))
                                 ts_str = data.get("timestamp")
                                 event_day = None
                                 if ts_str:
@@ -6946,8 +7062,38 @@ def _scan_sessions_sync():
                                     # table — or by _default when the model id was unknown there.
                                     sess["cost"] = calculate_cost(sess.get("model"), sess["tokens"]["input"], sess["tokens"]["output"], sess["tokens"]["cached"], provider=sess.get("_provider"), at=sess["timestamp"])
                             if data.get("type") == "response_item":
-                                if data.get("payload", {}).get("type") == "function_call":
-                                    tool = data["payload"].get("name")
+                                response = data.get("payload") or {}
+                                response_type = response.get("type")
+
+                                # Sites calls appear either as native function calls or
+                                # nested inside Codex's `functions.exec` custom tool.
+                                # Track their call IDs and only inspect the matching
+                                # output; this prevents a URL merely mentioned in chat
+                                # from turning into a published artifact.
+                                if response_type in ("function_call", "custom_tool_call"):
+                                    call_name = response.get("name")
+                                    call_input = response.get("arguments") if response_type == "function_call" else response.get("input")
+                                    is_sites_call = (
+                                        isinstance(call_name, str) and bool(_CODEX_SITES_TOOL_RE.search(call_name))
+                                    ) or (
+                                        isinstance(call_input, str) and bool(_CODEX_SITES_TOOL_RE.search(call_input))
+                                    )
+                                    if is_sites_call:
+                                        call_meta = _codex_site_metadata(call_input)
+                                        if call_meta:
+                                            codex_site_meta.update(call_meta)
+                                        call_id = response.get("call_id") or response.get("id")
+                                        if isinstance(call_id, str):
+                                            codex_site_calls[call_id] = call_meta
+
+                                if response_type in ("function_call_output", "custom_tool_call_output"):
+                                    call_id = response.get("call_id")
+                                    call_meta = codex_site_calls.get(call_id) if isinstance(call_id, str) else None
+                                    if call_meta is not None:
+                                        record_codex_site_output(call_meta, response.get("output"), data.get("timestamp"))
+
+                                if response_type == "function_call":
+                                    tool = response.get("name")
                                     if tool not in sess["mcp_tools"]: sess["mcp_tools"].append(tool)
                                     _count_tool(sess.setdefault("tool_counts", {}), tool)
                                     # Skill activation breadcrumb: the agent reads
@@ -6957,7 +7103,7 @@ def _scan_sessions_sync():
                                         _sc[_skm.group(1)] = _sc.get(_skm.group(1), 0) + 1
                                     if tool == "update_plan":
                                         try:
-                                            args = json.loads(data["payload"].get("arguments") or "{}")
+                                            args = json.loads(response.get("arguments") or "{}")
                                             steps = args.get("plan") or []
                                             if steps:
                                                 content = (args.get("explanation") or "") + "\n\n" + "\n".join(
@@ -6967,6 +7113,10 @@ def _scan_sessions_sync():
                                                 sess["plans"].append({"session_id": sid, "agent": "codex", "timestamp": sess["timestamp"], "content": content})
                                         except Exception: pass
                 except Exception: pass
+
+            if published_sites:
+                sess["published_artifacts"] = sorted(
+                    published_sites.values(), key=lambda a: str(a.get("timestamp") or ""), reverse=True)
             
             if day_snap:
                 tbd = {}

--- a/backend/scan_cache.py
+++ b/backend/scan_cache.py
@@ -34,7 +34,7 @@ logger = logging.getLogger("tokentelemetry.scan_cache")
 # update that affects cached costs. `_mtime` only detects source-transcript
 # changes; this detects code changes. A mismatch is a miss, so stale entries
 # are transparently reparsed and rewritten — never migrated in place.
-CACHE_VERSION = 10  # v2: added "loop" field; v3: added loop footprint_tokens/footprint_cost; v4: added published_artifacts; v5: page artifacts carry source path; v6: added "goals" (/goal); v7: Claude cached-read costs use cumulative usage and record untracked background activity; v8: Muse/Prime/Codex model metadata; v9: DeepSeek V4 repricing (#303) — cached sessions store a computed cost, so a rate change must invalidate them; v10: claude-sonnet-5 repriced to its real $2/$10 (#250) — cached sessions store a computed cost, so a rate change must invalidate them
+CACHE_VERSION = 11  # v2: added "loop" field; v3: added loop footprint_tokens/footprint_cost; v4: added published_artifacts; v5: page artifacts carry source path; v6: added "goals" (/goal); v7: Claude cached-read costs use cumulative usage and record untracked background activity; v8: Muse/Prime/Codex model metadata; v9: DeepSeek V4 repricing (#303) — cached sessions store a computed cost, so a rate change must invalidate them; v10: claude-sonnet-5 repriced to its real $2/$10 (#250) — cached sessions store a computed cost, so a rate change must invalidate them; v11: the assistant usage-dedupe no longer discards the whole record, so continuation records now yield their tool_use blocks — cached sessions are missing the Artifact publishes, skills and tool counts that lived in them
 
 
 def _require_safe_component(candidate: str) -> str:

--- a/backend/scan_cache.py
+++ b/backend/scan_cache.py
@@ -34,7 +34,7 @@ logger = logging.getLogger("tokentelemetry.scan_cache")
 # update that affects cached costs. `_mtime` only detects source-transcript
 # changes; this detects code changes. A mismatch is a miss, so stale entries
 # are transparently reparsed and rewritten — never migrated in place.
-CACHE_VERSION = 11  # v2: added "loop" field; v3: added loop footprint_tokens/footprint_cost; v4: added published_artifacts; v5: page artifacts carry source path; v6: added "goals" (/goal); v7: Claude cached-read costs use cumulative usage and record untracked background activity; v8: Muse/Prime/Codex model metadata; v9: DeepSeek V4 repricing (#303) — cached sessions store a computed cost, so a rate change must invalidate them; v10: claude-sonnet-5 repriced to its real $2/$10 (#250) — cached sessions store a computed cost, so a rate change must invalidate them; v11: the assistant usage-dedupe no longer discards the whole record, so continuation records now yield their tool_use blocks — cached sessions are missing the Artifact publishes, skills and tool counts that lived in them
+CACHE_VERSION = 12  # v2: added "loop" field; v3: added loop footprint_tokens/footprint_cost; v4: added published_artifacts; v5: page artifacts carry source path; v6: added "goals" (/goal); v7: Claude cached-read costs use cumulative usage and record untracked background activity; v8: Muse/Prime/Codex model metadata; v9: DeepSeek V4 repricing (#303) — cached sessions store a computed cost, so a rate change must invalidate them; v10: claude-sonnet-5 repriced to its real $2/$10 (#250); v11: assistant usage-dedupe fix restores continuation tool blocks; v12: Codex Sites are published artifacts
 
 
 def _require_safe_component(candidate: str) -> str:

--- a/backend/test_codex_sites.py
+++ b/backend/test_codex_sites.py
@@ -1,0 +1,208 @@
+"""Regression tests for Codex Sites published from a Codex session.
+
+Run: pytest backend/test_codex_sites.py
+"""
+import asyncio
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+import main  # noqa: E402
+
+
+SID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+SITE_URL = "https://agentic-evaluation-plan.workspace.chatgpt.site"
+
+
+def _jl(**data):
+    return json.dumps(data) + "\n"
+
+
+def _write_codex_session(codex_dir, records):
+    transcript = (
+        codex_dir
+        / "sessions"
+        / "2026"
+        / "07"
+        / "20"
+        / f"rollout-2026-07-20T10-00-00-{SID}.jsonl"
+    )
+    transcript.parent.mkdir(parents=True, exist_ok=True)
+    transcript.write_text("".join(records), encoding="utf-8")
+
+
+@pytest.fixture
+def scan_env(tmp_path, monkeypatch):
+    missing = tmp_path / "missing"
+    for attr in (
+        "CLAUDE_DIR", "GEMINI_DIR", "QWEN_DIR", "VIBE_DIR", "OLLAMA_DIR",
+        "GROK_SESSIONS_DIR", "GROK_UNIFIED_LOG", "VSCODE_STORAGE", "CURSOR_STORAGE",
+        "COPILOT_CLI_DIR", "ANTIGRAVITY_BRAIN_DIR", "ANTIGRAVITY_CLI_DIR",
+        "HERMES_DIR", "PI_SESSIONS_DIR",
+    ):
+        monkeypatch.setattr(main, attr, missing / attr.lower())
+    monkeypatch.setattr(main, "ANTIGRAVITY_BRAIN_SOURCES", [])
+    monkeypatch.setattr(main, "ANTIGRAVITY_BRAIN_DIRS", [])
+    monkeypatch.setattr(main, "_antigravity_cli_meta", lambda *args, **kwargs: {})
+    monkeypatch.setattr(main, "CODEX_DIR", tmp_path / ".codex")
+    monkeypatch.setattr(main, "CURSOR_DIR", tmp_path / ".cursor")
+    monkeypatch.setattr(main, "OPENCODE_DB", tmp_path / "opencode.db")
+    monkeypatch.setattr(main, "HERMES_DB", tmp_path / "hermes-state.db")
+    monkeypatch.setattr(main, "HERMES_PROFILES_DIR", missing / "hermes-profiles")
+    monkeypatch.setattr(main, "PROJECT_ALIASES_FILE", tmp_path / "aliases.json")
+    monkeypatch.setenv("TOKENTELEMETRY_DATA_DIR", str(tmp_path / "tt_data"))
+    return tmp_path
+
+
+def _codex_session(scan_env):
+    return next(s for s in main._scan_sessions_sync() if s["agent"] == "codex")
+
+
+def _site_create_call():
+    return _jl(
+        type="response_item",
+        timestamp="2026-07-20T10:01:00Z",
+        payload={
+            "type": "custom_tool_call",
+            "call_id": "site-create",
+            "name": "exec",
+            "input": (
+                "const result = await tools.mcp__codex_apps__sites_create_site({"
+                " title: 'Agentic Evaluation Plan', slug: 'agentic-evaluation-plan',"
+                " description: 'Evidence-first evaluator plan.' });"
+            ),
+        },
+    )
+
+
+def _site_deployment_call():
+    return _jl(
+        type="response_item",
+        timestamp="2026-07-20T10:02:00Z",
+        payload={
+            "type": "custom_tool_call",
+            "call_id": "site-status",
+            "name": "exec",
+            "input": (
+                "const result = await tools.mcp__codex_apps__sites_get_deployment_status({"
+                " project_id: projectId, deployment_id: deploymentId });"
+            ),
+        },
+    )
+
+
+def _site_output(call_id, timestamp, text):
+    return _jl(
+        type="response_item",
+        timestamp=timestamp,
+        payload={
+            "type": "custom_tool_call_output",
+            "call_id": call_id,
+            "output": [{"type": "text", "text": text}],
+        },
+    )
+
+
+def _base_records():
+    return [
+        _jl(
+            type="session_meta",
+            timestamp="2026-07-20T10:00:00Z",
+            payload={"cwd": "/tmp/codex-site-project", "model": "gpt-5.6"},
+        ),
+        _jl(
+            type="event_msg",
+            timestamp="2026-07-20T10:00:01Z",
+            payload={"type": "user_message", "message": "Publish the plan as a Site"},
+        ),
+    ]
+
+
+def test_deployed_codex_site_is_a_published_artifact(scan_env):
+    _write_codex_session(scan_env / ".codex", _base_records() + [
+        _site_create_call(),
+        _site_output("site-create", "2026-07-20T10:01:02Z", '{"id":"appgprj_example"}'),
+        _site_deployment_call(),
+        _site_output("site-status", "2026-07-20T10:02:05Z", json.dumps({"status": "succeeded", "url": SITE_URL})),
+    ])
+
+    artifact = _codex_session(scan_env)["published_artifacts"][0]
+
+    assert artifact == {
+        "kind": "site",
+        "url": SITE_URL,
+        "title": "Agentic Evaluation Plan",
+        "description": "Evidence-first evaluator plan.",
+        "session_id": SID,
+        "agent": "codex",
+        "timestamp": "2026-07-20T10:02:05Z",
+    }
+
+
+def test_native_codex_sites_event_is_a_published_artifact(scan_env):
+    native_records = _base_records() + [
+        _jl(
+            type="event_msg",
+            timestamp="2026-07-20T10:01:00Z",
+            payload={"type": "item_completed", "item": {
+                "type": "McpToolCall", "appName": "Sites", "tool": "sites.create_site",
+                "status": "completed", "arguments": {
+                    "title": "Native Site", "description": "Captured from the Sites connector.",
+                }, "result": {"structuredContent": {"id": "appgprj_example"}},
+            }},
+        ),
+        _jl(
+            type="event_msg",
+            timestamp="2026-07-20T10:02:05Z",
+            payload={"type": "item_completed", "item": {
+                "type": "McpToolCall", "appName": "Sites", "tool": "sites.get_deployment_status",
+                "status": "completed", "arguments": {"deployment_id": "appgdep_example"},
+                "result": {"structuredContent": {"status": "succeeded", "url": SITE_URL}},
+            }},
+        ),
+    ]
+    _write_codex_session(scan_env / ".codex", native_records)
+
+    artifact = _codex_session(scan_env)["published_artifacts"][0]
+
+    assert artifact["kind"] == "site"
+    assert artifact["title"] == "Native Site"
+    assert artifact["description"] == "Captured from the Sites connector."
+    assert artifact["url"] == SITE_URL
+
+
+def test_only_sites_tool_output_can_create_a_codex_site_artifact(scan_env):
+    _write_codex_session(scan_env / ".codex", _base_records() + [
+        _jl(
+            type="event_msg",
+            timestamp="2026-07-20T10:01:00Z",
+            payload={"type": "user_message", "message": f"Do not publish {SITE_URL}"},
+        ),
+    ])
+
+    assert "published_artifacts" not in _codex_session(scan_env)
+
+
+def test_codex_site_artifacts_survive_cache_and_project_rollup(scan_env, monkeypatch):
+    _write_codex_session(scan_env / ".codex", _base_records() + [
+        _site_create_call(),
+        _site_deployment_call(),
+        _site_output("site-status", "2026-07-20T10:02:05Z", json.dumps({"url": SITE_URL})),
+    ])
+    session = _codex_session(scan_env)
+    payload = main._codex_cache_payload(session)
+    restored = {"plans": []}
+    main._apply_codex_cache_hit(restored, json.loads(json.dumps(payload)))
+    assert restored["published_artifacts"] == session["published_artifacts"]
+
+    async def fake_cached(fresh=False):
+        return [session]
+
+    monkeypatch.setattr(main, "get_sessions_cached", fake_cached)
+    monkeypatch.setattr(main, "load_hidden", lambda: set())
+    project = asyncio.run(main.get_projects())[0]
+    assert project["artifacts"][0]["kind"] == "site"
+    assert project["artifacts"][0]["url"] == SITE_URL

--- a/backend/test_published_artifacts.py
+++ b/backend/test_published_artifacts.py
@@ -328,3 +328,76 @@ def test_project_artifact_keys_are_unique(scan_env, monkeypatch):
         keys = [a.get("url") or a.get("path") for a in proj.get("artifacts", [])]
         assert len(keys) == len(set(keys)), (
             "duplicate React key in %s: %s" % (proj.get("name"), keys))
+# --- a split assistant message must not swallow its tool_use ----------------
+
+def _assistant_split(msg_id, ts, blocks, usage=True):
+    """One record of an assistant message that Claude wrote across several.
+
+    Every record of the same message repeats the same `message.id` and the same
+    cumulative `usage`, which is why the scan counts usage only for the first —
+    but the tool_use blocks live in the LATER records.
+    """
+    msg = {"id": msg_id, "model": "claude-opus-4-8", "content": blocks}
+    if usage:
+        msg["usage"] = {"input_tokens": 100, "output_tokens": 50}
+    return _jl(type="assistant", timestamp=ts, message=msg)
+
+
+def test_artifact_in_a_continuation_record_is_still_found(scan_env):
+    """Regression: the usage-dedupe used to `continue` past the whole record.
+
+    An Artifact call that landed in the second record of a split assistant
+    message was therefore never registered, so its tool_result found no
+    matching call and the publish vanished from the project's Artifacts tab —
+    with no error anywhere.
+    """
+    MID = "msg_split_0001"
+    _write_session(scan_env / ".claude", [
+        # First record of the message: prose only. Usage counted here.
+        _assistant_split(MID, "2026-07-20T10:01:00Z",
+                         [{"type": "text", "text": "Publishing the page now."}]),
+        # Second record, SAME id and SAME usage: this is where the call lives.
+        _assistant_split(MID, "2026-07-20T10:01:01Z",
+                         [{"type": "tool_use", "id": "t1", "name": "Artifact",
+                           "input": {"file_path": "/tmp/a.html", "title": "A"}}]),
+        _artifact_result("t1", "2026-07-20T10:01:05Z", f"Published a at {URL1}"),
+    ])
+    sess = _claude_session(scan_env)
+
+    arts = sess.get("published_artifacts") or []
+    assert [a["url"] for a in arts] == [URL1], (
+        "the publish was dropped because its call sat in a continuation record")
+
+    # ...and the repeated usage is still counted exactly once.
+    assert sess["tokens"]["input"] == 100
+    assert sess["tokens"]["output"] == 50
+
+
+def test_repeated_usage_is_never_double_counted(scan_env):
+    """The dedupe still has to do its original job: three records of one
+    message carry the same cumulative usage, and it counts once."""
+    MID = "msg_split_0002"
+    _write_session(scan_env / ".claude", [
+        _assistant_split(MID, "2026-07-20T10:01:00Z", [{"type": "text", "text": "one"}]),
+        _assistant_split(MID, "2026-07-20T10:01:01Z", [{"type": "text", "text": "two"}]),
+        _assistant_split(MID, "2026-07-20T10:01:02Z", [{"type": "text", "text": "three"}]),
+    ])
+    sess = _claude_session(scan_env)
+    assert sess["tokens"]["input"] == 100
+    assert sess["tokens"]["output"] == 50
+
+
+def test_tools_in_a_continuation_record_are_counted(scan_env):
+    """Artifacts were the visible symptom; every tool_use in a continuation
+    record was invisible, including Skill and ExitPlanMode."""
+    MID = "msg_split_0003"
+    _write_session(scan_env / ".claude", [
+        _assistant_split(MID, "2026-07-20T10:01:00Z", [{"type": "text", "text": "working"}]),
+        _assistant_split(MID, "2026-07-20T10:01:01Z", [
+            {"type": "tool_use", "id": "p1", "name": "ExitPlanMode",
+             "input": {"plan": "step one, then step two"}},
+        ]),
+    ])
+    sess = _claude_session(scan_env)
+    assert sess["has_plan"] is True
+    assert any("step one" in p["content"] for p in sess["plans"])

--- a/frontend/src/app/projects/[path]/_lib/project-context.tsx
+++ b/frontend/src/app/projects/[path]/_lib/project-context.tsx
@@ -10,11 +10,12 @@ export interface PlanSnippet {
 }
 
 /* A user-facing artifact an agent produced as a deliverable. kind "page" is a
-   hosted claude.ai page from Claude Code's Artifact tool (has url); kind
-   "document" is a local doc like Antigravity's task/plan/walkthrough (has
-   path, served via /artifacts?path=). Extracted by the backend scan. */
+   hosted claude.ai page from Claude Code's Artifact tool; kind "site" is a
+   deployed Codex Site; kind "document" is a local doc like Antigravity's
+   task/plan/walkthrough (has path, served via /artifacts?path=). Extracted by
+   the backend scan. */
 export interface PublishedArtifact {
-  kind?: "page" | "document";
+  kind?: "page" | "site" | "document";
   url?: string | null;
   path?: string | null;
   title?: string | null;

--- a/frontend/src/app/projects/[path]/artifacts/page.tsx
+++ b/frontend/src/app/projects/[path]/artifacts/page.tsx
@@ -159,6 +159,7 @@ function DocumentPreview({ path }: { path: string }) {
 
 function ArtifactCard({ a, sessionHref }: { a: PublishedArtifact; sessionHref: string | null }) {
   const isPage = !!a.url;
+  const isSite = a.kind === "site";
   return (
     <Card padding="none" className="overflow-hidden">
       <div className="flex items-center justify-between gap-3 px-5 py-4 border-b border-[var(--tt-border)]">
@@ -168,6 +169,11 @@ function ArtifactCard({ a, sessionHref }: { a: PublishedArtifact; sessionHref: s
           <CardTitle className="!text-[13px] truncate" title={a.title || a.url || a.file_name || undefined}>
             {a.title || a.file_name || "Untitled artifact"}
           </CardTitle>
+          {isSite && (
+            <span className="shrink-0 rounded bg-[var(--tt-brand-bg)] px-1.5 py-0.5 text-[8px] font-semibold uppercase tracking-[0.08em] text-[var(--tt-brand)]">
+              Codex Site
+            </span>
+          )}
         </div>
         {a.timestamp && (
           <span className="text-[10px] uppercase tracking-[0.18em] text-[var(--tt-fg-dim)] shrink-0">
@@ -219,6 +225,7 @@ function ArtifactCard({ a, sessionHref }: { a: PublishedArtifact; sessionHref: s
 
 function ArtifactRow({ a, sessionHref }: { a: PublishedArtifact; sessionHref: string | null }) {
   const isPage = !!a.url;
+  const isSite = a.kind === "site";
   const openHref = a.url || (a.path ? rawFileUrl(a.path) : null);
   return (
     <div className="flex items-center gap-3 px-5 py-2.5">
@@ -230,6 +237,11 @@ function ArtifactRow({ a, sessionHref }: { a: PublishedArtifact; sessionHref: st
       >
         {a.title || a.file_name || "Untitled artifact"}
       </span>
+      {isSite && (
+        <span className="shrink-0 rounded bg-[var(--tt-brand-bg)] px-1.5 py-0.5 text-[8px] font-semibold uppercase tracking-[0.08em] text-[var(--tt-brand)]">
+          Site
+        </span>
+      )}
       {a.timestamp && (
         <span className="text-[10px] uppercase tracking-[0.18em] text-[var(--tt-fg-dim)] shrink-0 text-right">
           {format(new Date(a.timestamp), "MMM d, HH:mm")}

--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -29,12 +29,12 @@ interface Artifact {
 }
 
 /* A deliverable artifact from this session. kind "page" is a hosted claude.ai
-   page published by Claude Code's Artifact tool (has url); kind "document" is
-   a local doc like Antigravity's task/plan/walkthrough (has path) — those
-   already render in the local-files list, so the Published Pages section only
-   shows url-bearing entries. */
+   page published by Claude Code's Artifact tool; kind "site" is a deployed
+   Codex Site; kind "document" is a local doc like Antigravity's
+   task/plan/walkthrough (has path) — those already render in the local-files
+   list, so this panel only shows url-bearing entries. */
 interface PublishedArtifact {
-  kind?: "page" | "document";
+  kind?: "page" | "site" | "document";
   url?: string | null;
   path?: string | null;
   title?: string | null;
@@ -2183,7 +2183,7 @@ function ArtifactsPanel({ artifacts, published: publishedAll = [] }: { artifacts
       {published.length > 0 && (
         <div className="space-y-3">
           <div className="flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--tt-fg-muted)]">
-            <Globe size={12} /> Published Pages
+            <Globe size={12} /> Published Deliverables
           </div>
           {published.map((p) => (
             <a
@@ -2197,6 +2197,11 @@ function ArtifactsPanel({ artifacts, published: publishedAll = [] }: { artifacts
                 <span className="text-[11px] font-medium text-[var(--tt-fg)] truncate" title={p.title || p.url || undefined}>
                   {p.title || p.file_name || "Untitled artifact"}
                 </span>
+                {p.kind === "site" && (
+                  <span className="shrink-0 rounded bg-[var(--tt-brand-bg)] px-1.5 py-0.5 text-[8px] font-semibold uppercase tracking-[0.08em] text-[var(--tt-brand)]">
+                    Codex Site
+                  </span>
+                )}
                 <ExternalLink size={10} className="shrink-0 text-[var(--tt-fg-dim)] group-hover:text-[var(--tt-brand)] transition-colors" />
               </div>
               {p.description && (


### PR DESCRIPTION
Reported: a published artifact was missing from a project's Artifacts tab, with no error anywhere.

The publish was in the transcript. Its `Artifact` tool_use and the tool_result carrying the hosted URL were on adjacent lines. Three other publishes in the same session scanned fine. All four records were structurally identical — same tool name, same `action`, same input keys, same `isSidechain`, same `sessionId`.

## Cause

Claude writes **one** assistant message as several JSONL records — prose first, then the tool_use blocks — and every record repeats the same `message.id` and the same cumulative `usage`. To avoid counting that usage several times, the scan kept a set of seen message ids and, on a repeat:

```python
if message_id in seen_assistant_message_ids:
    continue
```

`continue` abandons the **whole record**, not just the usage. Everything below is in the same loop iteration: the `for item in msg["content"]` pass that records tool names and counts, Skill invocations, ExitPlanMode plans, CronCreate / ScheduleWakeup loop detection, thinking blocks — and the Artifact calls.

So any tool call that landed in a continuation record was invisible. An Artifact call landing there meant its tool_result later found no matching call and the publish was dropped silently.

Whether a publish survived came down to whether its call happened to sit in the *first* record of its message — which is exactly why three of four made it:

| line | artifact | `message.id` seen before? | |
|---|---|---|---|
| 2837 | 843dd310 | no | scanned |
| **5535** | **a166e98a** | **yes** | **skipped** |
| 5551 | 4e9aed8f | no | scanned |
| 6132 | 8f365256 | no | scanned |

## Fix

Clear `usage` instead of abandoning the record, and move the token accounting behind its own `if usage:`. Usage is still counted exactly once per message id; the record is still read.

`scan_cache.CACHE_VERSION` → 11. This changes computed values, and without the bump every already-cached session would keep serving a payload missing these artifacts, skills and tool counts — the fix would appear to do nothing.

## Verification

Full reparse of the real store, before vs after:

| | before | after |
|---|---|---|
| published artifacts | 7 | **8** |
| skills | 85 | 104 |
| tool entries | 2316 | 2491 |
| plans | 119 | 120 |

The recovered artifact is the one from the report. Nothing was lost.

**Token math is untouched**, which is the thing that had to hold: **262 of 263 Claude sessions are byte-identical** on input/output/cached/total and cost. The two sessions that moved are the live session that wrote this and an **OpenCode** session — both simply grew between the two captures, and OpenCode cannot be affected by a change to the Claude branch at all.

Three tests, each checked against the bug rather than merely passing. Reverting the fix fails:

- `test_artifact_in_a_continuation_record_is_still_found`
- `test_tools_in_a_continuation_record_are_counted`

while `test_repeated_usage_is_never_double_counted` passes either way — it guards the behaviour the `continue` existed for in the first place, so the fix cannot regress into double-counting.

Suite 670 passed / 22 failed, failure names identical to baseline.

## Note

Independent of #316, which fixes duplicate artifact *cards* (one artifact shown twice). This one is the opposite failure: an artifact shown zero times. Both can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
