### PR TITLE
fix(quotas): reject a future fetchedAt when loading the quota cache

### DIFF
--- a/backend/quotas.py
+++ b/backend/quotas.py
@@ -30,6 +30,10 @@ from tt_paths import data_dir
 SCHEMA = "tokentelemetry.quotas.v1"
 FRESHNESS = timedelta(minutes=5)
 CACHE_LOCK_TIMEOUT_SECONDS = 15
+# A fetchedAt read off disk this far ahead of the loader's own clock cannot
+# be trusted; treat it as no cached snapshot rather than an indefinitely
+# fresh one.
+MAX_FUTURE_SKEW = timedelta(minutes=5)
 
 # ``flock``/``msvcrt.locking`` coordinate separate processes, but their
 # same-process behaviour differs by platform. Keep a per-cache thread lock as
@@ -249,10 +253,12 @@ class QuotaSnapshot:
         }
 
     @classmethod
-    def from_wire(cls, provider_id: str, value: Dict[str, Any]) -> Optional["QuotaSnapshot"]:
+    def from_wire(cls, provider_id: str, value: Dict[str, Any], now: datetime) -> Optional["QuotaSnapshot"]:
         fetched_at = _date(value.get("fetchedAt"))
         resources = value.get("resources")
         if not fetched_at or not isinstance(resources, dict):
+            return None
+        if fetched_at > now + MAX_FUTURE_SKEW:
             return None
         parsed = {
             str(key): QuotaResource.from_wire(resource)
@@ -1379,10 +1385,11 @@ class QuotaService:
             providers = value.get("providers") if isinstance(value, dict) else None
             if not isinstance(providers, dict):
                 return
+            loaded_at = self.now()
             snapshots = {
                 provider_id: snapshot
                 for provider_id, raw in providers.items()
-                if isinstance(raw, dict) and (snapshot := QuotaSnapshot.from_wire(provider_id, raw))
+                if isinstance(raw, dict) and (snapshot := QuotaSnapshot.from_wire(provider_id, raw, loaded_at))
             }
         except (OSError, json.JSONDecodeError):
             return

--- a/backend/test_quotas.py
+++ b/backend/test_quotas.py
@@ -417,6 +417,68 @@ def test_second_service_reloads_a_fresh_disk_cache_before_refreshing(tmp_path):
     assert result["providers"]["opencode"]["plan"] == "first"
 
 
+def test_load_discards_a_disk_cache_written_with_a_clock_ahead_of_now(tmp_path):
+    class Provider:
+        provider_id = "opencode"
+        display_name = "OpenCode"
+
+        def __init__(self):
+            self.calls = 0
+
+        def has_local_credentials(self):
+            return True
+
+        def refresh(self, now):
+            self.calls += 1
+            return QuotaSnapshot(self.provider_id, self.display_name, now, {})
+
+    cache_path = tmp_path / "quotas.json"
+    # A skewed clock (dual-boot RTC offset, a resumed VM snapshot) wrote a
+    # cache whose fetchedAt is months in the future.
+    skewed_at = datetime(2027, 3, 1, tzinfo=timezone.utc)
+    QuotaService([Provider()], cache_path=cache_path, now=lambda: skewed_at).collect(force=True)
+
+    corrected_at = datetime(2026, 9, 10, tzinfo=timezone.utc)
+    reader = Provider()
+    service = QuotaService([reader], cache_path=cache_path, now=lambda: corrected_at)
+
+    result = service.collect()
+
+    assert reader.calls == 1
+    assert result["providers"]["opencode"]["fetchedAt"] == "2026-09-10T00:00:00Z"
+    assert result["providers"]["opencode"]["stale"] is False
+
+
+def test_load_still_trusts_a_fetched_at_a_few_seconds_ahead_of_the_loading_clock(tmp_path):
+    class Provider:
+        provider_id = "opencode"
+        display_name = "OpenCode"
+
+        def __init__(self):
+            self.calls = 0
+
+        def has_local_credentials(self):
+            return True
+
+        def refresh(self, now):
+            self.calls += 1
+            return QuotaSnapshot(self.provider_id, self.display_name, now, {})
+
+    cache_path = tmp_path / "quotas.json"
+    # Ordinary jitter between two processes' clocks, well inside
+    # MAX_FUTURE_SKEW, must not be treated as a corrupted cache.
+    written_at = datetime(2026, 9, 10, 12, 0, 5, tzinfo=timezone.utc)
+    QuotaService([Provider()], cache_path=cache_path, now=lambda: written_at).collect(force=True)
+
+    reader = Provider()
+    reader_now = datetime(2026, 9, 10, 12, 0, 0, tzinfo=timezone.utc)
+    service = QuotaService([reader], cache_path=cache_path, now=lambda: reader_now)
+
+    service.collect()
+
+    assert reader.calls == 0
+
+
 def test_second_service_never_saves_an_older_in_memory_snapshot_over_newer_disk_cache(tmp_path):
     class Provider:
         provider_id = "codex"


### PR DESCRIPTION
## Summary
Fixes the quota cache freshness check so a `fetchedAt` read off disk that is ahead of the loading clock is treated as no cached snapshot, instead of as fresh forever.

## Type of change
- [x] Bug fix

## The bug
`QuotaSnapshot.from_wire` (`backend/quotas.py`) accepted any parseable `fetchedAt` from the persisted cache with no upper bound. If the cache was written while the system clock was ahead (a dual-boot RTC offset, a resumed VM snapshot), the stored `fetchedAt` lands in the future. `collect()`'s `is_fresh = current and generated_at < current.fetched_at + FRESHNESS` and `QuotaSnapshot.wire`'s `stale = generated_at >= expires` both only guard the upper side, so once wall time is corrected, every later request reads the frozen snapshot as fresh and the provider is never contacted again until real time catches up to the bogus timestamp.

## The fix
`from_wire` now takes the loader's own `now` and discards a snapshot whose `fetchedAt` is more than 5 minutes ahead of it, the same way it already discards an entry with no `fetchedAt` or non-dict `resources`. The dropped entry means the provider has no cached snapshot on the next `collect()`, so a real refresh runs. Snapshots built during a live refresh are unaffected: `provider.refresh(generated_at)` always sets `fetched_at` from that same call's `generated_at`, never from disk.

## How I verified it
- Added `test_load_discards_a_disk_cache_written_with_a_clock_ahead_of_now`, which seeds a cache with a `fetchedAt` months in the future (mirroring the report's scenario), then loads it with a corrected clock: fails on `main`, passes on this branch.
- Added `test_load_still_trusts_a_fetched_at_a_few_seconds_ahead_of_the_loading_clock` as a control: ordinary clock jitter between two processes should not force a spurious refresh. Passes on both.
- Ran the full `backend/` suite in a clean `python:3.12-slim` container both before and after: same 10 pre-existing failures in unrelated files (`test_antigravity_cli.py`, `test_delegation.py`, `test_hook_push_cwd.py`, `test_update_check.py`), 826 passed after vs. 824 before (the 2 new tests), nothing newly broken.

I did not test what happens when the OS clock itself is skewed forward at the moment of an actual live refresh, as opposed to a value already sitting on disk. That's a real clock problem, not a cache-trust one, and the report is specifically about a corrected clock disagreeing with a stale disk value.

Closes #345
