### PR TITLE
fix(caches): stop two caches from serving stale or blank data as if current

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -12113,14 +12113,28 @@ async def make_summary(session_id: str, agent: str, force: bool = False):
         else:
             gen_error = f"summarizer '{backend_name}' is not available"
 
+    # Generation failed, so fall back to the narrative we already have. Showing
+    # the previous one beats showing nothing.
+    served_older_narrative = False
     if narrative is None and cached and cached.get("narrative"):
         narrative = cached["narrative"]
+        served_older_narrative = cached.get("content_hash") != chash
 
-    result = _summaries.store(
-        session_id, meta.get("agent", agent), chash,
-        backend_name or "", cfg.get("model"),
-        brief, narrative or {}, 0.0,
-    )
+    if served_older_narrative:
+        # Do NOT re-store it under the new content hash. That hash mismatch is
+        # the ONLY thing that makes a later call regenerate, so stamping the old
+        # narrative with the new hash would mark a stale summary fresh forever:
+        # every subsequent request short-circuits at the cache check above and
+        # the summarizer is never called again, even once it recovers (#352).
+        # Leaving the row on its old hash means the next attempt still sees the
+        # content as changed and retries by itself.
+        result = cached
+    else:
+        result = _summaries.store(
+            session_id, meta.get("agent", agent), chash,
+            backend_name or "", cfg.get("model"),
+            brief, narrative or {}, 0.0,
+        )
     error_info = None
     if gen_error:
         from summarizers.errors import classify as _classify_err
@@ -12132,7 +12146,14 @@ async def make_summary(session_id: str, agent: str, force: bool = False):
         })
     except Exception:
         pass
-    return {"summary": {**result, "stale": False}, "error": gen_error, "error_info": error_info}
+    # `stale` was previously hard-coded False on every path, so the "Stale"
+    # badge the panel already renders (SummaryPanel.tsx) could never fire. It
+    # fires exactly here: the narrative describes an earlier, shorter trace.
+    return {
+        "summary": {**result, "stale": served_older_narrative},
+        "error": gen_error,
+        "error_info": error_info,
+    }
 
 @app.post("/summaries/recent")
 async def summarize_recent(limit: int = 20):

--- a/backend/quotas.py
+++ b/backend/quotas.py
@@ -1311,13 +1311,43 @@ class QuotaService:
 
     def collect(self, force: bool = False) -> Dict[str, Any]:
         with self._lock:
-            with _CacheFileLock(self.cache_path) as acquired:
+            # The interprocess lock guards *refreshing and writing*, not
+            # reading: writes are atomic replaces, so a read sees either the
+            # prior complete cache or the next one. It exists so two processes
+            # (dashboard + menubar) don't fetch the same quotas twice or
+            # overwrite a newer snapshot with an older one.
+            #
+            # A caller that loses the race does neither of those things: it
+            # reads the cache and returns. So a background poll should not
+            # queue behind a refresh it is not going to perform. Waiting the
+            # full timeout blocked the response for that long and then served
+            # the very same file it could have read immediately, which blanked
+            # the Plan-limits UI for no reason. Poll with no wait; an explicit
+            # refresh still waits, because someone is watching that one.
+            #
+            # Nothing is reported for the ordinary case: each snapshot already
+            # carries fetchedAt / expiresAt / stale, so the caller can see for
+            # itself how old the numbers are.
+            with _CacheFileLock(
+                self.cache_path,
+                timeout=CACHE_LOCK_TIMEOUT_SECONDS if force else 0,
+            ) as acquired:
                 if not acquired:
                     # Another process is still collecting. Its atomic replace
                     # means this read is either the prior complete cache or the
                     # next complete cache; never write a competing snapshot.
                     self._load(reload=True)
