### PR TITLE
fix(quotas): don't report 0% used when Grok's usage field is missing

### DIFF
--- a/backend/quotas.py
+++ b/backend/quotas.py
@@ -1031,7 +1031,7 @@ class GrokQuotaProvider:
             raise RuntimeError("invalid response")
         percent = _number(config.get("creditUsagePercent"))
         if percent is None:
-            percent = 0
+            raise RuntimeError("invalid response")
         try:
             settings_status, settings = self.fetch_json(self.settings_url, headers)
         except RuntimeError:

--- a/backend/test_quotas.py
+++ b/backend/test_quotas.py
@@ -190,6 +190,29 @@ def test_grok_provider_maps_its_weekly_credit_pool(tmp_path):
     assert snapshot.resources["weekly"].resets_at == datetime(2026, 9, 8, tzinfo=timezone.utc)
 
 
+def test_grok_provider_reports_invalid_response_when_credit_usage_percent_is_absent(tmp_path):
+    home = tmp_path / "home"
+    auth = home / ".grok" / "auth.json"
+    auth.parent.mkdir(parents=True)
+    auth.write_text(json.dumps({"https://auth.x.ai::account": {"key": "grok-token"}}))
+
+    def fetch(url, headers):
+        if url.endswith("/settings"):
+            return 200, {"subscription_tier_display": "SuperGrok"}
+        return 200, {"config": {"currentPeriod": {
+            "type": "USAGE_PERIOD_TYPE_WEEKLY",
+            "start": "2026-09-01T00:00:00Z",
+            "end": "2026-09-08T00:00:00Z",
+        }}}
+
+    provider = GrokQuotaProvider(home=home, fetch_json=fetch)
+    try:
+        provider.refresh(datetime(2026, 9, 1, tzinfo=timezone.utc))
+        raise AssertionError("expected invalid response")
+    except RuntimeError as error:
+        assert str(error) == "invalid response"
+
+
 def test_gemini_provider_discovers_project_and_maps_per_model_buckets(tmp_path):
     home = tmp_path / "home"
     credentials = home / ".gemini" / "oauth_creds.json"


### PR DESCRIPTION
`GrokQuotaProvider.refresh` substituted 0 for a missing `creditUsagePercent`, so a renamed or dropped field rendered as "0% used, 100 remaining" instead of unknown. Every other resource in this file drops the resource, or raises `invalid response` when it's the provider's only one, on a missing usage field; Grok alone fabricated a zero.

Raised `invalid response` instead, same as `OpenCodeQuotaProvider` does a few hundred lines down when its own single resource can't be parsed. That routes through the existing `refreshFailed` classification, so the dashboard shows the resource as unavailable rather than a confident 0%.

Added a test with `creditUsagePercent` absent from the config. The new test fails without the change, since main just returns the old 0% snapshot. Full `backend/` suite: 834 passed, same 10 pre-existing failures either way (antigravity_cli, a delegation aggregate, hook_push_cwd, update_check), none touching quotas.py.

Fixes #347
