### PR TITLE
feat: endpoint presets for OpenAI-compatible summarizer (MiniMax, llama.cpp)

### DIFF
--- a/UPDATE.json
+++ b/UPDATE.json
@@ -257,7 +257,7 @@
         {
           "title": "Agent brands are easier to scan",
           "description": "Connected agents, settings, project badges, trace headers, and the website now use each agent's own mark and color so mixed-agent work is easier to recognize at a glance.",
-          "href": "/"
+          "href": "/settings"
         }
       ]
     },

--- a/UPDATE.json
+++ b/UPDATE.json
@@ -257,7 +257,7 @@
         {
           "title": "Agent brands are easier to scan",
           "description": "Connected agents, settings, project badges, trace headers, and the website now use each agent's own mark and color so mixed-agent work is easier to recognize at a glance.",
-          "href": "/settings"
+          "href": "/"
         }
       ]
     },
@@ -300,6 +300,17 @@
           "title": "Tool reliability",
           "description": "Tool failures were already parsed out of the Hermes log and then discarded. The Hermes page now shows which tools are used most and which fail most, counting only tools with at least three calls so a single failed call does not read as a 100% failure rate.",
           "href": "/hermes"
+        }
+      ]
+    },
+    {
+      "tag": "2026-08-01",
+      "title": "One-click endpoints for hosted summarizers",
+      "highlights": [
+        {
+          "title": "Endpoint presets in the OpenAI-compatible backend",
+          "description": "The summarizer's OpenAI-compatible backend now has preset buttons that fill in the endpoint and a starting model for you. MiniMax (global and China) and a local llama.cpp server are there; paste your API key and hit Test connection. Hosted providers that speak the OpenAI API work through this backend, so there's no separate setup per vendor.",
+          "href": "/settings"
         }
       ]
     },

