### PR TITLE
fix(paths): strip VS Code leading slash from Windows paths in canonical_project

### DIFF
--- a/backend/test_project_paths.py
+++ b/backend/test_project_paths.py
@@ -128,6 +128,25 @@ def test_canonical_project_leaves_posix_backslashes_alone():
     assert canonical_project("/data/weird\\name") == "/data/weird\\name"
 
 
+def test_canonical_project_strips_vscode_leading_slash():
+    # VS Code on Windows stores file:///c%3A/Users/dev/proj, which unquotes
+    # to /c:/Users/dev/proj. The leading slash and lowercase drive letter must
+    # be normalised to match what Claude Code / Codex emit (C:/Users/dev/proj).
+    f = canonical_project
+    assert f("/c:/Users/dev/proj") == "C:/Users/dev/proj"
+    assert f("/C:/Users/dev/proj") == "C:/Users/dev/proj"   # upcase idempotent
+    assert f("/c:/Users/dev/proj/") == "C:/Users/dev/proj"  # trailing sep stripped
+
+
+def test_canonical_project_preserves_drive_root():
+    # "C:" (no trailing slash) means "current dir on drive C" on Windows —
+    # that is not the same as the drive root "C:/". Stripping the slash corrupts.
+    f = canonical_project
+    assert f("C:/") == "C:/"
+    assert f("c:/") == "c:/"   # POSIX-cased passthrough (not a VS Code path)
+    assert f("C:") == "C:"     # bare drive specifier must not gain a slash
+
+
 def test_canonical_project_passes_sentinels_through():
     f = canonical_project
     assert f("unknown") == "unknown"

--- a/backend/tt_paths.py
+++ b/backend/tt_paths.py
@@ -31,6 +31,8 @@ DEFAULT_DIRNAME = ".tokentelemetry"
 
 # Windows-shaped path prefixes: a drive letter (`C:`) or a UNC root (`\\`).
 _WIN_PATH_RE = re.compile(r"^(?:[A-Za-z]:|\\\\)")
+# VS Code on Windows stores file URIs as /c:/... after unquoting.
+_VSCODE_WIN_PATH_RE = re.compile(r"^/([A-Za-z]):/")
 
 
 def canonical_project(path: str | None) -> str | None:
@@ -43,17 +45,35 @@ def canonical_project(path: str | None) -> str | None:
     slashes; every path loses trailing separators. A backslash inside a POSIX
     path is a legal filename character there, so it is never rewritten.
 
-    Not folded on purpose: letter case (``C:\\Repo`` vs ``c:/repo`` stay
-    distinct — folding would merge different directories on case-sensitive
-    filesystems). Non-path values ("unknown", agent sentinels, ``None``,
-    ``""``) pass through unchanged.
+    Exception: VS Code on Windows emits ``file:///c%3A/...`` which
+    URL-decodes to ``/c:/...``; the leading slash is stripped and the drive
+    letter is uppercased to match what other agents emit (``C:/...``).
+    That single normalisation intentionally changes case for that prefix.
+
+    Not folded on purpose: letter case elsewhere (``C:\\Repo`` vs ``c:/repo``
+    stay distinct — folding would merge different directories on
+    case-sensitive filesystems). Non-path values ("unknown", agent sentinels,
+    ``None``, ``""``) pass through unchanged.
     """
     if not isinstance(path, str) or not path:
         return path
+    # VS Code on Windows produces file:///c%3A/... which unquotes to /c:/...
+    # Strip the spurious leading slash and upcase the drive letter so it
+    # matches what Claude Code and other agents emit (C:/...).
+    m = _VSCODE_WIN_PATH_RE.match(path)
+    if m:
+        path = m.group(1).upper() + ":/" + path[len(m.group(0)):]
     if _WIN_PATH_RE.match(path):
         path = path.replace("\\", "/")
+    had_trailing_slash = path.endswith("/") or path.endswith("\\")
     trimmed = path.rstrip("/")
     # A lone "/" or "//" must not collapse to "".
+    # "C:/" (drive root) must stay "C:/" — "C:" means "current dir on
+    # drive C" in Windows, which is semantically different. Only restore
+    # the slash when the input actually had one (i.e. this was a root path,
+    # not a bare drive specifier).
+    if re.match(r"^[A-Za-z]:$", trimmed) and had_trailing_slash:
+        return trimmed + "/"
     return trimmed if trimmed else path
 
 


### PR DESCRIPTION
Closes #293.

## Root cause

VS Code on Windows stores workspace folder URIs as `file:///c%3A/Users/dev/proj`. After `unquote(folder_url.replace("file://", ""))` this becomes `/c:/Users/dev/proj` — a leading slash before a lowercase drive letter.

`canonical_project`'s Windows-path regex (`^(?:[A-Za-z]:|\\\\)`) requires the drive letter at position 0, so the leading slash caused the path to fall through unmodified. That made it a different project identity from `C:/Users/dev/proj` (the form Claude Code, Codex, and others produce), splitting one real folder into two cards.

## Fix — `backend/tt_paths.py`

**New pre-processing step:** detect `/[A-Za-z]:/` at the start of the path, strip the leading slash, and upcase the drive letter so the result matches the canonical `C:/...` form other agents emit. Only the drive letter is upcased — the rest of the path is left as-is to preserve the existing invariant against merging case-distinct directories on case-sensitive filesystems.

**Drive-root fix:** `canonical_project("C:/")` returned `"C:"` because `rstrip("/")` stripped the trailing slash. `"C:"` means "current directory on drive C" on Windows — not the drive root — so it's a corruption. A guard after `rstrip` re-adds the slash when the result is a bare drive letter.

## Tests added — `backend/test_project_paths.py`

`test_canonical_project_strips_vscode_leading_slash` — verifies `/c:/...`, `/C:/...`, and trailing-slash variants all normalise to `C:/...`.

`test_canonical_project_preserves_drive_root` — verifies `C:/` is not stripped to `C:`.

All existing `canonical_project` tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)