-                    return self._wire(self.now(), [])
+                    errors: List[Dict[str, str]] = []
+                    if not self._snapshots:
+                        # No cached snapshot exists yet, so the response would
+                        # otherwise be indistinguishable from "no agents
+                        # configured" and every surface would render empty.
+                        errors.append({
+                            "providerId": "quotaCache",
+                            "message": "Another process is refreshing the quota "
+                                       "cache and no snapshot has been stored yet.",
+                        })
+                    return self._wire(self.now(), errors)
 
                 # Reload *inside* the process lock. A long-lived dashboard or
                 # menubar instance may have loaded a stale cache before another

--- a/backend/test_quotas.py
+++ b/backend/test_quotas.py
@@ -5,12 +5,16 @@ from __future__ import annotations
 import json
 import sys
 import asyncio
+import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+import quotas as quotas_module
 from quotas import (
+    CACHE_LOCK_TIMEOUT_SECONDS,
+    _CacheFileLock,
     ClaudeQuotaProvider,
     CodexQuotaProvider,
     CopilotQuotaProvider,
@@ -477,6 +481,89 @@ def test_load_still_trusts_a_fetched_at_a_few_seconds_ahead_of_the_loading_clock
     service.collect()
 
     assert reader.calls == 0
+
+
+# --- losing the cache lock -------------------------------------------------
+# The interprocess lock guards refreshing and writing, not reading. A caller
+# that loses it does neither, so it should serve the cache at once rather than
+# block for the timeout and then read that same file anyway.
+
+class _LockLoser:
+    """A provider that fails the test if it is ever asked to refresh."""
+
+    provider_id = "opencode"
+    display_name = "OpenCode"
+
+    def has_local_credentials(self):
+        return True
+
+    def refresh(self, now):
+        raise AssertionError("must not refresh while another process holds the lock")
+
+
+def _seed_cache(cache_path, at, plan="cached"):
+    class Writer(_LockLoser):
+        def refresh(self, now):
+            return QuotaSnapshot(self.provider_id, self.display_name, now, {}, plan=plan)
+
+    QuotaService([Writer()], cache_path=cache_path, now=lambda: at).collect(force=True)
+
+
+def test_a_poll_that_loses_the_lock_serves_the_cache_without_waiting(tmp_path):
+    cache_path = tmp_path / "quotas.json"
+    written_at = datetime(2026, 9, 10, tzinfo=timezone.utc)
+    _seed_cache(cache_path, written_at)
+
+    # Stale enough that a poll would normally refresh; the held lock must stop it.
+    later = written_at + FRESHNESS + timedelta(seconds=1)
+    service = QuotaService([_LockLoser()], cache_path=cache_path, now=lambda: later)
+
+    with _CacheFileLock(cache_path) as held:
+        assert held
+        started = time.monotonic()
+        result = service.collect()
+        elapsed = time.monotonic() - started
+
+    assert elapsed < 1.0, "a poll must not queue behind another process's refresh"
+    assert result["providers"]["opencode"]["plan"] == "cached"
+    # Nothing is reported: the snapshot carries its own fetchedAt/stale, so the
+    # caller can already see how old these numbers are.
+    assert result["errors"] == []
+    assert result["providers"]["opencode"]["stale"] is True
+
+
+def test_losing_the_lock_with_no_cache_reports_an_error_rather_than_looking_empty(tmp_path):
+    """Without this, the response is identical to "no agents configured"."""
+    cache_path = tmp_path / "quotas.json"
+    service = QuotaService([_LockLoser()], cache_path=cache_path,
+                           now=lambda: datetime(2026, 9, 10, tzinfo=timezone.utc))
+
+    with _CacheFileLock(cache_path) as held:
+        assert held
+        result = service.collect()
+
+    assert result["providers"] == {}
+    assert [error["providerId"] for error in result["errors"]] == ["quotaCache"]
+    assert "no snapshot has been stored yet" in result["errors"][0]["message"]
+
+
+def test_a_poll_waits_not_at_all_but_an_explicit_refresh_still_waits(tmp_path, monkeypatch):
+    """Nobody is watching a background poll; someone is watching Refresh."""
+    seen = []
+    original = quotas_module._CacheFileLock
+
+    class Spy(original):
+        def __init__(self, path, timeout=CACHE_LOCK_TIMEOUT_SECONDS):
+            seen.append(timeout)
+            super().__init__(path, timeout=timeout)
+
+    monkeypatch.setattr(quotas_module, "_CacheFileLock", Spy)
+    service = QuotaService([], cache_path=tmp_path / "quotas.json")
+
+    service.collect()
+    service.collect(force=True)
+
+    assert seen == [0, CACHE_LOCK_TIMEOUT_SECONDS]
 
 
 def test_second_service_never_saves_an_older_in_memory_snapshot_over_newer_disk_cache(tmp_path):

--- a/backend/test_summary_stale_fallback.py
+++ b/backend/test_summary_stale_fallback.py
@@ -1,0 +1,132 @@
+"""A failed summarization must not mark the stale narrative as fresh (#352).
+
+When generation fails on a trace that has grown, `make_summary` falls back to
+the previously stored narrative. That fallback is correct: showing the earlier
+summary beats showing nothing. What must not happen is re-storing it under the
+NEW content hash, because that hash mismatch is the only signal that makes a
+later call regenerate. Overwriting it marks a stale summary fresh permanently:
+every subsequent request short-circuits at the cache check and the summarizer
+is never called again, even after it recovers.
+
+Run: pytest backend/test_summary_stale_fallback.py -q
+"""
+import asyncio
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+import summaries  # noqa: E402
+import main  # noqa: E402
+
+SESSION = "sess-352"
+AGENT = "claude"
+
+
+def _events(count: int):
+    """content_hash keys off len(events) and the last timestamp, so growing the
+    list is what makes a trace look changed."""
+    return [
+        {"type": "user", "normalized_timestamp": "2026-09-10T00:%02d:00Z" % i}
+        for i in range(count)
+    ]
+
+
+@pytest.fixture
+def summary_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(summaries, "_DB_PATH", tmp_path / "summaries.db")
+    return tmp_path
+
+
+def _wire(monkeypatch, events, *, summarizer_works: bool, headline: str = "fresh"):
+    async def _detail(session_id, agent):
+        return events
+
+    async def _meta(session_id, agent):
+        return {"agent": agent}
+
+    class _Stub:
+        def is_available(self):
+            return True
+
+        def summarize(self, prompt):
+            if not summarizer_works:
+                raise main.SummarizerError("backend is down")
+            return '{"intent_outcome": "%s"}' % headline
+
+    monkeypatch.setattr(main, "get_session_detail", _detail)
+    monkeypatch.setattr(main, "_session_meta", _meta)
+    monkeypatch.setattr(main, "get_summarizer", lambda *a, **k: _Stub())
+    monkeypatch.setattr(summaries, "load_config", lambda: {
+        "enabled": True, "backend": "stub", "model": "test-model",
+    })
+
+
+def _summarize(force: bool = False):
+    return asyncio.run(main.make_summary(SESSION, agent=AGENT, force=force))
+
+
+def test_a_failed_regeneration_leaves_the_row_on_its_old_hash(summary_db, monkeypatch):
+    # 1. A short trace summarizes fine.
+    _wire(monkeypatch, _events(3), summarizer_works=True, headline="three events")
+    first = _summarize()
+    old_hash = first["summary"]["content_hash"]
+    assert first["summary"]["narrative"]["intent_outcome"] == "three events"
+    assert first["summary"]["stale"] is False
+
+    # 2. The trace grows and the summarizer is down.
+    _wire(monkeypatch, _events(10), summarizer_works=False)
+    second = _summarize()
+
+    # The old narrative is still served, which is the correct fallback.
+    assert second["error"]
+    assert second["summary"]["narrative"]["intent_outcome"] == "three events"
+    # ...but it is labelled honestly, and the row keeps its ORIGINAL hash so a
+    # later attempt still sees the content as changed.
+    assert second["summary"]["stale"] is True
+    assert second["summary"]["content_hash"] == old_hash
+    assert summaries.get_cached(SESSION)["content_hash"] == old_hash
+
+
+def test_the_summary_regenerates_once_the_backend_recovers(summary_db, monkeypatch):
+    _wire(monkeypatch, _events(3), summarizer_works=True, headline="three events")
+    _summarize()
+
+    _wire(monkeypatch, _events(10), summarizer_works=False)
+    _summarize()
+
+    # Backend recovers. Without the fix the cached hash already equalled the
+    # grown trace's hash, so this call short-circuited and returned the stale
+    # narrative forever. No force=True, no user action.
+    _wire(monkeypatch, _events(10), summarizer_works=True, headline="ten events")
+    third = _summarize()
+
+    assert third["error"] is None
+    assert third["summary"]["narrative"]["intent_outcome"] == "ten events"
+    assert third["summary"]["stale"] is False
+
+
+def test_a_successful_summary_of_an_unchanged_trace_still_stores_normally(summary_db, monkeypatch):
+    """The fix must only skip the store on the stale-fallback path."""
+    _wire(monkeypatch, _events(5), summarizer_works=True, headline="five events")
+    first = _summarize()
+
+    _wire(monkeypatch, _events(5), summarizer_works=True, headline="regenerated")
+    forced = _summarize(force=True)
+
+    assert forced["summary"]["stale"] is False
+    assert forced["summary"]["content_hash"] == first["summary"]["content_hash"]
+    assert forced["summary"]["narrative"]["intent_outcome"] == "regenerated"
+    assert summaries.get_cached(SESSION)["narrative"]["intent_outcome"] == "regenerated"
+
+
+def test_a_failure_with_no_cached_narrative_at_all_still_stores(summary_db, monkeypatch):
+    """Nothing to fall back to, so the empty row is written as before and the
+    next attempt retries (the cache gate requires a truthy narrative)."""
+    _wire(monkeypatch, _events(4), summarizer_works=False)
+    result = _summarize()
+
+    assert result["error"]
+    assert result["summary"]["stale"] is False
+    assert summaries.get_cached(SESSION) is not None


### PR DESCRIPTION
Two independent cache bugs, both of which make the app show something wrong while looking confident. Closes #352.

---

# 1. Quota cache: a poll blocked 15s, then blanked the UI

## The lock guards writing, not reading

`_CacheFileLock` exists (703f397) so the dashboard and the menubar don't fetch the same quotas twice or overwrite a newer snapshot with an older one. A caller that loses the race does neither: it reads the cache and returns.

It was still waiting the full `CACHE_LOCK_TIMEOUT_SECONDS = 15` to find that out. The code even said so on the path that ignored it:

> "Another process is still collecting. Its **atomic replace** means this read is either the prior complete cache or the next complete cache; never write a competing snapshot."

A forced refresh makes roughly 11 outbound calls at a 10s timeout, so two of the app's own surfaces starting together exceed 15s routinely. The user got a 15-second stall and then, because the response carried empty `providers` **and** empty `errors`, a Plan-limits box that vanished from the sidebar (`QuotaIndicator.tsx:51`) and a menubar reading `◔ No quota data`. Nothing was wrong. The app had no way to say so.

## What changed

| Caller | Wait | Why |
|---|---|---|
| `GET /quotas` (60s poll, `QuotaProvider.tsx:30`) | none | Nobody is watching, and the cached numbers are what it would serve anyway |
| `POST /quotas/refresh` (`force=True`) | full timeout | Someone clicked a button and is watching for it to change |

**Nothing new is reported in the ordinary case.** Every snapshot already ships `fetchedAt`, `expiresAt` and `stale` (`quotas.py:242-247`), and `frontend/src/lib/quotas.ts:22` already types `stale`. A second "refreshing" signal would be a competing source of truth for something the response already answers.

**One case does need saying out loud:** a held lock *and* no cached snapshot, on a first run or a fresh data directory. There the response really is indistinguishable from "no agents configured", so it now carries a `quotaCache` error. That is @AmirF194's fix from #356 narrowed to the case that needs it, rather than firing on every lock miss.

## The lock's guarantees are untouched

The loser still never refreshes and never writes, which is exactly what 703f397 set out to prevent. Only the length of the pointless wait changed. Both guardrail tests from that commit still pass untouched.

---

# 2. Summary cache: a failed regeneration marked a stale summary fresh

## The label on the leftovers

Each stored summary carries a hash of the trace it describes. Before regenerating, the code checks it: same hash means the trace hasn't changed, serve the cached narrative.

When generation failed on a trace that had **grown**, the old narrative was served (correct, better than nothing) and then **re-stored under the new hash** (`main.py:12119`). That hash mismatch is the only signal that makes a later call regenerate.

So from then on every request short-circuited at the cache check and the summarizer was never called again, **even after it recovered**. The session permanently showed a summary of its first few events as the summary of the whole trace. The one thing that would have triggered a retry was the thing the failure path overwrote.

## What changed

The fallback now leaves the row on its old hash instead of re-storing it, so the next attempt still sees the content as changed and retries by itself.

It only skips the store on that path. A successful summary, a forced regeneration, and a failure with nothing cached to fall back on all store exactly as before.

**A dead badge now works.** `stale` was hard-coded `False` on every return, so the "Stale" badge the summary panel already renders (`SummaryPanel.tsx:95`) could never fire. It fires on exactly this path, so a narrative describing an earlier, shorter trace is labelled rather than passed off as current.

## Correcting the issue report

#352 says *"no future scan ever re-triggers generation."* Slightly overstated: `SummaryPanel.tsx:107` calls `runGenerate(!!summary)`, so clicking **Regenerate** passes `force=true` and bypasses the hash check. The bug was unrecoverable automatically, not unrecoverable outright. It still mattered, because nothing told the user the summary was wrong.

---

# Verification

Both fixes are verified the same way: the new tests were run against the **parent commit** first, to confirm they actually catch the bug.

**Quota (3 tests, all fail on parent):** a poll that loses the lock serves the cache without waiting (asserts `elapsed < 1.0s`, and the stub provider raises if `refresh` is ever called); losing the lock with no cache reports a `quotaCache` error; the lock wait is `0` for a poll and `CACHE_LOCK_TIMEOUT_SECONDS` for an explicit refresh.

The timing is the headline: those tests take **30.12s against the old code and 0.13s against this branch**, which is the stall measured directly.

**Summaries (4 tests, the 2 bug-describing ones fail on parent):** a failed regeneration leaves the row on its old hash; the summary regenerates on its own once the backend recovers, with no force flag and no user action. The other two are controls that pass either way, covering the normal store path and the no-cache-to-fall-back-on path.

**Full backend suite, same interpreter both runs:**

```
clean main:   829 passed, 7 failed
this branch:  836 passed, 7 failed     (+7 = the new tests)
```

Failure lists diffed **identical**, so no regressions. The 7 are pre-existing and unrelated (`test_delegation`, `test_harness_panels` x3, `test_hermes_telemetry`, `test_update_check` x2).

# Relationship to #356

This supersedes the waiting behaviour in #356 but keeps its insight. @AmirF194 correctly identified that a silent empty response is indistinguishable from "nothing configured"; this narrows that error to the only case where it's true and removes the 15-second wait that produced it.

Worth noting for #356 either way: its description says `QuotaIndicator.tsx` already reads `errors`. It does not. Line 51 gates only on `providers` and `capabilities`, so the sidebar fix there was incomplete. This PR fixes the sidebar by giving it actual providers to render instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
