### PR TITLE
fix(hermes): don't let a NULL token column zero the known one

### DIFF
--- a/backend/harness_panels/hermes.py
+++ b/backend/harness_panels/hermes.py
@@ -67,7 +67,7 @@ def _usage() -> Optional[Dict[str, Any]]:
         rows = conn.execute(
             "SELECT billing_provider, billing_mode, COUNT(*) sessions, "
             "       SUM(api_call_count) calls, "
-            "       SUM(input_tokens + output_tokens) tokens, "
+            "       SUM(COALESCE(input_tokens, 0) + COALESCE(output_tokens, 0)) tokens, "
             "       SUM(cache_read_tokens) cache, "
             "       SUM(reasoning_tokens) reasoning, "
             "       SUM(COALESCE(actual_cost_usd, 0)) actual "

--- a/backend/test_harness_panels_agents.py
+++ b/backend/test_harness_panels_agents.py
@@ -644,3 +644,37 @@ def test_hermes_billing_processes_and_dashboard_link(tmp_path, monkeypatch):
     sec = next(s for s in doc["sections"] if s["title"] == "Credential stores")
     assert "auth.json" in json.dumps(sec) and ".env" in json.dumps(sec)
     assert "sk-should-never-be-read" not in flat, "credential values are never read"
+
+
+def test_hermes_billing_tokens_survives_null_pair(tmp_path, monkeypatch):
+    """A NULL half of the input/output pair must not zero out the known half.
+
+    session_model_usage rows can have output_tokens unset while input_tokens
+    is recorded; SQLite's arithmetic SUM propagates that NULL through the
+    whole expression, discarding the known input tokens too (#342).
+    """
+    root = tmp_path / ".hermes"
+    root.mkdir(parents=True)
+    con = sqlite3.connect(root / "state.db")
+    con.execute(
+        "CREATE TABLE session_model_usage (session_id TEXT, model TEXT, "
+        "billing_provider TEXT, billing_mode TEXT, api_call_count INT, "
+        "input_tokens INT, output_tokens INT, cache_read_tokens INT, "
+        "cache_write_tokens INT, reasoning_tokens INT, "
+        "estimated_cost_usd REAL, actual_cost_usd REAL, cost_status TEXT)")
+    con.executemany(
+        "INSERT INTO session_model_usage VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)", [
+            ("s1", "gpt-5.4", "openai-codex", "subscription_included",
+             10, 100, None, 0, 0, 0, 0.0, 0.0, "included"),
+            ("s2", "gpt-5.4", "openai-codex", "subscription_included",
+             5, 50, 25, 0, 0, 0, 0.0, 0.0, "included"),
+        ])
+    con.commit()
+    con.close()
+
+    monkeypatch.setattr(hp_paths, "HERMES_DIR", root)
+    doc = hermes_panel.build_hermes(with_disk=False)
+
+    bill = next(s for s in doc["sections"] if s["title"] == "Billing by provider")
+    row = next(r for r in bill["rows"] if r[0] == "openai-codex")
+    assert row[3] == 175, "the 100 known input tokens from the NULL-output row must count"


### PR DESCRIPTION
Wrapped both operands in `COALESCE` in the Hermes billing rollup, matching the `actual_cost_usd` sum three lines below, per the fix you already sketched in the issue.

Added a test with two rows in the same provider/mode group, one with `output_tokens = NULL` and a known `input_tokens`. The new test fails without the change (75 instead of 175, the known 100 gets dropped) and passes with it. Ran the full backend suite on python 3.11 both ways; the 10 failures elsewhere (antigravity artifacts, delegation, push-cwd hooks, update-check prefs) are there on main too and unrelated to this change.

Left the `actual_cost_usd` zero-vs-unknown question and the `copilot.py` case out of this one, since you filed them for a joint decision separately.

Fixes #342
