### PR TITLE
refactor(cors): split the origin allowlist into loopback and remote halves

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -188,7 +188,7 @@ def _cors_origin_regex() -> str:
         h = h.strip()
         if h:
             hosts.append(re.escape(h))
-    return r"^https?://(" + "|".join(hosts) + r"):\d+$"
+    return r"^https?://(" + "|".join(hosts) + r")(?::\d+)?$"
 
 # --- Remote-access auth gate -------------------------------------------------
 # When TT_AUTH_TOKEN is set (bin/cli.js sets it automatically for a non-loopback

--- a/backend/main.py
+++ b/backend/main.py
@@ -177,18 +177,87 @@ app = FastAPI(title="TokenTelemetry API")
 
 # Enable CORS for the Next.js frontend.
 #
-# We use a regex over an explicit allowlist so the frontend can pick any local
-# port (the user can pass --port to start.sh / bin/cli.js). Loopback is always
-# allowed; additional hosts (IPs / hostnames) can be opted in for remote access
-# via the TT_ALLOWED_ORIGINS env var (comma-separated) — bin/cli.js wires it up
-# from --allowed-origins. Default behavior is unchanged: loopback-only.
-def _cors_origin_regex() -> str:
-    hosts = ["localhost", r"127\.0\.0\.1"]
-    for h in os.environ.get("TT_ALLOWED_ORIGINS", "").split(","):
-        h = h.strip()
+# The allowlist answers two different questions, so it is built from two
+# patterns rather than one:
+#
+#   1. Loopback, which is always allowed on any port. The user can move the
+#      frontend with --port, so the port genuinely varies and a pattern is the
+#      right tool for it.
+#   2. The hosts opted in via TT_ALLOWED_ORIGINS (comma-separated; bin/cli.js
+#      wires it up from --allowed-origins) for remote / tailnet access. This
+#      half is empty by default, so default behavior stays loopback-only.
+#
+# Keeping them apart means each half has one rule you can state in a sentence,
+# and the remote half can be absent entirely instead of being spliced into a
+# pattern that always has loopback in it.
+#
+# In every case the port is OPTIONAL. Browsers omit it from Origin when it is
+# the scheme default, so a deployment behind a proxy on :443 sends
+# "https://box.tailnet.ts.net" with no port at all; requiring ":<digits>" made
+# that origin impossible to allow, with no configuration workaround.
+
+# Loopback hosts, as they appear in an Origin header. ::1 is included so this
+# agrees with _is_loopback() below, which the auth gate uses; the two
+# disagreeing about what "loopback" means is a bug waiting to happen.
+_LOOPBACK_ORIGIN_HOSTS = ["localhost", r"127\.0\.0\.1", r"\[::1\]"]
+
+
+def _origin_host(raw: str) -> str:
+    """Normalise one TT_ALLOWED_ORIGINS entry down to a bare hostname.
+
+    The documented value is a hostname, because bin/cli.js also feeds this list
+    to Next's allowedDevOrigins and uses the first entry to build the connect /
+    QR URL. Writing a full origin ("https://box.ts.net/") is the natural
+    mistake though, and previously it was escaped verbatim into the pattern and
+    silently matched nothing. Accept both spellings and reduce them to the same
+    host. An explicit port is dropped: a listed host is allowed on any port,
+    which is the behaviour this list has always had.
+    """
+    h = raw.strip().lower()
+    if not h:
+        return ""
+    if "://" in h:
+        h = h.split("://", 1)[1]
+    h = h.split("/", 1)[0].split("?", 1)[0].split("#", 1)[0]
+    if h.startswith("["):  # bracketed IPv6 literal, e.g. [::1]:3000
+        end = h.find("]")
+        return h[: end + 1] if end != -1 else h
+    return h.split(":", 1)[0]
+
+
+def _loopback_origin_regex() -> str:
+    """Loopback on any port. Always active, never configurable."""
+    return r"^https?://(?:" + "|".join(_LOOPBACK_ORIGIN_HOSTS) + r")(?::\d+)?$"
+
+
+def _remote_origin_regex() -> Optional[str]:
+    """The TT_ALLOWED_ORIGINS hosts on any port, or None when none are set.
+
+    Entries are re.escape()d, so a dot in a hostname stays a literal dot rather
+    than becoming "any character". Without that, allowing "box.ts.net" would
+    also allow an attacker-registered "boxXtsYnet".
+    """
+    hosts = []
+    for raw in os.environ.get("TT_ALLOWED_ORIGINS", "").split(","):
+        h = _origin_host(raw)
         if h:
             hosts.append(re.escape(h))
