### PR TITLE
fix(windows): spawn npm.cmd with shell:true to avoid EINVAL

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -557,7 +557,9 @@ async function start(options) {
   const frontend = spawn(npmCommand, ['run', 'dev', '--', '--hostname', host, '--port', String(frontPort)], {
     cwd: frontendDir,
     stdio: 'inherit',
-    shell: false,
+    // Windows: .cmd files cannot be spawned directly (EINVAL); shell:true routes
+    // through cmd.exe. Local patch 2026-09-04 (upstream bug, see nodejs/node#59210).
+    shell: isWindows,
     detached: !isWindows,
     // The frontend derives its API base from window.location at runtime (see
     // frontend/src/lib/api.ts), so it only needs the API *port* — the host


### PR DESCRIPTION
## Problem

`tokentelemetry dashboard` fails on Windows immediately after dependency install:

```
Error: spawn EINVAL
    at ChildProcess.spawn (node:internal/child_process:420:11)
```

## Root cause

Node's `child_process.spawn` cannot launch a `.cmd` file directly with `shell: false` on Windows — it throws EINVAL (see nodejs/node#59210). The frontend spawn at `bin/cli.js:557` uses `npm.cmd` with `shell: false`, so the dashboard never starts on Windows.

## Fix

Route the frontend spawn through cmd.exe on Windows only:

```js
shell: isWindows,
```

POSIX behavior unchanged (`shell: false` on macOS/Linux).

## Tests

- `node --test bin/cli.test.js` — 17/17 pass
- `node bin/cli.js dashboard` on Windows 11 — both services (FastAPI :8000 + Next.js :3000) start and respond

## Risk

Low. Single-line change, Windows-only branch. On POSIX the value is identical to before.