### PR TITLE
feat: show peer messages between local agent sessions

### DIFF
--- a/UPDATE.json
+++ b/UPDATE.json
@@ -1,6 +1,16 @@
 {
   "releases": [
     {
+      "tag": "2026-09-03",
+      "title": "See when sessions talk to each other",
+      "highlights": [
+        {
+          "title": "Peer messages between sessions",
+          "description": "Agent sessions running on the same machine can message each other. The session view now shows those exchanges: which session was on the other end, in which direction, how long delivery took, and the first line of what was said. Each side records only its own half, so the two are matched on the delivery receipt and an exchange whose other half is missing says so instead of being dropped."
+        }
+      ]
+    },
+    {
       "tag": "2026-09-02",
       "title": "Desktop app, Settings redesign & keyboard shortcuts",
       "featured": true,

--- a/backend/main.py
+++ b/backend/main.py
@@ -29,6 +29,7 @@ import scan_cache
 import harness_panels
 import codex_goals
 import hermes_telemetry as _ht
+import session_links
 import hashlib
 
 def _aware(dt):
@@ -2968,6 +2969,26 @@ async def get_quotas():
 async def refresh_quotas():
     """Request a fresh provider fetch while retaining last-good snapshots."""
     return await _asyncio.to_thread(_get_quota_service().collect, True)
+
+
+@app.get("/sessions/links")
+async def get_session_links():
+    """Peer messages between local agent sessions — who talked to whom.
+
+    MUST stay declared above `/sessions/{session_id}` (further down this file).
+    FastAPI matches routes in definition order, so moving this below it makes
+    "links" bind as a session id and this endpoint becomes unreachable.
+
+    Sessions on one machine can message each other, and each side records only
+    its own half. Both halves are joined on the delivery receipt's ``msg_id``,
+    the one value they share (see session_links for why name and timestamp are
+    not usable as keys).
+
+    Deliberately NOT part of the session scan: peer traffic is sparse, and
+    folding it in would force a scan_cache.CACHE_VERSION bump that reparses the
+    user's whole history. Runs off its own mtime-keyed cache instead.
+    """
+    return await _asyncio.to_thread(session_links.build_graph, CLAUDE_DIR / "projects")
 
 # @app.get("/local-runtime")
 # async def get_local_runtime():

--- a/backend/session_links.py
+++ b/backend/session_links.py
@@ -1,0 +1,333 @@
+"""Peer messages between two local agent sessions — the edges of a session graph.
+
+Claude Code sessions running on one machine can message each other. Both sides
+record their own half of the exchange, and NEITHER half names the other by
+session id:
+
+* the SENDER writes an assistant row holding a ``SendMessage`` ``tool_use``
+  whose ``input.to`` is whatever the model typed — a display name with a short
+  ref (``"Some session [37079d]"``) or a raw socket
+  (``"uds:/tmp/cc-socks/4878.sock"``). The matching ``tool_result`` carries the
+  delivery receipt, including ``msg_id``.
+* the RECEIVER writes a user row whose ``origin`` is a structured envelope:
+  ``{kind: "peer", msg_id, name, verifiedPeerPid, hopChain, fromMode, body}``.
+
+``msg_id`` is the ONLY value both sides record, which makes it the join key.
+Matching on display name would mis-attach the moment two sessions share a name
+(they are user-chosen and not unique), and matching on timestamp would break
+under concurrent sends — both halves of a real exchange land within ~100ms, so
+a time window cannot separate two conversations happening at once.
+
+An edge is emitted even when only one half is found. A session's transcript is
+deleted, rotated, or simply lives outside the scanned directory often enough
+that dropping half-edges would silently under-report the graph; ``resolved``
+says which case a row is, so the UI can render the difference rather than
+pretend a one-sided edge is complete.
+
+WHY THIS IS NOT PART OF THE MAIN SESSION SCAN
+Peer messages are sparse: 2 across 100 transcripts (230 MB) on the development
+machine. Folding a new field into the session scan would force a
+``scan_cache.CACHE_VERSION`` bump, re-parsing the user's ENTIRE history to
+surface a rare relationship. Instead this module owns a small mtime-keyed cache
+of its own. A substring prefilter (checked before any JSON decoding) keeps a
+cold full scan under ~1s over that same 230 MB, because only ~300 of several
+million lines survive the filter.
+"""
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+logger = logging.getLogger("tokentelemetry.session_links")
+
+# Only lines containing one of these can possibly be a peer send or receive.
+# Checked as a raw substring against the undecoded line: json.loads() on every
+# line of a 230 MB tree is the entire cost of this scan, and this skips ~99.99%
+# of them. '"peer"' is quoted to avoid matching the word inside prose.
+#
+# "msg_id" is load-bearing and easy to omit by mistake: a SendMessage
+# tool_result names neither the tool nor the peer, so a filter of just
+# ('"peer"', "SendMessage") drops every delivery receipt, and with it every
+# msg_id — leaving each send unjoinable and the graph one-sided.
+_PREFILTER = ('"peer"', "SendMessage", "msg_id")
+
+# A message body is arbitrary text the peer wrote. The endpoint returns a short
+# preview so the UI can show what an exchange was ABOUT without shipping a
+# multi-kilobyte body into a list view; full text stays in the session detail.
+PREVIEW_CHARS = 240
+
+
+def _preview(text: Any) -> str:
+    """First meaningful line of a body, collapsed and truncated for a list row."""
+    if not isinstance(text, str):
+        return ""
+    # Peer messages lead with a self-contained summary line by convention, so
+    # the first non-empty line is the most informative thing to show.
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if line:
+            return line[:PREVIEW_CHARS] + ("…" if len(line) > PREVIEW_CHARS else "")
+    return ""
+
+
+def _msg_id_from_result(block: Dict[str, Any], row: Dict[str, Any]) -> Optional[str]:
+    """Pull the delivery receipt's ``msg_id`` out of a SendMessage tool_result.
+
+    Two encodings carry it and neither is guaranteed, so both are tried. The
+    row-level ``toolUseResult`` is the structured form; ``content[].text`` holds
+    the same payload as a JSON *string* and is what older transcripts have.
+    """
+    structured = row.get("toolUseResult")
+    if isinstance(structured, dict):
+        candidate = structured.get("msg_id")
+        if isinstance(candidate, str) and candidate:
+            return candidate
+    content = block.get("content")
+    if isinstance(content, list):
+        for part in content:
+            if not isinstance(part, dict) or part.get("type") != "text":
+                continue
+            text = part.get("text")
+            if not isinstance(text, str) or "msg_id" not in text:
+                continue
+            try:
+                payload = json.loads(text)
+            except (TypeError, ValueError):
+                continue
+            if isinstance(payload, dict):
+                candidate = payload.get("msg_id")
+                if isinstance(candidate, str) and candidate:
+                    return candidate
+    return None
+
+
+def parse_transcript(path: Path) -> Dict[str, Any]:
+    """Extract every peer send and receive from one transcript.
+
+    Returns ``{"session": <id>, "cwd": <str|None>, "sent": [...], "received": [...]}``.
+    A send is only reported once its receipt is found: the ``tool_use`` supplies
+    the address and the human-readable summary, the ``tool_result`` supplies the
+    ``msg_id`` that lets it be joined, and an edge keyed on nothing is useless.
+
+    ``cwd`` is taken from the rows that carry peer events, latest wins — NOT from
+    the first row of the file. A session can move between directories (a resumed
+    session, or one that entered a worktree mid-run), so the opening cwd can name
+    a directory the session had already left by the time it spoke to a peer.
+    """
+    session_id = path.stem
+    cwd: Optional[str] = None
+    # tool_use id -> the parts of the send known before its receipt arrives.
+    pending: Dict[str, Dict[str, Any]] = {}
+    sent: List[Dict[str, Any]] = []
+    received: List[Dict[str, Any]] = []
+
+    try:
+        handle = open(path, "r", encoding="utf-8", errors="replace")
+    except OSError as exc:  # unreadable transcript must never break the scan
+        logger.debug("session_links: cannot open %s (%s)", path, exc)
+        return {"session": session_id, "cwd": None, "sent": [], "received": []}
+
+    with handle:
+        for line in handle:
+            if not any(token in line for token in _PREFILTER):
+                continue
+            try:
+                row = json.loads(line)
+            except (TypeError, ValueError):
+                continue
+            if not isinstance(row, dict):
+                continue
+            row_cwd = row.get("cwd") if isinstance(row.get("cwd"), str) else None
+
+            origin = row.get("origin")
+            if isinstance(origin, dict) and origin.get("kind") == "peer":
+                body = origin.get("body")
+                cwd = row_cwd or cwd
+                received.append({
+                    "msg_id": origin.get("msg_id"),
+                    "from_name": origin.get("name"),
+                    "from_address": origin.get("from"),
+                    "from_pid": origin.get("verifiedPeerPid"),
+                    "from_mode": origin.get("fromMode"),
+                    # A hop chain longer than one means the message was relayed
+                    # rather than sent directly, which changes what the edge means.
+                    "hops": len(origin.get("hopChain") or []),
+                    "at": row.get("timestamp"),
+                    "chars": len(body) if isinstance(body, str) else 0,
+                    "preview": _preview(body),
+                })
+                continue
+
+            content = (row.get("message") or {}).get("content")
+            if not isinstance(content, list):
+                continue
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                if block.get("type") == "tool_use" and block.get("name") == "SendMessage":
+                    payload = block.get("input") or {}
+                    message = payload.get("message")
+                    cwd = row_cwd or cwd
+                    pending[block.get("id")] = {
+                        "to_address": payload.get("to"),
+                        "summary": payload.get("summary"),
+                        "at": row.get("timestamp"),
+                        "chars": len(message) if isinstance(message, str) else 0,
+                        "preview": _preview(message),
+                    }
+                elif block.get("type") == "tool_result":
+                    record = pending.pop(block.get("tool_use_id"), None)
+                    if record is None:
+                        continue
+                    msg_id = _msg_id_from_result(block, row)
+                    if msg_id:
+                        record["msg_id"] = msg_id
+                        sent.append(record)
+                    # No receipt means nothing was delivered, so there is no
+                    # edge to draw. The common case is a pure idle-notification
+                    # subscription: it is a real SendMessage call with no
+                    # message body, and counting it would inflate "sent" with
+                    # exchanges that never carried anything.
+
+    return {"session": session_id, "cwd": cwd, "sent": sent, "received": received}
+
+
+# path -> ((mtime_ns, size), parsed). Transcripts are append-only while a
+# session is live, so any size change is a real change and a re-parse is cheap.
+_CACHE: Dict[str, Tuple[Tuple[int, int], Dict[str, Any]]] = {}
+_CACHE_MAX = 512
+
+
+def _parse_cached(path: Path) -> Dict[str, Any]:
+    try:
+        stat = path.stat()
+        stamp = (stat.st_mtime_ns, stat.st_size)
+    except OSError:
+        return parse_transcript(path)
+    key = str(path)
+    hit = _CACHE.get(key)
+    if hit is not None and hit[0] == stamp:
+        return hit[1]
+    parsed = parse_transcript(path)
+    if key not in _CACHE and len(_CACHE) >= _CACHE_MAX:
+        _CACHE.pop(next(iter(_CACHE)))
+    _CACHE[key] = (stamp, parsed)
+    return parsed
+
+
+def clear_cache() -> None:
+    """Drop the parse cache. Tests reuse file names across temp dirs."""
+    _CACHE.clear()
+
+
+def _transcripts(projects_dir: Path) -> Iterable[Path]:
+    if not projects_dir.is_dir():
+        return []
+    return sorted(projects_dir.glob("*/*.jsonl"))
+
+
+def build_graph(projects_dir: Path) -> Dict[str, Any]:
+    """Join both halves of every peer exchange into a session-to-session graph.
+
+    Nodes are sessions that sent or received at least once; a session with no
+    peer traffic is not part of this graph and is deliberately absent rather
+    than present with zero counts.
+    """
+    by_msg: Dict[str, Dict[str, Any]] = {}
+    nodes: Dict[str, Dict[str, Any]] = {}
+    unjoinable: List[Dict[str, Any]] = []
+
+    def node(session_id: str, cwd: Optional[str]) -> Dict[str, Any]:
+        entry = nodes.get(session_id)
+        if entry is None:
+            entry = {"session": session_id, "cwd": cwd, "sent": 0, "received": 0, "peers": set()}
+            nodes[session_id] = entry
+        elif entry["cwd"] is None and cwd:
+            entry["cwd"] = cwd
+        return entry
+
+    def edge(msg_id: str) -> Dict[str, Any]:
+        entry = by_msg.get(msg_id)
+        if entry is None:
+            entry = {
+                "msg_id": msg_id, "from_session": None, "to_session": None,
+                "from_cwd": None, "to_cwd": None, "from_name": None,
+                "to_address": None, "summary": None, "preview": "", "chars": 0,
+                "sent_at": None, "received_at": None, "hops": None,
+                "from_mode": None, "resolved": False,
+            }
+            by_msg[msg_id] = entry
+        return entry
+
+    for path in _transcripts(projects_dir):
+        parsed = _parse_cached(path)
+        session_id, cwd = parsed["session"], parsed["cwd"]
+        if not parsed["sent"] and not parsed["received"]:
+            continue
+        entry = node(session_id, cwd)
+
+        for record in parsed["sent"]:
+            entry["sent"] += 1
+            link = edge(record["msg_id"])
+            link["from_session"] = session_id
+            link["from_cwd"] = cwd
+            link["to_address"] = record.get("to_address")
+            link["summary"] = record.get("summary")
+            link["sent_at"] = record.get("at")
+            # The sender holds the message it actually composed, so its preview
+            # and length win over the receiver's copy when both exist.
+            link["preview"] = record.get("preview") or link["preview"]
+            link["chars"] = record.get("chars") or link["chars"]
+
+        for record in parsed["received"]:
+            entry["received"] += 1
+            msg_id = record.get("msg_id")
+            if not msg_id:
+                # No join key: countable, but it can never become an edge.
+                unjoinable.append({"session": session_id, "from_name": record.get("from_name"),
+                                   "at": record.get("at")})
+                continue
+            link = edge(msg_id)
+            link["to_session"] = session_id
+            link["to_cwd"] = cwd
+            link["from_name"] = record.get("from_name")
+            link["received_at"] = record.get("at")
+            link["hops"] = record.get("hops")
+            link["from_mode"] = record.get("from_mode")
+            if not link["preview"]:
+                link["preview"] = record.get("preview") or ""
+            if not link["chars"]:
+                link["chars"] = record.get("chars") or 0
+
+    edges = []
+    for link in by_msg.values():
+        link["resolved"] = bool(link["from_session"] and link["to_session"])
+        if link["from_session"] and link["to_session"]:
+            nodes[link["from_session"]]["peers"].add(link["to_session"])
+            nodes[link["to_session"]]["peers"].add(link["from_session"])
+        edges.append(link)
+
+    # Newest first: a peer conversation is read like a log, and an unsent edge
+    # (received_at only) still has a usable time.
+    edges.sort(key=lambda e: e.get("sent_at") or e.get("received_at") or "", reverse=True)
+
+    node_list = []
+    for entry in nodes.values():
+        node_list.append({**entry, "peers": sorted(entry["peers"]),
+                          "peer_count": len(entry["peers"])})
+    node_list.sort(key=lambda n: (n["sent"] + n["received"]), reverse=True)
+
+    return {
+        "edges": edges,
+        "nodes": node_list,
+        "totals": {
+            "edges": len(edges),
+            "resolved": sum(1 for e in edges if e["resolved"]),
+            "sessions": len(node_list),
+            # Surfaced rather than hidden: a non-zero value here means the graph
+            # is knowably incomplete, which is different from having no traffic.
+            "unjoinable_receives": len(unjoinable),
+        },
+    }

--- a/backend/session_links.py
+++ b/backend/session_links.py
@@ -242,7 +242,8 @@ def build_graph(projects_dir: Path) -> Dict[str, Any]:
     def node(session_id: str, cwd: Optional[str]) -> Dict[str, Any]:
         entry = nodes.get(session_id)
         if entry is None:
-            entry = {"session": session_id, "cwd": cwd, "sent": 0, "received": 0, "peers": set()}
+            entry = {"session": session_id, "cwd": cwd, "name": None,
+                     "sent": 0, "received": 0, "peers": set()}
             nodes[session_id] = entry
         elif entry["cwd"] is None and cwd:
             entry["cwd"] = cwd
@@ -303,6 +304,13 @@ def build_graph(projects_dir: Path) -> Dict[str, Any]:
 
     edges = []
     for link in by_msg.values():
+        # Only the RECEIVING side records a peer's display name, so a session's
+        # own name is learned from the messages it SENT to others. Recording it
+        # on the node lets the far end be labelled by name even on an edge whose
+        # sender addressed it by raw socket, which is what the transport falls
+        # back to when replying.
+        if link["from_session"] and link["from_name"] and link["from_session"] in nodes:
+            nodes[link["from_session"]]["name"] = link["from_name"]
         link["resolved"] = bool(link["from_session"] and link["to_session"])
         if link["from_session"] and link["to_session"]:
             nodes[link["from_session"]]["peers"].add(link["to_session"])

--- a/backend/test_session_links.py
+++ b/backend/test_session_links.py
@@ -1,0 +1,247 @@
+"""Tests for cross-session peer messages (session_links).
+
+Two Claude sessions on one machine can message each other, and each side records
+only its own half. Covers:
+  - build_graph(): both halves join on msg_id into one resolved edge.
+  - the prefilter reaches a delivery receipt, which names neither the tool
+    nor the peer (the bug that made every send unjoinable).
+  - cwd is the directory a session was in when it spoke, not the one it opened in.
+  - a half-edge stays visible and is marked unresolved rather than dropped.
+  - a SendMessage that delivered nothing (an idle subscription) is not an edge.
+  - a receive with no msg_id is counted, not silently discarded.
+  - the mtime cache re-parses an appended transcript.
+
+Run: pytest backend/test_session_links.py
+"""
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+import session_links  # noqa: E402
+
+
+SENDER = "aaaaaaaa-0000-0000-0000-000000000001"
+RECEIVER = "bbbbbbbb-0000-0000-0000-000000000002"
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    # Temp dirs reuse file names across tests, and the cache is keyed by path.
+    session_links.clear_cache()
+    yield
+    session_links.clear_cache()
+
+
+def _write(path: Path, rows):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row) + "\n")
+
+
+def _send_rows(msg_id, to, summary, body, cwd, at="2026-09-02T17:55:06.306Z"):
+    """The sender's two rows: the tool_use, then its delivery receipt.
+
+    The receipt deliberately mentions neither "SendMessage" nor "peer" — that is
+    exactly how the real transcript looks, and why the prefilter needs msg_id.
+    """
+    return [
+        {"type": "assistant", "timestamp": at, "cwd": cwd,
+         "message": {"content": [
+             {"type": "tool_use", "id": "toolu_1", "name": "SendMessage",
+              "input": {"to": to, "summary": summary, "message": body}}]}},
+        {"type": "user", "timestamp": at, "cwd": cwd,
+         "toolUseResult": {"success": True, "msg_id": msg_id},
+         "message": {"content": [
+             {"type": "tool_result", "tool_use_id": "toolu_1",
+              "content": [{"type": "text",
+                           "text": json.dumps({"success": True, "msg_id": msg_id})}]}]}},
+    ]
+
+
+def _receive_row(msg_id, from_name, body, cwd, at="2026-09-02T17:55:06.402Z", hops=1):
+    return {"type": "user", "timestamp": at, "cwd": cwd, "userType": "external",
+            "origin": {"kind": "peer", "from": "uds:/tmp/cc-socks/4878.sock",
+                       "verifiedPeerPid": 4878, "msg_id": msg_id, "name": from_name,
+                       "hopChain": ["a" * 24] * hops, "fromMode": "bypass",
+                       "body": body}}
+
+
+def test_both_halves_join_on_msg_id_into_one_edge(tmp_path):
+    """The join key is msg_id, and it is the only value both sides record.
+
+    The sender addresses the peer by display name and the receiver identifies it
+    by pid and socket; neither names a session id, so nothing but msg_id can
+    connect the two rows.
+    """
+    _write(tmp_path / "proj-a" / f"{SENDER}.jsonl",
+           _send_rows("msg-1", "Peer session [37079d]", "ask about design",
+                      "Need your conclusions.\nMore detail here.", "/w/a"))
+    _write(tmp_path / "proj-b" / f"{RECEIVER}.jsonl",
+           [_receive_row("msg-1", "sender session", "Need your conclusions.", "/w/b")])
+
+    graph = session_links.build_graph(tmp_path)
+
+    assert graph["totals"] == {"edges": 1, "resolved": 1, "sessions": 2,
+                               "unjoinable_receives": 0}
+    edge = graph["edges"][0]
+    assert edge["from_session"] == SENDER
+    assert edge["to_session"] == RECEIVER
+    assert edge["resolved"] is True
+    assert edge["from_cwd"] == "/w/a"
+    assert edge["to_cwd"] == "/w/b"
+    # The sender's own label for the message, which the receiver never sees.
+    assert edge["summary"] == "ask about design"
+    assert edge["to_address"] == "Peer session [37079d]"
+    assert edge["from_name"] == "sender session"
+    # Preview comes from the sender's composed text, first non-empty line only.
+    assert edge["preview"] == "Need your conclusions."
+    assert edge["hops"] == 1
+
+    by_id = {n["session"]: n for n in graph["nodes"]}
+    assert by_id[SENDER]["sent"] == 1 and by_id[SENDER]["received"] == 0
+    assert by_id[RECEIVER]["received"] == 1 and by_id[RECEIVER]["sent"] == 0
+    assert by_id[SENDER]["peers"] == [RECEIVER]
+    assert by_id[RECEIVER]["peers"] == [SENDER]
+
+
+def test_prefilter_reaches_a_receipt_that_names_neither_the_tool_nor_a_peer(tmp_path):
+    """Regression: a delivery receipt contains no "SendMessage" and no "peer".
+
+    Filtering on only those two tokens skips the receipt, so msg_id is never
+    found, every send is dropped, and the graph silently renders one-sided.
+    """
+    rows = _send_rows("msg-1", "Peer [37079d]", "s", "body", "/w/a")
+    receipt = json.dumps(rows[1])
+    assert "SendMessage" not in receipt and '"peer"' not in receipt
+    assert "msg_id" in receipt  # the only usable token
+
+    _write(tmp_path / "proj-a" / f"{SENDER}.jsonl", rows)
+    graph = session_links.build_graph(tmp_path)
+
+    assert graph["nodes"][0]["sent"] == 1
+    assert graph["edges"][0]["msg_id"] == "msg-1"
+
+
+def test_cwd_is_where_the_session_spoke_not_where_it_opened(tmp_path):
+    """A resumed session can change directory, so the first row's cwd can be stale.
+
+    Taking the opening cwd attributes the exchange to a directory the session had
+    already left.
+    """
+    rows = [
+        # An early, unrelated row that still trips the prefilter.
+        {"type": "user", "timestamp": "2026-09-02T10:00:00.000Z", "cwd": "/w/old",
+         "message": {"content": [{"type": "text", "text": "mentions SendMessage"}]}},
+    ] + _send_rows("msg-1", "Peer [37079d]", "s", "body", "/w/new")
+    _write(tmp_path / "proj-a" / f"{SENDER}.jsonl", rows)
+
+    graph = session_links.build_graph(tmp_path)
+
+    assert graph["nodes"][0]["cwd"] == "/w/new"
+    assert graph["edges"][0]["from_cwd"] == "/w/new"
+
+
+def test_a_half_edge_is_kept_and_marked_unresolved(tmp_path):
+    """Only one transcript is present, so the peer's side cannot be found.
+
+    Dropping it would under-report the graph; the UI needs to tell "no traffic"
+    apart from "traffic whose other half we cannot see".
+    """
+    _write(tmp_path / "proj-b" / f"{RECEIVER}.jsonl",
+           [_receive_row("msg-1", "a session not on disk", "hello", "/w/b")])
+
+    graph = session_links.build_graph(tmp_path)
+
+    assert graph["totals"]["edges"] == 1
+    assert graph["totals"]["resolved"] == 0
+    edge = graph["edges"][0]
+    assert edge["resolved"] is False
+    assert edge["from_session"] is None
+    assert edge["to_session"] == RECEIVER
+    assert edge["from_name"] == "a session not on disk"
+    # A one-sided edge still connects nothing, so no peer is claimed.
+    assert graph["nodes"][0]["peers"] == []
+
+
+def test_a_send_that_delivered_nothing_is_not_an_edge(tmp_path):
+    """A pure idle-notification subscription is a SendMessage with no receipt.
+
+    It carries no message, so counting it would inflate "sent" with exchanges
+    that never happened.
+    """
+    _write(tmp_path / "proj-a" / f"{SENDER}.jsonl", [
+        {"type": "assistant", "timestamp": "2026-09-02T17:55:00.000Z", "cwd": "/w/a",
+         "message": {"content": [
+             {"type": "tool_use", "id": "toolu_9", "name": "SendMessage",
+              "input": {"to": "Peer [37079d]"}}]}},
+        {"type": "user", "timestamp": "2026-09-02T17:55:00.100Z", "cwd": "/w/a",
+         "toolUseResult": {"success": True, "message": "Subscribed"},
+         "message": {"content": [
+             {"type": "tool_result", "tool_use_id": "toolu_9",
+              "content": [{"type": "text", "text": "Subscribed — will notify when idle."}]}]}},
+    ])
+
+    graph = session_links.build_graph(tmp_path)
+
+    assert graph["totals"]["edges"] == 0
+    assert graph["nodes"] == []
+
+
+def test_a_receive_without_a_join_key_is_counted_not_discarded(tmp_path):
+    """No msg_id means the edge can never be completed, but it did happen.
+
+    Reporting it in totals keeps "the graph is incomplete" visible instead of
+    quietly shrinking the result.
+    """
+    row = _receive_row("msg-x", "peer", "hi", "/w/b")
+    del row["origin"]["msg_id"]
+    _write(tmp_path / "proj-b" / f"{RECEIVER}.jsonl", [row])
+
+    graph = session_links.build_graph(tmp_path)
+
+    assert graph["totals"]["unjoinable_receives"] == 1
+    assert graph["totals"]["edges"] == 0
+    assert graph["nodes"][0]["received"] == 1
+
+
+def test_appending_to_a_transcript_invalidates_the_cache(tmp_path):
+    """Transcripts are append-only while a session is live, so size changes."""
+    path = tmp_path / "proj-a" / f"{SENDER}.jsonl"
+    _write(path, _send_rows("msg-1", "Peer [37079d]", "s", "one", "/w/a"))
+    assert session_links.build_graph(tmp_path)["totals"]["edges"] == 1
+
+    rows = _send_rows("msg-2", "Peer [37079d]", "s", "two", "/w/a",
+                      at="2026-09-02T18:00:00.000Z")
+    for row in rows:  # a second exchange, distinct tool_use id
+        for block in row["message"]["content"]:
+            block["id" if block.get("type") == "tool_use" else "tool_use_id"] = "toolu_2"
+    with open(path, "a", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row) + "\n")
+
+    graph = session_links.build_graph(tmp_path)
+    assert graph["totals"]["edges"] == 2
+    # Newest first.
+    assert graph["edges"][0]["msg_id"] == "msg-2"
+
+
+def test_a_directory_with_no_peer_traffic_yields_an_empty_graph(tmp_path):
+    _write(tmp_path / "proj-a" / f"{SENDER}.jsonl", [
+        {"type": "user", "timestamp": "2026-09-02T10:00:00.000Z", "cwd": "/w/a",
+         "message": {"content": [{"type": "text", "text": "ordinary turn"}]}}])
+
+    graph = session_links.build_graph(tmp_path)
+
+    assert graph == {"edges": [], "nodes": [],
+                     "totals": {"edges": 0, "resolved": 0, "sessions": 0,
+                                "unjoinable_receives": 0}}
+
+
+def test_a_missing_projects_directory_is_not_an_error(tmp_path):
+    graph = session_links.build_graph(tmp_path / "does-not-exist")
+    assert graph["totals"]["edges"] == 0

