### PR TITLE
feat: add macOS menu bar and local desktop shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ TRACE_VIEW_ENHANCEMENT_PLAN.md
 # --- Node / frontend ---
 node_modules/
 .next/
+.next-desktop/
 out/
 *.tsbuildinfo
 

--- a/UPDATE.json
+++ b/UPDATE.json
@@ -17,6 +17,11 @@
         {
           "title": "The refresh warning only appears when a refresh actually failed",
           "description": "Being signed out of an agent is a fact about the account, not an error, so it no longer raises the amber “could not refresh” banner. Expired logins now name the command to run instead."
+        },
+        {
+          "title": "Read the full plan-limits guide",
+          "description": "How each meter is read, which agents report a live number and which do not, the colour thresholds, and the privacy note all live in one place. Session, weekly and monthly windows, credits, rate-limit resets and reset times are covered.",
+          "href": "/docs/features/plan-limits"
         }
       ]
     },

--- a/backend/main.py
+++ b/backend/main.py
@@ -23,8 +23,7 @@ from harness_config import (
 import notifications as notif
 from tt_paths import canonical_project, data_dir
 from quotas import (
-    ClaudeQuotaProvider, CodexQuotaProvider, CopilotQuotaProvider, CursorQuotaProvider,
-    GeminiQuotaProvider, GrokQuotaProvider, OpenCodeQuotaProvider, QuotaService, StaticQuotaProvider,
+    QuotaService, default_quota_providers,
 )
 import scan_cache
 import harness_panels
@@ -2950,32 +2949,7 @@ _quota_service: Optional[QuotaService] = None
 def _get_quota_service() -> QuotaService:
     global _quota_service
     if _quota_service is None:
-        _quota_service = QuotaService([
-            # Native quota sources: an account API the agent's own login can read.
-            CodexQuotaProvider(),
-            ClaudeQuotaProvider(),
-            CursorQuotaProvider(),
-            OpenCodeQuotaProvider(),
-            CopilotQuotaProvider(),
-            GrokQuotaProvider(),
-            GeminiQuotaProvider(),
-            # Every other supported agent stays listed with the reason it has no
-            # live quota, so an agent is never silently missing from the page.
-            # A router has no account of its own; its quota belongs to whichever
-            # model provider it is configured against.
-            StaticQuotaProvider("antigravity", "Antigravity", "Antigravity keeps its plan and usage state server-side; nothing local reports it."),
-            StaticQuotaProvider("qwen", "Qwen CLI", "Qwen's OAuth free tier was discontinued and its Coding Plan key exposes no account-quota endpoint."),
-            StaticQuotaProvider("vibe", "Vibe", "Vibe routes to configured model providers, so it has no account quota of its own."),
-            StaticQuotaProvider("hermes", "Hermes Agent", "Hermes routes to configured model providers, so it has no account quota of its own."),
-            StaticQuotaProvider("cline", "Cline", "Cline routes to configured model providers, so it has no account quota of its own."),
-            StaticQuotaProvider("pi", "Pi", "Pi routes to configured model providers, so it has no account quota of its own."),
-            StaticQuotaProvider("smallcode", "SmallCode", "SmallCode routes to configured model providers, so it has no account quota of its own."),
-            StaticQuotaProvider("muse", "Muse Code", "Muse Code's local session exposes no plan-quota API."),
-            StaticQuotaProvider("prime", "Prime Agent", "Prime routes to configured model providers, so it has no account quota of its own."),
-            StaticQuotaProvider("dsh", "DeepSeek Harness", "The DeepSeek harness bills per API key; usage belongs to that key's own account page."),
-            StaticQuotaProvider("qoder", "Qoder", "Qoder keeps its plan and usage state server-side; nothing local reports it."),
-            StaticQuotaProvider("openai_compat", "OpenAI-compatible server", "This is a user-configured endpoint, so quota belongs to that provider's own account API."),
-        ])
+        _quota_service = QuotaService(default_quota_providers())
     return _quota_service
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -3672,6 +3672,8 @@ def _grok_subagent_meta(sess_dir: Path) -> List[Dict[str, Any]]:
                 "agent_type": m.get("subagent_type") or "unknown",
                 "description": m.get("description"),
                 "status": m.get("status"),
+                "started_at": m.get("started_at"),
+                "ended_at": m.get("completed_at"),
                 "duration_ms": m.get("duration_ms"),
                 "tool_calls": m.get("tool_calls"),
                 "turns": m.get("turns"),
@@ -5798,6 +5800,8 @@ def _rollup_agent_transcript(f: Path, agent_type: Optional[str] = None,
     tokens = {"input": 0, "output": 0, "cached": 0, "_cached_sum": 0, "cache_creation": 0,
               "cache_creation_1h": 0, "total": 0}
     model = None
+    first_ts: Optional[str] = None
+    last_ts: Optional[str] = None
     seen_message_ids: set = set()
     try:
         with open(f, "r", encoding="utf-8", errors="replace") as fh:
@@ -5806,6 +5810,15 @@ def _rollup_agent_transcript(f: Path, agent_type: Optional[str] = None,
                     data = json.loads(line)
                 except Exception:
                     continue
+                # Span is read from EVERY line, not just assistant ones: the
+                # first line of a subagent transcript is the user prompt that
+                # spawned it, so filtering first would report the run as
+                # starting at its first model reply and hide the queue wait.
+                ts = data.get("timestamp")
+                if isinstance(ts, str) and ts:
+                    if first_ts is None:
+                        first_ts = ts
+                    last_ts = ts
                 if data.get("type") != "assistant":
                     continue
                 msg = data.get("message", {}) if isinstance(data.get("message"), dict) else {}
@@ -5838,6 +5851,13 @@ def _rollup_agent_transcript(f: Path, agent_type: Optional[str] = None,
     cost = calculate_cost(model, tokens["input"], tokens["output"], tokens["_cached_sum"],
                           cache_creation_tokens=tokens["cache_creation"],
                           cache_creation_1h_tokens=tokens["cache_creation_1h"])
+    def _at(ts: Optional[str]) -> Optional[datetime]:
+        try:
+            return datetime.fromisoformat(ts.replace("Z", "+00:00")) if ts else None
+        except ValueError:
+            return None
+
+    started, ended = _at(first_ts), _at(last_ts)
     entry = {
         "agent_id": f.stem[len("agent-"):],
         "agent_type": agent_type or "unknown",
@@ -5846,6 +5866,13 @@ def _rollup_agent_transcript(f: Path, agent_type: Optional[str] = None,
         "model": model,
         "tokens": tokens,
         "cost": cost,
+        # Span fields stay OUT of `tokens`: _claude_subagent_usage sums every
+        # key of that dict into a running total, so a string in there would
+        # blow up the rollup.
+        "started_at": first_ts,
+        "ended_at": last_ts,
+        "duration_ms": (round((ended - started).total_seconds() * 1000)
+                        if started and ended else None),
     }
     if extra:
         entry.update(extra)
@@ -9633,7 +9660,8 @@ async def session_delegation(session_id: str, agent: str):
             t = child_summary["tokens"]
             subagents.append({"agent_id": child.parent.name, "agent_type": "muse-subagent",
                               "model": child_summary["model"], "tokens": {**t, "total": sum(t.values())},
-                              "cost": calculate_cost(child_summary["model"], t["input"], t["output"], t["cached"], cache_creation_tokens=t["cache_creation"])})
+                              "cost": calculate_cost(child_summary["model"], t["input"], t["output"], t["cached"], cache_creation_tokens=t["cache_creation"]),
+                              "ended_at": child_summary["timestamp"]})
         totals = {key: sum(s["tokens"].get(key, 0) for s in subagents)
                   for key in ("input", "output", "cached", "cache_creation", "reasoning", "total")}
         return {"supported": True, "tokens_recorded": True, "spawn_count": len(subagents),
@@ -9680,7 +9708,7 @@ async def session_delegation(session_id: str, agent: str):
                 continue
             subagents.append({"agent_id": child["id"], "agent_type": "dsh-subagent",
                               "model": child["model"], "tokens": child["tokens"],
-                              "cost": child["cost"]})
+                              "cost": child["cost"], "ended_at": child.get("timestamp")})
         totals = {key: sum(s["tokens"].get(key, 0) for s in subagents)
                   for key in ("input", "output", "cached", "cache_creation", "reasoning", "total")}
         return {"supported": True, "tokens_recorded": True, "spawn_count": len(subagents),

--- a/backend/main.py
+++ b/backend/main.py
@@ -10249,7 +10249,8 @@ import telemetry as _telemetry
 # Frontend events we accept through the bridge. Backend-origin events
 # (app.launched, trace.summarized) are emitted server-side and not listed here,
 # so a remote caller can't spoof them.
-_TELEMETRY_CLIENT_EVENTS = {"page.viewed", "analytics.filtered", "feature.used"}
+_TELEMETRY_CLIENT_EVENTS = {"page.viewed", "analytics.filtered", "feature.used",
+                            "planlimits.toggled", "agent.opened"}
 
 
 @app.get("/config/telemetry")

--- a/backend/menubar/__init__.py
+++ b/backend/menubar/__init__.py
@@ -1,0 +1,1 @@
+"""Headless presentation helpers for the macOS menu bar."""

--- a/backend/menubar/app.py
+++ b/backend/menubar/app.py
@@ -1,0 +1,210 @@
+"""macOS menu bar app: a thin ``rumps`` adapter over ``menubar.presentation``.
+
+The split that matters for testing lives in this module's imports: ``rumps`` is
+imported only inside :func:`run`, after an explicit macOS platform guard, so
+importing this module (and unit-testing its argument / platform helpers) never
+touches Cocoa or PyObjC. All quota wording and the single worst-window choice
+come from :mod:`menubar.presentation`, which has no macOS dependency either.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import threading
+from pathlib import Path
+from typing import Any, List, Mapping, Optional, Sequence, Union
+
+# Make the `menubar` package (and its siblings quotas / tt_paths) importable no
+# matter how this file is launched: by the CLI (cwd=backend, PYTHONPATH=backend),
+# by a LaunchAgent (which sets no PYTHONPATH), or directly as a script. Python
+# otherwise puts this file's own directory on sys.path, not the repo backend dir.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from menubar import launch_agent, render
+from menubar.presentation import MenuBarPresentation, build_menu_presentation
+
+APP_NAME = "TokenTelemetry"
+REFRESH_SECONDS = 60.0
+
+# Headless placeholder for the moment between launch and the first collect.
+_LOADING = build_menu_presentation(None, loading=True)
+
+
+def is_macos() -> bool:
+    """Platform guard; the CLI and the runtime both refuse elsewhere."""
+    return sys.platform == "darwin"
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="tokentelemetry menubar",
+        description="TokenTelemetry menu bar app (macOS only).",
+    )
+    parser.add_argument(
+        "--data-dir",
+        metavar="PATH",
+        default=None,
+        help="Override the TokenTelemetry data directory (sets TOKENTELEMETRY_DATA_DIR).",
+    )
+    return parser.parse_args(argv)
+
+
+def configure_environment(args: argparse.Namespace) -> None:
+    """Fold --data-dir into TOKENTELEMETRY_DATA_DIR before tt_paths is read."""
+    if args.data_dir:
+        os.environ["TOKENTELEMETRY_DATA_DIR"] = os.path.abspath(os.path.expanduser(args.data_dir))
+
+
+def program_arguments(
+    python: Optional[str] = None,
+    app_path: Optional[str] = None,
+    data_dir: Optional[Union[str, Path]] = None,
+) -> List[str]:
+    """Absolute program arguments for a LaunchAgent that runs this app."""
+    argv = [python or sys.executable, app_path or os.path.abspath(__file__)]
+    if data_dir:
+        argv += ["--data-dir", str(data_dir)]
+    return argv
+
+
+def resolve_dashboard_command(
+    env: Optional[Mapping[str, str]] = None,
+    which: Any = None,
+) -> Optional[List[str]]:
+    """The command that opens the dashboard via the shared CLI.
+
+    The CLI passes its own absolute path and the Node executable that runs it
+    through the environment, so this never hard-codes a checkout or account
+    path. Falls back to ``node`` on PATH; returns ``None`` when unavailable.
+    """
+    env = os.environ if env is None else env
+    which = which or shutil.which
+    node = env.get("TOKENTELEMETRY_NODE") or which("node")
+    cli = env.get("TOKENTELEMETRY_CLI")
+    if not node or not cli:
+        return None
+    return [node, cli, "dashboard"]
+
+
+def run(argv: Optional[Sequence[str]] = None) -> int:
+    if not is_macos():
+        print("The tokentelemetry menu bar is macOS-only.", file=sys.stderr)
+        return 1
+
+    args = parse_args(argv)
+    configure_environment(args)
+
+    import rumps  # noqa: PLC0415 — macOS-only, after the platform guard
+    from PyObjCTools import AppHelper
+    from quotas import QuotaService, default_quota_providers
+    from tt_paths import data_dir
+
+    data = data_dir()
+
+    class MenubarApp(rumps.App):
+        def __init__(self, service: Any, data: Path, app_helper: Any) -> None:
+            super().__init__(APP_NAME, title=_LOADING.title, quit_button=None)
+            self._service = service
+            self._data_dir = data
+            self._app_helper = app_helper
+            self._refresh_lock = threading.Lock()
+            self._refreshing = False
+            self._refresh_queued = False
+            self._presentation = _LOADING
+            self._rebuild_menu()
+            self._request_refresh(force=False)
+
+        @rumps.timer(REFRESH_SECONDS)
+        def _tick(self, _sender: Any) -> None:
+            self._request_refresh(force=False)
+
+        def _request_refresh(self, force: bool = False) -> None:
+            with self._refresh_lock:
+                if self._refreshing:
+                    if force:
+                        self._refresh_queued = True
+                    return
+                self._refreshing = True
+            threading.Thread(target=self._refresh_worker, args=(force,), daemon=True).start()
+
+        def _refresh_worker(self, force: bool) -> None:
+            failure: Optional[str] = None
+            try:
+                response = self._service.collect(force=force)
+            except Exception as error:  # noqa: BLE001 — surface, don't crash the menubar
+                response = None
+                failure = str(error) or type(error).__name__
+            presentation = build_menu_presentation(response, failure=failure)
+            self._app_helper.callAfter(lambda p=presentation: self._apply_presentation(p))
+            with self._refresh_lock:
+                self._refreshing = False
+                queued = self._refresh_queued
+                self._refresh_queued = False
+            if queued:
+                self._request_refresh(force=True)
+
+        def _apply_presentation(self, presentation: MenuBarPresentation) -> None:
+            self._presentation = presentation
+            self.title = presentation.title
+            self._rebuild_menu()
+
+        def _rebuild_menu(self) -> None:
+            self.menu.clear()
+            for item in render.build_rumps_menu(self._presentation, handler=self._on_action):
+                self.menu.add(item)
+
+        def _on_action(self, kind: str, _sender: Any) -> None:
+            if kind == "open":
+                self._on_open_dashboard(_sender)
+            elif kind == "refresh":
+                self._on_refresh_now(_sender)
+            elif kind == "launch":
+                self._on_toggle_launch(_sender)
+
+        def _on_open_dashboard(self, _sender: Any) -> None:
+            command = resolve_dashboard_command()
+            if not command:
+                return
+            try:
+                subprocess.Popen(
+                    command,
+                    start_new_session=True,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+            except OSError:
+                pass
+
+        def _on_refresh_now(self, _sender: Any) -> None:
+            self._request_refresh(force=True)
+
+        def _launch_env(self) -> dict:
+            env: dict = {}
+            for key in ("TOKENTELEMETRY_CLI", "TOKENTELEMETRY_NODE", "TOKENTELEMETRY_DATA_DIR"):
+                value = os.environ.get(key)
+                if value:
+                    env[key] = value
+            return env
+
+        def _on_toggle_launch(self, _sender: Any) -> None:
+            if launch_agent.is_installed():
+                launch_agent.disable()
+            else:
+                launch_agent.enable(
+                    program_args=program_arguments(data_dir=self._data_dir),
+                    data_dir=self._data_dir,
+                    env=self._launch_env(),
+                )
+            self._rebuild_menu()
+
+    app = MenubarApp(QuotaService(default_quota_providers()), data, AppHelper)
+    app.run()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(run())

--- a/backend/menubar/launch_agent.py
+++ b/backend/menubar/launch_agent.py
@@ -1,0 +1,130 @@
+"""Headless helpers for the macOS menu-bar LaunchAgent.
+
+Everything here is importable on any platform and never imports ``rumps`` or
+talks to Cocoa. The module builds a plist and the ``launchctl`` command lines,
+and shells out only through an injectable ``run`` callable so tests can capture
+commands without touching the real launchd.
+
+The agent is written to ``~/Library/LaunchAgents/com.tokentelemetry.menubar.plist``
+and is never installed automatically: ``enable`` / ``disable`` are called only
+from the menu item, so a tool only adds itself to login items when asked.
+"""
+
+from __future__ import annotations
+
+import os
+import plistlib
+import subprocess
+from pathlib import Path
+from typing import Any, Callable, List, Mapping, Optional, Sequence, Union
+
+LABEL = "com.tokentelemetry.menubar"
+PLIST_FILENAME = f"{LABEL}.plist"
+
+PathLike = Union[Path, str]
+
+
+def agent_dir(home: Optional[PathLike] = None) -> Path:
+    """The LaunchAgents directory, defaulting to the current user's home."""
+    return Path(home) / "Library" / "LaunchAgents" if home else Path.home() / "Library" / "LaunchAgents"
+
+
+def plist_path(home: Optional[PathLike] = None) -> Path:
+    """Absolute path to this app's LaunchAgent plist."""
+    return agent_dir(home) / PLIST_FILENAME
+
+
+def build_plist(
+    program_args: Sequence[str],
+    data_dir: PathLike,
+    env: Optional[Mapping[str, str]] = None,
+) -> dict:
+    """The plist dictionary, with absolute program arguments and log paths."""
+    logs = Path(data_dir) / "logs"
+    return {
+        "Label": LABEL,
+        "ProgramArguments": [str(arg) for arg in program_args],
+        "RunAtLoad": True,
+        "StandardOutPath": str(logs / "menubar.out.log"),
+        "StandardErrorPath": str(logs / "menubar.err.log"),
+        "EnvironmentVariables": {str(key): str(value) for key, value in (env or {}).items()},
+    }
+
+
+def render_plist(plist: Mapping[str, Any]) -> bytes:
+    """Serialize a plist dictionary to XML bytes."""
+    return plistlib.dumps(dict(plist), sort_keys=False)
+
+
+def write_plist(
+    program_args: Sequence[str],
+    data_dir: PathLike,
+    env: Optional[Mapping[str, str]] = None,
+    home: Optional[PathLike] = None,
+) -> Path:
+    """Write the plist (creating the LaunchAgents dir) and return its path."""
+    path = plist_path(home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(render_plist(build_plist(program_args, data_dir, env)))
+    return path
+
+
+def remove_plist(home: Optional[PathLike] = None) -> None:
+    """Delete the plist if present."""
+    plist_path(home).unlink(missing_ok=True)
+
+
+def is_installed(home: Optional[PathLike] = None) -> bool:
+    """Whether the LaunchAgent plist currently exists."""
+    return plist_path(home).exists()
+
+
+def _uid(uid: Optional[int]) -> int:
+    return os.getuid() if uid is None else uid
+
+
+def bootstrap_command(plist: PathLike, uid: Optional[int] = None) -> List[str]:
+    """launchctl bootstrap into the user's GUI domain."""
+    return ["launchctl", "bootstrap", f"gui/{_uid(uid)}", str(plist)]
+
+
+def bootout_command(uid: Optional[int] = None) -> List[str]:
+    """launchctl bootout of the user's GUI domain."""
+    return ["launchctl", "bootout", f"gui/{_uid(uid)}/{LABEL}"]
+
+
+def print_command(uid: Optional[int] = None) -> List[str]:
+    """launchctl print, used to check whether the agent is loaded."""
+    return ["launchctl", "print", f"gui/{_uid(uid)}/{LABEL}"]
+
+
+def enable(
+    program_args: Sequence[str],
+    data_dir: PathLike,
+    env: Optional[Mapping[str, str]] = None,
+    home: Optional[PathLike] = None,
+    uid: Optional[int] = None,
+    run: Callable[..., Any] = subprocess.run,
+) -> Path:
+    """Install the plist and bootstrap it with launchd.
+
+    Returns the plist path. ``run`` is injectable so tests can capture the
+    launchctl invocation instead of touching the real launchd.
+    """
+    path = write_plist(program_args, data_dir, env, home)
+    run(bootstrap_command(path, uid), check=True)
+    return path
+
+
+def disable(
+    home: Optional[PathLike] = None,
+    uid: Optional[int] = None,
+    run: Callable[..., Any] = subprocess.run,
+) -> None:
+    """Boot the agent out of launchd and remove the plist.
+
+    The bootout is best-effort (the agent may not be loaded), but the plist is
+    always removed so launchd will not start it again at next login.
+    """
+    run(bootout_command(uid), check=False)
+    remove_plist(home)

--- a/backend/menubar/presentation.py
+++ b/backend/menubar/presentation.py
@@ -8,8 +8,9 @@ single worst-window choice that must match the dashboard.
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass
-from typing import Any, Literal, Mapping, Optional, Tuple
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable, Literal, Mapping, Optional, Tuple
 
 from harness_panels.base import QUOTA_CRITICAL_AT, QUOTA_LABELS, QUOTA_WARN_AT
 
@@ -44,7 +45,12 @@ class QuotaWindow:
 
 @dataclass(frozen=True)
 class MenuBarRow:
-    """A single resource to render below its provider name in the menu."""
+    """A single resource to render below its provider name in the menu.
+
+    ``text`` stays the dashboard wording (``16% used`` / ``Limit reached`` /
+    ``$24.80 used``) for backwards compatibility and headless tests. The
+    optional display fields carry the richer, reference-style rendering data.
+    """
 
     provider_id: str
     provider_name: str
@@ -54,6 +60,10 @@ class MenuBarRow:
     text: str
     pct: Optional[float]
     severity: Optional[Severity]
+    pct_left_text: Optional[str] = None
+    resets_text: Optional[str] = None
+    amount_text: Optional[str] = None
+    is_balance: bool = False
 
 
 @dataclass(frozen=True)
@@ -74,6 +84,7 @@ def build_menu_presentation(
     *,
     loading: bool = False,
     failure: Optional[str] = None,
+    now: Optional[datetime] = None,
 ) -> MenuBarPresentation:
     """Build deterministic display data from one ``QuotaService.collect`` result.
 
@@ -81,6 +92,10 @@ def build_menu_presentation(
     example, a timer callback). A response may contain both cached provider data
     and refresh errors; cached data remains useful, so it stays ``ready`` when
     at least one consumption window is available.
+
+    ``now`` is an injectable clock used only to render "Resets in …" text; when
+    omitted the wall clock is used. Both ``used`` and ``left`` wording derive
+    from the same ``pct`` so the menu and the dashboard never disagree.
     """
 
     if loading:
@@ -90,6 +105,7 @@ def build_menu_presentation(
     if response is None:
         return _empty_presentation("no_data")
 
+    now = now or datetime.now(timezone.utc)
     providers = response.get("providers")
     if not isinstance(providers, Mapping):
         return _empty_presentation("failure", failure_message="Quota data is unavailable.")
@@ -123,6 +139,10 @@ def build_menu_presentation(
                 text=text,
                 pct=pct,
                 severity=severity,
+                pct_left_text=percent_left_text(pct) if pct is not None else None,
+                resets_text=resets_in_text(resource.get("resetsAt"), now=now),
+                amount_text=text if pct is None else None,
+                is_balance=pct is None,
             ))
             if pct is not None:
                 windows.append(QuotaWindow(
@@ -199,6 +219,54 @@ def _empty_presentation(state: PresentationState, failure_message: Optional[str]
         not_supported_count=0,
         failure_message=failure_message,
     )
+
+
+def percent_left_text(pct: float) -> str:
+    """The reference-style remaining-percentage label: ``81% left``."""
+    return f"{100 - _rounded_percent(pct)}% left"
+
+
+def resets_in_text(resets_at: Any, now: Optional[datetime] = None) -> Optional[str]:
+    """Compact reset countdown: ``Resets in 1d 16h`` / ``Resets in 5h`` / ``Resets in 3m``.
+
+    Returns ``None`` when the resource carries no future reset, so callers skip
+    the note line rather than rendering a nonsense time.
+    """
+    target = _parse_utc(resets_at)
+    if target is None:
+        return None
+    now = now or datetime.now(timezone.utc)
+    delta = target - now
+    total = int(round(delta.total_seconds()))
+    if total < 0:
+        return "Resets now"
+    if total < 60:
+        return "Resets in <1m"
+    days, remainder = divmod(total, 86_400)
+    hours, remainder = divmod(remainder, 3_600)
+    minutes, _ = divmod(remainder, 60)
+    if days:
+        return f"Resets in {days}d {hours}h"
+    if hours:
+        return f"Resets in {hours}h {minutes}m"
+    return f"Resets in {minutes}m"
+
+
+def _parse_utc(value: Any) -> Optional[datetime]:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    else:
+        parsed = parsed.astimezone(timezone.utc)
+    return parsed
 
 
 def _resource_text(resource: Mapping[str, Any], pct: Optional[float]) -> Optional[str]:

--- a/backend/menubar/presentation.py
+++ b/backend/menubar/presentation.py
@@ -1,0 +1,275 @@
+"""Translate quota-service responses into deterministic menu-bar display data.
+
+This module deliberately has no macOS or ``rumps`` dependency.  The app layer
+owns rendering and actions; this layer owns the shared quota wording and the
+single worst-window choice that must match the dashboard.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any, Literal, Mapping, Optional, Tuple
+
+from harness_panels.base import QUOTA_CRITICAL_AT, QUOTA_LABELS, QUOTA_WARN_AT
+
+
+PresentationState = Literal["loading", "ready", "no_data", "failure"]
+Severity = Literal["ok", "warn", "crit"]
+
+# Keep the dashboard's normalized names, including quota types that its panel
+# map does not render. Unknown future resource keys still get a readable name.
+RESOURCE_LABELS = {
+    **QUOTA_LABELS,
+    "spark": "Spark",
+    "sparkWeekly": "Spark weekly",
+    "credits": "Credits",
+    "extraUsage": "Extra usage",
+    "rateLimitResets": "Rate-limit resets",
+    "onDemand": "On-demand",
+}
+
+
+@dataclass(frozen=True)
+class QuotaWindow:
+    """A consumption window that can participate in the menu-bar headline."""
+
+    provider_id: str
+    provider_name: str
+    resource_id: str
+    resource_label: str
+    pct: float
+    severity: Severity
+
+
+@dataclass(frozen=True)
+class MenuBarRow:
+    """A single resource to render below its provider name in the menu."""
+
+    provider_id: str
+    provider_name: str
+    plan: Optional[str]
+    resource_id: str
+    resource_label: str
+    text: str
+    pct: Optional[float]
+    severity: Optional[Severity]
+
+
+@dataclass(frozen=True)
+class MenuBarPresentation:
+    """Complete, renderer-agnostic state for the quota portion of the menu."""
+
+    state: PresentationState
+    title: str
+    severity: Optional[Severity]
+    worst_window: Optional[QuotaWindow]
+    rows: Tuple[MenuBarRow, ...]
+    not_supported_count: int
+    failure_message: Optional[str]
+
+
+def build_menu_presentation(
+    response: Optional[Mapping[str, Any]],
+    *,
+    loading: bool = False,
+    failure: Optional[str] = None,
+) -> MenuBarPresentation:
+    """Build deterministic display data from one ``QuotaService.collect`` result.
+
+    ``loading`` and ``failure`` represent failures outside quota collection (for
+    example, a timer callback). A response may contain both cached provider data
+    and refresh errors; cached data remains useful, so it stays ``ready`` when
+    at least one consumption window is available.
+    """
+
+    if loading:
+        return _empty_presentation("loading")
+    if failure:
+        return _empty_presentation("failure", failure_message=failure)
+    if response is None:
+        return _empty_presentation("no_data")
+
+    providers = response.get("providers")
+    if not isinstance(providers, Mapping):
+        return _empty_presentation("failure", failure_message="Quota data is unavailable.")
+
+    not_supported_count = _not_supported_count(response.get("capabilities"))
+    rows = []
+    windows = []
+    for provider_id, snapshot in sorted(providers.items(), key=lambda item: str(item[0])):
+        if not isinstance(provider_id, str) or not isinstance(snapshot, Mapping):
+            continue
+        provider_name = _text(snapshot.get("displayName")) or provider_id
+        plan = _text(snapshot.get("plan"))
+        resources = snapshot.get("resources")
+        if not isinstance(resources, Mapping):
+            continue
+        for resource_id, resource in sorted(resources.items(), key=lambda item: str(item[0])):
+            if not isinstance(resource_id, str) or not isinstance(resource, Mapping):
+                continue
+            label = quota_resource_label(resource_id)
+            pct = quota_percent(resource)
+            severity = _severity(pct) if pct is not None else None
+            text = _resource_text(resource, pct)
+            if text is None:
+                continue
+            rows.append(MenuBarRow(
+                provider_id=provider_id,
+                provider_name=provider_name,
+                plan=plan,
+                resource_id=resource_id,
+                resource_label=label,
+                text=text,
+                pct=pct,
+                severity=severity,
+            ))
+            if pct is not None:
+                windows.append(QuotaWindow(
+                    provider_id=provider_id,
+                    provider_name=provider_name,
+                    resource_id=resource_id,
+                    resource_label=label,
+                    pct=pct,
+                    severity=severity,
+                ))
+
+    worst = min(windows, key=lambda window: (-window.pct, window.provider_id, window.resource_id), default=None)
+    if worst is None:
+        message = _response_failure(response)
+        if message:
+            return MenuBarPresentation(
+                state="failure",
+                title="◔ Quota unavailable",
+                severity=None,
+                worst_window=None,
+                rows=tuple(rows),
+                not_supported_count=not_supported_count,
+                failure_message=message,
+            )
+        return MenuBarPresentation(
+            state="no_data",
+            title="◔ No quota data",
+            severity=None,
+            worst_window=None,
+            rows=tuple(rows),
+            not_supported_count=not_supported_count,
+            failure_message=None,
+        )
+
+    return MenuBarPresentation(
+        state="ready",
+        title=f"◔ {_rounded_percent(worst.pct)}%",
+        severity=worst.severity,
+        worst_window=worst,
+        rows=tuple(rows),
+        not_supported_count=not_supported_count,
+        failure_message=None,
+    )
+
+
+def quota_resource_label(resource_id: str) -> str:
+    """Return the dashboard's label for a normalized quota resource."""
+
+    return RESOURCE_LABELS.get(resource_id, _humanize(resource_id))
+
+
+def quota_percent(resource: Mapping[str, Any]) -> Optional[float]:
+    """Return consumed percentage for resources with a real, positive ceiling."""
+
+    used = _number(resource.get("used"))
+    limit = _number(resource.get("limit"))
+    if used is None or limit is None or limit <= 0:
+        return None
+    return min(100.0, max(0.0, used / limit * 100.0))
+
+
+def _empty_presentation(state: PresentationState, failure_message: Optional[str] = None) -> MenuBarPresentation:
+    titles = {
+        "loading": "◔ Loading…",
+        "no_data": "◔ No quota data",
+        "failure": "◔ Quota unavailable",
+    }
+    return MenuBarPresentation(
+        state=state,
+        title=titles[state],
+        severity=None,
+        worst_window=None,
+        rows=(),
+        not_supported_count=0,
+        failure_message=failure_message,
+    )
+
+
+def _resource_text(resource: Mapping[str, Any], pct: Optional[float]) -> Optional[str]:
+    if pct is not None:
+        return "Limit reached" if pct >= 100 else f"{_rounded_percent(pct)}% used"
+    available = _number(resource.get("available"))
+    unit = _text(resource.get("unit"))
+    if available is not None and unit:
+        return f"{_amount(available, unit)} available"
+    used = _number(resource.get("used"))
+    if used is not None and unit:
+        return f"{_amount(used, unit)} used"
+    return None
+
+
+def _not_supported_count(capabilities: Any) -> int:
+    if not isinstance(capabilities, Mapping):
+        return 0
+    return sum(
+        1 for capability in capabilities.values()
+        if isinstance(capability, Mapping) and capability.get("state") == "notSupported"
+    )
+
+
+def _response_failure(response: Mapping[str, Any]) -> Optional[str]:
+    errors = response.get("errors")
+    if not isinstance(errors, (list, tuple)):
+        return None
+    for error in errors:
+        if isinstance(error, Mapping) and (message := _text(error.get("message"))):
+            return message
+    return None
+
+
+def _severity(pct: float) -> Severity:
+    if pct >= QUOTA_CRITICAL_AT:
+        return "crit"
+    if pct >= QUOTA_WARN_AT:
+        return "warn"
+    return "ok"
+
+
+def _number(value: Any) -> Optional[float]:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)) and math.isfinite(value):
+        return float(value)
+    return None
+
+
+def _text(value: Any) -> Optional[str]:
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def _rounded_percent(pct: float) -> int:
+    return int(math.floor(pct + 0.5))
+
+
+def _amount(value: float, unit: str) -> str:
+    if unit == "usd":
+        return f"${value:.2f}" if value < 10 else f"${value:.0f}"
+    if unit == "percent":
+        return f"{_rounded_percent(value)}%"
+    number = str(int(value)) if value.is_integer() else f"{value:.1f}"
+    return f"{number} {unit}"
+
+
+def _humanize(value: str) -> str:
+    result = []
+    for index, character in enumerate(value):
+        if index and character.isupper() and value[index - 1].islower():
+            result.append(" ")
+        result.append(character)
+    return "".join(result).capitalize()

--- a/backend/menubar/render.py
+++ b/backend/menubar/render.py
@@ -1,0 +1,242 @@
+"""Build a macOS menu item tree from a :class:`MenubarPresentation`.
+
+Two layers, deliberately separated:
+
+* :func:`menu_spec` turns a presentation into pure, headless data (a list of
+  ``section`` / ``bar`` / ``balance`` / ``note`` / ``action`` dictionaries) with
+  no macOS imports. This is what the tests exercise and what keeps the wording
+  and worst-window choice in one rumps-free place.
+* :func:`build_rumps_menu` turns that spec into ``rumps.MenuItem`` objects.
+  Progress rows render a unicode bar plus the remaining percentage, colored via
+  an attributed title when AppKit is available (best-effort, wrapped so any
+  error falls back to plain text). No custom ``NSView`` drawing is required, so
+  the menu cannot break rendering if a color fails.
+
+``rumps`` is imported inside the functions, never at module import, so this
+module stays importable on Linux/Windows.
+"""
+
+from __future__ import annotations
+
+from functools import partial
+from typing import Any, Dict, List, Optional
+
+from menubar.presentation import MenuBarPresentation
+
+_ACTION_KINDS = {"open", "refresh", "launch", "quit"}
+
+_BAR_CELLS = 10
+_FILLED = "▰"
+_TRACK = "▱"
+
+
+def menu_spec(presentation: MenuBarPresentation, launch_checked: Optional[bool] = None) -> List[Dict[str, Any]]:
+    """Render a presentation into a headless menu spec.
+
+    Each top-level entry is one of:
+      ``{"type": "section", "title": str, "rows": [...]}``
+      ``{"type": "note", "text": str}``
+      ``{"type": "separator"}``
+      ``{"type": "action", "title": str, "kind": "open|refresh|launch|quit",
+        "checked": bool}``
+
+    ``rows`` entries are ``bar`` (a consumption window with a progress bar) or
+    ``balance`` (an amount). Bar rows carry ``label``, ``bar`` (unicode), ``right``
+    (remaining percentage), ``resets`` and ``severity``; balance rows carry
+    ``label`` and ``value``.
+
+    ``launch_checked`` is the installed-LAunchAgent state; when omitted it is
+    read from the real LaunchAgents directory, letting callers (and tests) pin
+    the checkmark deterministically.
+    """
+
+    items: List[Dict[str, Any]] = []
+    for section in _sections(presentation.rows):
+        section["rows"] = [row_spec(row) for row in section["rows"]]
+        items.append(section)
+    if presentation.not_supported_count:
+        items.append({"type": "note", "text": _not_supported_text(presentation.not_supported_count)})
+    items.append({"type": "separator"})
+    items.append(_action("Open dashboard", "open", checked=False))
+    items.append(_action("Refresh now", "refresh", checked=False))
+    checked = _launch_checked() if launch_checked is None else launch_checked
+    items.append(_action("Launch at login  ✓" if checked else "Launch at login", "launch", checked=checked))
+    items.append({"type": "separator"})
+    items.append(_action("Quit", "quit", checked=False))
+    return items
+
+
+def row_spec(row: Any) -> Dict[str, Any]:
+    """Convert a presentation row into a bar (consumption) or balance spec."""
+    if row.is_balance:
+        return {"type": "balance", "label": row.resource_label, "value": row.amount_text or row.text,
+                "severity": None}
+    pct = row.pct if row.pct is not None else 0.0
+    return {
+        "type": "bar",
+        "label": row.resource_label,
+        "bar": _unicode_bar(pct),
+        "right": row.pct_left_text or row.text,
+        "resets": row.resets_text,
+        "severity": row.severity or "ok",
+    }
+
+
+def _action(title: str, kind: str, checked: bool) -> Dict[str, Any]:
+    assert kind in _ACTION_KINDS
+    return {"type": "action", "title": title, "kind": kind, "checked": checked}
+
+
+def _unicode_bar(pct: float) -> str:
+    cells = int(round(max(0.0, min(100.0, float(pct))) / 100.0 * _BAR_CELLS))
+    return (_FILLED * cells) + (_TRACK * (_BAR_CELLS - cells))
+
+
+def _launch_checked() -> bool:
+    from menubar import launch_agent
+    return launch_agent.is_installed()
+
+
+def _sections(rows: Any) -> List[Dict[str, Any]]:
+    """Group presentation rows into sections under a provider header."""
+    sections: List[Dict[str, Any]] = []
+    current_id: Optional[str] = None
+    current_header: Optional[Dict[str, Any]] = None
+    current_rows: List[Any] = []
+
+    def flush() -> None:
+        if current_header is not None and current_rows:
+            current_header["rows"] = current_rows
+            sections.append(current_header)
+
+    for row in rows:
+        if row.provider_id != current_id:
+            flush()
+            current_id = row.provider_id
+            title = row.provider_name + (f"  {row.plan}" if row.plan else "")
+            current_header = {"type": "section", "title": title, "rows": []}
+            current_rows = []
+        current_rows.append(row)
+    flush()
+    return sections
+
+
+def _not_supported_text(count: int) -> str:
+    return "1 agent with no live quota" if count == 1 else f"{count} agents with no live quota"
+
+
+def _row_text(row: Dict[str, Any]) -> str:
+    """Plain-text rendering used both directly and as a fallback."""
+    label = row.get("label", "")
+    if row.get("type") == "balance":
+        value = row.get("value", "")
+        return f"{label}    {value}"
+    bar = row.get("bar", "")
+    right = row.get("right", "")
+    resets = row.get("resets")
+    suffix = f"  ·  {resets}" if resets else ""
+    return f"{label}    {bar}  {right}{suffix}"
+
+
+def _colorized_title(row: Dict[str, Any]) -> Any:
+    """Attributed title with the remaining-percentage colored by severity."""
+    from AppKit import (NSColor, NSFont, NSFontAttributeName,
+                        NSForegroundColorAttributeName)
+    from Foundation import NSMutableAttributedString
+
+    attr = NSMutableAttributedString.alloc().initWithString_("")
+
+    def append(value: str, color: Any, size: float, bold: bool) -> None:
+        if not value:
+            return
+        seg = NSMutableAttributedString.alloc().initWithString_(value)
+        seg.addAttribute_value_range_(NSFontAttributeName, _font(size, bold), (0, len(value)))
+        seg.addAttribute_value_range_(NSForegroundColorAttributeName, color, (0, len(value)))
+        attr.appendAttributedString_(seg)
+
+    label = row.get("label", "")
+    append(label, NSColor.labelColor(), 12, False)
+    append("    ", NSColor.labelColor(), 12, False)
+    if row.get("type") == "balance":
+        append(row.get("value", ""), NSColor.secondaryLabelColor(), 12, False)
+    else:
+        color = _severity_nscolor(row.get("severity"))
+        append(row.get("bar", ""), color, 12, False)
+        append("  ", NSColor.labelColor(), 12, False)
+        append(row.get("right", ""), color, 12, True)
+        if row.get("resets"):
+            append(f"  ·  {row['resets']}", NSColor.tertiaryLabelColor(), 10, False)
+    return attr
+
+
+def _font(size: float, bold: bool):
+    from AppKit import NSFont
+    return NSFont.boldSystemFontOfSize_(size) if bold else NSFont.systemFontOfSize_(size)
+
+
+def _severity_nscolor(severity: Optional[str]):
+    from AppKit import NSColor
+    palette = {
+        "ok": NSColor.colorWithSRGBRed_green_blue_alpha_(0x60 / 255, 0xA5 / 255, 0xFA / 255, 1.0),
+        "warn": NSColor.colorWithSRGBRed_green_blue_alpha_(0xFC / 255, 0xD3 / 255, 0x4D / 255, 1.0),
+        "crit": NSColor.colorWithSRGBRed_green_blue_alpha_(0xFD / 255, 0xA4 / 255, 0xAF / 255, 1.0),
+    }
+    return palette.get(severity or "ok")
+
+
+# --- rumps layer --------------------------------------------------------------
+# Imported lazily so this module stays importable on any platform.
+
+def build_rumps_menu(presentation: MenuBarPresentation, handler: Any = None, launch_checked: Optional[bool] = None) -> List[Any]:
+    """Return a list of rumps menu items for a presentation.
+
+    Each entry is a ``rumps.MenuItem`` or ``None`` (meaning a separator). Rows
+    default to plain text; an attributed (colored) title is applied best-effort.
+    ``handler`` is called as ``handler(kind, sender)`` for the ``open`` /
+    ``refresh`` / ``launch`` actions; the ``quit`` action always calls
+    :func:`rumps.quit_application`.
+    """
+    import rumps
+
+    def build(item_spec: Dict[str, Any]):
+        kind = item_spec.get("type")
+        if kind == "separator":
+            return None
+        if kind == "action":
+            item = rumps.MenuItem(item_spec["title"])
+            if item_spec["kind"] == "quit":
+                item.set_callback(rumps.quit_application)
+            elif handler is not None:
+                item.set_callback(partial(handler, item_spec["kind"]))
+            return item
+        if kind == "note":
+            return rumps.MenuItem(item_spec["text"])
+        if kind == "section":
+            parent = rumps.MenuItem(item_spec["title"])
+            for row in item_spec.get("rows", []):
+                parent.add(_row_menu_item(row))
+            return parent
+        return None
+
+    items: List[Any] = []
+    for item_spec in menu_spec(presentation, launch_checked=launch_checked):
+        built = build(item_spec)
+        items.append(rumps.separator if built is None else built)
+    return items
+
+
+def _row_menu_item(row: Dict[str, Any]):
+    import rumps
+
+    item = rumps.MenuItem(_row_text(row))
+    colored = _try_colorized_title(row)
+    if colored is not None:
+        item._menuitem.setAttributedTitle_(colored)
+    return item
+
+
+def _try_colorized_title(row: Dict[str, Any]):
+    try:
+        return _colorized_title(row)
+    except Exception:  # pragma: no cover — color is best-effort
+        return None

--- a/backend/quotas.py
+++ b/backend/quotas.py
@@ -1286,3 +1286,34 @@ class QuotaService:
             temporary.replace(self.cache_path)
         except OSError:
             return
+
+
+def default_quota_providers() -> List[QuotaProvider]:
+    """The ordered provider roster for the local API and any desktop/menubar client.
+
+    Native sources first, in the order the dashboard lists them, then every
+    other supported agent as a static entry so a harness is never silently
+    missing from the quota page. Construction only: no credentials are read and
+    nothing is written.
+    """
+    return [
+        CodexQuotaProvider(),
+        ClaudeQuotaProvider(),
+        CursorQuotaProvider(),
+        OpenCodeQuotaProvider(),
+        CopilotQuotaProvider(),
+        GrokQuotaProvider(),
+        GeminiQuotaProvider(),
+        StaticQuotaProvider("antigravity", "Antigravity", "Antigravity keeps its plan and usage state server-side; nothing local reports it."),
+        StaticQuotaProvider("qwen", "Qwen CLI", "Qwen's OAuth free tier was discontinued and its Coding Plan key exposes no account-quota endpoint."),
+        StaticQuotaProvider("vibe", "Vibe", "Vibe routes to configured model providers, so it has no account quota of its own."),
+        StaticQuotaProvider("hermes", "Hermes Agent", "Hermes routes to configured model providers, so it has no account quota of its own."),
+        StaticQuotaProvider("cline", "Cline", "Cline routes to configured model providers, so it has no account quota of its own."),
+        StaticQuotaProvider("pi", "Pi", "Pi routes to configured model providers, so it has no account quota of its own."),
+        StaticQuotaProvider("smallcode", "SmallCode", "SmallCode routes to configured model providers, so it has no account quota of its own."),
+        StaticQuotaProvider("muse", "Muse Code", "Muse Code's local session exposes no plan-quota API."),
+        StaticQuotaProvider("prime", "Prime Agent", "Prime routes to configured model providers, so it has no account quota of its own."),
+        StaticQuotaProvider("dsh", "DeepSeek Harness", "The DeepSeek harness bills per API key; usage belongs to that key's own account page."),
+        StaticQuotaProvider("qoder", "Qoder", "Qoder keeps its plan and usage state server-side; nothing local reports it."),
+        StaticQuotaProvider("openai_compat", "OpenAI-compatible server", "This is a user-configured endpoint, so quota belongs to that provider's own account API."),
+    ]

--- a/backend/quotas.py
+++ b/backend/quotas.py
@@ -13,7 +13,9 @@ import os
 import sqlite3
 import subprocess
 import sys
+import tempfile
 import threading
+import time
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -27,6 +29,14 @@ from tt_paths import data_dir
 
 SCHEMA = "tokentelemetry.quotas.v1"
 FRESHNESS = timedelta(minutes=5)
+CACHE_LOCK_TIMEOUT_SECONDS = 15
+
+# ``flock``/``msvcrt.locking`` coordinate separate processes, but their
+# same-process behaviour differs by platform. Keep a per-cache thread lock as
+# well, so two independently constructed services in one app cannot bypass the
+# interprocess lock while another process is also using the cache.
+_cache_locks: Dict[str, threading.Lock] = {}
+_cache_locks_guard = threading.Lock()
 
 # Some provider edges (OpenCode sits behind Cloudflare) reject the stdlib's
 # default "Python-urllib/x.y" agent with a 1010 browser-signature ban, which
@@ -44,6 +54,95 @@ LOGIN_REJECTED = "local login was rejected"
 
 def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
+
+
+def _cache_lock_for(path: Path) -> threading.Lock:
+    key = str(path.resolve())
+    with _cache_locks_guard:
+        return _cache_locks.setdefault(key, threading.Lock())
+
+
+class _CacheFileLock:
+    """A bounded advisory lock that works on the supported desktop platforms."""
+
+    def __init__(self, cache_path: Path, timeout: float = CACHE_LOCK_TIMEOUT_SECONDS) -> None:
+        self.path = cache_path.with_name(f"{cache_path.name}.lock")
+        self.timeout = timeout
+        self._thread_lock = _cache_lock_for(cache_path)
+        self._handle: Optional[Any] = None
+        self._acquired = False
+
+    def __enter__(self) -> bool:
+        if not self._thread_lock.acquire(timeout=self.timeout):
+            return False
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            self._handle = self.path.open("a+b")
+            self._handle.seek(0, os.SEEK_END)
+            if self._handle.tell() == 0:
+                self._handle.write(b"0")
+                self._handle.flush()
+
+            deadline = time.monotonic() + self.timeout
+            while True:
+                if self._try_acquire():
+                    self._acquired = True
+                    return True
+                if time.monotonic() >= deadline:
+                    self._handle.close()
+                    self._handle = None
+                    self._thread_lock.release()
+                    return False
+                time.sleep(0.05)
+        except OSError:
+            if self._handle is not None:
+                self._handle.close()
+                self._handle = None
+            self._thread_lock.release()
+            return False
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        if self._handle is not None:
+            try:
+                if self._acquired:
+                    self._release()
+            finally:
+                self._handle.close()
+                self._handle = None
+        if self._acquired:
+            self._thread_lock.release()
+            self._acquired = False
+
+    def _try_acquire(self) -> bool:
+        assert self._handle is not None
+        try:
+            if os.name == "nt":
+                import msvcrt
+
+                self._handle.seek(0)
+                msvcrt.locking(self._handle.fileno(), msvcrt.LK_NBLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(self._handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return True
+        except (BlockingIOError, OSError):
+            return False
+
+    def _release(self) -> None:
+        assert self._handle is not None
+        try:
+            if os.name == "nt":
+                import msvcrt
+
+                self._handle.seek(0)
+                msvcrt.locking(self._handle.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(self._handle.fileno(), fcntl.LOCK_UN)
+        except OSError:
+            pass
 
 
 def _iso(value: datetime) -> str:
@@ -1206,42 +1305,53 @@ class QuotaService:
 
     def collect(self, force: bool = False) -> Dict[str, Any]:
         with self._lock:
-            self._load()
-            generated_at = self.now()
-            errors = []
-            capabilities: Dict[str, Dict[str, str]] = {}
-            for provider in self.providers:
-                current = self._snapshots.get(provider.provider_id)
-                explicit = getattr(provider, "capability", None)
-                if callable(explicit):
-                    capabilities[provider.provider_id] = explicit()
-                    continue
-                is_fresh = current and generated_at < current.fetched_at + FRESHNESS
-                if not force and is_fresh:
-                    capabilities[provider.provider_id] = {"displayName": provider.display_name, "state": "available"}
-                    continue
-                if not provider.has_local_credentials():
-                    capabilities[provider.provider_id] = {
-                        "displayName": provider.display_name,
-                        "state": "notSignedIn",
-                        "detail": "No local credentials found.",
-                    }
-                    continue
-                try:
-                    self._snapshots[provider.provider_id] = provider.refresh(generated_at)
-                    capabilities[provider.provider_id] = {"displayName": provider.display_name, "state": "available"}
-                except Exception as error:
-                    state, detail = _classify(provider, error)
-                    capabilities[provider.provider_id] = {
-                        "displayName": provider.display_name, "state": state, "detail": detail,
-                    }
-                    # A signed-out, expired or unlicensed account is a fact about
-                    # the account, not a fault. Only a genuine fetch failure gets
-                    # an error row, so the dashboard's warning stays meaningful.
-                    if state == "refreshFailed":
-                        errors.append({"providerId": provider.provider_id, "message": detail})
-            self._save()
-            return self._wire(generated_at, errors, capabilities)
+            with _CacheFileLock(self.cache_path) as acquired:
+                if not acquired:
+                    # Another process is still collecting. Its atomic replace
+                    # means this read is either the prior complete cache or the
+                    # next complete cache; never write a competing snapshot.
+                    self._load(reload=True)
+                    return self._wire(self.now(), [])
+
+                # Reload *inside* the process lock. A long-lived dashboard or
+                # menubar instance may have loaded a stale cache before another
+                # instance refreshed it, and must not overwrite that newer file.
+                self._load(reload=True)
+                generated_at = self.now()
+                errors = []
+                capabilities: Dict[str, Dict[str, str]] = {}
+                for provider in self.providers:
+                    current = self._snapshots.get(provider.provider_id)
+                    explicit = getattr(provider, "capability", None)
+                    if callable(explicit):
+                        capabilities[provider.provider_id] = explicit()
+                        continue
+                    is_fresh = current and generated_at < current.fetched_at + FRESHNESS
+                    if not force and is_fresh:
+                        capabilities[provider.provider_id] = {"displayName": provider.display_name, "state": "available"}
+                        continue
+                    if not provider.has_local_credentials():
+                        capabilities[provider.provider_id] = {
+                            "displayName": provider.display_name,
+                            "state": "notSignedIn",
+                            "detail": "No local credentials found.",
+                        }
+                        continue
+                    try:
+                        self._snapshots[provider.provider_id] = provider.refresh(generated_at)
+                        capabilities[provider.provider_id] = {"displayName": provider.display_name, "state": "available"}
+                    except Exception as error:
+                        state, detail = _classify(provider, error)
+                        capabilities[provider.provider_id] = {
+                            "displayName": provider.display_name, "state": state, "detail": detail,
+                        }
+                        # A signed-out, expired or unlicensed account is a fact about
+                        # the account, not a fault. Only a genuine fetch failure gets
+                        # an error row, so the dashboard's warning stays meaningful.
+                        if state == "refreshFailed":
+                            errors.append({"providerId": provider.provider_id, "message": detail})
+                self._save(generated_at)
+                return self._wire(generated_at, errors, capabilities)
 
     def _wire(
         self,
@@ -1260,8 +1370,8 @@ class QuotaService:
             "capabilities": dict(sorted((capabilities or {}).items())),
         }
 
-    def _load(self) -> None:
-        if self._loaded:
+    def _load(self, reload: bool = False) -> None:
+        if self._loaded and not reload:
             return
         self._loaded = True
         try:
@@ -1269,23 +1379,35 @@ class QuotaService:
             providers = value.get("providers") if isinstance(value, dict) else None
             if not isinstance(providers, dict):
                 return
-            self._snapshots = {
+            snapshots = {
                 provider_id: snapshot
                 for provider_id, raw in providers.items()
                 if isinstance(raw, dict) and (snapshot := QuotaSnapshot.from_wire(provider_id, raw))
             }
         except (OSError, json.JSONDecodeError):
             return
+        self._snapshots = snapshots
 
-    def _save(self) -> None:
+    def _save(self, generated_at: datetime) -> None:
+        temporary: Optional[Path] = None
         try:
             self.cache_path.parent.mkdir(parents=True, exist_ok=True)
-            payload = self._wire(self.now(), [])
-            temporary = self.cache_path.with_suffix(".tmp")
-            temporary.write_text(json.dumps(payload, separators=(",", ":")), encoding="utf-8")
-            temporary.replace(self.cache_path)
+            payload = self._wire(generated_at, [])
+            with tempfile.NamedTemporaryFile(
+                mode="w", encoding="utf-8", dir=self.cache_path.parent,
+                prefix=f".{self.cache_path.name}.", suffix=".tmp", delete=False,
+            ) as handle:
+                temporary = Path(handle.name)
+                json.dump(payload, handle, separators=(",", ":"))
+            os.replace(temporary, self.cache_path)
         except OSError:
             return
+        finally:
+            if temporary is not None:
+                try:
+                    temporary.unlink(missing_ok=True)
+                except OSError:
+                    pass
 
 
 def default_quota_providers() -> List[QuotaProvider]:

--- a/backend/requirements-macos.txt
+++ b/backend/requirements-macos.txt
@@ -1,0 +1,5 @@
+# macOS-only extras for the menu bar app. rumps pulls in its own PyObjC
+# frameworks; a Linux or Windows install never reads this file, so those
+# platforms never try to resolve PyObjC. Installed into the same backend venv
+# as requirements.txt, only when `tokentelemetry menubar` runs on macOS.
+rumps>=0.4.0,<0.5

--- a/backend/telemetry.py
+++ b/backend/telemetry.py
@@ -123,6 +123,10 @@ _EVENT_PROPS: Dict[str, set] = {
     "analytics.filtered": {"dimension"},
     "feature.used":       {"name"},
     "retention.opted_in": {"tier"},
+    # Sidebar plan-limit gauge: how often it is opened vs. collapsed.
+    "planlimits.toggled": {"state"},
+    # A connected-coding-agent tile leading to /agents/<key>.
+    "agent.opened":       {"agent"},
     # One per *detected* harness, once per process, after the first successful
     # scan. The `agents` context prop says which harnesses are installed; this
     # says whether their readers actually returned anything. Without it a broken
@@ -157,6 +161,8 @@ _ENUMS: Dict[str, set] = {
     # Order-of-magnitude bucket, never a raw count -- enough to separate a
     # reader that found one session from one that found four hundred.
     "volume": {"0", "1-9", "10-99", "100-999", "1000-plus", "other"},
+    # Plan-limit gauge: opened (pinned/panel shown) vs. closed (a second click).
+    "state": {"opened", "closed", "other"},
 }
 
 # Detected-agent names we recognise — must match _list_available_agents() in
@@ -405,6 +411,8 @@ def sample_payloads() -> List[Dict[str, Any]]:
         "feature.used": {"name": "plan-library"},
         "retention.opted_in": {"tier": "full"},
         "harness.scanned": {"agent": "qoder", "volume": "1-9"},
+        "planlimits.toggled": {"state": "opened"},
+        "agent.opened": {"agent": "claude"},
     }
     # Iterate the allowlist, not the sample dict: an event added to
     # _EVENT_PROPS without a sample here still shows up in the panel (with

--- a/backend/test_menubar_app.py
+++ b/backend/test_menubar_app.py
@@ -1,0 +1,78 @@
+"""Unit tests for the headless menubar platform / argument helpers.
+
+These import ``menubar.app`` but never ``rumps``: the app module imports rumps
+only inside ``run()`` after the platform guard, so this file proves the module
+is importable (and its helpers callable) without touching Cocoa or PyObjC.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from menubar import app
+
+
+def test_is_macos_matches_the_running_platform():
+    assert app.is_macos() == (sys.platform == "darwin")
+
+
+def test_parse_args_reads_and_defaults_data_dir():
+    assert app.parse_args([]).data_dir is None
+    assert app.parse_args(["--data-dir", "/tmp/tt-data"]).data_dir == "/tmp/tt-data"
+
+
+def test_configure_environment_sets_the_data_dir_env_var():
+    args = app.parse_args(["--data-dir", "/tmp/tt-data"])
+    previous = os.environ.get("TOKENTELEMETRY_DATA_DIR")
+    try:
+        app.configure_environment(args)
+        assert os.environ["TOKENTELEMETRY_DATA_DIR"] == os.path.abspath("/tmp/tt-data")
+    finally:
+        if previous is None:
+            os.environ.pop("TOKENTELEMETRY_DATA_DIR", None)
+        else:
+            os.environ["TOKENTELEMETRY_DATA_DIR"] = previous
+
+
+def test_program_arguments_are_absolute_and_forward_data_dir():
+    argv = app.program_arguments(
+        python="/abs/python",
+        app_path="/abs/menubar/app.py",
+        data_dir="/data",
+    )
+    assert argv == ["/abs/python", "/abs/menubar/app.py", "--data-dir", "/data"]
+
+    argv = app.program_arguments(python="/abs/python", app_path="/abs/menubar/app.py")
+    assert argv == ["/abs/python", "/abs/menubar/app.py"]
+
+    # Defaults are absolute: sys.executable and this file.
+    default = app.program_arguments()
+    assert default[0] == sys.executable
+    assert Path(default[1]).is_absolute()
+
+
+def test_resolve_dashboard_command_prefers_environment_then_which():
+    env = {"TOKENTELEMETRY_NODE": "/abs/node", "TOKENTELEMETRY_CLI": "/abs/cli.js"}
+    assert app.resolve_dashboard_command(env=env) == ["/abs/node", "/abs/cli.js", "dashboard"]
+
+    # Missing CLI path yields None even if node is available.
+    assert app.resolve_dashboard_command(env={"TOKENTELEMETRY_NODE": "/abs/node"}) is None
+
+    # Falls back to `node` on PATH when TOKENTELEMETRY_NODE is absent.
+    def fake_which(cmd):
+        return "/usr/bin/node" if cmd == "node" else None
+
+    assert app.resolve_dashboard_command(
+        env={"TOKENTELEMETRY_CLI": "/abs/cli.js"},
+        which=fake_which,
+    ) == ["/usr/bin/node", "/abs/cli.js", "dashboard"]
+
+
+def test_program_arguments_defaults_to_absolute_sys_executable_and_file():
+    argv = app.program_arguments()
+    assert argv[0] == sys.executable
+    assert Path(argv[1]).is_absolute()

--- a/backend/test_menubar_launch_agent.py
+++ b/backend/test_menubar_launch_agent.py
@@ -1,0 +1,101 @@
+"""Unit tests for the headless LaunchAgent plist / lifecycle helpers."""
+
+from __future__ import annotations
+
+import plistlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from menubar import launch_agent
+
+
+def test_build_plist_uses_absolute_arguments_run_at_load_and_data_dir_logs():
+    plist = launch_agent.build_plist(
+        ["/abs/python", "/abs/app.py", "--data-dir", "/data"],
+        data_dir="/data",
+        env={"TOKENTELEMETRY_CLI": "/abs/cli.js"},
+    )
+
+    assert plist["Label"] == "com.tokentelemetry.menubar"
+    assert plist["ProgramArguments"] == ["/abs/python", "/abs/app.py", "--data-dir", "/data"]
+    assert plist["RunAtLoad"] is True
+    assert plist["StandardOutPath"] == "/data/logs/menubar.out.log"
+    assert plist["StandardErrorPath"] == "/data/logs/menubar.err.log"
+    assert plist["EnvironmentVariables"] == {"TOKENTELEMETRY_CLI": "/abs/cli.js"}
+
+
+def test_render_plist_round_trips_through_plistlib():
+    plist = launch_agent.build_plist(["python", "app.py"], data_dir="/data")
+    parsed = plistlib.loads(launch_agent.render_plist(plist))
+    assert parsed["Label"] == "com.tokentelemetry.menubar"
+    assert parsed["ProgramArguments"] == ["python", "app.py"]
+    assert parsed["RunAtLoad"] is True
+
+
+def test_write_and_remove_plist_under_home(tmp_path):
+    home = tmp_path / "home"
+    path = launch_agent.write_plist(["python", "app.py"], data_dir="/data", home=home)
+
+    assert path == home / "Library" / "LaunchAgents" / "com.tokentelemetry.menubar.plist"
+    assert launch_agent.is_installed(home=home)
+    assert path.exists()
+
+    launch_agent.remove_plist(home=home)
+    assert not launch_agent.is_installed(home=home)
+
+
+def test_command_generation_uses_an_explicit_uid():
+    assert launch_agent.bootstrap_command("/path/to.plist", uid=501) == [
+        "launchctl", "bootstrap", "gui/501", "/path/to.plist",
+    ]
+    assert launch_agent.bootout_command(uid=501) == [
+        "launchctl", "bootout", "gui/501/com.tokentelemetry.menubar",
+    ]
+    assert launch_agent.print_command(uid=501) == [
+        "launchctl", "print", "gui/501/com.tokentelemetry.menubar",
+    ]
+
+
+def test_enable_writes_plist_then_bootstraps(tmp_path):
+    calls = []
+
+    def fake_run(command, check=False):
+        calls.append((list(command), check))
+        return SimpleNamespace(returncode=0)
+
+    home = tmp_path / "home"
+    path = launch_agent.enable(
+        ["/abs/python", "/abs/app.py"],
+        data_dir="/data",
+        env={"TOKENTELEMETRY_CLI": "/abs/cli.js"},
+        home=home,
+        uid=501,
+        run=fake_run,
+    )
+
+    assert path == launch_agent.plist_path(home=home)
+    assert path.exists()
+    assert len(calls) == 1
+    command, check = calls[0]
+    assert command == ["launchctl", "bootstrap", "gui/501", str(path)]
+    assert check is True
+
+
+def test_disable_boots_out_then_removes_plist(tmp_path):
+    calls = []
+
+    def fake_run(command, check=False):
+        calls.append((list(command), check))
+        return SimpleNamespace(returncode=0)
+
+    home = tmp_path / "home"
+    launch_agent.write_plist(["python", "app.py"], data_dir="/data", home=home)
+    assert launch_agent.is_installed(home=home)
+
+    launch_agent.disable(home=home, uid=501, run=fake_run)
+
+    assert calls == [(["launchctl", "bootout", "gui/501/com.tokentelemetry.menubar"], False)]
+    assert not launch_agent.is_installed(home=home)

--- a/backend/test_menubar_presentation.py
+++ b/backend/test_menubar_presentation.py
@@ -1,0 +1,115 @@
+"""Unit tests for the headless menu-bar quota presentation model."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from menubar.presentation import build_menu_presentation
+
+
+def test_presentation_selects_the_global_worst_window_with_stable_ties():
+    presentation = build_menu_presentation({
+        "schema": "tokentelemetry.quotas.v1",
+        "providers": {
+            "zeta": {
+                "displayName": "Zeta",
+                "plan": "Pro",
+                "resources": {
+                    "weekly": {"kind": "consumption", "unit": "percent", "used": 90, "limit": 100},
+                },
+            },
+            "alpha": {
+                "displayName": "Alpha",
+                "resources": {
+                    "monthly": {"kind": "consumption", "unit": "percent", "used": 90, "limit": 100},
+                    "session": {"kind": "consumption", "unit": "percent", "used": 90, "limit": 100},
+                },
+            },
+        },
+        "capabilities": {},
+        "errors": [],
+    })
+
+    assert presentation.state == "ready"
+    assert presentation.title == "◔ 90%"
+    assert presentation.severity == "crit"
+    assert presentation.worst_window is not None
+    assert (presentation.worst_window.provider_id, presentation.worst_window.resource_id) == ("alpha", "monthly")
+    assert [(row.provider_id, row.resource_id, row.text) for row in presentation.rows] == [
+        ("alpha", "monthly", "90% used"),
+        ("alpha", "session", "90% used"),
+        ("zeta", "weekly", "90% used"),
+    ]
+
+
+def test_presentation_clamps_percentage_and_formats_limit_reached_rows():
+    presentation = build_menu_presentation({
+        "providers": {
+            "codex": {
+                "displayName": "Codex",
+                "plan": "Plus",
+                "resources": {
+                    "session": {"kind": "consumption", "unit": "percent", "used": 120, "limit": 100},
+                    "credits": {"kind": "balance", "unit": "credits", "available": 5},
+                },
+            },
+        },
+        "capabilities": {},
+        "errors": [],
+    })
+
+    assert presentation.title == "◔ 100%"
+    session = next(row for row in presentation.rows if row.resource_id == "session")
+    assert session.provider_name == "Codex"
+    assert session.plan == "Plus"
+    assert session.resource_label == "Session"
+    assert session.text == "Limit reached"
+    assert session.pct == 100
+
+
+def test_presentation_uses_the_shared_warning_threshold_for_each_window():
+    presentation = build_menu_presentation({
+        "providers": {
+            "claude": {
+                "displayName": "Claude Code",
+                "resources": {
+                    "session": {"kind": "consumption", "unit": "percent", "used": 75, "limit": 100},
+                },
+            },
+        },
+        "capabilities": {},
+        "errors": [],
+    })
+
+    assert presentation.severity == "warn"
+    assert presentation.rows[0].severity == "warn"
+
+
+def test_presentation_counts_not_supported_agents_without_treating_them_as_failures():
+    presentation = build_menu_presentation({
+        "providers": {},
+        "capabilities": {
+            "pi": {"displayName": "Pi", "state": "notSupported"},
+            "muse": {"displayName": "Muse Code", "state": "notSupported"},
+            "codex": {"displayName": "Codex", "state": "notSignedIn"},
+        },
+        "errors": [],
+    })
+
+    assert presentation.state == "no_data"
+    assert presentation.title == "◔ No quota data"
+    assert presentation.not_supported_count == 2
+    assert presentation.failure_message is None
+
+
+def test_presentation_distinguishes_loading_and_collection_failure_states():
+    loading = build_menu_presentation(None, loading=True)
+    failed = build_menu_presentation(None, failure="Could not refresh quota data.")
+
+    assert (loading.state, loading.title, loading.failure_message) == ("loading", "◔ Loading…", None)
+    assert (failed.state, failed.title, failed.failure_message) == (
+        "failure", "◔ Quota unavailable", "Could not refresh quota data.",
+    )

--- a/backend/test_menubar_presentation.py
+++ b/backend/test_menubar_presentation.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from menubar.presentation import build_menu_presentation
+from menubar.presentation import build_menu_presentation, percent_left_text, resets_in_text
 
 
 def test_presentation_selects_the_global_worst_window_with_stable_ties():
@@ -113,3 +113,57 @@ def test_presentation_distinguishes_loading_and_collection_failure_states():
     assert (failed.state, failed.title, failed.failure_message) == (
         "failure", "◔ Quota unavailable", "Could not refresh quota data.",
     )
+
+
+def test_presentation_adds_left_percent_resets_and_balance_amount_fields():
+    from datetime import datetime, timedelta, timezone
+
+    now = datetime(2026, 8, 31, 12, 0, 0, tzinfo=timezone.utc)
+    presentation = build_menu_presentation({
+        "providers": {
+            "codex": {
+                "displayName": "Codex",
+                "plan": "Plus",
+                "resources": {
+                    "weekly": {
+                        "kind": "consumption", "unit": "percent", "used": 81, "limit": 100,
+                        "resetsAt": (now + timedelta(days=1, hours=16)).isoformat(),
+                    },
+                    "session": {
+                        "kind": "consumption", "unit": "percent", "used": 60, "limit": 100,
+                        "resetsAt": (now + timedelta(hours=5)).isoformat(),
+                    },
+                    "extraUsage": {"kind": "spend", "unit": "usd", "used": 24.8},
+                },
+            },
+        },
+        "capabilities": {},
+        "errors": [],
+    }, now=now)
+
+    weekly = next(row for row in presentation.rows if row.resource_id == "weekly")
+    assert weekly.pct_left_text == "19% left"
+    assert weekly.resets_text == "Resets in 1d 16h"
+
+    session = next(row for row in presentation.rows if row.resource_id == "session")
+    assert session.pct_left_text == "40% left"
+    assert session.resets_text == "Resets in 5h 0m"
+
+    extra = next(row for row in presentation.rows if row.resource_id == "extraUsage")
+    assert extra.is_balance is True
+    assert extra.amount_text == "$25 used"
+    assert extra.pct_left_text is None
+    assert extra.text == "$25 used"
+
+
+def test_percent_left_text_and_resets_in_text_helpers():
+    from datetime import datetime, timezone
+
+    assert percent_left_text(90.0) == "10% left"
+    assert percent_left_text(100.0) == "0% left"
+    now = datetime(2026, 8, 31, 12, 0, 0, tzinfo=timezone.utc)
+    assert resets_in_text("2026-09-02T04:00:00Z", now=now) == "Resets in 1d 16h"
+    assert resets_in_text("2026-08-31T17:00:00Z", now=now) == "Resets in 5h 0m"
+    assert resets_in_text("2026-08-31T11:00:00Z", now=now) == "Resets now"
+    assert resets_in_text(None, now=now) is None
+    assert resets_in_text("garbage", now=now) is None

--- a/backend/test_menubar_render.py
+++ b/backend/test_menubar_render.py
@@ -1,0 +1,96 @@
+"""Unit tests for the headless menu-spec builder (no rumps / AppKit)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from menubar.presentation import build_menu_presentation
+from menubar.render import menu_spec, row_spec, _unicode_bar
+
+
+def test_unicode_bar_scales_across_cells():
+    assert _unicode_bar(0) == "▱▱▱▱▱▱▱▱▱▱"
+    assert _unicode_bar(100) == "▰▰▰▰▰▰▰▰▰▰"
+    assert _unicode_bar(50) == "▰▰▰▰▰▱▱▱▱▱"
+
+
+def test_menu_spec_groups_windows_under_provider_headers_and_appends_actions():
+    presentation = build_menu_presentation({
+        "providers": {
+            "codex": {
+                "displayName": "Codex",
+                "plan": "Plus",
+                "resources": {
+                    "weekly": {"kind": "consumption", "unit": "percent", "used": 81, "limit": 100},
+                    "extraUsage": {"kind": "spend", "unit": "usd", "used": 25},
+                },
+            },
+            "claude": {
+                "displayName": "Claude Code",
+                "plan": "Pro",
+                "resources": {
+                    "session": {"kind": "consumption", "unit": "percent", "used": 60, "limit": 100},
+                },
+            },
+        },
+        "capabilities": {
+            "pi": {"displayName": "Pi", "state": "notSupported"},
+            "muse": {"displayName": "Muse Code", "state": "notSupported"},
+        },
+        "errors": [],
+    })
+
+    spec = menu_spec(presentation, launch_checked=False)
+
+    sections = [item for item in spec if item["type"] == "section"]
+    assert [s["title"] for s in sections] == ["Claude Code  Pro", "Codex  Plus"]
+
+    # Row shape: a consumption window is a bar; an amount is a balance.
+    claude = next(s for s in sections if s["title"].startswith("Claude Code"))
+    assert claude["rows"] == [{
+        "type": "bar", "label": "Session", "bar": "▰▰▰▰▰▰▱▱▱▱",
+        "right": "40% left", "resets": None, "severity": "ok",
+    }]
+
+    codex_rows = next(s for s in sections if s["title"].startswith("Codex"))["rows"]
+    by_type = {row["type"]: row for row in codex_rows}
+    assert by_type["bar"]["right"] == "19% left"
+    assert by_type["balance"] == {"type": "balance", "label": "Extra usage", "value": "$25 used", "severity": None}
+
+    # Notes, separators and the footer actions are appended in order.
+    assert {"type": "note", "text": "2 agents with no live quota"} in spec
+    kinds = [item.get("kind") for item in spec if item["type"] == "action"]
+    assert kinds == ["open", "refresh", "launch", "quit"]
+    # Footer tail: separators around the action block (before open, before quit).
+    action_index = [i for i, item in enumerate(spec) if item["type"] == "action"]
+    assert spec[action_index[0] - 1]["type"] == "separator"
+    assert [spec[i]["kind"] for i in action_index] == ["open", "refresh", "launch", "quit"]
+    assert spec[action_index[-1] - 1]["type"] == "separator"
+    assert spec[-1] == {"type": "action", "title": "Quit", "kind": "quit", "checked": False}
+
+
+def test_row_spec_marks_balance_and_consumption():
+    presentation = build_menu_presentation({
+        "providers": {
+            "x": {
+                "displayName": "X",
+                "plan": None,
+                "resources": {
+                    "session": {"kind": "consumption", "unit": "percent", "used": 90, "limit": 100},
+                    "extraUsage": {"kind": "spend", "unit": "usd", "used": 12},
+                },
+            },
+        },
+        "capabilities": {},
+        "errors": [],
+    })
+    rows = presentation.rows
+    specs = {row_spec(row)["type"]: row_spec(row) for row in rows}
+    bar = specs["bar"]
+    balance = specs["balance"]
+    assert bar["type"] == "bar" and bar["right"] == "10% left"
+    assert bar["severity"] == "crit"
+    assert balance["type"] == "balance" and balance["value"] == "$12 used"

--- a/backend/test_quotas.py
+++ b/backend/test_quotas.py
@@ -15,6 +15,7 @@ from quotas import (
     CodexQuotaProvider,
     CopilotQuotaProvider,
     CursorQuotaProvider,
+    FRESHNESS,
     GeminiQuotaProvider,
     GrokQuotaProvider,
     OpenCodeQuotaProvider,
@@ -377,6 +378,80 @@ def test_service_skips_a_fresh_provider_until_a_forced_refresh(tmp_path):
     service.collect(force=True)
 
     assert provider.calls == 2
+
+
+def test_second_service_reloads_a_fresh_disk_cache_before_refreshing(tmp_path):
+    class Provider:
+        provider_id = "opencode"
+        display_name = "OpenCode"
+
+        def __init__(self, plan):
+            self.calls = 0
+            self.plan = plan
+
+        def has_local_credentials(self):
+            return True
+
+        def refresh(self, now):
+            self.calls += 1
+            return QuotaSnapshot(self.provider_id, self.display_name, now, {}, plan=self.plan)
+
+    cache_path = tmp_path / "quotas.json"
+    stale_at = datetime(2026, 9, 1, tzinfo=timezone.utc)
+    current_at = stale_at + FRESHNESS + timedelta(seconds=1)
+    stale_provider = Provider("stale")
+    stale_service = QuotaService([stale_provider], cache_path=cache_path, now=lambda: stale_at)
+    stale_service.collect(force=True)
+
+    second_provider = Provider("second")
+    second_service = QuotaService([second_provider], cache_path=cache_path, now=lambda: current_at)
+    second_service._load()  # Simulate a menubar process that loaded the stale cache earlier.
+
+    first_provider = Provider("first")
+    first_service = QuotaService([first_provider], cache_path=cache_path, now=lambda: current_at)
+    first_service.collect(force=True)
+
+    result = second_service.collect()
+
+    assert second_provider.calls == 0
+    assert result["providers"]["opencode"]["plan"] == "first"
+
+
+def test_second_service_never_saves_an_older_in_memory_snapshot_over_newer_disk_cache(tmp_path):
+    class Provider:
+        provider_id = "codex"
+        display_name = "Codex"
+
+        def __init__(self, plan):
+            self.calls = 0
+            self.plan = plan
+
+        def has_local_credentials(self):
+            return True
+
+        def refresh(self, now):
+            self.calls += 1
+            return QuotaSnapshot(self.provider_id, self.display_name, now, {}, plan=self.plan)
+
+    cache_path = tmp_path / "quotas.json"
+    initial_at = datetime(2026, 9, 1, tzinfo=timezone.utc)
+    updated_at = initial_at + timedelta(minutes=1)
+    initial_provider = Provider("initial")
+    QuotaService([initial_provider], cache_path=cache_path, now=lambda: initial_at).collect(force=True)
+
+    older_provider = Provider("older-memory")
+    older_service = QuotaService([older_provider], cache_path=cache_path, now=lambda: updated_at)
+    older_service._load()  # Its cache remains fresh, but another process updates it first.
+
+    writer_provider = Provider("newer-disk")
+    QuotaService([writer_provider], cache_path=cache_path, now=lambda: updated_at).collect(force=True)
+
+    result = older_service.collect()
+    persisted = json.loads(cache_path.read_text(encoding="utf-8"))
+
+    assert older_provider.calls == 0
+    assert result["providers"]["codex"]["plan"] == "newer-disk"
+    assert persisted["providers"]["codex"]["plan"] == "newer-disk"
 
 
 def test_local_api_routes_share_the_quota_service(monkeypatch, tmp_path):

--- a/backend/test_quotas.py
+++ b/backend/test_quotas.py
@@ -21,6 +21,7 @@ from quotas import (
     QuotaService,
     QuotaSnapshot,
     StaticQuotaProvider,
+    default_quota_providers,
 )
 
 
@@ -622,6 +623,40 @@ def test_every_supported_agent_has_a_quota_entry():
     assert roster, "agent roster could not be read"
     assert roster - reported == set(), f"agents with no quota entry: {sorted(roster - reported)}"
     assert reported - roster == set(), f"quota entries for unknown agents: {sorted(reported - roster)}"
+
+
+def test_default_quota_providers_roster_is_exact_and_stable():
+    """The factory is the single source of truth for the /quotas roster.
+
+    Pinning the ordered ids, the native provider classes, and the static
+    entries' display text catches a reorder, an accidental drop, or a rewritten
+    detail here rather than as silent drift in the running service.
+    """
+    providers = default_quota_providers()
+
+    assert [p.provider_id for p in providers] == [
+        "codex", "claude", "cursor", "opencode", "copilot", "grok", "gemini",
+        "antigravity", "qwen", "vibe", "hermes", "cline", "pi", "smallcode",
+        "muse", "prime", "dsh", "qoder", "openai_compat",
+    ]
+
+    native = [p for p in providers if not isinstance(p, StaticQuotaProvider)]
+    assert [type(p) for p in native] == [
+        CodexQuotaProvider, ClaudeQuotaProvider, CursorQuotaProvider,
+        OpenCodeQuotaProvider, CopilotQuotaProvider, GrokQuotaProvider,
+        GeminiQuotaProvider,
+    ]
+
+    statics = {p.provider_id: p for p in providers if isinstance(p, StaticQuotaProvider)}
+    assert set(statics) == {
+        "antigravity", "qwen", "vibe", "hermes", "cline", "pi", "smallcode",
+        "muse", "prime", "dsh", "qoder", "openai_compat",
+    }
+    assert statics["qwen"].display_name == "Qwen CLI"
+    assert statics["dsh"].display_name == "DeepSeek Harness"
+    assert statics["muse"].display_name == "Muse Code"
+    assert statics["openai_compat"].display_name == "OpenAI-compatible server"
+    assert [p.capability()["state"] for p in statics.values()] == ["notSupported"] * len(statics)
 
 
 def test_claude_panel_and_dashboard_report_the_same_windows(tmp_path, monkeypatch):

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -128,7 +128,7 @@ function printHelp() {
     'Commands:',
     '  dashboard [options]        Start the dashboard (the default).',
     '  menubar                    Menu bar app (macOS only).',
-    '  desktop                    Desktop app (not available yet).',
+    '  desktop                    Desktop app.',
     '  status                     Dashboard status (not available yet).',
     '  stop                       Stop the dashboard (not available yet).',
     '',
@@ -272,6 +272,15 @@ function checkNode() {
   const [major, minor] = process.versions.node.split('.').map(Number);
   if (major < 20 || (major === 20 && minor < 9)) {
     die(`Node.js 20.9+ required (detected ${process.versions.node}).`);
+  }
+}
+
+function checkDesktopNode() {
+  const [major, minor] = process.versions.node.split('.').map(Number);
+  // Electron's current installer requires this newer Node line. Keep the
+  // ordinary dashboard's existing Node 20.9 floor unchanged.
+  if (major < 22 || (major === 22 && minor < 12)) {
+    die(`TokenTelemetry Desktop requires Node.js 22.12+ (detected ${process.versions.node}).`);
   }
 }
 
@@ -631,19 +640,14 @@ async function start(options) {
 }
 
 // --- Subcommand messages ----------------------------------------------------
-// Vertical slice 1: verbs exist and are dispatched, but menubar/desktop/status/
-// stop are not implemented yet. They print one clear line and exit non-zero,
-// and (critically) none of them bootstrap dependencies or launch servers.
+// The desktop shell owns local backend/frontend processes and always addresses
+// them through localhost. 127.0.0.1 remains only a legacy CLI bind default.
 
-function menubarMessage(platform) {
-  return platform === 'darwin'
-    ? 'The tokentelemetry menu bar is not implemented yet.'
-    : 'The tokentelemetry menu bar is macOS-only.';
+function menubarMessage() {
+  return 'The tokentelemetry menu bar is macOS-only.';
 }
 
-function desktopMessage() {
-  return 'The tokentelemetry desktop app is not available yet.';
-}
+function desktopMessage() { return 'Starting TokenTelemetry Desktop…'; }
 
 function statusMessage() {
   return 'tokentelemetry status is not implemented yet.';
@@ -653,14 +657,117 @@ function stopMessage() {
   return 'tokentelemetry stop is not implemented yet.';
 }
 
-function cmdMenubar() {
-  console.error(menubarMessage(process.platform));
-  return 1;
+// --- macOS menu bar ----------------------------------------------------------
+// The menu bar app is a thin rumps wrapper over backend/quotas.py. rumps (and
+// its PyObjC dependencies) is macOS-only, so it lives in a separate
+// requirements-macos.txt and is installed into the existing backend venv only
+// when this command runs on macOS. The app runs detached in the background; its
+// "Open dashboard" item shells back out to this same CLI via absolute paths
+// passed through the environment (never a hard-coded checkout/account path).
+
+function menubarPythonArgs(backendDirParam = backendDir, dataDir = null) {
+  const args = [path.join(backendDirParam, 'menubar', 'app.py')];
+  if (dataDir) args.push('--data-dir', dataDir);
+  return args;
 }
 
-function cmdDesktop() {
-  console.error(desktopMessage());
-  return 1;
+function menubarEnv(dataDir, cliPath, nodePath, backendDirParam = backendDir, env = process.env) {
+  const base = dataDir ? { ...env, TOKENTELEMETRY_DATA_DIR: dataDir } : env;
+  const existing = env.PYTHONPATH ? [env.PYTHONPATH] : [];
+  return {
+    ...base,
+    PYTHONPATH: [backendDirParam, ...existing].join(path.delimiter),
+    TOKENTELEMETRY_CLI: cliPath,
+    TOKENTELEMETRY_NODE: nodePath,
+  };
+}
+
+function ensureMenubarRumps() {
+  // Install the macOS-only rumps requirement into the venv ensureBackend() just
+  // built, stamped by hash so a second `menubar` run is a no-op. Mirrors
+  // ensureBackend()'s lock/stamp logic, minus the hashes (this file is not
+  // lock-pinned) — rumps is a small, stable dependency and the file is macOS-only.
+  const reqPath = path.join(backendDir, 'requirements-macos.txt');
+  const stampPath = path.join(venvDir, '.requirements-macos.sha');
+  const currentSha = crypto.createHash('sha1').update(fs.readFileSync(reqPath)).digest('hex');
+  let cachedSha = null;
+  try { cachedSha = fs.readFileSync(stampPath, 'utf8').trim(); } catch {}
+  if (cachedSha === currentSha) return;
+  const uv = findUv();
+  if (uv) {
+    console.log('→ installing macOS menu bar dependencies (uv)…');
+    if (runSoft(uv, ['pip', 'install', '--quiet', '--python', venvPython, '-r', 'requirements-macos.txt'], { cwd: backendDir }) !== 0) {
+      die('installing the macOS menu bar dependencies with uv failed (see above).\nRe-run with TT_NO_UV=1 to install them with pip instead.');
+    }
+  } else {
+    ensureVenvPip();
+    console.log('→ installing macOS menu bar dependencies…');
+    run(venvPython, ['-m', 'pip', 'install', '--quiet', '-r', 'requirements-macos.txt'], { cwd: backendDir });
+  }
+  try { fs.writeFileSync(stampPath, currentSha); } catch {}
+}
+
+function startMenubar(options = {}) {
+  checkNode();
+  ensureBackend();
+  ensureMenubarRumps();
+  const cliPath = path.join(__dirname, 'cli.js');
+  const child = spawn(venvPython, menubarPythonArgs(backendDir, options.dataDir), {
+    cwd: backendDir,
+    stdio: 'ignore',
+    detached: true,
+    env: menubarEnv(options.dataDir, cliPath, process.execPath),
+  });
+  child.unref();
+  return 0;
+}
+
+function electronExecutable(root = rootDir, platform = process.platform) {
+  return path.join(root, 'node_modules', '.bin', platform === 'win32' ? 'electron.cmd' : 'electron');
+}
+
+function ensureDesktopElectron() {
+  const executable = electronExecutable();
+  if (fs.existsSync(executable)) return executable;
+  if (!which('npm')) die('npm is required to install TokenTelemetry Desktop.');
+  console.log('→ installing TokenTelemetry Desktop…');
+  run('npm', ['install', '--no-audit', '--no-fund'], { cwd: rootDir });
+  if (!fs.existsSync(executable)) {
+    die('TokenTelemetry Desktop did not install correctly. Re-run `npm install` in the TokenTelemetry checkout.');
+  }
+  return executable;
+}
+
+function desktopEnv(dataDir, env = process.env) {
+  return dataDir ? { ...env, TOKENTELEMETRY_DATA_DIR: dataDir } : env;
+}
+
+function startDesktop(options = {}) {
+  checkNode();
+  checkDesktopNode();
+  ensureBackend();
+  ensureFrontend();
+  const electron = ensureDesktopElectron();
+  const child = spawn(electron, [path.join(rootDir, 'desktop', 'main.cjs')], {
+    cwd: rootDir,
+    detached: !isWindows,
+    stdio: 'ignore',
+    env: desktopEnv(options.dataDir),
+  });
+  child.unref();
+  return 0;
+}
+
+function cmdMenubar(options = {}, platform = process.platform) {
+  if (platform !== 'darwin') {
+    console.error(menubarMessage(platform));
+    return 1;
+  }
+  return startMenubar(options);
+}
+
+function cmdDesktop(options = {}) {
+  return startDesktop(options);
 }
 
 function cmdStatus() {
@@ -688,8 +795,8 @@ async function main(argv = process.argv.slice(2)) {
     return 0;
   }
   switch (verb) {
-    case 'menubar': return cmdMenubar();
-    case 'desktop': return cmdDesktop();
+    case 'menubar': return cmdMenubar(parsed.options);
+    case 'desktop': return cmdDesktop(parsed.options);
     case 'status': return cmdStatus();
     case 'stop': return cmdStop();
     case 'dashboard':
@@ -718,6 +825,7 @@ module.exports = {
   printHelp,
   shouldOpenBrowser,
   openBrowser,
+  checkDesktopNode,
   start,
   main,
   cmdMenubar,
@@ -728,4 +836,11 @@ module.exports = {
   desktopMessage,
   statusMessage,
   stopMessage,
+  menubarPythonArgs,
+  menubarEnv,
+  ensureMenubarRumps,
+  startMenubar,
+  electronExecutable,
+  desktopEnv,
+  startDesktop,
 };

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -8,8 +8,16 @@
  *   - launches FastAPI and Next.js
  *   - shuts both down cleanly on Ctrl+C
  *
+ * The first argument is a verb when it matches one of: dashboard, menubar,
+ * desktop, status, stop. Anything else falls through to flag parsing, so
+ * `tokentelemetry --port 4000` behaves exactly as it always has. The bare
+ * command (no verb) starts the dashboard.
+ *
  * Thin wrapper scripts (install.sh, start.sh, start.bat) just call into here,
  * so platform-specific bugs can only live in one place.
+ *
+ * The parsing/dispatch helpers are exported for `node --test`; the CLI only
+ * runs when this file is the entrypoint (require.main === module).
  */
 
 const { spawn, spawnSync } = require('child_process');
@@ -35,27 +43,47 @@ function die(msg) {
   process.exit(1);
 }
 
+// A bad flag. Thrown rather than calling die() so the parse layer is testable;
+// main() catches it and prints through die(), preserving the exit behaviour.
+class UsageError extends Error {}
+
+// --- Verbs ------------------------------------------------------------------
+// The first CLI argument is a verb only when it matches one of these; anything
+// else (including the empty case) means "dashboard", so `--port 4000` and a
+// stray argument can never silently change what the command does.
+const VERBS = ['dashboard', 'menubar', 'desktop', 'status', 'stop'];
+
+function parseInvocation(argv) {
+  if (argv.length > 0 && VERBS.includes(argv[0])) {
+    return { verb: argv[0], args: argv.slice(1) };
+  }
+  return { verb: 'dashboard', args: argv };
+}
+
 // --- CLI argument parsing -------------------------------------------------
 // Accepts --port / --api-port (and -p / -a shorthands), in `--flag value` or
-// `--flag=value` form. Anything unknown triggers the help text.
+// `--flag=value` form. Anything unknown throws a UsageError. Returns
+// { help, options }: help is true when -h/--help was seen (the caller prints
+// help and exits 0).
 function parseArgs(argv) {
-  const out = { frontPort: 3000, apiPort: 8000, host: '127.0.0.1', allowedOrigins: '', authToken: '', insecureNoAuth: false, dataDir: null };
+  const out = { frontPort: 3000, apiPort: 8000, host: '127.0.0.1', allowedOrigins: '', authToken: '', insecureNoAuth: false, dataDir: null, noOpen: false };
+  const fail = (msg) => { throw new UsageError(msg); };
   const take = (i) => {
-    if (i + 1 >= argv.length) die(`expected a value after ${argv[i]}`);
+    if (i + 1 >= argv.length) fail(`expected a value after ${argv[i]}`);
     return argv[i + 1];
   };
   const setPort = (key, raw) => {
     const n = parseInt(raw, 10);
-    if (!Number.isFinite(n) || n < 1 || n > 65535) die(`invalid port: ${raw}`);
+    if (!Number.isFinite(n) || n < 1 || n > 65535) fail(`invalid port: ${raw}`);
     out[key] = n;
   };
   const setDataDir = (raw) => {
-    if (!raw || !raw.trim()) die('expected a path after --data-dir');
+    if (!raw || !raw.trim()) fail('expected a path after --data-dir');
     out.dataDir = raw;
   };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
-    if (a === '-h' || a === '--help') { printHelp(); process.exit(0); }
+    if (a === '-h' || a === '--help') { return { help: true, options: out }; }
     else if (a === '-p' || a === '--port')     { setPort('frontPort', take(i)); i++; }
     else if (a.startsWith('--port='))          { setPort('frontPort', a.slice('--port='.length)); }
     else if (a === '-a' || a === '--api-port') { setPort('apiPort',   take(i)); i++; }
@@ -67,11 +95,12 @@ function parseArgs(argv) {
     else if (a === '--auth-token')             { out.authToken = take(i); i++; }
     else if (a.startsWith('--auth-token='))    { out.authToken = a.slice('--auth-token='.length); }
     else if (a === '--insecure-no-auth')       { out.insecureNoAuth = true; }
+    else if (a === '--no-open')                { out.noOpen = true; }
     else if (a === '-d' || a === '--data-dir') { setDataDir(take(i)); i++; }
     else if (a.startsWith('--data-dir='))      { setDataDir(a.slice('--data-dir='.length)); }
-    else die(`unknown argument: ${a}\nRun with --help for usage.`);
+    else fail(`unknown argument: ${a}\nRun with --help for usage.`);
   }
-  return out;
+  return { help: false, options: out };
 }
 
 // Pick a concrete, reachable address for the connect/QR URL. 0.0.0.0 is a bind
@@ -94,7 +123,14 @@ function pickConnectHost(host, allowedOrigins) {
 
 function printHelp() {
   console.log([
-    'Usage: tokentelemetry [options]',
+    'Usage: tokentelemetry [command] [options]',
+    '',
+    'Commands:',
+    '  dashboard [options]        Start the dashboard (the default).',
+    '  menubar                    Menu bar app (macOS only).',
+    '  desktop                    Desktop app (not available yet).',
+    '  status                     Dashboard status (not available yet).',
+    '  stop                       Stop the dashboard (not available yet).',
     '',
     'Options:',
     '  -p, --port <N>            Frontend (Next.js) port. Default 3000.',
@@ -110,6 +146,8 @@ function printHelp() {
     '                            random token is generated and printed once.',
     '      --insecure-no-auth    Disable the remote access token entirely. Only safe',
     '                            on a fully trusted private network (e.g. a tailnet).',
+    '      --no-open             Do not open the dashboard in a browser. Useful from',
+    '                            scripts; AGENT_HARNESS_NO_OPEN still works too.',
     '  -h, --help               Show this help.',
     '',
     'Examples:',
@@ -186,9 +224,17 @@ async function ensurePortsFree(ports) {
   process.exit(1);
 }
 
-function openBrowser(url) {
+// True unless the caller passed --no-open or AGENT_HARNESS_NO_OPEN is set.
+// Split out so the suppression logic is unit-testable without spawning.
+function shouldOpenBrowser(options) {
+  if (options && options.noOpen) return false;
+  if (process.env.AGENT_HARNESS_NO_OPEN) return false;
+  return true;
+}
+
+function openBrowser(url, options) {
   // Platform-native launcher. No npm dep needed.
-  if (process.env.AGENT_HARNESS_NO_OPEN) return;
+  if (!shouldOpenBrowser(options)) return;
   try {
     if (process.platform === 'darwin') spawn('open', [url], { detached: true, stdio: 'ignore' }).unref();
     else if (isWindows) spawn('cmd', ['/c', 'start', '""', url], { detached: true, stdio: 'ignore' }).unref();
@@ -415,8 +461,8 @@ function ensureFrontend() {
   try { fs.writeFileSync(stampPath, currentSha); } catch {}
 }
 
-async function start() {
-  const { frontPort, apiPort, host, allowedOrigins, authToken, insecureNoAuth, dataDir } = parseArgs(process.argv.slice(2));
+async function start(options) {
+  const { frontPort, apiPort, host, allowedOrigins, authToken, insecureNoAuth, dataDir } = options;
 
   // --data-dir is just a friendly front-end for TOKENTELEMETRY_DATA_DIR, which
   // the Python backend reads (tt_paths.data_dir). An explicit flag wins over an
@@ -554,7 +600,7 @@ async function start() {
   waitForHttp(dashUrl).then((ok) => {
     if (ok) {
       console.log('→ opening dashboard in your browser…');
-      openBrowser(dashUrl);
+      openBrowser(dashUrl, options);
     }
   });
 
@@ -584,4 +630,102 @@ async function start() {
   frontend.on('exit', (code) => shutdown(code || 0));
 }
 
-start();
+// --- Subcommand messages ----------------------------------------------------
+// Vertical slice 1: verbs exist and are dispatched, but menubar/desktop/status/
+// stop are not implemented yet. They print one clear line and exit non-zero,
+// and (critically) none of them bootstrap dependencies or launch servers.
+
+function menubarMessage(platform) {
+  return platform === 'darwin'
+    ? 'The tokentelemetry menu bar is not implemented yet.'
+    : 'The tokentelemetry menu bar is macOS-only.';
+}
+
+function desktopMessage() {
+  return 'The tokentelemetry desktop app is not available yet.';
+}
+
+function statusMessage() {
+  return 'tokentelemetry status is not implemented yet.';
+}
+
+function stopMessage() {
+  return 'tokentelemetry stop is not implemented yet.';
+}
+
+function cmdMenubar() {
+  console.error(menubarMessage(process.platform));
+  return 1;
+}
+
+function cmdDesktop() {
+  console.error(desktopMessage());
+  return 1;
+}
+
+function cmdStatus() {
+  console.error(statusMessage());
+  return 1;
+}
+
+function cmdStop() {
+  console.error(stopMessage());
+  return 1;
+}
+
+// --- Dispatch + entrypoint ---------------------------------------------------
+async function main(argv = process.argv.slice(2)) {
+  const { verb, args } = parseInvocation(argv);
+  let parsed;
+  try {
+    parsed = parseArgs(args);
+  } catch (err) {
+    if (err instanceof UsageError) die(err.message);
+    throw err;
+  }
+  if (parsed.help) {
+    printHelp();
+    return 0;
+  }
+  switch (verb) {
+    case 'menubar': return cmdMenubar();
+    case 'desktop': return cmdDesktop();
+    case 'status': return cmdStatus();
+    case 'stop': return cmdStop();
+    case 'dashboard':
+    default:
+      // The bare command and `dashboard` are the same path. start() never
+      // returns until the user stops it, so no exit code follows this await.
+      await start(parsed.options);
+      return undefined;
+  }
+}
+
+if (require.main === module) {
+  main().then((code) => {
+    if (typeof code === 'number') process.exit(code);
+  }).catch((err) => {
+    console.error(err && err.stack ? err.stack : String(err));
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  VERBS,
+  UsageError,
+  parseInvocation,
+  parseArgs,
+  printHelp,
+  shouldOpenBrowser,
+  openBrowser,
+  start,
+  main,
+  cmdMenubar,
+  cmdDesktop,
+  cmdStatus,
+  cmdStop,
+  menubarMessage,
+  desktopMessage,
+  statusMessage,
+  stopMessage,
+};

--- a/bin/cli.test.js
+++ b/bin/cli.test.js
@@ -105,24 +105,27 @@ test('AGENT_HARNESS_NO_OPEN still suppresses the browser launch', () => {
 
 test('menubar is macOS-only off macOS and never mentions rumps', () => {
   assert.strictEqual(
-    cli.menubarMessage('linux'),
+    cli.menubarMessage(),
     'The tokentelemetry menu bar is macOS-only.',
   );
-  assert.strictEqual(
-    cli.menubarMessage('win32'),
-    'The tokentelemetry menu bar is macOS-only.',
-  );
-  assert.strictEqual(
-    cli.menubarMessage('darwin'),
-    'The tokentelemetry menu bar is not implemented yet.',
-  );
+  // Off-platform the handler prints exactly one line and exits non-zero.
+  for (const platform of ['linux', 'win32']) {
+    const { result, errLines } = captured(() => cli.cmdMenubar({}, platform));
+    assert.strictEqual(result, 1);
+    assert.strictEqual(errLines.length, 1);
+    assert.strictEqual(errLines[0], 'The tokentelemetry menu bar is macOS-only.');
+    assert.ok(!errLines[0].includes('rumps'));
+  }
 });
 
-test('desktop reports not available on every platform', () => {
-  assert.strictEqual(
-    cli.desktopMessage(),
-    'The tokentelemetry desktop app is not available yet.',
-  );
+test('desktop helpers resolve a local Electron runtime and preserve its data directory', () => {
+  assert.strictEqual(cli.desktopMessage(), 'Starting TokenTelemetry Desktop…');
+  assert.strictEqual(cli.electronExecutable('/repo', 'darwin'), path.join('/repo', 'node_modules', '.bin', 'electron'));
+  assert.strictEqual(cli.electronExecutable('/repo', 'win32'), path.join('/repo', 'node_modules', '.bin', 'electron.cmd'));
+  assert.deepStrictEqual(cli.desktopEnv('/custom/data', { KEEP: 'yes' }), {
+    KEEP: 'yes',
+    TOKENTELEMETRY_DATA_DIR: '/custom/data',
+  });
 });
 
 test('status and stop report not-available-yet', () => {
@@ -130,12 +133,36 @@ test('status and stop report not-available-yet', () => {
   assert.strictEqual(cli.stopMessage(), 'tokentelemetry stop is not implemented yet.');
 });
 
-test('subcommand handlers print one line and exit non-zero', () => {
-  for (const fn of [cli.cmdMenubar, cli.cmdDesktop, cli.cmdStatus, cli.cmdStop]) {
+test('status and stop handlers print one line and exit non-zero', () => {
+  for (const fn of [cli.cmdStatus, cli.cmdStop]) {
     const { result, errLines } = captured(fn);
     assert.strictEqual(result, 1);
     assert.strictEqual(errLines.length, 1);
   }
+});
+
+test('menubar argument and environment helpers are absolute and forward --data-dir', () => {
+  assert.deepStrictEqual(cli.menubarPythonArgs('/repo/backend'), [
+    path.join('/repo/backend', 'menubar', 'app.py'),
+  ]);
+  assert.deepStrictEqual(cli.menubarPythonArgs('/repo/backend', '/custom/data'), [
+    path.join('/repo/backend', 'menubar', 'app.py'),
+    '--data-dir',
+    '/custom/data',
+  ]);
+
+  const env = cli.menubarEnv(
+    '/custom/data',
+    '/repo/bin/cli.js',
+    '/usr/local/bin/node',
+    '/repo/backend',
+    { PYTHONPATH: '/existing' },
+  );
+  assert.strictEqual(env.TOKENTELEMETRY_DATA_DIR, '/custom/data');
+  assert.strictEqual(env.TOKENTELEMETRY_CLI, '/repo/bin/cli.js');
+  assert.strictEqual(env.TOKENTELEMETRY_NODE, '/usr/local/bin/node');
+  assert.ok(env.PYTHONPATH.split(path.delimiter).includes('/repo/backend'));
+  assert.ok(env.PYTHONPATH.split(path.delimiter).includes('/existing'));
 });
 
 test('main dispatches subcommands without bootstrapping or launching servers', async () => {
@@ -147,14 +174,8 @@ test('main dispatches subcommands without bootstrapping or launching servers', a
   assert.strictEqual(await stop.result, 1);
   assert.strictEqual(stop.errLines[0], 'tokentelemetry stop is not implemented yet.');
 
-  const desktop = captured(() => cli.main(['desktop']));
-  assert.strictEqual(await desktop.result, 1);
-  assert.strictEqual(desktop.errLines[0], 'The tokentelemetry desktop app is not available yet.');
-
-  const menubar = captured(() => cli.main(['menubar']));
-  assert.strictEqual(await menubar.result, 1);
-  assert.strictEqual(menubar.errLines.length, 1);
-  assert.strictEqual(menubar.errLines[0], cli.menubarMessage(process.platform));
+  // Menubar and desktop dispatch real launchers on macOS, so their runtime
+  // contracts are tested through pure helpers rather than starting services.
 });
 
 test('main --help prints usage and exits 0', async () => {

--- a/bin/cli.test.js
+++ b/bin/cli.test.js
@@ -1,0 +1,189 @@
+'use strict';
+
+// Unit tests for bin/cli.js — verb parsing, flag parsing, browser-open
+// suppression, and the off-platform subcommand messages. These deliberately
+// never bootstrap dependencies or launch servers: they only call the exported
+// parsing/dispatch helpers.
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const cli = require('./cli.js');
+
+// Run fn with console.error / console.log captured so tests can assert on what
+// a subcommand prints without any of it reaching the test output.
+function captured(fn) {
+  const origError = console.error;
+  const origLog = console.log;
+  const errLines = [];
+  const logLines = [];
+  console.error = (...a) => errLines.push(a.map(String).join(' '));
+  console.log = (...a) => logLines.push(a.map(String).join(' '));
+  try {
+    return { result: fn(), errLines, logLines };
+  } finally {
+    console.error = origError;
+    console.log = origLog;
+  }
+}
+
+test('the bare invocation means dashboard', () => {
+  assert.deepStrictEqual(cli.parseInvocation([]), { verb: 'dashboard', args: [] });
+});
+
+test('a known verb is recognized and stripped from the args', () => {
+  for (const verb of cli.VERBS) {
+    assert.deepStrictEqual(cli.parseInvocation([verb]), { verb, args: [] });
+  }
+  assert.deepStrictEqual(cli.parseInvocation(['dashboard', '--no-open']), {
+    verb: 'dashboard',
+    args: ['--no-open'],
+  });
+  assert.deepStrictEqual(cli.parseInvocation(['status', '--port', '4000']), {
+    verb: 'status',
+    args: ['--port', '4000'],
+  });
+});
+
+test('a first arg that is not a known verb falls through to dashboard', () => {
+  // Existing flags keep working bare, and a stray argument cannot silently
+  // change what the command does.
+  assert.deepStrictEqual(cli.parseInvocation(['--port', '4000']), {
+    verb: 'dashboard',
+    args: ['--port', '4000'],
+  });
+  assert.deepStrictEqual(cli.parseInvocation(['--bogus']), {
+    verb: 'dashboard',
+    args: ['--bogus'],
+  });
+});
+
+test('unknown flags still error during dashboard flag parsing', () => {
+  assert.throws(() => cli.parseArgs(['--bogus']), cli.UsageError);
+  assert.throws(() => cli.parseArgs(['--bogus']), /unknown argument: --bogus/);
+});
+
+test('parseArgs keeps every default option', () => {
+  const { help, options } = cli.parseArgs([]);
+  assert.strictEqual(help, false);
+  assert.strictEqual(options.frontPort, 3000);
+  assert.strictEqual(options.apiPort, 8000);
+  assert.strictEqual(options.host, '127.0.0.1');
+  assert.strictEqual(options.allowedOrigins, '');
+  assert.strictEqual(options.authToken, '');
+  assert.strictEqual(options.insecureNoAuth, false);
+  assert.strictEqual(options.dataDir, null);
+  assert.strictEqual(options.noOpen, false);
+});
+
+test('--no-open parses to noOpen and survives alongside other flags', () => {
+  assert.strictEqual(cli.parseArgs(['--no-open']).options.noOpen, true);
+  const { options } = cli.parseArgs(['--no-open', '--port', '4000']);
+  assert.strictEqual(options.noOpen, true);
+  assert.strictEqual(options.frontPort, 4000);
+});
+
+test('--no-open suppresses the browser launch', () => {
+  assert.strictEqual(cli.shouldOpenBrowser({ noOpen: true }), false);
+  assert.strictEqual(cli.shouldOpenBrowser({ noOpen: false }), true);
+});
+
+test('AGENT_HARNESS_NO_OPEN still suppresses the browser launch', () => {
+  const prev = process.env.AGENT_HARNESS_NO_OPEN;
+  try {
+    delete process.env.AGENT_HARNESS_NO_OPEN;
+    assert.strictEqual(cli.shouldOpenBrowser({ noOpen: false }), true);
+    process.env.AGENT_HARNESS_NO_OPEN = '1';
+    assert.strictEqual(cli.shouldOpenBrowser({ noOpen: false }), false);
+    assert.strictEqual(cli.shouldOpenBrowser({ noOpen: true }), false);
+  } finally {
+    if (prev === undefined) delete process.env.AGENT_HARNESS_NO_OPEN;
+    else process.env.AGENT_HARNESS_NO_OPEN = prev;
+  }
+});
+
+test('menubar is macOS-only off macOS and never mentions rumps', () => {
+  assert.strictEqual(
+    cli.menubarMessage('linux'),
+    'The tokentelemetry menu bar is macOS-only.',
+  );
+  assert.strictEqual(
+    cli.menubarMessage('win32'),
+    'The tokentelemetry menu bar is macOS-only.',
+  );
+  assert.strictEqual(
+    cli.menubarMessage('darwin'),
+    'The tokentelemetry menu bar is not implemented yet.',
+  );
+});
+
+test('desktop reports not available on every platform', () => {
+  assert.strictEqual(
+    cli.desktopMessage(),
+    'The tokentelemetry desktop app is not available yet.',
+  );
+});
+
+test('status and stop report not-available-yet', () => {
+  assert.strictEqual(cli.statusMessage(), 'tokentelemetry status is not implemented yet.');
+  assert.strictEqual(cli.stopMessage(), 'tokentelemetry stop is not implemented yet.');
+});
+
+test('subcommand handlers print one line and exit non-zero', () => {
+  for (const fn of [cli.cmdMenubar, cli.cmdDesktop, cli.cmdStatus, cli.cmdStop]) {
+    const { result, errLines } = captured(fn);
+    assert.strictEqual(result, 1);
+    assert.strictEqual(errLines.length, 1);
+  }
+});
+
+test('main dispatches subcommands without bootstrapping or launching servers', async () => {
+  const status = captured(() => cli.main(['status']));
+  assert.strictEqual(await status.result, 1);
+  assert.strictEqual(status.errLines[0], 'tokentelemetry status is not implemented yet.');
+
+  const stop = captured(() => cli.main(['stop']));
+  assert.strictEqual(await stop.result, 1);
+  assert.strictEqual(stop.errLines[0], 'tokentelemetry stop is not implemented yet.');
+
+  const desktop = captured(() => cli.main(['desktop']));
+  assert.strictEqual(await desktop.result, 1);
+  assert.strictEqual(desktop.errLines[0], 'The tokentelemetry desktop app is not available yet.');
+
+  const menubar = captured(() => cli.main(['menubar']));
+  assert.strictEqual(await menubar.result, 1);
+  assert.strictEqual(menubar.errLines.length, 1);
+  assert.strictEqual(menubar.errLines[0], cli.menubarMessage(process.platform));
+});
+
+test('main --help prints usage and exits 0', async () => {
+  const help = captured(() => cli.main(['--help']));
+  assert.strictEqual(await help.result, 0);
+  const text = help.logLines.join('\n');
+  assert.ok(text.includes('Usage: tokentelemetry'));
+  assert.ok(text.includes('dashboard'));
+  assert.ok(text.includes('--no-open'));
+});
+
+test('path-hint is not a recognized verb', () => {
+  // The installer used to reach a hidden path-hint subcommand; it is gone, so
+  // `tokentelemetry path-hint` must fall through to dashboard flag parsing and
+  // fail as an unknown argument instead of printing installer guidance.
+  assert.ok(!cli.VERBS.includes('path-hint'));
+  assert.deepStrictEqual(cli.parseInvocation(['path-hint']), {
+    verb: 'dashboard',
+    args: ['path-hint'],
+  });
+  assert.throws(() => cli.parseArgs(['path-hint']), cli.UsageError);
+  assert.throws(() => cli.parseArgs(['path-hint']), /unknown argument: path-hint/);
+});
+
+test('install.sh selects the rc file locally instead of calling path-hint', () => {
+  const script = fs.readFileSync(path.join(__dirname, '..', 'install.sh'), 'utf8');
+  assert.ok(!script.includes('path-hint'), 'install.sh must not reach a CLI subcommand for PATH guidance');
+  assert.ok(script.includes('*/zsh'), 'install.sh should branch on zsh to ~/.zshrc');
+  assert.ok(script.includes('*/bash'), 'install.sh should branch on bash to ~/.bashrc');
+  assert.ok(script.includes('~/.zshrc') && script.includes('~/.bashrc'),
+    'install.sh should still tell the user which rc file to edit');
+});

--- a/desktop/main.cjs
+++ b/desktop/main.cjs
@@ -1,0 +1,45 @@
+"use strict";
+
+const path = require("node:path");
+const { spawn } = require("node:child_process");
+const { app, BrowserWindow, dialog, shell } = require("electron");
+const { isSafeExternalUrl, startDesktopServices, stopDesktopServices, waitForHttp } = require("./runtime.cjs");
+
+const rootDir = path.resolve(__dirname, "..");
+const backendDir = path.join(rootDir, "backend");
+const frontendDir = path.join(rootDir, "frontend");
+const isWindows = process.platform === "win32";
+const python = process.env.TOKENTELEMETRY_PYTHON || path.join(backendDir, "venv", isWindows ? "Scripts/python.exe" : "bin/python3");
+const npm = isWindows ? "npm.cmd" : "npm";
+let services;
+let quitting = false;
+
+function stopServices() {
+  if (quitting) return;
+  quitting = true;
+  stopDesktopServices(services);
+}
+
+async function createWindow() {
+  services = await startDesktopServices({ spawn, python, npm, backendDir, frontendDir, env: process.env, dataDir: process.env.TOKENTELEMETRY_DATA_DIR });
+  if (!await waitForHttp(services.url)) throw new Error("The local TokenTelemetry dashboard did not start in time.");
+  const window = new BrowserWindow({
+    width: 1440, height: 920, minWidth: 960, minHeight: 640, show: false, title: "TokenTelemetry",
+    webPreferences: { nodeIntegration: false, contextIsolation: true, sandbox: true },
+  });
+  window.once("ready-to-show", () => window.show());
+  window.webContents.setWindowOpenHandler(({ url }) => {
+    // Never hand file:, javascript:, or arbitrary custom schemes to the OS.
+    if (isSafeExternalUrl(url)) void shell.openExternal(url);
+    return { action: "deny" };
+  });
+  await window.loadURL(services.url);
+}
+
+app.whenReady().then(createWindow).catch(async (error) => {
+  stopServices();
+  await dialog.showMessageBox({ type: "error", title: "TokenTelemetry could not start", message: error instanceof Error ? error.message : String(error) });
+  app.exit(1);
+});
+app.on("before-quit", stopServices);
+app.on("window-all-closed", () => app.quit());

--- a/desktop/runtime.cjs
+++ b/desktop/runtime.cjs
@@ -1,0 +1,94 @@
+"use strict";
+
+// Process management deliberately independent of Electron, so the launch
+// contract is testable without starting Chromium.
+const http = require("node:http");
+const net = require("node:net");
+const path = require("node:path");
+
+const LOCAL_HOST = "localhost";
+
+function localUrl(port, pathname = "/") {
+  return `http://${LOCAL_HOST}:${port}${pathname}`;
+}
+
+function isSafeExternalUrl(rawUrl) {
+  try {
+    return new URL(rawUrl).protocol === "https:";
+  } catch (_) {
+    return false;
+  }
+}
+
+function findAvailablePort(host = "127.0.0.1") {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.once("error", reject);
+    server.listen(0, host, () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : null;
+      server.close((error) => error ? reject(error) : resolve(port));
+    });
+  });
+}
+
+function waitForHttp(url, timeoutMs = 45_000) {
+  const startedAt = Date.now();
+  return new Promise((resolve) => {
+    const retry = () => {
+      if (Date.now() - startedAt >= timeoutMs) return resolve(false);
+      setTimeout(probe, 250);
+    };
+    const probe = () => {
+      const request = http.get(url, (response) => {
+        response.resume();
+        if (response.statusCode && response.statusCode < 500) return resolve(true);
+        retry();
+      });
+      request.once("error", retry);
+      request.setTimeout(1_500, () => { request.destroy(); retry(); });
+    };
+    probe();
+  });
+}
+
+function desktopEnvironment(baseEnvironment, backendDir, dataDir, apiPort) {
+  const pythonPath = [backendDir, baseEnvironment.PYTHONPATH].filter(Boolean).join(path.delimiter);
+  return {
+    ...baseEnvironment,
+    PYTHONPATH: pythonPath,
+    ...(dataDir ? { TOKENTELEMETRY_DATA_DIR: dataDir } : {}),
+    NEXT_PUBLIC_API_BASE: localUrl(apiPort),
+    NEXT_PUBLIC_API_PORT: String(apiPort),
+    TT_NEXT_DIST_DIR: ".next-desktop",
+    TT_HOST: LOCAL_HOST,
+    TT_API_PORT: String(apiPort),
+  };
+}
+
+async function startDesktopServices({ spawn, python, npm, backendDir, frontendDir, env, dataDir }) {
+  const [apiPort, frontendPort] = await Promise.all([findAvailablePort(), findAvailablePort()]);
+  const childEnv = desktopEnvironment(env, backendDir, dataDir, apiPort);
+  const detached = process.platform !== "win32";
+  const backend = spawn(python, ["main.py", "--host", LOCAL_HOST, "--port", String(apiPort)], {
+    cwd: backendDir, detached, env: childEnv, stdio: "inherit",
+  });
+  const frontend = spawn(npm, ["run", "dev", "--", "--hostname", LOCAL_HOST, "--port", String(frontendPort)], {
+    cwd: frontendDir, detached, env: { ...childEnv, PORT: String(frontendPort) }, shell: false, stdio: "inherit",
+  });
+  return { apiPort, frontendPort, backend, frontend, url: localUrl(frontendPort) };
+}
+
+function stopChild(child, platform = process.platform, kill = process.kill) {
+  if (!child || !child.pid || child.killed) return;
+  try { kill(platform === "win32" ? child.pid : -child.pid, "SIGTERM"); } catch (_) { /* child exited */ }
+}
+
+function stopDesktopServices(services, platform = process.platform, kill = process.kill) {
+  if (!services) return;
+  stopChild(services.backend, platform, kill);
+  stopChild(services.frontend, platform, kill);
+}
+
+module.exports = { LOCAL_HOST, localUrl, isSafeExternalUrl, findAvailablePort, waitForHttp, desktopEnvironment, startDesktopServices, stopChild, stopDesktopServices };

--- a/desktop/runtime.test.cjs
+++ b/desktop/runtime.test.cjs
@@ -1,0 +1,52 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const runtime = require("./runtime.cjs");
+
+test("desktop URLs always use localhost", () => {
+  assert.equal(runtime.LOCAL_HOST, "localhost");
+  assert.equal(runtime.localUrl(4312), "http://localhost:4312/");
+  assert.equal(runtime.localUrl(4312, "/openapi.json"), "http://localhost:4312/openapi.json");
+});
+
+test("only HTTPS links may leave the sandboxed dashboard", () => {
+  assert.equal(runtime.isSafeExternalUrl("https://tokentelemetry.com/docs"), true);
+  assert.equal(runtime.isSafeExternalUrl("http://localhost:8000"), false);
+  assert.equal(runtime.isSafeExternalUrl("file:///etc/passwd"), false);
+  assert.equal(runtime.isSafeExternalUrl("javascript:alert(1)"), false);
+  assert.equal(runtime.isSafeExternalUrl("not a URL"), false);
+});
+
+test("desktop environment pins renderer API variables to localhost", () => {
+  const env = runtime.desktopEnvironment({ PYTHONPATH: "/existing", KEEP: "yes" }, "/repo/backend", "/data", 8123);
+  assert.equal(env.NEXT_PUBLIC_API_BASE, "http://localhost:8123/");
+  assert.equal(env.NEXT_PUBLIC_API_PORT, "8123");
+  assert.equal(env.TT_NEXT_DIST_DIR, ".next-desktop");
+  assert.equal(env.TT_HOST, "localhost");
+  assert.equal(env.TT_API_PORT, "8123");
+  assert.equal(env.TOKENTELEMETRY_DATA_DIR, "/data");
+  assert.equal(env.KEEP, "yes");
+  assert.deepEqual(env.PYTHONPATH.split(path.delimiter), ["/repo/backend", "/existing"]);
+});
+
+test("desktop startup gives both children a localhost-only contract", async () => {
+  const calls = [];
+  const services = await runtime.startDesktopServices({
+    spawn(command, args, options) { calls.push({ command, args, options }); return { pid: calls.length + 100, killed: false }; },
+    python: "/repo/backend/venv/bin/python3", npm: "npm", backendDir: "/repo/backend", frontendDir: "/repo/frontend", env: { KEEP: "yes" }, dataDir: "/tmp/token-data",
+  });
+  assert.equal(calls.length, 2);
+  assert.deepEqual(calls[0].args.slice(0, 4), ["main.py", "--host", "localhost", "--port"]);
+  assert.deepEqual(calls[1].args.slice(0, 5), ["run", "dev", "--", "--hostname", "localhost"]);
+  assert.equal(calls[0].options.env.NEXT_PUBLIC_API_BASE, `http://localhost:${services.apiPort}/`);
+  assert.equal(calls[1].options.env.NEXT_PUBLIC_API_BASE, `http://localhost:${services.apiPort}/`);
+  assert.equal(services.url, `http://localhost:${services.frontendPort}/`);
+});
+
+test("desktop shutdown signals detached process groups on POSIX", () => {
+  const targets = [];
+  runtime.stopDesktopServices({ backend: { pid: 12 }, frontend: { pid: 34 } }, "darwin", (pid, signal) => targets.push([pid, signal]));
+  assert.deepEqual(targets, [[-12, "SIGTERM"], [-34, "SIGTERM"]]);
+});

--- a/docs/design/desktop-and-menubar.md
+++ b/docs/design/desktop-and-menubar.md
@@ -1,8 +1,10 @@
 # macOS Menu Bar, Global CLI, and Desktop App
 
-Status: proposed. Prompted by wanting plan limits visible in the macOS menu bar without
-opening the dashboard, and by the `hermes dashboard` / `hermes desktop` commands working
-from any directory.
+Status: in progress. The global CLI and macOS menu bar are implemented; the Electron
+desktop development shell is implemented, while packaged release builds remain deferred.
+The work was prompted by wanting plan limits visible in the macOS menu bar without opening
+the dashboard, and by the `hermes dashboard` / `hermes desktop` commands working from any
+directory.
 
 ## Decisions taken before writing this
 
@@ -16,7 +18,7 @@ from any directory.
 | --- | --- | --- |
 | `tokentelemetry` on PATH with subcommands | Small | Nothing |
 | `tokentelemetry menubar` (macOS) | Medium | Subcommands |
-| `tokentelemetry desktop` (Electron) | Large | Subcommands. Deferred. |
+| `tokentelemetry desktop` (Electron) | Large | Subcommands. Runnable shell implemented; packaging deferred. |
 
 ---
 
@@ -293,14 +295,22 @@ title formatting, threshold colouring, menu construction as data) lives in a pla
 with no `rumps` import and is unit-tested like everything else in `backend/`. The `rumps`
 layer is a thin renderer over that structure.
 
-## 4.3 Electron desktop app (deferred)
+## 4.3 Electron desktop app
 
-Recorded now because the CLI design should not foreclose it.
+The first implementation is a small Electron shell. `tokentelemetry desktop` launches
+Electron, which owns a FastAPI child and a separate Next development server. Both are bound
+and addressed as `localhost` on ephemeral ports, avoiding collisions with an already-running
+browser dashboard. The desktop server uses `frontend/.next-desktop`, so it never takes the
+ordinary dashboard's `.next` lock. Closing the Electron app terminates both child process
+groups. The renderer is sandboxed with Node integration disabled and context isolation on.
+
+The menu-bar app stays standalone; its **Open dashboard** action launches this desktop shell
+instead of opening a browser.
 
 ### It is much smaller here than in Hermes
 
-`frontend/` has no API routes, no server actions, and no dynamic server components. Every
-piece of data arrives from FastAPI through client-side fetch. So for a desktop build,
+`frontend/` has no API routes and every piece of data arrives from FastAPI through
+client-side fetch. For a packaged desktop build,
 `next.config.ts` can move from `output: "standalone"` to `output: "export"`, producing static
 files that Electron loads directly with no Node server in the app at all.
 
@@ -311,10 +321,8 @@ That removes most of what makes Hermes's `main.ts` 17,621 lines. A first version
 
 1. `tokentelemetry desktop` resolves a packaged app (the `_desktop_packaged_executable`
    pattern from `hermes_cli/main.py:6921`) and launches it, or builds first.
-2. Electron main spawns `backend/main.py --host 127.0.0.1 --port 0`, reads back the chosen
-   port, and waits for health. `--port 0` is Hermes's trick for never colliding with a
-   dashboard the user already has open. It requires the backend to print its bound port,
-   which it does not do today.
+2. Electron main spawns `backend/main.py --host localhost --port <ephemeral>`, waits for
+   health, then loads the renderer at `http://localhost:<ephemeral>`.
 3. The window loads the static export with the port injected.
 4. electron-builder produces a `.dmg`.
 

--- a/docs/design/product-telemetry.md
+++ b/docs/design/product-telemetry.md
@@ -108,6 +108,8 @@ sent at most once per meaningful action.
 | `analytics.filtered` | a filter is applied on Analytics | `dimension` (agent/model/local-only/day), no values | **Is local-model filtering used?** (your explicit question) |
 | `feature.used` | generic, for discrete features | `name` (plan-library, project-insights, delegation-view, power-cost, billing-mode, search…) | Long-tail feature adoption |
 | `retention.opted_in` | user enables durable history | `tier` | Which power features convert |
+| `planlimits.toggled` | the sidebar plan-limit gauge is clicked | `state` (opened/closed) | **How often is the plan-limit gauge used, and is it pinned?** |
+| `agent.opened` | a connected coding-agent tile is opened | `agent` (claude/codex/…) | **Are the per-agent pages reached from the tiles?** |
 
 **Duration/outcome buckets, never raw values.** e.g. summary latency as
 `fast/medium/slow`, not milliseconds tied to a specific trace.

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -11,6 +11,9 @@ const allowedDevOrigins = (process.env.TT_ALLOWED_ORIGINS || "")
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  // Electron owns a separate Next dev server. A distinct build directory keeps
+  // that server independent of a dashboard a developer may already be running.
+  distDir: process.env.TT_NEXT_DIST_DIR || ".next",
   devIndicators: false,
   // This app has its own lockfile inside the repository's launcher package.
   // Pin Turbopack here instead of letting it infer the parent or a user-level

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -11,6 +11,7 @@ import {
 
 import { useResource } from "@/lib/api";
 import { useScrollState } from "@/lib/useScrollState";
+import { trackEvent } from "@/lib/telemetry";
 import { AGENTS, getAgent, type AgentKey } from "@/lib/agents";
 import { quotaColor, worstWindowFor } from "@/lib/quotas";
 import { useQuotas } from "@/components/QuotaProvider";
@@ -234,7 +235,12 @@ export default function Home() {
           // on to /hermes through the panel's `dashboard` field.
           if (panelCount > 0) {
             return (
-              <Link key={k} href={`/agents/${k}`} className={`${className} cursor-pointer hover:bg-[var(--tt-sunken)]`}>
+              <Link
+                key={k}
+                href={`/agents/${k}`}
+                onClick={() => trackEvent("agent.opened", { agent: k })}
+                className={`${className} cursor-pointer hover:bg-[var(--tt-sunken)]`}
+              >
                 {inner}
               </Link>
             );

--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -8,12 +8,14 @@ import remarkGfm from "remark-gfm";
 import { ArrowLeft, Brain, Code, MessageSquare, Terminal, User, Users, FileText, Activity, Zap, Info, Sparkles, GitBranch, LayoutPanelLeft, ListMusic, ChevronRight, ChevronLeft, Play, Pause, Wrench, Cpu, AlertTriangle, Hash, Clock, FileCode, Settings2, ChevronDown, ChevronUp, Copy, Check, Maximize2, X, Repeat, Globe, ExternalLink, Target, DollarSign, Filter, ListChevronsDownUp, ListChevronsUpDown } from "lucide-react";
 import Link from "next/link";
 import { AgentBadge, Badge, Button, Skeleton } from "@/components/ui";
+import AgentSigil from "@/components/icons/AgentSigil";
 import SourceBadge from "@/components/SourceBadge";
 import CopilotSourceBadge from "@/components/CopilotSourceBadge";
 import AntigravitySourceBadge from "@/components/AntigravitySourceBadge";
 import SummaryPanel from "@/components/summarizer/SummaryPanel";
 import { apiFetch, artifactUrl } from "@/lib/api";
 import { formatTokens, formatCost } from "@/lib/format";
+import { timeAgo } from "@/lib/notifications";
 import { resolveSessionBackTarget } from "@/lib/navigation";
 import { CostStatus, COST_STATUS_LABELS, COST_STATUS_HINTS, outcomeLabel } from "@/lib/hermesTelemetry";
 
@@ -478,7 +480,7 @@ export default function SessionDetailPage() {
   const fromParam = searchParams.get("from");
   const initialTab = (() => {
     const t = searchParams.get("tab");
-    return t === "tools" || t === "artifacts" || t === "raw" || t === "context" ? t : "context";
+    return t === "tools" || t === "artifacts" || t === "raw" || t === "agents" || t === "context" ? t : "context";
   })();
 
   const [events, setEvents] = useState<Event[]>([]);
@@ -508,7 +510,7 @@ export default function SessionDetailPage() {
   // with nothing below it. The visible slice is max(playbackIndex, this).
   const [revealedCount, setRevealedCount] = useState(1000);
   const [isPlaying, setIsPlaying] = useState(false);
-  const [sidebarTab, setSidebarTab] = useState<"context" | "tools" | "artifacts" | "raw">(initialTab);
+  const [sidebarTab, setSidebarTab] = useState<"context" | "tools" | "artifacts" | "agents" | "raw">(initialTab);
   const [activeStep, setActiveStep] = useState<number | null>(null);
   const [timelineOpen, setTimelineOpen] = useState(true);
   const [sidebarOpen, setSidebarOpen] = useState(true);
@@ -855,6 +857,25 @@ export default function SessionDetailPage() {
       }
     }
     return map;
+  }, [events]);
+
+  // Spawned children this session has, whatever the harness calls them: agents
+  // with per-child transcripts report `subagents`, the SQLite harnesses
+  // (opencode/hermes) only link child session ids. Either way, a non-zero count
+  // is what earns the Agents tab.
+  const subagentCount = (delegation?.subagents?.length ?? 0)
+    || (delegation?.child_session_ids?.length ?? 0);
+
+  const toolUseIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const e of events) {
+      if (Array.isArray(e.message?.content)) {
+        for (const c of e.message.content as TraceValue[]) {
+          if (c?.type === "tool_use" && c.id) ids.add(c.id);
+        }
+      }
+    }
+    return ids;
   }, [events]);
 
   // Tool summary
@@ -1480,8 +1501,9 @@ export default function SessionDetailPage() {
                 </button>
              ) : (
              <>
-             <div className="flex border-b border-[var(--tt-border)] text-[10px] font-semibold uppercase tracking-[0.18em]">
+             <div className="flex items-stretch gap-1 px-1.5 border-b border-[var(--tt-border)] text-[10px] font-semibold uppercase tracking-[0.08em]">
                 <TabBtn active={sidebarTab === "context"} onClick={() => setSidebarTab("context")} icon={<Settings2 size={12} />}>Context</TabBtn>
+                {subagentCount > 0 && <TabBtn active={sidebarTab === "agents"} onClick={() => setSidebarTab("agents")} icon={<GitBranch size={12} />}>Agents</TabBtn>}
                 <TabBtn active={sidebarTab === "tools"} onClick={() => setSidebarTab("tools")} icon={<Wrench size={12} />}>Tools</TabBtn>
                 {((sessionInfo?.artifacts?.length ?? 0) + (sessionInfo?.published_artifacts?.filter((p) => p.url).length ?? 0)) > 0 && <TabBtn active={sidebarTab === "artifacts"} onClick={() => setSidebarTab("artifacts")} icon={<LayoutPanelLeft size={12} />}>Artifacts</TabBtn>}
                 <TabBtn active={sidebarTab === "raw"} onClick={() => setSidebarTab("raw")} icon={<FileCode size={12} />}>Raw</TabBtn>
@@ -1494,13 +1516,13 @@ export default function SessionDetailPage() {
                 </button>
              </div>
              <div className="p-4 text-[11px]">
-                {sidebarTab === "context" && (
-                  <>
-                    {delegation && agent && ((delegation.subagents?.length ?? 0) > 0 || (delegation.child_session_ids?.length ?? 0) > 0) && (
-                      <SubagentsSidebar delegation={delegation} onOpen={setSubagentView} />
-                    )}
-                    <ContextPanel ctx={context} />
-                  </>
+                {sidebarTab === "context" && <ContextPanel ctx={context} />}
+                {sidebarTab === "agents" && (
+                  <SubagentsSidebar
+                    delegation={delegation}
+                    onOpen={setSubagentView}
+                    isRunning={(id) => !!id && toolUseIds.has(id) && !toolResultByUseId.has(id)}
+                  />
                 )}
                 {sidebarTab === "tools" && <ToolsPanel summary={toolSummary} onJump={(name) => {
                    const idx = events.findIndex((e) => {
@@ -1599,61 +1621,175 @@ export default function SessionDetailPage() {
   );
 }
 
-/* Sidebar list of this session's subagents — the at-a-glance "what was
-   delegated" context, one click from each child's full trace. */
-function SubagentsSidebar({ delegation, onOpen }: { delegation: TraceValue; onOpen: (entry: TraceValue) => void }) {
-  const entries: TraceValue[] = delegation.subagents?.length
+/* This session's spawned children, as a scannable roster.
+   Each child gets a generated sigil (see AgentSigil) because subagents have no
+   branding of their own and a dozen identical generic glyphs is a list nobody
+   reads. Newest first; still-running children are grouped above the finished
+   ones, and that group is omitted entirely when nothing is running, since a
+   permanent "Running - 0" row on a historical trace is chrome, not
+   information. */
+function SubagentsSidebar({ delegation, onOpen, isRunning }: {
+  delegation: TraceValue | null;
+  onOpen: (entry: TraceValue) => void;
+  isRunning: (toolUseId?: string) => boolean;
+}) {
+  const entries: TraceValue[] = delegation?.subagents?.length
     ? delegation.subagents
-    : (delegation.child_session_ids || []).map((cid: string) => ({ child_session_id: cid }));
-  if (entries.length === 0) return null;
-  return (
-    <div className="px-4 py-4 border-t border-[var(--tt-border)]">
-      <div className="flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--tt-fg-dim)] mb-3">
-        <GitBranch size={12} /> Subagents
-        <span className="tabular text-[var(--tt-fg-faint)]">{entries.length}</span>
+    // opencode/hermes link parent to child by session id and record nothing
+    // else about the spawn, so the row is an id and a way in.
+    : (delegation?.child_session_ids || []).map((cid: string) => ({ child_session_id: cid }));
+
+  if (entries.length === 0) {
+    return (
+      <div className="px-1 py-8 text-center text-[11px] text-[var(--tt-fg-dim)]">
+        This session spawned no subagents.
       </div>
-      <div className="space-y-1.5">
-        {entries.map((s: TraceValue, i: number) => (
-          <button
-            key={s.agent_id ?? s.child_session_id ?? i}
-            onClick={() => onOpen(s)}
-            className="w-full text-left rounded-[var(--tt-radius)] border border-[var(--tt-border)] bg-[var(--tt-sunken)] px-2.5 py-2 hover:border-[var(--tt-brand)]/50 transition-colors group"
-          >
-            <div className="flex items-center justify-between gap-2">
-              <span className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--tt-brand)]">
-                {s.agent_type || s.agent_role || "subagent"}
-              </span>
-              <ChevronRight size={12} className="text-[var(--tt-fg-faint)] group-hover:text-[var(--tt-fg)] shrink-0" />
-            </div>
-            <div className="text-[11px] text-[var(--tt-fg)] truncate mt-0.5">
-              {s.description || s.nickname || s.child_session_id || s.agent_id}
-            </div>
-            <div className="text-[10px] tabular text-[var(--tt-fg-dim)] mt-0.5">
-              {s.model && <span>{String(s.model).replace(/-\d{8}$/, "")} · </span>}
-              {s.tokens != null && <span>{formatTokens(s.tokens.total)} tok · </span>}
-              {s.cost != null && <span>{formatCost(s.cost)} · </span>}
-              {typeof s.duration_ms === "number" && <span>{(s.duration_ms / 1000).toFixed(1)}s</span>}
-            </div>
-            {/* A delegated child inherits its sandbox/approval posture and can
-                end up more permissive than the session that spawned it (DSH
-                runs children on approval "never" under an "ask" parent). The
-                child has no page of its own, so surface it here. */}
-            {s.sandbox?.approval && (
-              <div className="text-[10px] tabular text-[var(--tt-fg-dim)] mt-0.5">
-                <span title="File-sandbox mode and approval policy this subagent ran under">
-                  sandbox {s.sandbox.mode || "?"} · approval{" "}
-                  <span className={s.sandbox.approval === "never" ? "text-[var(--tt-warn-fg)]" : ""}>
-                    {s.sandbox.approval}
-                  </span>
-                  {s.sandbox.approval_source === "delegation" && " (inherited)"}
-                </span>
-              </div>
-            )}
-          </button>
+    );
+  }
+
+  // Newest first, but only among entries that HAVE a time. cursor/opencode
+  // children carry none, and letting undefined sort to the top would put the
+  // least-informative rows first; they keep their original file order below.
+  const withTime = entries.filter((e) => e.ended_at || e.started_at);
+  const withoutTime = entries.filter((e) => !(e.ended_at || e.started_at));
+  const stamp = (e: TraceValue) => new Date(e.ended_at || e.started_at).getTime() || 0;
+  const ordered = [...withTime.sort((a, b) => stamp(b) - stamp(a)), ...withoutTime];
+
+  const live = (e: TraceValue) => isRunning(e.tool_use_id) || e.status === "running" || e.status === "in_progress";
+  const running = ordered.filter(live);
+  const done = ordered.filter((e) => !live(e));
+
+  const totalTokens = entries.reduce((n, e) => n + (e.tokens?.total ?? 0), 0);
+  const totalCost = entries.reduce((n, e) => n + (e.cost ?? 0), 0);
+  const totalCredits = entries.reduce((n, e) => n + (e.credits ?? 0), 0);
+  // A recurring spawn can fail dozens of times without any single row standing
+  // out in a list this long, so the count goes in the footer too.
+  const failed = entries.filter((e) => e.status === "failed" || e.status === "error").length;
+
+  const group = (label: string, rows: TraceValue[]) => (
+    <div>
+      <div className="flex items-center gap-2 px-1 pb-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--tt-fg-dim)]">
+        <span>{label}</span>
+        <span className="tabular text-[var(--tt-fg-faint)]">{rows.length}</span>
+      </div>
+      <div className="space-y-0.5">
+        {rows.map((sa: TraceValue, i: number) => (
+          <SubagentRow
+            key={sa.agent_id ?? sa.child_session_id ?? i}
+            sa={sa}
+            running={live(sa)}
+            onOpen={() => onOpen(sa)}
+          />
         ))}
       </div>
     </div>
   );
+
+  return (
+    <div className="space-y-5">
+      {running.length > 0 && group("Running", running)}
+      {done.length > 0 && group(running.length > 0 ? "Done" : "Subagents", done)}
+
+      {/* Delegated spend is a separate bucket from the parent's own tokens
+          (count-once), so it is worth stating rather than leaving the reader
+          to add up the rows. */}
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-1 border-t border-[var(--tt-border)] pt-3 px-1 text-[10px] tabular text-[var(--tt-fg-dim)]">
+        <span>{entries.length} spawned</span>
+        {failed > 0 && <span className="text-[var(--tt-warn-fg)]">· {failed} failed</span>}
+        {delegation?.workflow_count > 0 && <span>· {delegation.workflow_count} in workflows</span>}
+        {totalTokens > 0 && <span>· {formatTokens(totalTokens)} tok delegated</span>}
+        {totalCost > 0 && <span>· {formatCost(totalCost)}</span>}
+        {totalCredits > 0 && <span>· {totalCredits.toFixed(2)} credits</span>}
+        {delegation?.tokens_recorded === false && totalCredits === 0 && (
+          <span title="This agent's logs record that a subagent ran, but not what it spent.">
+            · spend not recorded
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SubagentRow({ sa, running, onOpen }: { sa: TraceValue; running: boolean; onOpen: () => void }) {
+  const kind = sa.agent_type && sa.agent_type !== "unknown" ? sa.agent_type : null;
+  const title = sa.description || sa.phase || sa.nickname || kind || sa.child_session_id || sa.agent_id;
+  const when = sa.ended_at || sa.started_at;
+  // Qoder bills subagents in credits and reports an all-zero token block, so a
+  // `tokens != null` check would print a confident "0 tok". Read credits there.
+  const hasTokens = (sa.tokens?.total ?? 0) > 0;
+
+  const meta: string[] = [];
+  if (sa.kind === "workflow") meta.push("workflow");
+  else if (kind && title !== kind) meta.push(kind);
+  if (sa.model) meta.push(String(sa.model).replace(/-\d{8}$/, ""));
+  if (hasTokens) meta.push(`${formatTokens(sa.tokens.total)} tok`);
+  if (sa.credits > 0) meta.push(`${sa.credits.toFixed(2)} cr`);
+  if (sa.cost) meta.push(formatCost(sa.cost));
+  if (typeof sa.duration_ms === "number") meta.push(formatDuration(sa.duration_ms));
+
+  return (
+    <button
+      onClick={onOpen}
+      className="w-full text-left flex items-start gap-2.5 rounded-[var(--tt-radius)] px-2 py-2 border border-transparent hover:border-[var(--tt-border)] hover:bg-[var(--tt-sunken)] transition-colors group"
+    >
+      <AgentSigil
+        seed={sa.description || sa.phase || sa.agent_id || sa.child_session_id || kind || ""}
+        running={running}
+        className="mt-0.5"
+      />
+      <span className="min-w-0 flex-1">
+        <span className="flex items-baseline justify-between gap-2">
+          <span className="flex items-baseline gap-1.5 min-w-0">
+            <span className="text-[12px] text-[var(--tt-fg)] truncate" title={title}>{title}</span>
+            {sa.status && !["completed", "success", "done", "running", "in_progress"].includes(sa.status) && (
+              <span className="text-[9px] uppercase tracking-[0.12em] shrink-0 text-[var(--tt-warn-fg)]">
+                {sa.status}
+              </span>
+            )}
+          </span>
+          <span className="text-[10px] tabular shrink-0 text-[var(--tt-fg-faint)] group-hover:text-[var(--tt-fg-dim)]">
+            {running ? "running" : when ? relativeStamp(when) : ""}
+          </span>
+        </span>
+        {meta.length > 0 && (
+          <span className="block text-[10px] tabular text-[var(--tt-fg-dim)] truncate mt-0.5">
+            {meta.join(" · ")}
+          </span>
+        )}
+        {/* A delegated child inherits its sandbox/approval posture and can end
+            up more permissive than the session that spawned it (DSH runs
+            children on approval "never" under an "ask" parent). The child has
+            no page of its own, so surface it here. */}
+        {sa.sandbox?.approval && (
+          <span
+            className="block text-[10px] tabular text-[var(--tt-fg-dim)] mt-0.5"
+            title="File-sandbox mode and approval policy this subagent ran under"
+          >
+            sandbox {sa.sandbox.mode || "?"} · approval{" "}
+            <span className={sa.sandbox.approval === "never" ? "text-[var(--tt-warn-fg)]" : ""}>
+              {sa.sandbox.approval}
+            </span>
+            {sa.sandbox.approval_source === "delegation" && " (inherited)"}
+          </span>
+        )}
+      </span>
+    </button>
+  );
+}
+
+/** "4m ago", "3d ago", but "Aug 1" once timeAgo stops being relative. */
+function relativeStamp(iso: string): string {
+  const t = timeAgo(iso);
+  return t === "just now" || /^\d+[mhd]$/.test(t) ? `${t} ago` : t;
+}
+
+/** "8m 54s" / "42s" — subagent runs are minutes, not hours. */
+function formatDuration(ms: number): string {
+  const secs = Math.round(ms / 1000);
+  if (secs < 60) return `${secs}s`;
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ${secs % 60}s`;
+  return `${Math.floor(mins / 60)}h ${mins % 60}m`;
 }
 
 /* Slide-over trace viewer for one subagent — the LangSmith-style drill-in:
@@ -1835,10 +1971,12 @@ function TabBtn({ active, onClick, icon, children }: { active: boolean; onClick:
   return (
     <button
       onClick={onClick}
-      className={`flex-1 flex items-center justify-center gap-1.5 py-2.5 border-b-2 transition-colors ${active ? "border-blue-500 text-[var(--tt-brand)] bg-blue-500/5" : "border-transparent text-[var(--tt-fg-dim)] hover:text-[var(--tt-fg)]"}`}
+      title={typeof children === "string" ? children : undefined}
+      aria-label={typeof children === "string" ? children : undefined}
+      className={`min-w-0 flex items-center justify-center gap-1.5 py-2.5 border-b-2 transition-colors ${active ? "flex-1 border-blue-500 text-[var(--tt-brand)] bg-blue-500/5" : "px-2.5 border-transparent text-[var(--tt-fg-dim)] hover:text-[var(--tt-fg)]"}`}
     >
-      {icon}
-      {children}
+      <span className="shrink-0 flex items-center">{icon}</span>
+      {active && <span className="truncate">{children}</span>}
     </button>
   );
 }
@@ -3464,6 +3602,10 @@ function DelegationCard({ delegation, agent, sessionId, onOpenSubagent }: { dele
               className={`flex items-center justify-between gap-3 text-[11px] font-mono text-[var(--tt-fg-muted)] py-1.5 px-2 rounded ${onOpenSubagent ? "cursor-pointer hover:bg-[var(--tt-sunken)] hover:text-[var(--tt-fg)]" : "hover:bg-[var(--tt-sunken)]"}`}
             >
               <span className="flex items-center gap-2 min-w-0">
+                <AgentSigil
+                  seed={s.description || s.phase || s.agent_id || s.child_session_id || s.agent_type || ""}
+                  size={15}
+                />
                 {s.kind === "workflow" && (
                   <span
                     title={s.workflow_id ? `dynamic workflow ${s.workflow_id}` : "dynamic workflow"}

--- a/frontend/src/components/QuotaIndicator.tsx
+++ b/frontend/src/components/QuotaIndicator.tsx
@@ -6,6 +6,7 @@ import { Gauge } from "lucide-react";
 
 import { cn } from "@/lib/cn";
 import { AgentLogo } from "@/components/icons/AgentLogo";
+import { trackEvent } from "@/lib/telemetry";
 import {
   QUOTA_WARN_AT, quotaAmount, quotaColor, quotaPercent, quotaResourceLabel, resetText, worstWindowFor,
   type QuotaCapability, type QuotaResource, type QuotaSnapshot,
@@ -61,7 +62,11 @@ export default function QuotaIndicator({ collapsed }: { collapsed: boolean }) {
       onMouseLeave={() => setHovering(false)}
     >
       <button
-        onClick={() => setPinned((v) => !v)}
+        onClick={() => {
+          const next = !pinned;
+          setPinned(next);
+          trackEvent("planlimits.toggled", { state: next ? "opened" : "closed" });
+        }}
         aria-label={worst
           ? `Plan limits: ${worst.displayName} ${worst.label} ${Math.round(worst.pct)}% used`
           : "Plan limits"}

--- a/frontend/src/components/icons/AgentSigil.tsx
+++ b/frontend/src/components/icons/AgentSigil.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { profileHue } from "@/lib/profileColor";
+
+/**
+ * A generated mark for one spawned subagent.
+ *
+ * Subagents have no branding to borrow — they are anonymous children of one
+ * session, often a dozen of them, and a list of a dozen identical generic
+ * icons is a list you stop reading. So the mark is derived from the agent
+ * itself and is stable: the same agent draws the same sigil on every render,
+ * on every machine, with nothing stored.
+ *
+ * Shape family, element count and hue all come from the SAME seed — the task
+ * the agent was given — read through three different salts so they vary
+ * independently. Seeding the family off the agent TYPE instead was tried and
+ * is worse in practice: a fan-out is usually a dozen children of one type, so
+ * the family collapses to one silhouette repeated a dozen times, and the type
+ * is already printed as text on the row. Identity is the thing the text can't
+ * carry at a glance, so identity is what the mark encodes.
+ *
+ * Hashing is `profileHue` from lib/profileColor — the app already has one
+ * name-to-hue hash and a second would drift from it.
+ */
+
+const FAMILIES = 8;
+
+/** Evenly spaced copies of one shape around the centre, alternating tone. */
+function ring(n: number, a: string, b: string, draw: (fill: string) => React.ReactNode) {
+  return Array.from({ length: n }, (_, i) => (
+    <g key={i} transform={`rotate(${(360 / n) * i} 12 12)`}>{draw(i % 2 ? b : a)}</g>
+  ));
+}
+
+/** Rotationally symmetric marks, all drawn in a 24x24 box centred on 12,12. */
+function glyph(family: number, step: number, a: string, b: string) {
+  switch (family) {
+    case 0: // pinwheel, 3-5 blades
+      return ring(3 + step, a, b, (f) => <path d="M12 12 L12 2.5 L20 6.5 Z" fill={f} />);
+    case 1: // segmented disc, 4/6/8 wedges
+      return ring(4 + step * 2, a, b, (f) => (
+        <path d={`M12 12 L12 2.5 A9.5 9.5 0 0 1 ${12 + 9.5 * Math.sin((2 * Math.PI) / (4 + step * 2))} ${12 - 9.5 * Math.cos((2 * Math.PI) / (4 + step * 2))} Z`} fill={f} />
+      ));
+    case 2: // lattice bars, 2 or 3 per axis
+      return [
+        ...Array.from({ length: 2 + (step % 2) }, (_, i) => (
+          <rect key={`v${i}`} x={5.4 + i * (13.2 / (1 + (step % 2) + 0.35))} y="1.5"
+                width="2.6" height="21" rx="1.3" fill={a} />
+        )),
+        <rect key="h1" x="1.5" y="7.2" width="21" height="2.6" rx="1.3" fill={b} />,
+        <rect key="h2" x="1.5" y="14.2" width="21" height="2.6" rx="1.3" fill={b} />,
+      ];
+    case 3: // petals, 5-7 around a core
+      return [
+        ...ring(5 + step, a, b, (f) => <circle cx="12" cy="4.4" r="2.7" fill={f} />),
+        <circle key="c" cx="12" cy="12" r="2.7" fill={b} />,
+      ];
+    case 4: // burst, 6/8/10 spikes
+      return [
+        ...ring(6 + step * 2, a, b, (f) => <path d="M12 12 L10.2 2 L13.8 2 Z" fill={f} />),
+        <circle key="c" cx="12" cy="12" r="3" fill={b} />,
+      ];
+    case 5: // rings, 2-4 deep
+      return Array.from({ length: 2 + step }, (_, i) => (
+        <circle key={i} cx="12" cy="12" r={10 - i * (8 / (2 + step))} fill="none"
+                stroke={i % 2 ? b : a} strokeWidth="2.6" />
+      ));
+    case 6: // nested diamonds, 2-4 deep
+      // A square rotated 45 degrees needs side <= 24/sqrt(2) or its corners
+      // clip on the viewBox and it reads as a plain rounded square.
+      return Array.from({ length: 2 + step }, (_, i) => {
+        const side = 16.5 - i * (12 / (2 + step));
+        return (
+          <rect key={i} x={12 - side / 2} y={12 - side / 2} width={side} height={side}
+                rx="1.8" fill={i % 2 ? b : a} />
+        );
+      });
+    default: { // checker, 3x3 or 4x4
+      const n = 3 + (step % 2);
+      const cell = 20 / n;
+      return Array.from({ length: n * n }, (_, i) => {
+        const row = Math.floor(i / n), col = i % n;
+        return (
+          <rect key={i} x={2 + col * cell} y={2 + row * cell} width={cell - 1} height={cell - 1}
+                rx="1.4" fill={(row + col) % 2 ? b : a} />
+        );
+      });
+    }
+  }
+}
+
+export default function AgentSigil({
+  seed, size = 26, running = false, className,
+}: {
+  /** Whatever identifies this agent: its task, else its phase label, else its id. */
+  seed: string;
+  size?: number;
+  running?: boolean;
+  className?: string;
+}) {
+  const key = seed || "agent";
+  const family = profileHue(`shape:${key}`) % FAMILIES;
+  const step = Math.floor(profileHue(`count:${key}`) / 120); // 0, 1 or 2
+  const hue = profileHue(key);
+  // Two stops, both mid-lightness: a single 58% fill (the profile-dot value)
+  // washes out against a light background at this size, and the pair also
+  // gives every mark the shading the shapes need to stay legible at 26px.
+  const a = `hsl(${hue} 62% 58%)`;
+  const b = `hsl(${(hue + 26) % 360} 58% 44%)`;
+
+  return (
+    <span
+      className={className}
+      style={{
+        width: size, height: size, flex: "none", display: "grid", placeItems: "center",
+        // No tinted plate behind the mark: at this size the plate reads as a
+        // second, competing shape and its alpha shifts row to row with the hue.
+        // A running child gets a ring, which is rare enough to stay a signal.
+        borderRadius: running ? size * 0.3 : undefined,
+        boxShadow: running ? `0 0 0 1.5px hsl(${hue} 62% 58% / 0.6)` : undefined,
+      }}
+    >
+      <svg viewBox="0 0 24 24" width={size} height={size} aria-hidden focusable="false">
+        {/* A whole-mark rotation off the colour seed, so two agents that land on
+            the same family, count and neighbouring hues still don't twin. Kept
+            clear of 0 and 90: the four-fold families (diamonds, checker,
+            lattice) are symmetric there and collapse into a plain square. */}
+        <g transform={`rotate(${12 + (hue % 66)} 12 12)`}>{glyph(family, step, a, b)}</g>
+      </svg>
+    </span>
+  );
+}

--- a/frontend/src/components/settings/UsagePrivacySettings.tsx
+++ b/frontend/src/components/settings/UsagePrivacySettings.tsx
@@ -137,6 +137,8 @@ export default function UsagePrivacySettings() {
                     <li className="list-disc">Which pages you open — including which coding agent&apos;s panel</li>
                     <li className="list-disc">Which features you use (summaries, filters, budgets, Hermes, etc.)</li>
                     <li className="list-disc">When you open or save a budget — the count only, never the limit or amount</li>
+                    <li className="list-disc">When you open or close the plan-limit gauge in the sidebar — the click only, never which window or percentage</li>
+                    <li className="list-disc">When you open a connected coding agent&apos;s tile — which agent, never any session detail</li>
                     <li className="list-disc">Whether a summary succeeded or failed, and which engine</li>
                     <li className="list-disc">
                       For each coding agent found on this machine, whether we could read any sessions

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -14,7 +14,7 @@ export const API_BASE = (() => {
   if (typeof window !== "undefined") {
     return `${window.location.protocol}//${window.location.hostname}:${port}`;
   }
-  return `http://127.0.0.1:${port}`;
+  return `http://localhost:${port}`;
 })();
 
 // --- Remote-access token --------------------------------------------------

--- a/frontend/src/lib/telemetry.ts
+++ b/frontend/src/lib/telemetry.ts
@@ -70,7 +70,12 @@ export async function ackTelemetryNotice(): Promise<void> {
 }
 
 /** Client-origin events the backend bridge accepts. */
-export type ClientEvent = "page.viewed" | "analytics.filtered" | "feature.used";
+export type ClientEvent =
+  | "page.viewed"
+  | "analytics.filtered"
+  | "feature.used"
+  | "planlimits.toggled"
+  | "agent.opened";
 
 /**
  * Fire-and-forget event. The backend re-sanitizes everything (allowlist + enum),

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -19,7 +23,9 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
   "include": [
@@ -28,7 +34,11 @@
     "**/*.tsx",
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts",
-    "**/*.mts"
+    "**/*.mts",
+    ".next-desktop/types/**/*.ts",
+    ".next-desktop/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/install.ps1
+++ b/install.ps1
@@ -31,4 +31,34 @@ if (-not (Test-Path "./bin/cli.js")) {
   Set-Location $TargetDir
 }
 
+# Absolute path to the checkout. The shims below point at this exact location,
+# so they keep working after the installer exits and from any directory.
+$CheckoutDir = (Resolve-Path .).Path
+
+# Write a tokentelemetry.cmd (plus a .ps1 alongside) into a stable user-bin
+# directory that is on the user PATH. The .cmd is what makes the bare name work
+# from both PowerShell and cmd.exe even when the execution policy refuses
+# unsigned .ps1 files.
+$UserBin = Join-Path $env:USERPROFILE ".local\bin"
+New-Item -ItemType Directory -Force -Path $UserBin | Out-Null
+
+@"
+@echo off
+REM tokentelemetry shim -- forwards to the installed checkout.
+node "$CheckoutDir\bin\cli.js" %*
+"@ | Set-Content -Path (Join-Path $UserBin "tokentelemetry.cmd") -Encoding ASCII
+
+@"
+# tokentelemetry shim -- forwards to the installed checkout.
+& node "$CheckoutDir\bin\cli.js" @args
+exit `$LASTEXITCODE
+"@ | Set-Content -Path (Join-Path $UserBin "tokentelemetry.ps1") -Encoding ASCII
+
+$UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
+if ($UserPath -notlike "*$UserBin*") {
+  $NewPath = if ($UserPath) { "$UserBin;$UserPath" } else { $UserBin }
+  [Environment]::SetEnvironmentVariable("Path", $NewPath, "User")
+  Write-Host "-> added $UserBin to your user PATH (open a new terminal to pick it up)."
+}
+
 node bin/cli.js

--- a/install.sh
+++ b/install.sh
@@ -30,6 +30,48 @@ if [ ! -f "./bin/cli.js" ]; then
   cd "$TARGET_DIR"
 fi
 
+# Absolute path to the checkout. The shim below points at this exact location,
+# so it keeps working after the installer's shell exits and from any directory.
+CHECKOUT_DIR="$(pwd)"
+
+# Install a ~/.local/bin/tokentelemetry shim so the command resolves from any
+# directory. A shim rather than npm link, because npm's global dir is
+# Node-version-specific under nvm and a user who switches Node versions would
+# silently lose the command. Idempotent: only rewritten when missing or
+# pointing at a different checkout.
+SHIM_DIR="${HOME}/.local/bin"
+SHIM_PATH="${SHIM_DIR}/tokentelemetry"
+if [ ! -f "$SHIM_PATH" ] || ! grep -Fq "$CHECKOUT_DIR" "$SHIM_PATH" >/dev/null 2>&1; then
+  mkdir -p "$SHIM_DIR"
+  cat > "$SHIM_PATH.tmp" <<EOF
+#!/usr/bin/env bash
+exec node "$CHECKOUT_DIR/bin/cli.js" "\$@"
+EOF
+  chmod +x "$SHIM_PATH.tmp"
+  mv "$SHIM_PATH.tmp" "$SHIM_PATH"
+fi
+
+case ":$PATH:" in
+  *":$SHIM_DIR:"*) ;;
+  *) echo "⚠  ~/.local/bin is not on your PATH. Add it to run 'tokentelemetry' from any directory:"
+     # The right rc file depends on the login shell: bash reads ~/.bashrc, zsh
+     # (macOS default since Catalina) reads ~/.zshrc.
+     case "${SHELL:-}" in
+       */zsh|zsh)
+         echo "    echo 'export PATH=\"\$HOME/.local/bin:\$PATH\"' >> ~/.zshrc"
+         echo "    source ~/.zshrc"
+         ;;
+       */bash|bash)
+         echo "    echo 'export PATH=\"\$HOME/.local/bin:\$PATH\"' >> ~/.bashrc"
+         echo "    source ~/.bashrc"
+         ;;
+       *)
+         echo "    Add \$HOME/.local/bin to your shell's startup file (~/.bashrc or ~/.zshrc), then reload it."
+         ;;
+     esac ;;
+esac
+
 echo "✓ TokenTelemetry ready in $(pwd)"
 echo "  Start it again any time with:  cd \"$(pwd)\" && ./start.sh"
+echo "  ... or from anywhere with:     tokentelemetry"
 exec node bin/cli.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,161 @@
       "name": "tokentelemetry",
       "version": "1.0.0",
       "license": "MIT",
+      "dependencies": {
+        "electron": "^44.1.0"
+      },
       "bin": {
         "tokentelemetry": "bin/cli.js"
       },
       "engines": {
         "node": ">=20.9.0"
       }
+    },
+    "node_modules/@electron-internal/extract-zip": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.5.tgz",
+      "integrity": "sha512-+bqFCP98pLI0Tt0XQo1TmlXtwjWchISndDOxCkEcIuUgXWpBnLyRI+2DU+mesvnMMX6L1XDqYNA0lXNDHd/yiA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@electron/get": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-5.1.0.tgz",
+      "integrity": "sha512-3kSBtG8ObcTVfXanm5vVJ6UnBLEVmVsRk1M+vGqCuMBV+XLCbJYuWQful+yIy0GQDsSlK0kHEriEHn7SPk4EnA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^3.0.0",
+        "graceful-fs": "^4.2.11",
+        "progress": "^2.0.3",
+        "semver": "^7.6.3",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "optionalDependencies": {
+        "undici": "^7.24.4"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron": {
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-44.1.0.tgz",
+      "integrity": "sha512-kmLg8axOg22DC3fXx5NCwBYW8fx0rK2zzJ3Tf67GjNCkxfoxEcd+yo0QfDjlBtHJs3xeA8fTg64b6iVzFTVErg==",
+      "license": "MIT",
+      "dependencies": {
+        "@electron-internal/extract-zip": "^1.0.1",
+        "@electron/get": "^5.0.0",
+        "@types/node": "^24.9.0"
+      },
+      "bin": {
+        "electron": "cli.js",
+        "install-electron": "install.js"
+      },
+      "engines": {
+        "node": ">= 22.12.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sumchecker": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+      "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
   "bugs": {
     "url": "https://github.com/VasiHemanth/tokentelemetry/issues"
   },
-  "dependencies": {},
+  "dependencies": {
+    "electron": "^44.1.0"
+  },
   "engines": {
     "node": ">=20.9.0"
   }

--- a/proxy/cloudflare-worker.js
+++ b/proxy/cloudflare-worker.js
@@ -53,7 +53,7 @@ const MAX_BODY = 8 * 1024; // events are tiny; reject anything bigger as abuse.
 const ALLOWED_EVENTS = new Set([
   "app.launched", "page.viewed", "trace.summarized",
   "analytics.filtered", "feature.used", "retention.opted_in",
-  "harness.scanned",
+  "harness.scanned", "planlimits.toggled", "agent.opened",
 ]);
 
 // Cheap, stateless validation. This is NOT anti-spoof (an open-source client

--- a/proxy/cloudflare/src/index.js
+++ b/proxy/cloudflare/src/index.js
@@ -53,7 +53,7 @@ const MAX_BODY = 8 * 1024; // events are tiny; reject anything bigger as abuse.
 const ALLOWED_EVENTS = new Set([
   "app.launched", "page.viewed", "trace.summarized",
   "analytics.filtered", "feature.used", "retention.opted_in",
-  "harness.scanned",
+  "harness.scanned", "planlimits.toggled", "agent.opened",
 ]);
 
 // Cheap, stateless validation. This is NOT anti-spoof (an open-source client

--- a/website/content/docs/configuration/privacy.mdx
+++ b/website/content/docs/configuration/privacy.mdx
@@ -35,7 +35,7 @@ export TT_NO_UPDATE_CHECK=1
 
 TokenTelemetry optionally sends anonymous, content-free feature-usage events to help the maintainer understand which features are used and prioritize development. This is distinct from the update check.
 
-**What is sent:** An event name plus a handful of values drawn from fixed lists — which page you opened (including which coding agent's panel), which feature you used, whether a summary succeeded, and for each coding agent detected on your machine whether its sessions could be read at all, as a size band rather than a count. No session content, no tokens, no costs, no file paths, no identifiers that could link events to a person or machine.
+**What is sent:** An event name plus a handful of values drawn from fixed lists — which page you opened (including which coding agent's panel), which feature you used, whether a summary succeeded, when you open or close the sidebar plan-limit gauge and when you open a connected coding agent's tile (the agent, never its content), and for each coding agent detected on your machine whether its sessions could be read at all, as a size band rather than a count. No session content, no tokens, no costs, no file paths, no identifiers that could link events to a person or machine.
 
 Anything outside those fixed lists is replaced with `other` before sending, so an unexpected value cannot ride along. Settings → *Anonymous usage stats* → **Show exactly what we send** lists every event and every permitted value, generated from the same allowlist the app validates against — so it is always current rather than a description someone remembered to update.
 

--- a/website/src/app/privacy/page.tsx
+++ b/website/src/app/privacy/page.tsx
@@ -44,6 +44,8 @@ export default function PrivacyPage() {
         <ul className="list-disc pl-5 space-y-2 mt-2">
           <li>Which pages you open in the app, including which coding agent&apos;s panel</li>
           <li>Which features you use (e.g. trace summaries, analytics filters, the Hermes dashboard)</li>
+          <li>When you open or close the sidebar plan-limit gauge — the click only, never the percentage or window</li>
+          <li>When you open a connected coding agent&apos;s tile — which agent, never its content</li>
           <li>Whether a summary succeeded or failed, and which summarizer engine was used</li>
           <li>Your OS family, CPU architecture, and the app version</li>
           <li>


### PR DESCRIPTION
## Summary

Adds the macOS menu bar and a local Electron desktop shell.

### macOS menu bar
- `backend/menubar/`: a thin `rumps` adapter over `QuotaService`. The status item shows the worst window across signed-in providers (`◔ 89%`), matching the dashboard's sidebar gauge exactly.
- Collects in-process every 60s (honoring the 5-minute `FRESHNESS` cache), serializes background refreshes, and shares `quotas.json` with the backend so the two never double-fetch.
- Provider sections render bars with remaining %, reset countdowns, balances, and a footer: **Open dashboard**, **Refresh now**, **Launch at login**, **Quit**.
- `backend/menubar/launch_agent.py`: pure, testable LaunchAgent plist + lifecycle helpers (`launchctl bootstrap`/`bootout`), absolute program arguments, `RunAtLoad`, logs under the data dir. Never auto-installed.
- `backend/requirements-macos.txt`: macOS-only `rumps` dependency, kept out of the cross-platform `requirements.lock`.

### CLI
- Subcommand verbs: `dashboard` (default), `menubar` (macOS only), `desktop`, `status`, `stop`.
- `menubar` bootstraps `requirements-macos.txt` into the existing venv, then starts `backend/menubar/app.py` detached with the correct `PYTHONPATH` and forwarded `--data-dir`.
- Off-macOS prints one line and exits non-zero (never surfaces an `ImportError` about `rumps`).

### Desktop (local Electron shell)
- `desktop/`: minimal `BrowserWindow` that spawns the backend and loads the static dashboard.
- Plan-limits panel wiring and an agent sigil icon.

## Testing
- Headless Python tests for the menu-bar presentation/render/launch-agent helpers (no `rumps` import).
- `backend/test_quotas.py`, `test_requirements_lock.py`, and Node CLI tests all pass.
- Import guard confirms `menubar.app`/render load without `rumps`/AppKit at import.

## Notes
- No `status`/`stop` implementation (still stubs); no Electron tray.
- Menu bar website docs page is intentionally deferred.