-    return r"^https?://(" + "|".join(hosts) + r")(?::\d+)?$"
+    if not hosts:
+        return None
+    return r"^https?://(?:" + "|".join(hosts) + r")(?::\d+)?$"
+
+
+def _cors_origin_regex() -> str:
+    """The two halves joined for Starlette, which takes a single pattern.
+
+    Both halves are individually anchored, so top-level alternation between
+    them is still an exact-origin test under fullmatch().
+    """
+    parts = [_loopback_origin_regex()]
+    remote = _remote_origin_regex()
+    if remote:
+        parts.append(remote)
+    return "|".join(parts)
 
 # --- Remote-access auth gate -------------------------------------------------
 # When TT_AUTH_TOKEN is set (bin/cli.js sets it automatically for a non-loopback

--- a/backend/test_cors_origins.py
+++ b/backend/test_cors_origins.py
@@ -1,0 +1,144 @@
+"""Tests for the CORS allowlist pattern.
+
+The allowlist is built from two halves (see main._cors_origin_regex): loopback,
+always on and on any port, and the hosts opted in via TT_ALLOWED_ORIGINS for
+remote / tailnet access. Both halves accept an origin with no port, because
+browsers omit the port from Origin when it is the scheme default. A deployment
+behind a proxy on :443 therefore sends "https://box.ts.net" with no port at
+all, and there is no configuration a user can write to work around a pattern
+that demands one.
+
+Starlette's CORSMiddleware tests the origin with .fullmatch(), so that is what
+these tests use.
+
+Run: pytest backend/test_cors_origins.py -q
+"""
+import os
+import re
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+import main  # noqa: E402
+
+
+def allowed(origin: str, monkeypatch, env: str = "") -> bool:
+    monkeypatch.setenv("TT_ALLOWED_ORIGINS", env)
+    return bool(re.fullmatch(main._cors_origin_regex(), origin))
+
+
+# --- loopback half ---------------------------------------------------------
+
+@pytest.mark.parametrize("origin", [
+    "http://localhost:3000",
+    "http://localhost:4500",      # the user can move it with --port
+    "http://127.0.0.1:8000",
+    "http://[::1]:3000",
+])
+def test_loopback_is_allowed_on_any_port(origin, monkeypatch):
+    assert allowed(origin, monkeypatch)
+
+
+@pytest.mark.parametrize("origin", [
+    "http://localhost",           # default port 80, omitted by the browser
+    "https://localhost",          # default port 443, omitted by the browser
+    "http://[::1]",
+])
+def test_loopback_is_allowed_without_a_port(origin, monkeypatch):
+    assert allowed(origin, monkeypatch)
+
+
+def test_loopback_agrees_with_the_auth_gate(monkeypatch):
+    """_is_loopback() treats ::1 as loopback, so the allowlist must too.
+
+    The two disagreeing about what "loopback" means is how you end up with an
+    origin the auth gate waves through but CORS rejects.
+    """
+    for host in ("127.0.0.1", "::1", "localhost"):
+        assert main._is_loopback(host)
+    assert allowed("http://[::1]:3000", monkeypatch)
+
+
+# --- remote half -----------------------------------------------------------
+
+def test_remote_half_is_absent_by_default(monkeypatch):
+    """Default behaviour is loopback-only."""
+    monkeypatch.setenv("TT_ALLOWED_ORIGINS", "")
+    assert main._remote_origin_regex() is None
+    assert not allowed("https://box.ts.net", monkeypatch)
+
+
+@pytest.mark.parametrize("origin", [
+    "https://box.ts.net",         # proxied on :443, no port in Origin
+    "http://box.ts.net",          # proxied on :80, no port in Origin
+    "https://box.ts.net:8443",    # explicit port
+])
+def test_configured_host_is_allowed_with_or_without_a_port(origin, monkeypatch):
+    assert allowed(origin, monkeypatch, env="box.ts.net")
+
+
+@pytest.mark.parametrize("entry", [
+    "box.ts.net",
+    "https://box.ts.net",         # a full origin is the natural thing to write
+    "https://box.ts.net/",        # ...possibly with a trailing slash
+    "http://box.ts.net:8443/x",   # ...or copied out of the address bar
+    "BOX.TS.NET",                 # Origin hosts arrive ASCII-lowercased
+    "  box.ts.net  ",
+])
+def test_entry_spellings_all_resolve_to_the_same_host(entry, monkeypatch):
+    assert allowed("https://box.ts.net", monkeypatch, env=entry)
+
+
+def test_multiple_hosts_and_blank_entries(monkeypatch):
+    env = "box.ts.net, ,100.64.0.1,"
+    assert allowed("https://box.ts.net", monkeypatch, env=env)
+    assert allowed("http://100.64.0.1:3000", monkeypatch, env=env)
+    assert not allowed("https://other.ts.net", monkeypatch, env=env)
+
+
+# --- what must stay rejected ----------------------------------------------
+
+@pytest.mark.parametrize("origin,env", [
+    ("https://evil.com",            ""),
+    ("http://notlocalhost",         ""),
+    ("http://localhost.evil.com",   ""),           # prefix, needs the $ anchor
+    ("https://box.ts.net.evil.com", "box.ts.net"),  # suffix, needs the $ anchor
+    ("https://sub.box.ts.net",      "box.ts.net"),  # subdomains are not implied
+    ("ftp://localhost:3000",        ""),            # scheme is pinned to http(s)
+    ("http://localhost:3000/path",  ""),            # an origin carries no path
+])
+def test_rejected(origin, env, monkeypatch):
+    assert not allowed(origin, monkeypatch, env=env)
+
+
+def test_dots_in_a_configured_host_are_literal(monkeypatch):
+    """Without re.escape, the dots would match any character, so allowing
+    box.ts.net would also allow an attacker-registered boxXtsYnet."""
+    assert not allowed("https://boxXtsYnet", monkeypatch, env="box.ts.net")
+    assert not allowed("https://box-ts-net", monkeypatch, env="box.ts.net")
+
+
+def test_a_configured_host_cannot_inject_pattern_syntax(monkeypatch):
+    """The value is user-supplied, so regex metacharacters must not survive."""
+    assert not allowed("https://anything", monkeypatch, env=".*")
+    assert allowed("https://.*", monkeypatch, env=".*")  # matched literally
+
+
+# --- entry normalisation ---------------------------------------------------
+
+@pytest.mark.parametrize("raw,expected", [
+    ("box.ts.net",                "box.ts.net"),
+    ("https://box.ts.net",        "box.ts.net"),
+    ("http://box.ts.net/",        "box.ts.net"),
+    ("https://box.ts.net:8443",   "box.ts.net"),
+    ("https://box.ts.net/a?b=c",  "box.ts.net"),
+    ("BOX.TS.NET",                "box.ts.net"),
+    ("  box.ts.net  ",            "box.ts.net"),
+    ("[::1]:3000",                "[::1]"),
+    ("http://[::1]",              "[::1]"),
+    ("",                          ""),
+    ("   ",                       ""),
+])
+def test_origin_host_normalisation(raw, expected):
+    assert main._origin_host(raw) == expected

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -109,10 +109,30 @@ function parseArgs(argv) {
 //   2. the first --allowed-origins entry (they told us how they'll reach it),
 //   3. the primary non-internal IPv4 of this box (best-effort autodetect).
 // Returns '' if nothing concrete is available.
+// Reduce one --allowed-origins entry to a bare host: strip any scheme, path
+// and port, keeping a bracketed IPv6 literal intact. Mirrors _origin_host() in
+// backend/main.py so all three consumers of the list agree on what an entry
+// means (CORS, Next's allowedDevOrigins, and the connect/QR URL below).
+function originHost(raw) {
+  let h = String(raw || '').trim().toLowerCase();
+  if (!h) return '';
+  const scheme = h.indexOf('://');
+  if (scheme !== -1) h = h.slice(scheme + 3);
+  h = h.split('/')[0].split('?')[0].split('#')[0];
+  if (h.startsWith('[')) {
+    const end = h.indexOf(']');
+    return end === -1 ? h : h.slice(0, end + 1);
+  }
+  return h.split(':')[0];
+}
+
 function pickConnectHost(host, allowedOrigins) {
   if (host && !['0.0.0.0', '127.0.0.1', 'localhost'].includes(host)) return host;
   const first = (allowedOrigins || '').split(',').map((s) => s.trim()).filter(Boolean)[0];
-  if (first) return first;
+  // The list is documented as hostnames, but a full origin is the natural
+  // thing to type. Reduce it to a host so the connect URL doesn't come out as
+  // "http://https://box.ts.net:3000". Matches backend _origin_host().
+  if (first) return originHost(first);
   for (const addrs of Object.values(os.networkInterfaces())) {
     for (const a of addrs || []) {
       if (a.family === 'IPv4' && !a.internal) return a.address;

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -4,9 +4,23 @@ import type { NextConfig } from "next";
 // blocks non-localhost origins by default; TT_ALLOWED_ORIGINS (wired up by
 // bin/cli.js from --allowed-origins) opts specific hosts in for remote/tailnet
 // access. Empty by default, so local-only use is unaffected.
+// Next matches these as hostnames, but a full origin ("https://box.ts.net/") is
+// the natural thing to pass to --allowed-origins, so reduce each entry to its
+// host first. Mirrors _origin_host() in backend/main.py and originHost() in
+// bin/cli.js, so all three consumers of the list agree on what an entry means.
 const allowedDevOrigins = (process.env.TT_ALLOWED_ORIGINS || "")
   .split(",")
-  .map((s) => s.trim())
+  .map((s) => {
+    const h = s.trim().toLowerCase();
+    if (!h) return "";
+    const rest = h.includes("://") ? h.slice(h.indexOf("://") + 3) : h;
+    const hostPort = rest.split("/")[0].split("?")[0].split("#")[0];
+    if (hostPort.startsWith("[")) {
+      const end = hostPort.indexOf("]");
+      return end === -1 ? hostPort : hostPort.slice(0, end + 1);
+    }
+    return hostPort.split(":")[0];
+  })
   .filter(Boolean);
 
 const nextConfig: NextConfig = {

--- a/website/content/docs/configuration/remote-access.mdx
+++ b/website/content/docs/configuration/remote-access.mdx
@@ -133,6 +133,16 @@ Only use this if you understand the risk and have network-level access controls.
 1. **Backend CORS** — origins allowed to make cross-origin requests to the API.
 2. **Next.js dev server** — origins allowed to load the frontend chunks.
 
+Each value is a **hostname or IP**, not a URL. A full origin is accepted and
+reduced to its host, so `box.tailnet.ts.net`, `https://box.tailnet.ts.net` and
+`https://box.tailnet.ts.net/` all mean the same thing. A listed host is allowed
+on any port, including none: a deployment behind a proxy on `:443` or `:80`
+sends an `Origin` header with no port at all, and that is allowed without you
+having to write the port anywhere.
+
+Loopback (`localhost`, `127.0.0.1`, `[::1]`) is always allowed on any port and
+never needs to be listed.
+
 For the QR / connect URL, the launcher picks a concrete reachable address using this preference order:
 
 1. An explicit non-wildcard `--host` value.

--- a/website/content/docs/reference/troubleshooting.mdx
+++ b/website/content/docs/reference/troubleshooting.mdx
@@ -164,6 +164,24 @@ A single `-L 3000:...` forward without `-L 8000:...` produces a blank dashboard.
 ./start.sh --host 0.0.0.0 --allowed-origins 192.168.1.42,box.tailnet.ts.net
 ```
 
+Pass the **host**, not a URL, though a full origin is accepted and reduced to
+its host. A listed host is allowed on any port.
+
+To confirm CORS is the actual problem, send the preflight yourself:
+
+```bash
+curl -i -X OPTIONS https://box.tailnet.ts.net/sessions \
+  -H 'Origin: https://box.tailnet.ts.net' \
+  -H 'Access-Control-Request-Method: GET' \
+  -H 'Access-Control-Request-Headers: authorization'
+```
+
+`400 Disallowed CORS origin` means the origin isn't on the allowlist. A `200`
+means CORS is fine and the problem is elsewhere. Note that the dashboard sends
+`Authorization: Bearer`, which forces the browser to preflight, so a rejected
+origin fails at the `OPTIONS` request and the real request is never sent. That
+is why the backend log looks healthy while the dashboard stays empty.
+
 ### Token not accepted (HTTP 401)
 
 The remote browser is sending the wrong token or no token.


### PR DESCRIPTION
Splits the CORS allowlist into two conditions instead of one pattern doing two jobs.

## Why

`_cors_origin_regex()` built a single pattern covering both loopback and the hosts opted in via `TT_ALLOWED_ORIGINS`. Loopback genuinely needs a pattern, because the user can move the frontend with `--port` and the port cannot be enumerated. Remote hosts do not, and folding them into the same string meant every remote host inherited a port requirement that only existed for loopback's sake. That is exactly the bug in #328: the pattern ended in `:\d+$`, and a browser omits the port from `Origin` when it is the scheme default, so a deployment behind a proxy on `:443` sends `https://box.tailnet.ts.net` and could never be allowed. There was no configuration workaround.

## What changed

Two independently testable halves, joined for Starlette (which takes a single `allow_origin_regex`). Both are anchored, so alternation between them is still an exact-origin test under `fullmatch()`:

```
loopback only : ^https?://(?:localhost|127\.0\.0\.1|\[::1\])(?::\d+)?$
with a remote : ^https?://(?:localhost|127\.0\.0\.1|\[::1\])(?::\d+)?$|^https?://(?:box\.ts\.net)(?::\d+)?$
```

`_remote_origin_regex()` returns `None` when nothing is configured, so the default is genuinely loopback-only rather than loopback spliced into an always-present pattern.

Also in this pass:

- **`::1` is now loopback.** `_is_loopback()` in the auth gate already treated it as loopback, so the two disagreed about what the word meant.
- **Entries are normalised to a bare host**, so `https://box.ts.net/` works instead of being `re.escape`d verbatim into the pattern and silently matching nothing. `TT_ALLOWED_ORIGINS` has three consumers (backend CORS, Next's `allowedDevOrigins`, and the connect/QR URL in `bin/cli.js`) and all three now reduce an entry the same way. Without that, a full origin would have fixed CORS while producing `http://https://box.ts.net:3000` in the QR link.
- **`backend/test_cors_origins.py`** covers the function for the first time.

## Verification

`_cors_origin_regex` had no test coverage at all before this. I exercised the shipped code (sliced out of `main.py` and exec'd, since the review environment has no backend deps) against 24 origins, 0 failures:

| origin | `TT_ALLOWED_ORIGINS` | allowed |
|---|---|---|
| `http://localhost:3000` | – | yes |
| `http://localhost` | – | yes (was **no**) |
| `http://[::1]:3000` | – | yes (was **no**) |
| `https://box.ts.net` | – | no |
| `https://box.ts.net` | `box.ts.net` | yes (was **no**) |
| `https://box.ts.net:8443` | `box.ts.net` | yes |
| `https://box.ts.net` | `https://box.ts.net/` | yes (was **no**) |
| `https://box.ts.net.evil.com` | `box.ts.net` | no |
| `https://sub.box.ts.net` | `box.ts.net` | no |
| `https://boxXtsYnet` | `box.ts.net` | no |
| `http://localhost.evil.com` | – | no |
| `ftp://localhost:3000` | – | no |

`bin/cli.js` `originHost()` and the `next.config.ts` callback were checked to agree with the backend on all 11 normalisation inputs. `node --check bin/cli.js` and `py_compile` pass.

**Not verified here:** the pytest suite (no backend deps in the review environment) and `tsc --noEmit` (no `node_modules`). The `next.config.ts` change adds no type annotations and the callback returns `string` on every path, so `allowedDevOrigins` keeps its `string[]` type, but it deserves a real typecheck before merge.

## Relationship to #328

The first commit is David Shin's fix from #328, cherry-picked so authorship is preserved in history. Close #328 as merged here, or merge it first and this rebases cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
