### PR TITLE
fix(quotas): report a cache-lock timeout as an error, not an empty result

### DIFF
--- a/backend/quotas.py
+++ b/backend/quotas.py
@@ -1317,7 +1317,10 @@ class QuotaService:
                     # means this read is either the prior complete cache or the
                     # next complete cache; never write a competing snapshot.
                     self._load(reload=True)
-                    return self._wire(self.now(), [])
+                    return self._wire(self.now(), [{
+                        "providerId": "quotaCache",
+                        "message": "Could not acquire the quota cache lock; showing the last cached snapshot.",
+                    }])
 
                 # Reload *inside* the process lock. A long-lived dashboard or
                 # menubar instance may have loaded a stale cache before another

--- a/backend/test_quotas.py
+++ b/backend/test_quotas.py
@@ -22,6 +22,7 @@ from quotas import (
     QuotaService,
     QuotaSnapshot,
     StaticQuotaProvider,
+    _CacheFileLock,
     default_quota_providers,
 )
 
@@ -302,6 +303,30 @@ def test_service_keeps_last_good_snapshot_when_a_refresh_fails(tmp_path):
     assert second["providers"]["codex"]["fetchedAt"] == first["providers"]["codex"]["fetchedAt"]
     assert second["errors"] == [{"providerId": "codex", "message": "Could not refresh quota data."}]
     assert second["capabilities"]["codex"]["state"] == "refreshFailed"
+
+
+def test_service_reports_a_lock_timeout_as_an_error_not_an_empty_result(tmp_path, monkeypatch):
+    class Provider:
+        provider_id = "codex"
+        display_name = "Codex"
+
+        def has_local_credentials(self):
+            return True
+
+        def refresh(self, now):
+            raise AssertionError("must not refresh while the cache lock is held elsewhere")
+
+    monkeypatch.setattr(_CacheFileLock, "__enter__", lambda self: False)
+    monkeypatch.setattr(_CacheFileLock, "__exit__", lambda self, *exc: None)
+
+    result = QuotaService([Provider()], cache_path=tmp_path / "quotas.json").collect(force=True)
+
+    assert result["providers"] == {}
+    assert result["capabilities"] == {}
+    assert result["errors"] == [{
+        "providerId": "quotaCache",
+        "message": "Could not acquire the quota cache lock; showing the last cached snapshot.",
+    }]
 
 
 def test_service_reports_not_signed_in_and_unsupported_harnesses(tmp_path):


### PR DESCRIPTION
`_CacheFileLock.__enter__` gives up after 15s and `collect()`'s fallback returns `self._wire(self.now(), [])`. The `errors` list stayed empty, so `_response_failure` (menubar) and the dashboard's `providers.length === 0` check can't tell "we couldn't look" from "nothing configured", exactly as the finding says.

Added an error entry to that fallback (`providerId: "quotaCache"`, same shape the provider-refresh path already uses) so a lock timeout is visible instead of silent. Left the "serve the last cached snapshot" half of the suggestion alone: `self._load(reload=True)` runs right before the fallback already, so a real previous snapshot does get served, this path just never said so when it couldn't refresh.

Added `test_service_reports_a_lock_timeout_as_an_error_not_an_empty_result`, forcing `_CacheFileLock.__enter__` to return `False` and checking the response. The new test fails without the change and passes with it. Full `backend/` suite: 827 passed vs 826 before, same 10 pre-existing failures either way (antigravity_cli, delegation, hook_push_cwd, update_check, none of them touch quotas.py).

Didn't touch the frontend; `QuotaIndicator.tsx` and `presentation.py` both already read `errors`/`providers` the way this response now populates them.

Fixes #346