--- a/frontend/src/components/summarizer/BackendPicker.tsx
+++ b/frontend/src/components/summarizer/BackendPicker.tsx
@@ -304,6 +304,7 @@ function OpenAICompatForm({ model, onModelChange, config, onChange }: OpenAIComp
               <button
                 key={p.label}
                 type="button"
+                disabled={testing}
                 onClick={() => {
                   onChange?.({ ...config, endpoint: p.endpoint });
                   // Always reassign the model, including clearing it: a preset
@@ -311,9 +312,13 @@ function OpenAICompatForm({ model, onModelChange, config, onChange }: OpenAIComp
                   // Studio serves whatever is loaded). Leaving a stale hosted
                   // model id pointed at localhost is worse than an empty field.
                   onModelChange?.(p.model);
+                  // Clear any prior test result — it belongs to the previous
+                  // endpoint and would mislead the user into thinking this
+                  // preset has already been tested.
+                  setResult(null);
                 }}
                 className={cn(
-                  "h-6 px-2 rounded border text-[10.5px] font-medium transition-colors",
+                  "h-6 px-2 rounded border text-[10.5px] font-medium transition-colors disabled:opacity-50",
                   config.endpoint === p.endpoint
                     ? "border-[var(--tt-border-focus)] text-[var(--tt-fg)]"
                     : "border-[var(--tt-border-strong)] text-[var(--tt-fg-dim)] hover:text-[var(--tt-fg)]",

--- a/frontend/src/components/summarizer/BackendPicker.tsx
+++ b/frontend/src/components/summarizer/BackendPicker.tsx
@@ -306,7 +306,11 @@ function OpenAICompatForm({ model, onModelChange, config, onChange }: OpenAIComp
                 type="button"
                 onClick={() => {
                   onChange?.({ ...config, endpoint: p.endpoint });
-                  if (p.model) onModelChange?.(p.model);
+                  // Always reassign the model, including clearing it: a preset
+                  // with no model id means "the server picks" (llama.cpp / LM
+                  // Studio serve whatever is loaded). Leaving a stale hosted
+                  // model id pointed at localhost is worse than an empty field.
+                  onModelChange?.(p.model || null);
                 }}
                 className={cn(
                   "h-6 px-2 rounded border text-[10.5px] font-medium transition-colors",

--- a/frontend/src/components/summarizer/BackendPicker.tsx
+++ b/frontend/src/components/summarizer/BackendPicker.tsx
@@ -7,7 +7,7 @@ import { AgentLogo } from "@/components/icons/AgentLogo";
 import { cn } from "@/lib/cn";
 import {
   listCodexModels, listOllamaModels, testOpenAICompat,
-  DEFAULT_OPENAI_COMPAT,
+  DEFAULT_OPENAI_COMPAT, ENDPOINT_PRESETS,
   type CodexModel, type OllamaModel, type SummarizerBackend,
   type OpenAICompatConfig,
 } from "@/lib/summarizer";
@@ -297,7 +297,29 @@ function OpenAICompatForm({ model, onModelChange, config, onChange }: OpenAIComp
   return (
     <div className="mt-2 ml-11 mr-1 space-y-3">
       <div>
-        <label className={LABEL_CLS}>Endpoint</label>
+        <div className="flex items-baseline justify-between gap-2 mb-1.5">
+          <label className={cn(LABEL_CLS, "mb-0")}>Endpoint</label>
+          <div className="flex items-center gap-1.5">
+            {ENDPOINT_PRESETS.map((p) => (
+              <button
+                key={p.label}
+                type="button"
+                onClick={() => {
+                  onChange?.({ ...config, endpoint: p.endpoint });
+                  if (p.model) onModelChange?.(p.model);
+                }}
+                className={cn(
+                  "h-6 px-2 rounded border text-[10.5px] font-medium transition-colors",
+                  config.endpoint === p.endpoint
+                    ? "border-[var(--tt-border-focus)] text-[var(--tt-fg)]"
+                    : "border-[var(--tt-border-strong)] text-[var(--tt-fg-dim)] hover:text-[var(--tt-fg)]",
+                )}
+              >
+                {p.label}
+              </button>
+            ))}
+          </div>
+        </div>
         <input
           type="text"
           spellCheck={false}
@@ -307,8 +329,8 @@ function OpenAICompatForm({ model, onModelChange, config, onChange }: OpenAIComp
           className={FIELD_CLS}
         />
         <p className="text-[10.5px] text-[var(--tt-fg-dim)] mt-1.5">
-          Base URL of any OpenAI-compatible server (llama.cpp, vLLM, LM Studio, LocalAI…).
-          We POST to <code className="font-mono">/chat/completions</code> under it.
+          Base URL of any OpenAI-compatible server (llama.cpp, vLLM, LM Studio, LocalAI…)
+          or hosted gateway. We POST to <code className="font-mono">/chat/completions</code> under it.
         </p>
       </div>
 

--- a/frontend/src/components/summarizer/BackendPicker.tsx
+++ b/frontend/src/components/summarizer/BackendPicker.tsx
@@ -308,9 +308,9 @@ function OpenAICompatForm({ model, onModelChange, config, onChange }: OpenAIComp
                   onChange?.({ ...config, endpoint: p.endpoint });
                   // Always reassign the model, including clearing it: a preset
                   // with no model id means "the server picks" (llama.cpp / LM
-                  // Studio serve whatever is loaded). Leaving a stale hosted
+                  // Studio serves whatever is loaded). Leaving a stale hosted
                   // model id pointed at localhost is worse than an empty field.
-                  onModelChange?.(p.model || null);
+                  onModelChange?.(p.model);
                 }}
                 className={cn(
                   "h-6 px-2 rounded border text-[10.5px] font-medium transition-colors",

--- a/frontend/src/lib/summarizer.ts
+++ b/frontend/src/lib/summarizer.ts
@@ -40,6 +40,23 @@ export const DEFAULT_OPENAI_COMPAT: OpenAICompatConfig = {
   enable_thinking: false,
 };
 
+/**
+ * One-click prefill for a hosted OpenAI-compatible gateway. Only the endpoint
+ * and a starting model id — the key, sampling knobs and everything else stay
+ * the user's to fill in. Adding a provider is one entry here, not a new adapter.
+ */
+export interface EndpointPreset {
+  label: string;
+  endpoint: string;
+  model: string;
+}
+
+export const ENDPOINT_PRESETS: EndpointPreset[] = [
+  { label: "MiniMax", endpoint: "https://api.minimax.io/v1", model: "MiniMax-M3" },
+  { label: "MiniMax (China)", endpoint: "https://api.minimaxi.com/v1", model: "MiniMax-M3" },
+  { label: "Local (llama.cpp)", endpoint: "http://localhost:8080/v1", model: "" },
+];
+
 export interface SummarizerConfig {
   enabled: boolean;
   backend: string | null;

--- a/frontend/src/lib/summarizer.ts
+++ b/frontend/src/lib/summarizer.ts
@@ -48,13 +48,13 @@ export const DEFAULT_OPENAI_COMPAT: OpenAICompatConfig = {
 export interface EndpointPreset {
   label: string;
   endpoint: string;
-  model: string;
+  model: string | null;
 }
 
 export const ENDPOINT_PRESETS: EndpointPreset[] = [
   { label: "MiniMax", endpoint: "https://api.minimax.io/v1", model: "MiniMax-M3" },
   { label: "MiniMax (China)", endpoint: "https://api.minimaxi.com/v1", model: "MiniMax-M3" },
-  { label: "Local (llama.cpp)", endpoint: "http://localhost:8080/v1", model: "" },
+  { label: "Local (llama.cpp)", endpoint: "http://localhost:8080/v1", model: null },
 ];
 
 export interface SummarizerConfig {


### PR DESCRIPTION
Rebase of #218 onto current \`main\`.

The original PR added MiniMax as a standalone provider, then reverted that, then added endpoint presets to the existing OpenAI-compatible backend (commits 3+4). This rebase takes only the net useful change (endpoint presets) and skips the add/revert pair.

## What

- The OpenAI-compatible summarizer backend now shows preset buttons that fill in the endpoint URL and a starting model name for you
- Presets: MiniMax global, MiniMax China, and local llama.cpp
- Model field is cleared when switching to a preset that has none, keeping the dirty-check honest
- Hosted providers that speak the OpenAI API work through this backend with no extra setup per vendor

## Conflict resolution

One conflict in \`UPDATE.json\`: HEAD had newer release entries; the PR's "2026-08-01" entry was inserted in chronological order (after 2026-08-02, before 2026-07-30). \`BackendPicker.tsx\` and \`settings/page.tsx\` auto-merged; \`tsc --noEmit\` passes with zero errors.

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)