### PR TITLE
feat: `tokentelemetry menubar` opens the tray panel, on every platform

### DIFF
--- a/UPDATE.json
+++ b/UPDATE.json
@@ -1,6 +1,25 @@
 {
   "releases": [
     {
+      "tag": "2026-09-04",
+      "title": "The menu bar command opens the new panel",
+      "highlights": [
+        {
+          "title": "`tokentelemetry menubar` starts the tray panel",
+          "description": "The command still started the older macOS-only panel, so the redesigned one was reachable only through `tokentelemetry desktop`. It now runs the desktop app tray-only: the same panel, with each agent's real logo, and no dashboard window or dock icon behind it.",
+          "href": "/docs/reference/cli"
+        },
+        {
+          "title": "The menu bar works on Windows and Linux",
+          "description": "`menubar` used to refuse to run anywhere but macOS, because the panel was built on a macOS-only Python UI toolkit. The tray version runs wherever the desktop app does, and opens above or below the icon depending on where your tray sits."
+        },
+        {
+          "title": "Open dashboard works from a tray-only start",
+          "description": "With no window running, the panel's \"Open dashboard\" button creates one on first use rather than doing nothing."
+        }
+      ]
+    },
+    {
       "tag": "2026-09-03",
       "title": "A redesigned menu bar panel, and sessions that talk to each other",
       "highlights": [

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -127,7 +127,7 @@ function printHelp() {
     '',
     'Commands:',
     '  dashboard [options]        Start the dashboard (the default).',
-    '  menubar                    Menu bar app (macOS only).',
+    '  menubar                    Menu bar / system tray panel.',
     '  desktop                    Desktop app.',
     '  status                     Dashboard status (not available yet).',
     '  stop                       Stop the dashboard (not available yet).',
@@ -646,7 +646,7 @@ async function start(options) {
 // them through localhost. 127.0.0.1 remains only a legacy CLI bind default.
 
 function menubarMessage() {
-  return 'The tokentelemetry menu bar is macOS-only.';
+  return 'Starting the TokenTelemetry menu bar…';
 }
 
 function desktopMessage() { return 'Starting TokenTelemetry Desktop…'; }
@@ -659,66 +659,34 @@ function stopMessage() {
   return 'tokentelemetry stop is not implemented yet.';
 }
 
-// --- macOS menu bar ----------------------------------------------------------
-// The menu bar app is a thin rumps wrapper over backend/quotas.py. rumps (and
-// its PyObjC dependencies) is macOS-only, so it lives in a separate
-// requirements-macos.txt and is installed into the existing backend venv only
-// when this command runs on macOS. The app runs detached in the background; its
-// "Open dashboard" item shells back out to this same CLI via absolute paths
-// passed through the environment (never a hard-coded checkout/account path).
+// --- Menu bar / system tray ---------------------------------------------------
+// The menu bar panel is the desktop app started tray-only: same Electron
+// process as `tokentelemetry desktop`, minus the dashboard window. It renders
+// the app's own /menubar page, so the panel and the dashboard's plan-limits
+// section cannot drift, and it works anywhere Electron has a tray rather than
+// on macOS alone. The earlier rumps implementation is still in backend/menubar/
+// but is no longer wired to a command; retiring it is a separate change.
 
-function menubarPythonArgs(backendDirParam = backendDir, dataDir = null) {
-  const args = [path.join(backendDirParam, 'menubar', 'app.py')];
-  if (dataDir) args.push('--data-dir', dataDir);
-  return args;
-}
-
-function menubarEnv(dataDir, cliPath, nodePath, backendDirParam = backendDir, env = process.env) {
+function menubarEnv(dataDir, env = process.env) {
   const base = dataDir ? { ...env, TOKENTELEMETRY_DATA_DIR: dataDir } : env;
-  const existing = env.PYTHONPATH ? [env.PYTHONPATH] : [];
-  return {
-    ...base,
-    PYTHONPATH: [backendDirParam, ...existing].join(path.delimiter),
-    TOKENTELEMETRY_CLI: cliPath,
-    TOKENTELEMETRY_NODE: nodePath,
-  };
-}
-
-function ensureMenubarRumps() {
-  // Install the macOS-only rumps requirement into the venv ensureBackend() just
-  // built, stamped by hash so a second `menubar` run is a no-op. Mirrors
-  // ensureBackend()'s lock/stamp logic, minus the hashes (this file is not
-  // lock-pinned) — rumps is a small, stable dependency and the file is macOS-only.
-  const reqPath = path.join(backendDir, 'requirements-macos.txt');
-  const stampPath = path.join(venvDir, '.requirements-macos.sha');
-  const currentSha = crypto.createHash('sha1').update(fs.readFileSync(reqPath)).digest('hex');
-  let cachedSha = null;
-  try { cachedSha = fs.readFileSync(stampPath, 'utf8').trim(); } catch {}
-  if (cachedSha === currentSha) return;
-  const uv = findUv();
-  if (uv) {
-    console.log('→ installing macOS menu bar dependencies (uv)…');
-    if (runSoft(uv, ['pip', 'install', '--quiet', '--python', venvPython, '-r', 'requirements-macos.txt'], { cwd: backendDir }) !== 0) {
-      die('installing the macOS menu bar dependencies with uv failed (see above).\nRe-run with TT_NO_UV=1 to install them with pip instead.');
-    }
-  } else {
-    ensureVenvPip();
-    console.log('→ installing macOS menu bar dependencies…');
-    run(venvPython, ['-m', 'pip', 'install', '--quiet', '-r', 'requirements-macos.txt'], { cwd: backendDir });
-  }
-  try { fs.writeFileSync(stampPath, currentSha); } catch {}
+  // desktop/main.cjs reads this and skips creating the dashboard window.
+  return { ...base, TT_TRAY_ONLY: '1' };
 }
 
 function startMenubar(options = {}) {
   checkNode();
+  checkDesktopNode();
   ensureBackend();
-  ensureMenubarRumps();
-  const cliPath = path.join(__dirname, 'cli.js');
-  const child = spawn(venvPython, menubarPythonArgs(backendDir, options.dataDir), {
-    cwd: backendDir,
+  ensureFrontend();
+  const electron = ensureDesktopElectron();
+  const { command, args, shell } = desktopSpawnCommand(
+    electron, path.join(rootDir, 'desktop', 'main.cjs'));
+  const child = spawn(command, args, {
+    cwd: rootDir,
+    detached: !isWindows,
     stdio: 'ignore',
-    detached: true,
-    env: menubarEnv(options.dataDir, cliPath, process.execPath),
+    shell,
+    env: menubarEnv(options.dataDir),
   });
   child.unref();
   return 0;
@@ -776,11 +744,8 @@ function startDesktop(options = {}) {
   return 0;
 }
 
-function cmdMenubar(options = {}, platform = process.platform) {
-  if (platform !== 'darwin') {
-    console.error(menubarMessage(platform));
-    return 1;
-  }
+function cmdMenubar(options = {}) {
+  console.log(menubarMessage());
   return startMenubar(options);
 }
 
@@ -854,9 +819,7 @@ module.exports = {
   desktopMessage,
   statusMessage,
   stopMessage,
-  menubarPythonArgs,
   menubarEnv,
-  ensureMenubarRumps,
   startMenubar,
   electronExecutable,
   desktopEnv,

--- a/bin/cli.test.js
+++ b/bin/cli.test.js
@@ -103,19 +103,14 @@ test('AGENT_HARNESS_NO_OPEN still suppresses the browser launch', () => {
   }
 });
 
-test('menubar is macOS-only off macOS and never mentions rumps', () => {
-  assert.strictEqual(
-    cli.menubarMessage(),
-    'The tokentelemetry menu bar is macOS-only.',
-  );
-  // Off-platform the handler prints exactly one line and exits non-zero.
-  for (const platform of ['linux', 'win32']) {
-    const { result, errLines } = captured(() => cli.cmdMenubar({}, platform));
-    assert.strictEqual(result, 1);
-    assert.strictEqual(errLines.length, 1);
-    assert.strictEqual(errLines[0], 'The tokentelemetry menu bar is macOS-only.');
-    assert.ok(!errLines[0].includes('rumps'));
-  }
+test('the menu bar is no longer macOS-only and never mentions rumps', () => {
+  // It runs the desktop app tray-only now, so it works wherever Electron gives
+  // us a tray. The previous handler rejected linux and win32 outright, because
+  // the panel was a rumps/PyObjC app and those are macOS-only.
+  const message = cli.menubarMessage();
+  assert.strictEqual(message, 'Starting the TokenTelemetry menu bar…');
+  assert.ok(!message.includes('macOS'), message);
+  assert.ok(!message.includes('rumps'), message);
 });
 
 test('desktop helpers resolve a local Electron runtime and preserve its data directory', () => {
@@ -141,28 +136,20 @@ test('status and stop handlers print one line and exit non-zero', () => {
   }
 });
 
-test('menubar argument and environment helpers are absolute and forward --data-dir', () => {
-  assert.deepStrictEqual(cli.menubarPythonArgs('/repo/backend'), [
-    path.join('/repo/backend', 'menubar', 'app.py'),
-  ]);
-  assert.deepStrictEqual(cli.menubarPythonArgs('/repo/backend', '/custom/data'), [
-    path.join('/repo/backend', 'menubar', 'app.py'),
-    '--data-dir',
-    '/custom/data',
-  ]);
-
-  const env = cli.menubarEnv(
-    '/custom/data',
-    '/repo/bin/cli.js',
-    '/usr/local/bin/node',
-    '/repo/backend',
-    { PYTHONPATH: '/existing' },
+test('menubar asks for a tray-only run and otherwise matches desktop', () => {
+  // TT_TRAY_ONLY is the entire difference between the two commands:
+  // desktop/main.cjs reads it and skips creating the dashboard window. Pinning
+  // that here keeps `menubar` from quietly drifting into a second launcher.
+  assert.deepStrictEqual(
+    cli.menubarEnv('/custom/data', { KEEP: 'yes' }),
+    { ...cli.desktopEnv('/custom/data', { KEEP: 'yes' }), TT_TRAY_ONLY: '1' },
   );
-  assert.strictEqual(env.TOKENTELEMETRY_DATA_DIR, '/custom/data');
-  assert.strictEqual(env.TOKENTELEMETRY_CLI, '/repo/bin/cli.js');
-  assert.strictEqual(env.TOKENTELEMETRY_NODE, '/usr/local/bin/node');
-  assert.ok(env.PYTHONPATH.split(path.delimiter).includes('/repo/backend'));
-  assert.ok(env.PYTHONPATH.split(path.delimiter).includes('/existing'));
+
+  // With no --data-dir the app uses its default location, so the variable has
+  // to be absent rather than present and undefined.
+  const plain = cli.menubarEnv(null, { KEEP: 'yes' });
+  assert.strictEqual(plain.TT_TRAY_ONLY, '1');
+  assert.ok(!('TOKENTELEMETRY_DATA_DIR' in plain));
 });
 
 test('main dispatches subcommands without bootstrapping or launching servers', async () => {

--- a/desktop/main.cjs
+++ b/desktop/main.cjs
@@ -70,6 +70,9 @@ const npm = isWindows ? "npm.cmd" : "npm";
 // macOS uses the bundle's .icns once packaged, and `app.dock.setIcon` so an
 // unpackaged dev run isn't the generic Electron logo.
 const appIcon = path.join(__dirname, "assets", "icon.png");
+// `tokentelemetry menubar` sets this: start the tray panel and nothing else.
+// `tokentelemetry desktop` leaves it unset and gets the dashboard window too.
+const trayOnly = process.env.TT_TRAY_ONLY === "1";
 let services;
 let mainWindow;
 let trayPanel;
@@ -82,9 +85,15 @@ function stopServices() {
   stopDesktopServices(services);
 }
 
-async function createWindow() {
+// The backend and frontend that both the panel and the dashboard read from.
+// Split out of createWindow() because `tokentelemetry menubar` needs the
+// services without a window: the tray panel loads /menubar from this origin.
+async function startServices() {
   services = await startDesktopServices({ spawn, python, npm, backendDir, frontendDir, env: process.env, dataDir: process.env.TOKENTELEMETRY_DATA_DIR });
   if (!await waitForHttp(services.url)) throw new Error("The local TokenTelemetry dashboard did not start in time.");
+}
+
+async function createWindow(routePath = "") {
   const window = new BrowserWindow({
     width: 1440, height: 920, minWidth: 960, minHeight: 640, show: false, title: "TokenTelemetry",
     // Keep the OS-native title bar (draggable everywhere, all content clickable
@@ -102,41 +111,72 @@ async function createWindow() {
     return { action: "deny" };
   });
   mainWindow = window;
-  await window.loadURL(services.url);
+  await window.loadURL(dashboardUrl(routePath));
+  return window;
 }
 
-// Surface the dashboard when the tray panel asks for it. The window is only
-// created once, so this re-shows the existing one rather than opening a second.
+function dashboardUrl(routePath = "") {
+  return `${services.url.replace(/\/$/, "")}${routePath}`;
+}
+
+// Surface the dashboard when the tray panel asks for it. Started tray-only
+// there is no window yet, so the first "Open dashboard" is what creates one.
+// Early-returning instead would leave the panel's own button doing nothing.
 function showDashboard(routePath) {
-  if (!mainWindow || mainWindow.isDestroyed()) return;
-  const target = `${services.url.replace(/\/$/, "")}${routePath}`;
-  void mainWindow.loadURL(target);
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    void createWindow(routePath).catch((error) => {
+      console.warn("TokenTelemetry: could not open the dashboard —", error instanceof Error ? error.message : error);
+    });
+    return;
+  }
+  void mainWindow.loadURL(dashboardUrl(routePath));
   if (mainWindow.isMinimized()) mainWindow.restore();
   mainWindow.show();
   mainWindow.focus();
 }
 
+function startTray() {
+  trayPanel = createTrayPanel({
+    electron,
+    assetsDir: path.join(__dirname, "assets"),
+    baseUrl: services.url,
+    preloadPath: path.join(__dirname, "preload.cjs"),
+    onOpenDashboard: showDashboard,
+    platform: process.platform,
+  });
+}
+
 app.whenReady().then(() => {
   buildApplicationMenu();
   // macOS dock icon for an unpackaged (dev) run; packaged apps get the .icns.
-  if (isMac && app.dock && fs.existsSync(appIcon)) {
+  // Tray-only hides the dock entirely, so the icon is only worth setting when
+  // a dashboard window is part of this run.
+  if (isMac && app.dock && !trayOnly && fs.existsSync(appIcon)) {
     app.dock.setIcon(appIcon);
   }
-  return createWindow().then(() => {
+  return startServices().then(() => {
+    if (!trayOnly) return createWindow();
+    // `tokentelemetry menubar`: the panel is the whole app. Hiding the dock is
+    // what makes it a menu bar accessory rather than a windowless app sitting
+    // in the switcher with nothing to switch to.
+    if (isMac && app.dock) app.dock.hide();
+    return undefined;
+  }).then(() => {
     // Best-effort: a tray is a convenience, and a desktop environment without
     // a working tray (some Linux sessions) must not stop the app from running.
     try {
-      trayPanel = createTrayPanel({
-        electron,
-        assetsDir: path.join(__dirname, "assets"),
-        baseUrl: services.url,
-        preloadPath: path.join(__dirname, "preload.cjs"),
-        onOpenDashboard: showDashboard,
-        platform: process.platform,
-      });
+      startTray();
     } catch (error) {
       console.warn("TokenTelemetry: tray unavailable —", error instanceof Error ? error.message : error);
+      // Tray-only has no window to fall back on, so a failed tray would leave
+      // the app running with no way to reach or quit it. Show the dashboard
+      // instead of exiting: the services are already up and the data is there.
+      if (trayOnly) {
+        if (isMac && app.dock) app.dock.show();
+        return createWindow();
+      }
     }
+    return undefined;
   });
 }).catch(async (error) => {
   stopServices();

--- a/website/content/docs/reference/cli.mdx
+++ b/website/content/docs/reference/cli.mdx
@@ -20,12 +20,12 @@ The first argument is a command only when it matches a known verb; anything else
 | Command | Description |
 | --- | --- |
 | `dashboard` | Start the dashboard. The default when no command is given. |
-| `menubar` | Start the menu bar app. macOS only. |
+| `menubar` | Start the menu bar / system tray panel. |
 | `desktop` | Launch the [desktop app](/docs/features/desktop). |
 | `status` | Dashboard status. Not implemented yet. |
 | `stop` | Stop the dashboard. Not implemented yet. |
 
-> **`menubar` off macOS:** prints `The tokentelemetry menu bar is macOS-only.` and exits non-zero. It never surfaces an `ImportError` about `rumps`.
+> **`menubar` vs `desktop`:** both start the same app. `menubar` runs it tray-only, so you get the panel with no dashboard window and, on macOS, no dock icon. Its "Open dashboard" item creates the window on first use. `desktop` opens the window up front and adds the tray alongside it.
 
 ## CLI flags
 


### PR DESCRIPTION
The redesigned panel shipped in #326, but only `tokentelemetry desktop` could reach it. `menubar` still launched `backend/menubar/app.py`, so the command people actually run for a menu bar kept rendering the older drawn-card panel, and still refused to run anywhere but macOS.

It now starts the desktop app tray-only: the same Electron process as `desktop`, minus the dashboard window.

## What changed

**One panel instead of two.** `menubar` and `desktop` are now the same app in two modes, selected by `TT_TRAY_ONLY`. The panel is the app's own `/menubar` page, so it renders `PlanLimitsList` exactly as the dashboard sidebar does and the two cannot drift. #326 left both implementations in place and called retiring the Python one the obvious follow-up; this does the wiring half of that.

**It works off macOS.** The old handler rejected `linux` and `win32` outright, because rumps and its PyObjC dependencies are macOS-only. The tray runs wherever the desktop app does, and `popoverBounds` already opens the panel upward for the bottom-edge trays Windows and most Linux panels use.

**The dock is hidden on macOS.** That is what makes it a menu bar accessory rather than a windowless app sitting in the switcher with nothing to switch to.

## Worth a reviewer's attention

Two things only became reachable once a window stopped being guaranteed:

- **`showDashboard()` early-returned when no window existed**, which is precisely the tray-only state, so the panel's own "Open dashboard" button would have done nothing at all. It now creates the window on first use.
- **A failed tray was best-effort** because a window was always there to fall back on. Tray-only has no window, so the same failure would leave the app running with no way to reach it and no way to quit it. It now falls back to opening the dashboard, un-hiding the dock on the way, rather than leaving a headless process behind.

`createWindow()` did two jobs, starting the services and building the window. Tray-only needs the first without the second, so they are split into `startServices()` and `createWindow(routePath)`.

`bin/cli.js` drops `menubarPythonArgs`, the old `menubarEnv` and `ensureMenubarRumps`, which existed only to launch the Python app. **`backend/menubar/` stays on disk** and is untouched; deleting it is a separate decision, not one to make inside this change.

## Verification

Run, not just reasoned about:

- `tokentelemetry menubar` starts Electron detached with its backend child, and the app appears in neither the dock nor the switcher (checked through System Events, not by eye).
- A direct tray-only run logs `GET /menubar 200` followed by live `GET /quotas 200`, on dynamically chosen ports so it does not collide with a dashboard already on 8000.
- 33 JS tests pass across `bin/cli.test.js`, `desktop/runtime.test.cjs` and `desktop/tray.test.cjs`.

Two tests were rewritten rather than deleted. The macOS-only one now asserts the message names neither macOS nor rumps; the env one pins `TT_TRAY_ONLY` as the *only* difference between `menubar` and `desktop`, so the two cannot quietly become separate launchers again.

`desktop/main.cjs` itself has no unit coverage here: it imports `electron` at module scope, so it is exercised by running it rather than by a test. The parts that could be extracted as pure functions (`popoverBounds`, `desktopSpawnCommand`) already were, in #326.

## Note on scope

This does not package the app, so an unpackaged run still shows "Electron" as the macOS app-menu title. That is the same known packaging gap #326 recorded, unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
