### PR TITLE
Fix CORS allowlist for default ports

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -188,7 +188,7 @@ def _cors_origin_regex() -> str:
         h = h.strip()
         if h:
             hosts.append(re.escape(h))
-    return r"^https?://(" + "|".join(hosts) + r"):\d+$"
+    return r"^https?://(" + "|".join(hosts) + r")(?::\d+)?$"
 
 # --- Remote-access auth gate -------------------------------------------------
 # When TT_AUTH_TOKEN is set (bin/cli.js sets it automatically for a non-loopback


### PR DESCRIPTION
Allow explicitly permitted origins when browsers omit the default HTTP or HTTPS port.