--- a/backend/test_session_links.py
+++ b/backend/test_session_links.py
@@ -230,6 +230,40 @@ def test_appending_to_a_transcript_invalidates_the_cache(tmp_path):
     assert graph["edges"][0]["msg_id"] == "msg-2"
 
 
+def test_a_session_name_is_learned_from_what_it_sent(tmp_path):
+    """A reply is often addressed to a raw socket, which is useless as a label.
+
+    Only the RECEIVING side records a peer's display name, so a session's name
+    comes from the messages it sent. Without this the reply edge renders the peer
+    as "uds:/tmp/cc-socks/4878.sock" even though its name is known from the
+    outbound edge.
+    """
+    _write(tmp_path / "proj-a" / f"{SENDER}.jsonl",
+           _send_rows("msg-1", "Peer session [37079d]", "opening", "first", "/w/a")
+           + [_receive_row("msg-2", "peer display name", "reply", "/w/a",
+                           at="2026-09-02T18:00:01.000Z")])
+    reply = _send_rows("msg-2", "uds:/tmp/cc-socks/4878.sock", "reply", "reply", "/w/b",
+                       at="2026-09-02T18:00:00.000Z")
+    for row in reply:  # distinct tool_use id from the file above
+        for block in row["message"]["content"]:
+            block["id" if block.get("type") == "tool_use" else "tool_use_id"] = "toolu_2"
+    _write(tmp_path / "proj-b" / f"{RECEIVER}.jsonl",
+           [_receive_row("msg-1", "sender display name", "first", "/w/b")] + reply)
+
+    graph = session_links.build_graph(tmp_path)
+    names = {n["session"]: n["name"] for n in graph["nodes"]}
+
+    # Each name is recorded by the side that received from it.
+    assert names[SENDER] == "sender display name"
+    assert names[RECEIVER] == "peer display name"
+    # The reply edge still carries the unhelpful raw address it was sent to;
+    # the name lives on the node so the UI can prefer it.
+    reply_edge = next(e for e in graph["edges"] if e["msg_id"] == "msg-2")
+    assert reply_edge["to_address"] == "uds:/tmp/cc-socks/4878.sock"
+    assert reply_edge["to_session"] == SENDER
+    assert reply_edge["resolved"] is True
+
+
 def test_a_directory_with_no_peer_traffic_yields_an_empty_graph(tmp_path):
     _write(tmp_path / "proj-a" / f"{SENDER}.jsonl", [
         {"type": "user", "timestamp": "2026-09-02T10:00:00.000Z", "cwd": "/w/a",

--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -13,6 +13,7 @@ import SourceBadge from "@/components/SourceBadge";
 import CopilotSourceBadge from "@/components/CopilotSourceBadge";
 import AntigravitySourceBadge from "@/components/AntigravitySourceBadge";
 import SummaryPanel from "@/components/summarizer/SummaryPanel";
+import SessionLinksPanel from "@/components/SessionLinksPanel";
 import { apiFetch, artifactUrl } from "@/lib/api";
 import { formatTokens, formatCost } from "@/lib/format";
 import { timeAgo } from "@/lib/notifications";
@@ -1387,6 +1388,15 @@ export default function SessionDetailPage() {
                   <SummaryPanel key={id} sessionId={id} agent={agent} />
                 </div>
               )}
+             {/* Messages exchanged with other local sessions. Self-hides when this
+                 session has no peer traffic, which is the usual case. Gated on
+                 claude because only Claude transcripts record peer envelopes, so
+                 for any other agent the request could only ever return nothing. */}
+             {agent === "claude" && (
+               <div className="mb-8">
+                 <SessionLinksPanel sessionId={id} />
+               </div>
+             )}
              {/* Hermes session chain (compression / branched continuations) */}
              {agent === "hermes" && sessionInfo && allHermesSessions && (
                <HermesChainBanner current={sessionInfo} all={allHermesSessions} from={fromParam} />

--- a/frontend/src/components/SessionLinksPanel.tsx
+++ b/frontend/src/components/SessionLinksPanel.tsx
@@ -83,7 +83,14 @@ export default function SessionLinksPanel({ sessionId }: { sessionId: string }) 
                 <span style={{ color: "var(--tt-fg-muted)" }}>{outbound ? "to" : "from"}</span>
                 {peerId ? (
                   <Link
-                    href={`/sessions/${peerId}?from=/sessions/${sessionId}`}
+                    // `agent` is REQUIRED: the session detail endpoint declares it
+                    // as a mandatory query param, so a link without it 422s and the
+                    // page hangs on its loading state. Hardcoded to claude because
+                    // only Claude transcripts record peer envelopes, so every peer
+                    // in this graph is a Claude session by construction.
+                    href={`/sessions/${peerId}?agent=claude&from=${encodeURIComponent(
+                      `/sessions/${sessionId}?agent=claude`,
+                    )}`}
                     className="font-medium underline underline-offset-2"
                     style={{ color: "var(--tt-fg)" }}
                   >

--- a/frontend/src/components/SessionLinksPanel.tsx
+++ b/frontend/src/components/SessionLinksPanel.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+/**
+ * Peer messages this session exchanged with other local agent sessions.
+ *
+ * Renders nothing at all when the session has no peer traffic. That is the
+ * overwhelmingly common case (2 exchanges across 100 transcripts on the
+ * development machine), and an empty "no messages" card on every session detail
+ * page would be noise on a page that is already dense.
+ */
+
+import React from "react";
+import Link from "next/link";
+import { ArrowDownLeft, ArrowUpRight, Radio, Unlink } from "lucide-react";
+import { useResource } from "@/lib/api";
+import {
+  SessionLinkGraph,
+  edgesFor,
+  directionFor,
+  peerLabel,
+  peerSessionId,
+  latencyMs,
+} from "@/lib/sessionLinks";
+
+function shortId(id: string): string {
+  return id.slice(0, 8);
+}
+
+function whenLabel(iso: string | null): string {
+  if (!iso) return "";
+  const at = new Date(iso);
+  if (Number.isNaN(at.getTime())) return "";
+  // Local time on purpose: these are events on the user's own machine, and a
+  // UTC rendering would disagree with every other clock they can see.
+  return at.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+}
+
+export default function SessionLinksPanel({ sessionId }: { sessionId: string }) {
+  // No polling. Peer traffic is rare and the page is already poll-heavy; a
+  // stale edge costs the reader nothing, and re-scanning transcripts on a timer
+  // would be pure waste.
+  const { data } = useResource<SessionLinkGraph>("/sessions/links");
+  const edges = edgesFor(data, sessionId);
+
+  if (edges.length === 0) return null;
+
+  return (
+    <div
+      className="rounded-[var(--tt-radius-lg)] border p-4"
+      style={{ borderColor: "var(--tt-border)", background: "var(--tt-panel)" }}
+    >
+      <div className="mb-3 flex items-center gap-2">
+        <Radio size={15} style={{ color: "var(--tt-brand)" }} aria-hidden />
+        <h3 className="text-sm font-medium" style={{ color: "var(--tt-fg)" }}>
+          Peer messages
+        </h3>
+        <span className="text-xs" style={{ color: "var(--tt-fg-dim)" }}>
+          {edges.length} with {new Set(edges.map((e) => peerSessionId(e, sessionId) ?? peerLabel(e, sessionId))).size} session
+          {new Set(edges.map((e) => peerSessionId(e, sessionId) ?? peerLabel(e, sessionId))).size === 1 ? "" : "s"}
+        </span>
+      </div>
+
+      <ul className="flex flex-col gap-2">
+        {edges.map((edge) => {
+          const direction = directionFor(edge, sessionId);
+          const outbound = direction === "sent";
+          const peerId = peerSessionId(edge, sessionId);
+          const latency = latencyMs(edge);
+          const Icon = outbound ? ArrowUpRight : ArrowDownLeft;
+          return (
+            <li
+              key={edge.msg_id}
+              className="rounded-[var(--tt-radius)] border p-2.5"
+              style={{ borderColor: "var(--tt-border)", background: "var(--tt-sunken)" }}
+            >
+              <div className="flex items-center gap-2 text-xs">
+                <Icon size={13} aria-hidden style={{ color: "var(--tt-brand)" }} />
+                <span style={{ color: "var(--tt-fg-muted)" }}>{outbound ? "to" : "from"}</span>
+                {peerId ? (
+                  <Link
+                    href={`/sessions/${peerId}?from=/sessions/${sessionId}`}
+                    className="font-medium underline underline-offset-2"
+                    style={{ color: "var(--tt-fg)" }}
+                  >
+                    {peerLabel(edge, sessionId)}
+                  </Link>
+                ) : (
+                  <span className="font-medium" style={{ color: "var(--tt-fg)" }}>
+                    {peerLabel(edge, sessionId)}
+                  </span>
+                )}
+                {peerId && (
+                  <span className="font-mono" style={{ color: "var(--tt-fg-faint)" }}>
+                    {shortId(peerId)}
+                  </span>
+                )}
+                <span className="ml-auto" style={{ color: "var(--tt-fg-dim)" }}>
+                  {whenLabel(outbound ? edge.sent_at : edge.received_at)}
+                </span>
+              </div>
+
+              {edge.summary && (
+                <div className="mt-1.5 text-xs font-medium" style={{ color: "var(--tt-fg)" }}>
+                  {edge.summary}
+                </div>
+              )}
+              {edge.preview && (
+                <p className="mt-1 text-xs leading-snug" style={{ color: "var(--tt-fg-muted)" }}>
+                  {edge.preview}
+                </p>
+              )}
+
+              <div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px]"
+                   style={{ color: "var(--tt-fg-dim)" }}>
+                <span>{edge.chars.toLocaleString()} chars</span>
+                {latency !== null && <span>delivered in {latency} ms</span>}
+                {/* A relayed message did not come straight from the named peer. */}
+                {edge.hops !== null && edge.hops > 1 && <span>relayed via {edge.hops} hops</span>}
+                {!edge.resolved && (
+                  <span className="inline-flex items-center gap-1" style={{ color: "var(--tt-fg-muted)" }}>
+                    <Unlink size={10} aria-hidden />
+                    {/* Says why a peer has no link, so a missing transcript does
+                        not read as a rendering bug. */}
+                    other half not found on disk
+                  </span>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/components/SessionLinksPanel.tsx
+++ b/frontend/src/components/SessionLinksPanel.tsx
@@ -19,6 +19,7 @@ import {
   directionFor,
   peerLabel,
   peerSessionId,
+  nameIndex,
   latencyMs,
 } from "@/lib/sessionLinks";
 
@@ -41,6 +42,10 @@ export default function SessionLinksPanel({ sessionId }: { sessionId: string }) 
   // would be pure waste.
   const { data } = useResource<SessionLinkGraph>("/sessions/links");
   const edges = edgesFor(data, sessionId);
+  // Built from the whole graph, not just this session's edges: a peer's name is
+  // recorded by whoever RECEIVED from it, which may be an exchange this session
+  // was not part of.
+  const names = React.useMemo(() => nameIndex(data), [data]);
 
   if (edges.length === 0) return null;
 
@@ -55,8 +60,8 @@ export default function SessionLinksPanel({ sessionId }: { sessionId: string }) 
           Peer messages
         </h3>
         <span className="text-xs" style={{ color: "var(--tt-fg-dim)" }}>
-          {edges.length} with {new Set(edges.map((e) => peerSessionId(e, sessionId) ?? peerLabel(e, sessionId))).size} session
-          {new Set(edges.map((e) => peerSessionId(e, sessionId) ?? peerLabel(e, sessionId))).size === 1 ? "" : "s"}
+          {edges.length} with {new Set(edges.map((e) => peerSessionId(e, sessionId) ?? peerLabel(e, sessionId, names))).size} session
+          {new Set(edges.map((e) => peerSessionId(e, sessionId) ?? peerLabel(e, sessionId, names))).size === 1 ? "" : "s"}
         </span>
       </div>
 
@@ -82,11 +87,11 @@ export default function SessionLinksPanel({ sessionId }: { sessionId: string }) 
                     className="font-medium underline underline-offset-2"
                     style={{ color: "var(--tt-fg)" }}
                   >
-                    {peerLabel(edge, sessionId)}
+                    {peerLabel(edge, sessionId, names)}
                   </Link>
                 ) : (
                   <span className="font-medium" style={{ color: "var(--tt-fg)" }}>
-                    {peerLabel(edge, sessionId)}
+                    {peerLabel(edge, sessionId, names)}
                   </span>
                 )}
                 {peerId && (

--- a/frontend/src/lib/sessionLinks.ts
+++ b/frontend/src/lib/sessionLinks.ts
@@ -34,6 +34,9 @@ export interface SessionLinkEdge {
 export interface SessionLinkNode {
   session: string;
   cwd: string | null;
+  /** Display name, learned from messages this session SENT (only the receiving
+   *  side records a peer's name). Null when it never sent to a session on disk. */
+  name: string | null;
   sent: number;
   received: number;
   peers: string[];
@@ -68,15 +71,32 @@ export function directionFor(edge: SessionLinkEdge, id: string): "sent" | "recei
   return edge.from_session === id ? "sent" : "received";
 }
 
+/** session id -> display name, for labelling an end the edge itself only has an address for. */
+export function nameIndex(graph: SessionLinkGraph | undefined): Record<string, string> {
+  const index: Record<string, string> = {};
+  for (const node of graph?.nodes ?? []) {
+    if (node.name) index[node.session] = node.name;
+  }
+  return index;
+}
+
 /**
  * The other end's label, from `id`'s point of view.
  *
  * Falls back through what each half recorded: the receiver knows the sender's
- * display name, the sender only knows the address it typed. When neither half
- * is present the peer is genuinely unidentified, so say so rather than render
- * an empty cell.
+ * display name, the sender only knows the address it typed. That address is
+ * whatever the model wrote, and when a session replies it is often a raw
+ * "uds:/tmp/cc-socks/<pid>.sock" — accurate but unreadable, so a name learned
+ * from any other edge wins over it. When nothing identifies the peer, say so
+ * rather than render an empty cell.
  */
-export function peerLabel(edge: SessionLinkEdge, id: string): string {
+export function peerLabel(
+  edge: SessionLinkEdge,
+  id: string,
+  names: Record<string, string> = {},
+): string {
+  const peerId = peerSessionId(edge, id);
+  if (peerId && names[peerId]) return names[peerId];
   if (directionFor(edge, id) === "sent") {
     return edge.to_address || edge.to_session || "unknown session";
   }

--- a/frontend/src/lib/sessionLinks.ts
+++ b/frontend/src/lib/sessionLinks.ts
@@ -1,0 +1,101 @@
+/**
+ * Peer messages between two local agent sessions (GET /sessions/links).
+ *
+ * Each side of an exchange records only its own half, and the backend joins them
+ * on the delivery receipt's `msg_id`. An edge whose halves could not both be
+ * found is still returned, with `resolved: false` — see `SessionLinkEdge`.
+ */
+
+export interface SessionLinkEdge {
+  msg_id: string;
+  /** Null when the sender's transcript was not found on disk. */
+  from_session: string | null;
+  /** Null when the recipient's transcript was not found on disk. */
+  to_session: string | null;
+  from_cwd: string | null;
+  to_cwd: string | null;
+  /** Display name the RECEIVER saw. Absent on a send whose receipt is missing. */
+  from_name: string | null;
+  /** Whatever the sender typed as an address: a display name, or a raw socket. */
+  to_address: string | null;
+  /** The sender's own one-line label for the message. */
+  summary: string | null;
+  preview: string;
+  chars: number;
+  sent_at: string | null;
+  received_at: string | null;
+  /** >1 means the message was relayed rather than delivered directly. */
+  hops: number | null;
+  from_mode: string | null;
+  /** True only when BOTH transcripts were found and joined. */
+  resolved: boolean;
+}
+
+export interface SessionLinkNode {
+  session: string;
+  cwd: string | null;
+  sent: number;
+  received: number;
+  peers: string[];
+  peer_count: number;
+}
+
+export interface SessionLinkGraph {
+  edges: SessionLinkEdge[];
+  nodes: SessionLinkNode[];
+  totals: {
+    edges: number;
+    resolved: number;
+    sessions: number;
+    /** Non-zero means the graph is knowably incomplete, not merely empty. */
+    unjoinable_receives: number;
+  };
+}
+
+/** Edges where `id` is either end, newest first (the backend already sorts). */
+export function edgesFor(graph: SessionLinkGraph | undefined, id: string): SessionLinkEdge[] {
+  if (!graph) return [];
+  return graph.edges.filter((e) => e.from_session === id || e.to_session === id);
+}
+
+/**
+ * How an edge reads from one session's point of view.
+ *
+ * A session can appear on either end, so direction is relative rather than a
+ * property of the edge itself.
+ */
+export function directionFor(edge: SessionLinkEdge, id: string): "sent" | "received" {
+  return edge.from_session === id ? "sent" : "received";
+}
+
+/**
+ * The other end's label, from `id`'s point of view.
+ *
+ * Falls back through what each half recorded: the receiver knows the sender's
+ * display name, the sender only knows the address it typed. When neither half
+ * is present the peer is genuinely unidentified, so say so rather than render
+ * an empty cell.
+ */
+export function peerLabel(edge: SessionLinkEdge, id: string): string {
+  if (directionFor(edge, id) === "sent") {
+    return edge.to_address || edge.to_session || "unknown session";
+  }
+  return edge.from_name || edge.from_session || "unknown session";
+}
+
+/** The peer's session id, when its transcript was found. */
+export function peerSessionId(edge: SessionLinkEdge, id: string): string | null {
+  return directionFor(edge, id) === "sent" ? edge.to_session : edge.from_session;
+}
+
+/**
+ * Delivery latency in ms, or null when a half is missing.
+ *
+ * Both clocks are the same machine's, so this is a real measurement rather than
+ * a cross-host comparison.
+ */
+export function latencyMs(edge: SessionLinkEdge): number | null {
+  if (!edge.sent_at || !edge.received_at) return null;
+  const delta = Date.parse(edge.received_at) - Date.parse(edge.sent_at);
+  return Number.isFinite(delta) ? delta : null;
+}


### PR DESCRIPTION
Two agent sessions running on the same machine can message each other, and until now that left no trace anywhere in the dashboard. The exchange is recorded on disk; nothing read it.

## How the two halves are joined

Each side records only its own half, and **neither names the other by session id**:

- the **sender** writes a `SendMessage` tool_use whose address is whatever the model typed — a display name with a short ref, or a raw `uds:/tmp/cc-socks/<pid>.sock`;
- the **receiver** writes a user turn whose `origin` is a structured envelope carrying the sender's display name, pid, hop chain and body.

The one value both sides record is the delivery receipt's `msg_id`, so that is the join key. Name matching would mis-attach whenever two sessions share a user-chosen name, and both halves of a real exchange land within ~100 ms, so a time window cannot separate two conversations happening at once.

## Why it is not part of the session scan

Peer traffic is sparse: `origin.kind` across 100 transcripts on the development machine is `human` 400, `task-notification` 156, `peer` **2**. Folding a field into the session scan would force a `scan_cache.CACHE_VERSION` bump and reparse a user's entire history to surface a rare relationship. This carries its own mtime-keyed cache instead; a substring prefilter applied before any JSON decoding keeps a cold full scan at ~0.3 s over 230 MB, because only ~300 of several million lines survive it.

## Decisions worth reviewing

- **The prefilter must include `msg_id`.** A delivery receipt names neither the tool nor the peer, so filtering on only `"peer"` and `SendMessage` drops every receipt, and with it every join key, leaving each send unjoinable and the graph silently one-sided. There is a regression test asserting the receipt contains neither token.
- **`cwd` is read from the rows carrying peer events, latest wins**, not from the first row of the file. A resumed session can change directory, so the opening cwd can name a directory the session had already left.
- **A half-edge is kept and marked unresolved** rather than dropped, so "no peer traffic" stays distinguishable from "traffic whose other half is not on disk".
- **A `SendMessage` that returned no receipt is not an edge.** The common case is a pure idle-notification subscription, which delivers nothing.
- **`/sessions/links` must stay declared above `/sessions/{session_id}`.** FastAPI matches in definition order, so moving it below binds `links` as a session id and the endpoint becomes unreachable.

## Verification

- 10 new tests in `backend/test_session_links.py`.
- Full backend suite: zero new failures against `origin/main` (identical failure sets; the pre-existing ones are environmental).
- `tsc --noEmit` exits 0.
- The live endpoint reproduces the two-way exchange this branch was written from, both edges resolved, with 96 ms and 83 ms delivery latencies.
- The panel was verified in the browser end to end, including clicking through to the peer session and back.

## Note for whoever merges second

This branch and `feat/menubar-cards` both add a `2026-09-03` release to `UPDATE.json`, so the second to merge will conflict there. Merging the two highlight lists into one release entry is the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
