### PR TITLE
fix(sessions): sort project-scoped config first and label the colour coding

### DIFF
--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -2025,7 +2025,7 @@ function ContextRow({ k, v, mono = true }: { k: string; v?: TraceValue; mono?: b
 // Project-scoped entries live in the repo's own .claude/ (or equivalent) and are
 // the ones a reader is usually looking for, so they sort above the user-scoped
 // ones inherited from ~/. Ties break alphabetically.
-const byScopeThenName = (a: any, b: any) =>
+const byScopeThenName = (a: TraceValue, b: TraceValue) =>
   (a?.scope === "project" ? 0 : 1) - (b?.scope === "project" ? 0 : 1) ||
   String(a?.name ?? "").localeCompare(String(b?.name ?? ""));
 
@@ -2122,13 +2122,13 @@ function ContextPanel({ ctx }: { ctx: TraceValue }) {
               </summary>
               <ScopeLegend tone="cyan" />
               <div className="mt-2 flex flex-wrap gap-1.5">
-                {[...(ctx.projectConfig.skills ?? [])].sort(byScopeThenName).map((s: any, i: number) => (
+                {[...(ctx.projectConfig.skills ?? [])].sort(byScopeThenName).map((s: TraceValue) => (
                   <span
-                    key={i}
-                    title={`${s.scope} · ${s.agent}${s.description ? "\n" + s.description : ""}`}
-                    className={`text-[10px] font-mono px-2 py-0.5 rounded border ${s.scope === "project" ? "bg-cyan-500/10 text-[var(--tt-cyan-fg)] border-cyan-500/20" : "tt-tint-2 text-[var(--tt-fg-muted)] border-[var(--tt-border-strong)]"}`}
+                    key={`${s?.scope}-${s?.agent}-${s?.name}`}
+                    title={`${s?.scope} · ${s?.agent}${s?.description ? "\n" + s?.description : ""}`}
+                    className={`text-[10px] font-mono px-2 py-0.5 rounded border ${s?.scope === "project" ? "bg-cyan-500/10 text-[var(--tt-cyan-fg)] border-cyan-500/20" : "tt-tint-2 text-[var(--tt-fg-muted)] border-[var(--tt-border-strong)]"}`}
                   >
-                    {s.name}
+                    {s?.name}
                   </span>
                 ))}
               </div>
@@ -2141,10 +2141,10 @@ function ContextPanel({ ctx }: { ctx: TraceValue }) {
               </summary>
               <ScopeLegend tone="blue" />
               <div className="mt-2 space-y-1">
-                {[...(ctx.projectConfig.mcps ?? [])].sort(byScopeThenName).map((m: any, i: number) => (
-                  <div key={i} className="flex items-center justify-between gap-2 text-[10px] font-mono bg-[var(--tt-panel)]/70 border border-[var(--tt-border)] rounded px-2 py-1">
-                    <span className="text-[var(--tt-fg)] truncate" title={m.command || m.url || ""}>{m.name}</span>
-                    <span className={`px-1.5 py-0.5 rounded text-[8px] font-black uppercase ${m.scope === "project" ? "bg-blue-500/10 text-[var(--tt-brand)] border border-blue-500/20" : "tt-tint-2 text-[var(--tt-fg-muted)] border border-[var(--tt-border-strong)]"}`}>{m.agent}</span>
+                {[...(ctx.projectConfig.mcps ?? [])].sort(byScopeThenName).map((m: TraceValue) => (
+                  <div key={`${m?.scope}-${m?.agent}-${m?.name}`} className="flex items-center justify-between gap-2 text-[10px] font-mono bg-[var(--tt-panel)]/70 border border-[var(--tt-border)] rounded px-2 py-1">
+                    <span className="text-[var(--tt-fg)] truncate" title={m?.command || m?.url || ""}>{m?.name}</span>
+                    <span className={`px-1.5 py-0.5 rounded text-[8px] font-black uppercase ${m?.scope === "project" ? "bg-blue-500/10 text-[var(--tt-brand)] border border-blue-500/20" : "tt-tint-2 text-[var(--tt-fg-muted)] border border-[var(--tt-border-strong)]"}`}>{m?.agent}</span>
                   </div>
                 ))}
               </div>

--- a/frontend/src/app/sessions/[id]/page.tsx
+++ b/frontend/src/app/sessions/[id]/page.tsx
@@ -2022,6 +2022,29 @@ function ContextRow({ k, v, mono = true }: { k: string; v?: TraceValue; mono?: b
   );
 }
 
+// Project-scoped entries live in the repo's own .claude/ (or equivalent) and are
+// the ones a reader is usually looking for, so they sort above the user-scoped
+// ones inherited from ~/. Ties break alphabetically.
+const byScopeThenName = (a: any, b: any) =>
+  (a?.scope === "project" ? 0 : 1) - (b?.scope === "project" ? 0 : 1) ||
+  String(a?.name ?? "").localeCompare(String(b?.name ?? ""));
+
+// Skills tint project scope cyan, MCP badges tint it blue. The swatch has to
+// match whichever section it sits under or the legend lies about the colour.
+function ScopeLegend({ tone }: { tone: "cyan" | "blue" }) {
+  const project = tone === "cyan" ? "bg-cyan-500/10 border-cyan-500/20" : "bg-blue-500/10 border-blue-500/20";
+  return (
+    <div className="flex items-center gap-3 mt-1.5 text-[9px] font-mono text-[var(--tt-fg-faint)]">
+      <span className="flex items-center gap-1">
+        <span className={`inline-block w-2 h-2 rounded-sm border ${project}`} /> project
+      </span>
+      <span className="flex items-center gap-1">
+        <span className="inline-block w-2 h-2 rounded-sm border tt-tint-2 border-[var(--tt-border-strong)]" /> user
+      </span>
+    </div>
+  );
+}
+
 function DetailRow({ k, v, accent }: { k: string; v: React.ReactNode; accent?: string }) {
   return (
     <div className="flex justify-between gap-3">
@@ -2097,8 +2120,9 @@ function ContextPanel({ ctx }: { ctx: TraceValue }) {
               <summary className="text-[9px] font-semibold uppercase tracking-[0.16em] text-[var(--tt-fg-dim)] cursor-pointer hover:text-[var(--tt-fg)]">
                 Skills ({ctx.projectConfig.counts.skills}) ▸
               </summary>
+              <ScopeLegend tone="cyan" />
               <div className="mt-2 flex flex-wrap gap-1.5">
-                {ctx.projectConfig.skills.map((s: TraceValue, i: number) => (
+                {[...(ctx.projectConfig.skills ?? [])].sort(byScopeThenName).map((s: any, i: number) => (
                   <span
                     key={i}
                     title={`${s.scope} · ${s.agent}${s.description ? "\n" + s.description : ""}`}
@@ -2115,8 +2139,9 @@ function ContextPanel({ ctx }: { ctx: TraceValue }) {
               <summary className="text-[9px] font-semibold uppercase tracking-[0.16em] text-[var(--tt-fg-dim)] cursor-pointer hover:text-[var(--tt-fg)]">
                 MCP Servers ({ctx.projectConfig.counts.mcps}) ▸
               </summary>
+              <ScopeLegend tone="blue" />
               <div className="mt-2 space-y-1">
-                {ctx.projectConfig.mcps.map((m: TraceValue, i: number) => (
+                {[...(ctx.projectConfig.mcps ?? [])].sort(byScopeThenName).map((m: any, i: number) => (
                   <div key={i} className="flex items-center justify-between gap-2 text-[10px] font-mono bg-[var(--tt-panel)]/70 border border-[var(--tt-border)] rounded px-2 py-1">
                     <span className="text-[var(--tt-fg)] truncate" title={m.command || m.url || ""}>{m.name}</span>
                     <span className={`px-1.5 py-0.5 rounded text-[8px] font-black uppercase ${m.scope === "project" ? "bg-blue-500/10 text-[var(--tt-brand)] border border-blue-500/20" : "tt-tint-2 text-[var(--tt-fg-muted)] border border-[var(--tt-border-strong)]"}`}>{m.agent}</span>


### PR DESCRIPTION
Rebase of #235 onto current `main`.

## What

The trace sidebar's **Project Configuration** panel tinted project-scoped skills cyan and project-scoped MCP servers blue, but nothing on screen said what the tint meant. This PR:

- Adds a `ScopeLegend` component (two swatches: project / user) that appears beneath each collapsible section heading
- Sorts project-scoped entries to the top within each section via `byScopeThenName`
- Uses optional-chaining on `skills ?? []` / `mcps ?? []` for safety

## Conflict resolution

Rebased onto `main`; the one conflicting file (`sessions/[id]/page.tsx`) had accumulated a copiedId/copy-button block and `DetailRow`/`ContextRow` helpers since #235 was opened. Resolution kept HEAD's newer `ContextPanel` internals and grafted the PR's sort comparator, `ScopeLegend`, and `.sort()` call on top. TypeScript passes with zero errors.

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)